### PR TITLE
#19 - change type unions to common supertype

### DIFF
--- a/src/Ball2.jl
+++ b/src/Ball2.jl
@@ -26,7 +26,7 @@ We evaluate the support vector in a given direction:
 
 ```julia
 julia> σ(ones(5), B)
-5-element Array{Float64,1}:
+5-element Vector{Float64}:
 0.06742
 0.13484
 0.20226
@@ -75,7 +75,7 @@ The support vector in the given direction.
 
 If the given direction has norm zero, the origin is returned.
 """
-function σ(d::Union{Vector{Float64}, SparseVector{Float64,Int64}}, B::Ball2)::Vector{Float64}
+function σ(d::AbstractVector{Float64}, B::Ball2)::Vector{Float64}
     dnorm = norm(d)
     if dnorm > 0
         return B.center .+ d .* (B.radius / dnorm)

--- a/src/BallInf.jl
+++ b/src/BallInf.jl
@@ -60,7 +60,7 @@ function is such that `sign(0) = 0`, instead of 1. For this reason, we use the
 custom `unit_step` function, that allows to do: `B.center + unit_step.(d) * B.radius`
 (the dot operator performs broadcasting, to accept vector-valued entries).
 """
-function σ(d::Union{Vector{Float64}, SparseVector{Float64,Int64}}, B::BallInf)::Vector{Float64}
+function σ(d::AbstractVector{Float64}, B::BallInf)::Vector{Float64}
     return B.center .+ unit_step.(d) .* B.radius
 end
 

--- a/src/CartesianProduct.jl
+++ b/src/CartesianProduct.jl
@@ -122,7 +122,7 @@ Support vector of the Cartesian product of a finite number of sets.
 
 - `cp` -- cartesian product array
 """
-function σ(d::Union{Vector{Float64}, SparseVector{Float64,Int64}}, cp::CartesianProductArray)::Vector{Float64}
+function σ(d::AbstractVector{Float64}, cp::CartesianProductArray)::Vector{Float64}
     svec = Vector{Float64}(length(d))
     jinit = 1
     for sj in cp.sfarray

--- a/src/ConvexHull.jl
+++ b/src/ConvexHull.jl
@@ -42,7 +42,7 @@ Return the support vector of a convex hull in a given direction.
 - `d`  -- direction
 - `ch` -- the convex hull of two sets
 """
-function σ(d::Union{Vector{Float64}, SparseVector{Float64,Int64}}, ch::ConvexHull)::Vector{Float64}
+function σ(d::AbstractVector{Float64}, ch::ConvexHull)::Vector{Float64}
     σ1 = σ(d, ch.X)
     σ2 = σ(d, ch.Y)
     ρ1 = dot(d, σ1)::Float64

--- a/src/ExponentialMap.jl
+++ b/src/ExponentialMap.jl
@@ -183,7 +183,7 @@ If `S = (LMR)B`, where `L` and `R` are dense matrices, `M` is a matrix
 exponential, and `B` is a set, it follows that:
 `σ(d, S) = LMR σ(R^T M^T L^T d, B)` for any direction `d`.
 """
-function σ(d::Union{Vector{Float64}, SparseVector{Float64,Int64}},
+function σ(d::AbstractVector{Float64},
            eprojmap::ExponentialProjectionMap)::Vector{Float64}
     daux = transpose(eprojmap.projspmexp.L) * d
     aux1 = expmv(1.0, eprojmap.projspmexp.spmexp.M.', daux)

--- a/src/Hyperrectangle.jl
+++ b/src/Hyperrectangle.jl
@@ -45,8 +45,7 @@ end
 
 Return the support vector of a Hyperrectangle in a given direction.
 """
-function σ(d::Union{Vector{Float64}, SparseVector{Float64,Int64}},
-           H::Hyperrectangle)::Vector{Float64}
+function σ(d::AbstractVector{Float64}, H::Hyperrectangle)::Vector{Float64}
     return H.center .+ unit_step.(d) .* H.radius
 end
 
@@ -67,7 +66,7 @@ The list of vertices as an array of floating-point vectors.
 
 For high-dimensions, it is preferable to develop a `vertex_iterator` approach.
 """
-function vertices_list(H::Hyperrectangle)::Array{Vector{Float64}, 1}
+function vertices_list(H::Hyperrectangle)::Vector{Vector{Float64}}
     return [H.center .+ si .* H.radius for si in IterTools.product([[1, -1] for i = 1:dim(H)]...)]
 end
 

--- a/src/LinearConstraints.jl
+++ b/src/LinearConstraints.jl
@@ -71,12 +71,12 @@ The line `y = -x + 1` intersected with `y = x`:
 
 ```julia
 julia> intersection(Line([1., 1.], 1.), Line([-1., 1.], 0.))
-2-element Array{Float64,1}:
+2-element Vector{Float64}:
  0.5
  0.5
 ```
 """
-function intersection(Δ1::Line, Δ2::Line)::Array{Float64,1}
+function intersection(Δ1::Line, Δ2::Line)::Vector{Float64}
     b = [Δ1.b, Δ2.b]
     a = [Δ1.a.' ; Δ2.a.']
     return a \ b

--- a/src/LinearMap.jl
+++ b/src/LinearMap.jl
@@ -12,21 +12,21 @@ changes the behaviour of the support vector of the new set.
 - `M`  -- a linear map, which can a be densem matrix, sparse matrix or a subarray object
 - `sf` -- a convex set represented by its support function
 """
-type LinearMap{MT<:Union{Matrix{Float64}, SparseMatrixCSC{Float64,Int64}, SubArray},ST<:LazySet} <: LazySet
-    M::MT
-    sf::ST
+type LinearMap{T<:LazySet} <: LazySet
+    M::AbstractMatrix{Float64}
+    sf::T
 
-    LinearMap{MT,ST}(M::MT, S::ST) where {MT<:Union{Matrix{Float64}, SparseMatrixCSC{Float64,Int64}, SubArray},ST<:LazySet} = new(M, S)
+    LinearMap{T}(M::AbstractMatrix{Float64}, S::T) where {T<:LazySet} = new(M, S)
     # in case of constructing a linear map from a linear map, the matrix
     # multiplication is performed here
-    LinearMap{MT,LinearMap}(M::MT, S::LinearMap) where {MT<:Union{Matrix{Float64}, SparseMatrixCSC{Float64,Int64}, SubArray}} = new{MT,LinearMap}(M * S.M, S.sf)
+    LinearMap(M::AbstractMatrix{Float64}, S::LinearMap{T}) where {T<:LazySet} = new{T}(M * S.M, S.sf)
 end
-LinearMap(M::MT, sf::ST) where {MT<:Union{Matrix{Float64}, SparseMatrixCSC{Float64,Int64}, SubArray},ST<:LazySet} = LinearMap{MT,ST}(M, sf)
+LinearMap(M::AbstractMatrix{Float64}, sf::T) where {T<:LazySet} = LinearMap{T}(M, sf)
 
 import Base.*
 
 # linear map of a set
-function *(M::Union{Matrix, SparseMatrixCSC, SubArray}, sf::LazySet)
+function *(M::AbstractMatrix{Float64}, sf::LazySet)
     if findfirst(M) != 0
         return LinearMap(M, sf)
     else
@@ -35,7 +35,7 @@ function *(M::Union{Matrix, SparseMatrixCSC, SubArray}, sf::LazySet)
 end
 
 # linear map of a void set (has to be overridden due to polymorphism reasons)
-function *(M::Union{Matrix, SparseMatrixCSC}, sf::VoidSet)
+function *(M::AbstractMatrix{Float64}, sf::VoidSet)
     if dim(sf) == size(M, 2)
         return VoidSet(size(M, 1))
     else
@@ -72,7 +72,7 @@ If `S = MB`, where `M` is sa matrix and `B` is a set, it follows that
 - `d`  -- a direction
 - `lm` -- a linear map
 """
-function σ(d::Union{Vector{Float64}, SparseVector{Float64,Int64}}, lm::LinearMap)::Vector{Float64}
+function σ(d::AbstractVector{Float64}, lm::LinearMap)::Vector{Float64}
     return lm.M * σ(lm.M.' * d, lm.sf)
 end
 

--- a/src/MinkowskiSum.jl
+++ b/src/MinkowskiSum.jl
@@ -30,7 +30,7 @@ function dim(ms::MinkowskiSum)::Int64
 end
 
 # support vector of the Minkowski sum of two sets
-function σ(d::Union{Vector{Float64}, SparseVector{Float64,Int64}}, ms::MinkowskiSum)::Vector{Float64}
+function σ(d::AbstractVector{Float64}, ms::MinkowskiSum)::Vector{Float64}
     return σ(d, ms.X) + σ(d, ms.Y)
 end
 
@@ -60,7 +60,7 @@ MinkowskiSumArray() = MinkowskiSumArray{LazySet}(Vector{LazySet}(0))
 MinkowskiSumArray(sfarray::Vector{T}) where {T<:LazySet} = MinkowskiSumArray{T}(sfarray)
 
 function MinkowskiSumArray(n::Int64)::MinkowskiSumArray
-    arr = Array{LazySet, 1}(0)
+    arr = Vector{LazySet}(0)
     sizehint!(arr, n)
     return MinkowskiSumArray(arr)
 end
@@ -141,7 +141,7 @@ Support vector of the Minkowski sum of a finite number of sets.
 
 - `ms` -- Minkowski sum array
 """
-function σ(d::Union{Vector{Float64}, SparseVector{Float64,Int64}}, ms::MinkowskiSumArray)::Vector{Float64}
+function σ(d::AbstractVector{Float64}, ms::MinkowskiSumArray)::Vector{Float64}
     svec = zeros(length(d))
     for sj in ms.sfarray
         svec += σ(d, sj)

--- a/src/Polygon.jl
+++ b/src/Polygon.jl
@@ -13,7 +13,7 @@ Type that represents a convex polygon (in H-representation).
 - `constraints` --  an array of linear constraints
 """
 mutable struct HPolygon <: LazySet
-    constraints::Array{LinearConstraint, 1}
+    constraints::Vector{LinearConstraint}
 end
 HPolygon() = HPolygon([])
 
@@ -53,7 +53,7 @@ polytope).
 - `d` -- direction
 - `p` -- polyhedron in H-representation
 """
-function σ(d::Union{Vector{Float64}, SparseVector{Float64,Int64}}, p::HPolygon)::Vector{Float64}
+function σ(d::AbstractVector{Float64}, p::HPolygon)::Vector{Float64}
     n = length(p.constraints)
     if n == 0
         error("this polygon is empty")
@@ -112,7 +112,7 @@ This structure is optimized to evaluate the support function/vector with a large
 sequence of directions, which are one to one close.
 """
 mutable struct HPolygonOpt <: LazySet
-    constraints::Array{LinearConstraint, 1}
+    constraints::Vector{LinearConstraint}
     ind::Int64
     HPolygonOpt(constraints) = new(constraints, 1)
     HPolygonOpt(constraints, ind) = new(constraints, ind)
@@ -142,7 +142,7 @@ Return the support vector of the optimized polygon in a given direction.
 - `d` -- direction
 - `P` -- polyhedron in H-representation
 """
-function σ(d::Union{Vector{Float64}, SparseVector{Float64,Int64}}, p::HPolygonOpt)::Vector{Float64}
+function σ(d::AbstractVector{Float64}, p::HPolygonOpt)::Vector{Float64}
     n = length(p.constraints)
     cl = p.constraints
     if (d <= cl[p.ind].a)
@@ -208,7 +208,7 @@ Type that represents a polygon by its vertices.
 - `vl` -- the list of vertices
 """
 mutable struct VPolygon <: LazySet
-    vl::Array{Vector{Float64}, 1}
+    vl::Vector{Vector{Float64}}
 end
 VPolygon() = VPolygon([])
 
@@ -267,9 +267,9 @@ Return the list of vertices of a convex polygon.
 
 ### Output
 
-List of vertices as an array of vertex pairs, Array{Array{Float64,1},1}.
+List of vertices as an array of vertex pairs, Vector{Vector{Float64}}.
 """
-function vertices_list(po::Union{HPolygon, HPolygonOpt})::Array{Array{Float64,1},1}
+function vertices_list(po::Union{HPolygon, HPolygonOpt})::Vector{Vector{Float64}}
     n = length(po.constraints)
     vlist = [intersection(Line(po.constraints[i]), Line(po.constraints[i+1])) for i = 1:n-1]
     push!(vlist, intersection(Line(po.constraints[n]), Line(po.constraints[1])))

--- a/src/Polyhedron.jl
+++ b/src/Polyhedron.jl
@@ -13,7 +13,7 @@ Type that represents a convex polyhedron in H-representation.
 - `dim`    -- dimension
 """
 mutable struct Polyhedron <: LazySet
-    constraints::Array{LinearConstraint, 1}
+    constraints::Vector{LinearConstraint}
     dim::Int64
 end
 Polyhedron(n) = Polyhedron([], n)
@@ -41,7 +41,7 @@ Return the support vector of the polyhedron in a given direction.
 - `d` -- direction
 - `P` -- polyhedron in H-representation
 """
-function σ(d::Union{Vector{Float64}, SparseVector{Float64,Int64}}, p::Polyhedron)::Vector{Float64}
+function σ(d::AbstractVector{Float64}, p::Polyhedron)::Vector{Float64}
     model = Model(solver=GLPKSolverLP())
     n = length(p.constraints)
     @variable(model, x[1:p.dim])

--- a/src/Singleton.jl
+++ b/src/Singleton.jl
@@ -19,6 +19,6 @@ function dim(s::Singleton)::Int64
 end
 
 # support vector of a singleton
-function σ(d::Union{Vector{Float64}, SparseVector{Float64,Int64}}, s::LazySets.Singleton)::Vector{Float64}
+function σ(d::AbstractVector{Float64}, s::LazySets.Singleton)::Vector{Float64}
     return s.element
 end

--- a/src/VoidSet.jl
+++ b/src/VoidSet.jl
@@ -68,7 +68,7 @@ function dim(V::VoidSet)::Int64
 end
 
 # support vector of a VoidSet
-function σ(d::Union{Vector{Float64}, SparseVector{Float64,Int64}}, V::VoidSet)::Vector{Float64}
+function σ(d::AbstractVector{Float64}, V::VoidSet)::Vector{Float64}
     #error("evaluating the support vector of a void set is undefined")
     return zeros(length(d))
 end

--- a/src/helper_functions.jl
+++ b/src/helper_functions.jl
@@ -20,7 +20,7 @@ This function can be used with vector-valued arguments via the dot operator.
 
 ```julia
 julia> unit_step([-0.6, 1.3, 0.0])
-3-element Array{Float64,1}:
+3-element Vector{Float64}:
  -1.0
  1.0
  1.0
@@ -69,7 +69,6 @@ True iff arg(u) [2π] <= arg(v) [2π]
 The argument is measured in counter-clockwise fashion, with the 0 being the
 direction (1, 0).
 """
-function <=(u::Union{Vector{Float64}, SparseVector{Float64,Int64}},
-            v::Union{Vector{Float64}, SparseVector{Float64,Int64}})
+function <=(u::AbstractVector{Float64}, v::AbstractVector{Float64})
     return jump2pi(atan2(u[2], u[1])) <= jump2pi(atan2(v[2], v[1]))
 end


### PR DESCRIPTION
This also fixes the recent additional unit test for `LinearMap` (I do not know why it did not work; when I tried it locally it worked; I must have done another change).

I also took the liberty and replaced `Array{X, 1}` by `Vector{X}` everywhere.