### PR TITLE
#2 - alternative keyword constructor for Hyperrectangle

### DIFF
--- a/src/Hyperrectangle.jl
+++ b/src/Hyperrectangle.jl
@@ -103,8 +103,8 @@ end
 """
     norm(H::Hyperrectangle, [p])
 
-Return the norm of a Hyperrectangle. It is the norm of the enclosing hypercube
-of minimal volume.
+Return the norm of a Hyperrectangle. It is the norm of the enclosing ball (of
+the given norm) of minimal volume.
 
 ### Input
 
@@ -122,8 +122,8 @@ end
 """
     radius(H::Hyperrectangle, [p])
 
-Return the radius of a Hyperrectangle. It is the radius/norm of the enclosing
-hypercube of minimal volume with the same center.
+Return the radius of a Hyperrectangle. It is the radius of the enclosing ball
+(of the given norm) of minimal volume with the same center.
 
 ### Input
 
@@ -143,8 +143,8 @@ end
     diameter(H::Hyperrectangle, [p])
 
 Return the diameter of a hyperrectangle. It is the maximum distance between any
-two elements of the set, or, equivalently, the diameter of the enclosing
-hypercube of minimal volume with the same center.
+two elements of the set, or, equivalently, the diameter of the enclosing ball
+(of the given norm) of minimal volume with the same center.
 
 ### Input
 

--- a/src/Hyperrectangle.jl
+++ b/src/Hyperrectangle.jl
@@ -1,5 +1,7 @@
 using IterTools
 
+import Base.LinAlg:norm
+
 export Hyperrectangle, vertices_list, radius, diameter
 
 """
@@ -99,37 +101,60 @@ function vertices_list(H::Hyperrectangle)::Vector{Vector{Float64}}
 end
 
 """
-    radius(H::Hyperrectangle)
+    norm(H::Hyperrectangle, [p])
 
-Return the radius of a Hyperrectangle. It is the radius of the enclosing
-hypercube of minimal volume.
+Return the norm of a Hyperrectangle. It is the norm of the enclosing hypercube
+of minimal volume.
+
+### Input
+
+- `H` -- hyperrectangle
+- `p` -- (optional, default: `Inf`) norm
+
+### Output
+
+A real number representing the norm.
+"""
+function norm(H::Hyperrectangle, p=Inf)
+    return maximum(map(x -> norm(x, p), vertices_list(H)))
+end
+
+"""
+    radius(H::Hyperrectangle, [p])
+
+Return the radius of a Hyperrectangle. It is the radius/norm of the enclosing
+hypercube of minimal volume with the same center.
+
+### Input
+
+- `H` -- hyperrectangle
+- `p` -- (optional, default: `Inf`) norm
+
+### Output
+
+A real number representing the radius.
+"""
+function radius(H::Hyperrectangle, p=Inf)
+    # the radius is the same for all corners of the hyperrectangle
+    return norm(H.radius, p)
+end
+
+"""
+    diameter(H::Hyperrectangle, [p])
+
+Return the diameter of a hyperrectangle. It is the maximum distance between any
+two elements of the set, or, equivalently, the diameter of the enclosing
+hypercube of minimal volume with the same center.
 
 ### Input
 
 - `H` -- a hyperrectangle
+- `p` -- (optional, default: `Inf`) norm
 
 ### Output
 
-A real number representing its radius.
+A real number representing the diameter.
 """
-function radius(H::Hyperrectangle)::Float64
-    return maximum(map(norm, vertices_list(H)))
-end
-
-"""
-    diameter(H::Hyperrectangle)
-
-Return the diameter of a hyperrectangle. It the maximum norm (measured the
-infinity norm) of any element of the set.
-
-### Input
-
-- `H` -- a hyperrectangle
-
-### Output
-
-The diameter of the hyperrectangle.
-"""
-function diameter(H::Hyperrectangle)::Float64
-    return 2. * radius(Hyperrectangle(zeros(dim(H)), H.radius))
+function diameter(H::Hyperrectangle, p=Inf)
+    return 2. * radius(H, p)
 end

--- a/test/unit_Hyperrectangle.jl
+++ b/test/unit_Hyperrectangle.jl
@@ -69,7 +69,22 @@ vl = vertices_list(h)
 @test isin([1., 3.], vl) == true
 @test isin([5., 1.], vl) == true
 @test isin([5., 3.], vl) == true
-# Test Radius
-@test radius(h) == norm([5., 3.])
-# Test Diameter
-@test diameter(h) == norm([5., 3.] - [1., 1.])
+# norm
+@test norm(h) == norm([5., 3.], Inf)
+# radius
+@test radius(h) == norm([2., 1.], Inf)
+# diameter
+@test diameter(h) == norm([5., 3.] - [1., 1.], Inf)
+
+# alternative constructors
+c = ones(2)
+r = [0.1, 0.2]
+l = [0.9, 0.8]
+h = [1.1, 1.2]
+H1 = Hyperrectangle(c, r)
+H2 = Hyperrectangle(center=c, radius=r)
+H3 = Hyperrectangle(low=l, high=h)
+@test H1.center == H2.center
+@test H2.center ≈ H3.center
+@test H1.radius == H2.radius
+@test H2.radius ≈ H3.radius


### PR DESCRIPTION
The new constructor is slower and should only be used if performance is not critical.

```julia
c = ones(2)
r = [0.1, 0.2]
l = [0.9, 0.8]
h = [1.1, 1.2]

julia> @time H1 = Hyperrectangle(c, r)
  0.000010 seconds (5 allocations: 192 bytes)
LazySets.Hyperrectangle([1.0, 1.0], [0.1, 0.2])

julia> @time H2 = Hyperrectangle(center=c, radius=r)
  0.000048 seconds (18 allocations: 1.203 KiB)
LazySets.Hyperrectangle([1.0, 1.0], [0.1, 0.2])

julia> @time H3 = Hyperrectangle(low=l, high=h)
  0.000237 seconds (68 allocations: 3.484 KiB)
LazySets.Hyperrectangle([1.0, 1.0], [0.1, 0.2])
```