### PR TITLE
rename 'Int64'/'Integer' -> 'Int'

### DIFF
--- a/src/CartesianProduct.jl
+++ b/src/CartesianProduct.jl
@@ -134,7 +134,7 @@ Type that represents the Cartesian product of a finite number of convex sets.
 
 - `CartesianProductArray()` -- constructor for an empty Cartesian product
 
-- `CartesianProductArray(n::Integer)`
+- `CartesianProductArray(n::Int)`
   -- constructor for an empty Cartesian product with size hint
 """
 struct CartesianProductArray{S<:LazySet} <: LazySet
@@ -143,7 +143,7 @@ end
 # constructor for an empty Cartesian product
 CartesianProductArray() = CartesianProductArray{LazySet}(Vector{LazySet}(0))
 # constructor for an empty Cartesian product with size hint
-function CartesianProductArray(n::Integer)::CartesianProductArray
+function CartesianProductArray(n::Int)::CartesianProductArray
     arr = Vector{LazySet}(0)
     sizehint!(arr, n)
     return CartesianProductArray(arr)

--- a/src/ExponentialMap.jl
+++ b/src/ExponentialMap.jl
@@ -28,18 +28,18 @@ The evaluation of the exponential matrix action over vectors relies on the
 [Expokit](https://github.com/acroy/Expokit.jl) package.
 """
 struct SparseMatrixExp{N<:Real}
-    M::SparseMatrixCSC{N, Int64}
+    M::SparseMatrixCSC{N, Int}
 end
 
-function size(spmexp::SparseMatrixExp)::Tuple{Int64, Int64}
+function size(spmexp::SparseMatrixExp)::Tuple{Int, Int}
     return size(spmexp.M)
 end
 
-function size(spmexp::SparseMatrixExp, ax::Int64)::Int64
+function size(spmexp::SparseMatrixExp, ax::Int)::Int
     return size(spmexp.M, ax)
 end
 
-function get_column(spmexp::SparseMatrixExp, j::Int64)::Vector{Float64}
+function get_column(spmexp::SparseMatrixExp, j::Int)::Vector{Float64}
     n = size(spmexp, 1)
     aux = zeros(n)
     aux[j] = 1.0
@@ -47,7 +47,7 @@ function get_column(spmexp::SparseMatrixExp, j::Int64)::Vector{Float64}
 end
 
 function get_columns(spmexp::SparseMatrixExp,
-                     J::AbstractArray)::SparseMatrixCSC{Float64, Int64}
+                     J::AbstractArray)::SparseMatrixCSC{Float64, Int}
     n = size(spmexp, 1)
     aux = zeros(n)
     ans = spzeros(n, length(J))
@@ -61,7 +61,7 @@ function get_columns(spmexp::SparseMatrixExp,
     return ans
 end
 
-function get_row(spmexp::SparseMatrixExp, i::Int64)::Matrix{Float64}
+function get_row(spmexp::SparseMatrixExp, i::Int)::Matrix{Float64}
     n = size(spmexp, 1)
     aux = zeros(n)
     aux[i] = 1.0
@@ -69,7 +69,7 @@ function get_row(spmexp::SparseMatrixExp, i::Int64)::Matrix{Float64}
 end
 
 function get_rows(spmexp::SparseMatrixExp,
-                  I::AbstractArray{Int64})::SparseMatrixCSC{Float64, Int64}
+                  I::AbstractArray{Int})::SparseMatrixCSC{Float64, Int}
     n = size(spmexp, 1)
     aux = zeros(n)
     ans = spzeros(length(I), n)
@@ -175,9 +175,9 @@ Type that represents the projection of a sparse matrix exponential, i.e.,
 - `R` -- right multiplication matrix
 """
 struct ProjectionSparseMatrixExp{N<:Real}
-    L::SparseMatrixCSC{N, Int64}
+    L::SparseMatrixCSC{N, Int}
     spmexp::SparseMatrixExp{N}
-    R::SparseMatrixCSC{N, Int64}
+    R::SparseMatrixCSC{N, Int}
 end
 
 """

--- a/src/HPolygonOpt.jl
+++ b/src/HPolygonOpt.jl
@@ -30,7 +30,7 @@ The default constructor assumes that the given list of edges is sorted.
 It *does not perform* any sorting.
 Use `addconstraint!` to iteratively add the edges in a sorted way.
 
-- `HPolygonOpt(constraints_list::Vector{LinearConstraint{<:Real}}, ind::Int64)`
+- `HPolygonOpt(constraints_list::Vector{LinearConstraint{<:Real}}, ind::Int)`
   -- default constructor
 - `HPolygonOpt(constraints_list::Vector{LinearConstraint{<:Real}})`
   -- constructor without index
@@ -39,16 +39,16 @@ Use `addconstraint!` to iteratively add the edges in a sorted way.
 """
 mutable struct HPolygonOpt{N<:Real} <: LazySet
     constraints_list::Vector{LinearConstraint{N}}
-    ind::Int64
+    ind::Int
 
     # default constructor
     HPolygonOpt{N}(constraints_list::Vector{LinearConstraint{N}},
-                   ind::Int64) where {N<:Real} =
+                   ind::Int) where {N<:Real} =
         new{N}(constraints_list, ind)
 end
 # type-less convenience constructor
 HPolygonOpt(constraints_list::Vector{LinearConstraint{N}},
-            ind::Int64) where {N<:Real} =
+            ind::Int) where {N<:Real} =
     HPolygonOpt{N}(constraints_list, ind)
 
 # type-less convenience constructor without index

--- a/src/MinkowskiSum.jl
+++ b/src/MinkowskiSum.jl
@@ -100,7 +100,7 @@ This type assumes that the dimensions of all elements match.
 
 - `MinkowskiSumArray()` -- constructor for an empty sum
 
-- `MinkowskiSumArray(n::Integer)` -- constructor for an empty sum with size hint
+- `MinkowskiSumArray(n::Int)` -- constructor for an empty sum with size hint
 """
 struct MinkowskiSumArray{T<:LazySet} <: LazySet
     sfarray::Vector{T}
@@ -108,7 +108,7 @@ end
 # constructor for an empty sum
 MinkowskiSumArray() = MinkowskiSumArray{LazySet}(Vector{LazySet}(0))
 # constructor for an empty sum with size hint
-function MinkowskiSumArray(n::Integer)::MinkowskiSumArray
+function MinkowskiSumArray(n::Int)::MinkowskiSumArray
     arr = Vector{LazySet}(0)
     sizehint!(arr, n)
     return MinkowskiSumArray(arr)


### PR DESCRIPTION
`Int` is just an alias for `Int64` on 64-bit machines and should be preferred.
`Integer` is an abstract type and should be avoided for concrete types.