### PR TITLE
#36 - test existence of API methods

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,11 @@
 using LazySets, Base.Test
 
 # =======================================
+# Testing common API of all LazySet types
+# =======================================
+@time @testset "LazySets.LazySet" begin include("unit_LazySet.jl") end
+
+# =======================================
 # Testing types that inherit from LazySet
 # =======================================
 @time @testset "LazySets.Singleton" begin include("unit_Singleton.jl") end

--- a/test/unit_LazySet.jl
+++ b/test/unit_LazySet.jl
@@ -1,0 +1,7 @@
+# check that the following functions are provided by all LazySet types
+for S in subtypes(LazySet)
+    # support vector
+    @test method_exists(σ, (Vector{Float64}, S))
+    # dimension
+    @test method_exists(dim, (S,))
+end


### PR DESCRIPTION
The test is for `σ(::Vector{Float64}, ::S)` where `S<:LazySet`.
I also added a test for `dim(S)` because it worked 😎

@mforets:
For some subtypes the `σ` test breaks with `AbstractVector`, with `Real`, and with `<:Real` (I do not know the difference to `Real`, but apparently there is one because there are less cases working).
Should we fix that?

Also, should we additionally check for the same function with `Rational`?
Since we know that for `BallInf` it will not work, we could exclude `BallInf`.