### PR TITLE
containment methods

### DIFF
--- a/docs/src/lib/operations.md
+++ b/docs/src/lib/operations.md
@@ -82,6 +82,7 @@ dim(::LinearMap)
 ExponentialMap
 dim(::ExponentialMap)
 σ(::AbstractVector{Float64}, ::ExponentialMap)
+∈(::AbstractVector{Float64}, ::ExponentialMap{<:LazySet})
 ```
 
 ```@docs

--- a/docs/src/lib/operations.md
+++ b/docs/src/lib/operations.md
@@ -73,6 +73,7 @@ dim(::LinearMap)
 σ(::AbstractVector{Float64}, ::LinearMap)
 *(::AbstractMatrix{Float64}, ::LazySet)
 *(::Real, ::LazySet)
+∈(::AbstractVector{Float64}, ::LinearMap{<:LazySet, Float64})
 ```
 
 ### Exponential Map

--- a/docs/src/lib/representations.md
+++ b/docs/src/lib/representations.md
@@ -87,7 +87,7 @@ HPolygonOpt
 addconstraint!(::HPolygonOpt{Float64}, ::LinearConstraint{Float64})
 dim(::HPolygonOpt)
 σ(::AbstractVector{Float64}, ::HPolygonOpt{Float64})
-∈(::AbstractVector{Float64}, ::HPolygonOpt)
+∈(::AbstractVector{Float64}, ::HPolygonOpt{Float64})
 tovrep(::HPolygonOpt)
 vertices_list(::HPolygonOpt)
 ```

--- a/docs/src/lib/representations.md
+++ b/docs/src/lib/representations.md
@@ -61,8 +61,9 @@ dim(::Ball1)
 
 ```@docs
 Ballp
-dim(B::Ballp)
-σ(d::AbstractVector{Float64}, B::Ballp)
+dim(::Ballp)
+σ(::AbstractVector{Float64}, ::Ballp)
+∈(::AbstractVector{Float64}, ::Ballp{Float64})
 ```
 
 ## Polygons

--- a/docs/src/lib/representations.md
+++ b/docs/src/lib/representations.md
@@ -156,4 +156,5 @@ dim(::Zonotope)
 σ(d::AbstractVector{Float64}, Z::Zonotope)
 vertices_list(::Zonotope{Float64})
 order(::Zonotope)
+∈(::AbstractVector{Float64}, ::Zonotope{Float64})
 ```

--- a/docs/src/lib/representations.md
+++ b/docs/src/lib/representations.md
@@ -137,6 +137,9 @@ EmptySet
 
 ```@docs
 ZeroSet
+dim(::ZeroSet)
+σ(::AbstractVector{Float64}, ::ZeroSet)
+∈(::AbstractVector{Float64}, ::ZeroSet)
 ```
 
 ## Singletons

--- a/docs/src/lib/representations.md
+++ b/docs/src/lib/representations.md
@@ -144,6 +144,7 @@ ZeroSet
 Singleton
 dim(::Singleton)
 σ(::AbstractVector{Float64}, ::Singleton)
+∈(::AbstractVector{Float64}, ::Singleton{Float64})
 ```
 
 ## Zonotopes

--- a/docs/src/lib/representations.md
+++ b/docs/src/lib/representations.md
@@ -32,6 +32,7 @@ support_vector
 Ball2
 dim(::Ball2)
 σ(::AbstractVector{Float64}, ::Ball2)
+∈(::AbstractVector{Float64}, ::Ball2{Float64})
 ```
 
 ### Infinity norm ball

--- a/docs/src/lib/representations.md
+++ b/docs/src/lib/representations.md
@@ -44,6 +44,7 @@ vertices_list(::BallInf)
 norm(::BallInf, ::Real=Inf)
 radius(::BallInf, ::Real=Inf)
 diameter(::BallInf, ::Real=Inf)
+∈(::AbstractVector{Float64}, ::BallInf{Float64})
 ```
 
 ### Manhattan norm ball

--- a/docs/src/lib/representations.md
+++ b/docs/src/lib/representations.md
@@ -53,6 +53,7 @@ diameter(::BallInf, ::Real=Inf)
 Ball1
 dim(::Ball1)
 σ(::AbstractVector{Float64}, ::Ball1)
+∈(::AbstractVector{Float64}, ::Ball1{Float64})
 ```
 
 ### p-norm ball

--- a/docs/src/lib/representations.md
+++ b/docs/src/lib/representations.md
@@ -100,6 +100,7 @@ dim(::VPolygon)
 σ(::AbstractVector{Float64}, ::VPolygon)
 vertices_list(::VPolygon)
 singleton_list(::VPolygon)
+∈(::AbstractVector{Float64}, ::VPolygon{Float64})
 ```
 
 ## Lines and linear constraints

--- a/docs/src/lib/representations.md
+++ b/docs/src/lib/representations.md
@@ -121,6 +121,7 @@ vertices_list(::Hyperrectangle)
 norm(::Hyperrectangle, ::Real=Inf)
 radius(::Hyperrectangle, ::Real=Inf)
 diameter(::Hyperrectangle, ::Real=Inf)
+∈(::AbstractVector{Float64}, ::Hyperrectangle{Float64})
 high(::Hyperrectangle)
 low(::Hyperrectangle)
 ```

--- a/docs/src/lib/representations.md
+++ b/docs/src/lib/representations.md
@@ -131,6 +131,9 @@ low(::Hyperrectangle)
 
 ```@docs
 EmptySet
+dim(::EmptySet)
+σ(::AbstractVector{Float64}, ::EmptySet)
+∈(::AbstractVector{Float64}, ::EmptySet)
 ```
 
 ## ZeroSet

--- a/src/Ball1.jl
+++ b/src/Ball1.jl
@@ -107,7 +107,7 @@ Check whether a given point is contained in a ball in the 1-norm.
 ### Notes
 
 This implementation is worst-case optimized, i.e., it is optimistic and first
-computes (s. below) the whole sum before comparing to the radius.
+computes (see below) the whole sum before comparing to the radius.
 In applications where the point is typically far away from the ball, a fail-fast
 implementation with interleaved comparisons could be more efficient.
 

--- a/src/Ball2.jl
+++ b/src/Ball2.jl
@@ -129,7 +129,7 @@ Check whether a given point is contained in a ball in the 2-norm.
 ### Notes
 
 This implementation is worst-case optimized, i.e., it is optimistic and first
-computes (s. below) the whole sum before comparing to the radius.
+computes (see below) the whole sum before comparing to the radius.
 In applications where the point is typically far away from the ball, a fail-fast
 implementation with interleaved comparisons could be more efficient.
 

--- a/src/Ball2.jl
+++ b/src/Ball2.jl
@@ -1,3 +1,5 @@
+import Base.∈
+
 export Ball2
 
 """
@@ -91,10 +93,9 @@ If the direction has norm zero, the origin is returned.
 
 ### Notes
 
-Let `c` and `r` be the center and radius of a ball `B` in the 2-norm,
+Let ``c`` and ``r`` be the center and radius of a ball ``B`` in the 2-norm,
 respectively.
-For nonzero direction d, we have
-`σ(d, B) = c + d * (r / ||d||)`.
+For nonzero direction ``d`` we have ``σ(d, B) = c + r * (d / ‖d‖_2)``.
 
 This function requires computing the 2-norm of the input direction, which is
 performed in the given precision of the numeric datatype of both the direction
@@ -109,4 +110,53 @@ function σ(d::AbstractVector{N},
     else
         return @. B.center + d * (B.radius / dnorm)
     end
+end
+
+"""
+    ∈(x::AbstractVector{N}, B::Ball2{N})::Bool where {N<:Real}
+
+Check whether a given point is contained in a ball in the 2-norm.
+
+### Input
+
+- `x` -- point/vector
+- `B` -- ball in the 2-norm
+
+### Output
+
+`true` iff ``x ∈ B``.
+
+### Notes
+
+This implementation is worst-case optimized, i.e., it is optimistic and first
+computes (s. below) the whole sum before comparing to the radius.
+In applications where the point is typically far away from the ball, a fail-fast
+implementation with interleaved comparisons could be more efficient.
+
+### Algorithm
+
+Let ``B`` be an ``n``-dimensional ball in the 2-norm with radius ``r`` and let
+``c_i`` and ``x_i`` be the ball's center and the vector ``x`` in dimension
+``i``, respectively.
+Then ``x ∈ B`` iff ``\\left( ∑_{i=1}^n |c_i - x_i|^2 \\right)^{1/2} ≤ r``.
+
+### Examples
+
+```jldoctest
+julia> B = Ball2([1., 1.], sqrt(0.5))
+LazySets.Ball2{Float64}([1.0, 1.0], 0.7071067811865476)
+julia> ∈([.5, 1.6], B)
+false
+julia> ∈([.5, 1.5], B)
+true
+```
+"""
+function ∈(x::AbstractVector{<:Real},
+           B::Ball2{N})::Bool where {N<:AbstractFloat}
+    @assert length(x) == dim(B)
+    sum = zero(N)
+    for i in eachindex(x)
+        sum += (B.center[i] - x[i])^2
+    end
+    return sqrt(sum) <= B.radius
 end

--- a/src/BallInf.jl
+++ b/src/BallInf.jl
@@ -1,11 +1,12 @@
 import Base.LinAlg:norm,
-       Base.Iterators.repeated
+       Base.∈
 
 export BallInf,
        vertices_list,
        norm,
        radius,
-       diameter
+       diameter,
+       ∈
 
 """
     BallInf{N<:Real} <: LazySet
@@ -195,4 +196,46 @@ of minimal volume with the same center.
 """
 function diameter(B::BallInf, p::Real=Inf)::Real
     return radius(B, p) * 2
+end
+
+"""
+    ∈(x::AbstractVector{N}, B::BallInf{N})::Bool where {N<:Real}
+
+Check whether a given point is contained in a ball in the infinity norm.
+
+### Input
+
+- `x` -- point/vector
+- `B` -- ball in the infinity norm
+
+### Output
+
+`true` iff ``x ∈ B``.
+
+### Algorithm
+
+Let ``B`` be an ``n``-dimensional ball in the infinity norm with radius ``r``
+and let ``c_i`` and ``x_i`` be the ball's center and the vector ``x`` in
+dimension ``i``, respectively.
+Then ``x ∈ B`` iff ``|c_i - x_i| ≤ r`` for all ``i=1,…,n``.
+
+### Examples
+
+```jldoctest
+julia> B = BallInf([1., 1.], 1.);
+
+julia> ∈([.5, -.5], B)
+false
+julia> ∈([.5, 1.5], B)
+true
+```
+"""
+function ∈(x::AbstractVector{N}, B::BallInf{N})::Bool where {N<:Real}
+    @assert length(x) == dim(B)
+    for i in eachindex(x)
+        if abs(B.center[i] - x[i]) > B.radius
+            return false
+        end
+    end
+    return true
 end

--- a/src/Ballp.jl
+++ b/src/Ballp.jl
@@ -159,7 +159,7 @@ Check whether a given point is contained in a ball in the p-norm.
 ### Notes
 
 This implementation is worst-case optimized, i.e., it is optimistic and first
-computes (s. below) the whole sum before comparing to the radius.
+computes (see below) the whole sum before comparing to the radius.
 In applications where the point is typically far away from the ball, a fail-fast
 implementation with interleaved comparisons could be more efficient.
 

--- a/src/CartesianProduct.jl
+++ b/src/CartesianProduct.jl
@@ -149,18 +149,20 @@ end
 """
     ∈(x::AbstractVector{<:Real}, cp::CartesianProduct)::Bool
 
-Return whether a given vector is contained in a Cartesian product set.
+Check whether a given point is contained in a Cartesian product set.
 
 ### Input
 
-- `x`  -- vector
+- `x`  -- point/vector
 - `cp` -- Cartesian product
 
 ### Output
 
-Return `true` iff ``x ∈ cp``.
+`true` iff ``x ∈ cp``.
 """
 function ∈(x::AbstractVector{<:Real}, cp::CartesianProduct)::Bool
+    @assert length(x) == dim(cp)
+
     return ∈(view(x, 1:dim(cp.X)), cp.X) &&
            ∈(view(x, dim(cp.X)+1:length(x)), cp.Y)
 end
@@ -360,19 +362,21 @@ end
 """
     ∈(x::AbstractVector{<:Real}, cpa::CartesianProductArray)::Bool
 
-Return whether a given vector is contained in a Cartesian product of a finite
+Check whether a given point is contained in a Cartesian product of a finite
 number of sets.
 
 ### Input
 
-- `x`   -- vector
+- `x`   -- point/vector
 - `cpa` -- Cartesian product array
 
 ### Output
 
-Return `true` iff ``x ∈ cpa``.
+`true` iff ``x ∈ \\text{cpa}``.
 """
 function ∈(x::AbstractVector{<:Real}, cpa::CartesianProductArray)::Bool
+    @assert length(x) == dim(cpa)
+
     jinit = 1
     for sj in cpa
         jend = jinit + dim(sj) - 1

--- a/src/EmptySet.jl
+++ b/src/EmptySet.jl
@@ -1,9 +1,11 @@
+import Base.∈
+
 export EmptySet, ∅
 
 """
     EmptySet <: LazySet
 
-Type that represents the empty set, i.e. the set with no elements.
+Type that represents the empty set, i.e., the set with no elements.
 """
 struct EmptySet <: LazySet end
 
@@ -22,8 +24,14 @@ Return the dimension of the empty set, which is -1 by convention.
 ### Input
 
 - `S` -- an empty set
+
+### Output
+
+`-1` by convention.
 """
-dim(S::EmptySet)::Int = -1
+function dim(S::EmptySet)::Int
+    return -1
+end
 
 """
     σ(d, ∅)
@@ -33,7 +41,36 @@ Return the support vector of an empty set.
 ### Input
 
 - `∅` -- an empty set
+
+### Output
+
+An error.
 """
 function σ(d::AbstractVector, S::EmptySet)
     error("the support vector of an empty set does not exist")
+end
+
+"""
+    ∈(x::AbstractVector, ∅::EmptySet)::Bool
+
+Check whether a given point is contained in an empty set.
+
+### Input
+
+- `x` -- point/vector
+- `∅` -- empty set
+
+### Output
+
+The output is always `false`.
+
+### Examples
+
+```jldoctest
+julia> ∈([1.0, 0.0], ∅)
+false
+```
+"""
+function ∈(x::AbstractVector{<:Real}, Z::EmptySet)::Bool
+    return false
 end

--- a/src/HPolygon.jl
+++ b/src/HPolygon.jl
@@ -118,22 +118,29 @@ function σ(d::AbstractVector{<:Real}, P::HPolygon{N})::Vector{N} where {N<:Real
 end
 
 """
-    ∈(x::AbstractVector{<:Real}, P::HPolygon)::Bool
+    ∈(x::AbstractVector{N}, P::HPolygon{N})::Bool where {N<:Real}
 
-Return whether a given vector is contained in a polygon.
+Check whether a given 2D point is contained in a polygon in constraint
+representation.
 
 ### Input
 
-- `x` -- two-dimensional vector
+- `x` -- two-dimensional point/vector
 - `P` -- polygon in constraint representation
 
 ### Output
 
-Return `true` iff ``x ∈ P``.
+`true` iff ``x ∈ P``.
+
+### Algorithm
+
+This implementation checks if the point lies on the outside of each edge.
 """
-function ∈(x::AbstractVector{<:Real}, P::HPolygon)::Bool
+function ∈(x::AbstractVector{N}, P::HPolygon{N})::Bool where {N<:Real}
+    @assert length(x) == 2
+
     for c in P.constraints_list
-        if !(dot(c.a, x) <= c.b)
+        if dot(c.a, x) > c.b
             return false
         end
     end

--- a/src/HPolygonOpt.jl
+++ b/src/HPolygonOpt.jl
@@ -160,20 +160,21 @@ function σ(d::AbstractVector{<:Real},
 end
 
 """
-    ∈(x::AbstractVector{<:Real}, P::HPolygonOpt)::Bool
+    ∈(x::AbstractVector{N}, P::HPolygonOpt{N})::Bool where {N<:Real}
 
-Return whether a given vector is contained in an optimized polygon.
+Check whether a given 2D point is contained in an optimized polygon in
+constraint representation.
 
 ### Input
 
-- `x` -- two-dimensional vector
+- `x` -- two-dimensional point/vector
 - `P` -- optimized polygon in constraint representation
 
 ### Output
 
-Return `true` iff ``x ∈ P``.
+`true` iff ``x ∈ P``.
 """
-function ∈(x::AbstractVector{<:Real}, P::HPolygonOpt)::Bool
+function ∈(x::AbstractVector{N}, P::HPolygonOpt{N})::Bool where {N<:Real}
     return ∈(x, HPolygon(P.constraints_list))
 end
 

--- a/src/Hyperrectangle.jl
+++ b/src/Hyperrectangle.jl
@@ -1,4 +1,5 @@
-import Base.LinAlg:norm
+import Base.LinAlg:norm,
+       Base.∈
 
 export Hyperrectangle,
        vertices_list,
@@ -6,7 +7,8 @@ export Hyperrectangle,
        radius,
        diameter,
        low,
-       high
+       high,
+       ∈
 
 """
     Hyperrectangle{N<:Real} <: LazySet
@@ -252,4 +254,46 @@ dimension.
 """
 function low(H::Hyperrectangle{N})::Vector{N} where {N<:Real}
     return H.center .- H.radius
+end
+
+"""
+    ∈(x::AbstractVector{N}, H::Hyperrectangle{N})::Bool where {N<:Real}
+
+Check whether a given point is contained in a hyperrectangle.
+
+### Input
+
+- `x` -- point/vector
+- `H` -- hyperrectangle
+
+### Output
+
+`true` iff ``x ∈ H``.
+
+### Algorithm
+
+Let ``H`` be an ``n``-dimensional hyperrectangle, ``c_i`` and ``r_i`` be
+the ball's center and radius and ``x_i`` be the vector ``x`` in dimension ``i``,
+respectively.
+Then ``x ∈ H`` iff ``|c_i - x_i| ≤ r_i`` for all ``i=1,…,n``.
+
+### Examples
+
+```jldoctest
+julia> H = Hyperrectangle([1.0, 1.0], [2.0, 3.0]);
+
+julia> ∈([-1.1, 4.1], H)
+false
+julia> ∈([-1.0, 4.0], H)
+true
+```
+"""
+function ∈(x::AbstractVector{N}, H::Hyperrectangle{N})::Bool where {N<:Real}
+    @assert length(x) == dim(H)
+    for i in eachindex(x)
+        if abs(H.center[i] - x[i]) > H.radius[i]
+            return false
+        end
+    end
+    return true
 end

--- a/src/LinearMap.jl
+++ b/src/LinearMap.jl
@@ -141,7 +141,9 @@ Check whether a given point is contained in a linear map of a convex set.
 
 ### Algorithm
 
-This implementation inverts the matrix: ``x ∈ M⋅S`` iff ``M^{-1}⋅x ∈ S``.
+Note that ``x ∈ M⋅S`` iff ``M^{-1}⋅x ∈ S``.
+This implementation does not explicitly invert the matrix, which is why it also
+works for non-square matrices.
 
 ### Examples
 
@@ -153,9 +155,18 @@ false
 julia> ∈([3.0, 1.0], lm)
 true
 ```
+
+An example with non-square matrix:
+```jldoctest
+julia> B = BallInf(zeros(4), 1.);
+
+julia> M = [1. 0 0 0; 0 1 0 0]/2;
+
+julia> ∈([0.5, 0.5], M*B)
+true
+```
 """
 function ∈(x::AbstractVector{N},
            lm::LinearMap{<:LazySet, N})::Bool where {N<:Real}
-    @assert length(x) == dim(lm)
-    return ∈(inv(lm.M) * x, lm.sf)
+    return ∈(lm.M \ x, lm.sf)
 end

--- a/src/LinearMap.jl
+++ b/src/LinearMap.jl
@@ -1,4 +1,4 @@
-import Base.*
+import Base: *, ∈
 
 export LinearMap
 
@@ -123,4 +123,39 @@ that ``σ(d, L) = M⋅σ(M^T d, S)`` for any direction ``d``.
 """
 function σ(d::AbstractVector{<:Real}, lm::LinearMap)::AbstractVector{<:Real}
     return lm.M * σ(lm.M.' * d, lm.sf)
+end
+
+"""
+    ∈(x::AbstractVector{N}, lm::LinearMap{<:LazySet, N})::Bool where {N<:Real}
+
+Check whether a given point is contained in a linear map of a convex set.
+
+### Input
+
+- `x`  -- point/vector
+- `lm` -- linear map of a convex set
+
+### Output
+
+`true` iff ``x ∈ lm``.
+
+### Algorithm
+
+This implementation inverts the matrix: ``x ∈ M⋅S`` iff ``M^{-1}⋅x ∈ S``.
+
+### Examples
+
+```jldoctest
+julia> lm = LinearMap([2.0 0.0; 0.0 1.0], BallInf([1., 1.], 1.));
+
+julia> ∈([5.0, 1.0], lm)
+false
+julia> ∈([3.0, 1.0], lm)
+true
+```
+"""
+function ∈(x::AbstractVector{N},
+           lm::LinearMap{<:LazySet, N})::Bool where {N<:Real}
+    @assert length(x) == dim(lm)
+    return ∈(inv(lm.M) * x, lm.sf)
 end

--- a/src/Singleton.jl
+++ b/src/Singleton.jl
@@ -85,3 +85,21 @@ true
 function ∈(x::AbstractVector{N}, S::Singleton{N})::Bool where {N<:Real}
     return x == S.element
 end
+
+"""
+    ∈(x::Singleton, set::LazySet)::Bool
+
+Check whether a given singleton is contained in a convex set.
+
+### Input
+
+- `x`   -- singleton
+- `set` -- convex set
+
+### Output
+
+`true` iff ``x ∈ \text{set}``.
+"""
+function ∈(x::Singleton, set::LazySet)::Bool
+    return ∈(x.element, set)
+end

--- a/src/Singleton.jl
+++ b/src/Singleton.jl
@@ -1,3 +1,5 @@
+import Base.∈
+
 export Singleton
 
 """
@@ -48,4 +50,38 @@ given direction.
 function σ(d::AbstractVector{<:Real},
            S::LazySets.Singleton{N})::Vector{N} where {N<:Real}
     return S.element
+end
+
+"""
+    ∈(x::AbstractVector{N}, S::Singleton{N})::Bool where {N<:Real}
+
+Check whether a given point is contained in a singleton.
+
+### Input
+
+- `x` -- point/vector
+- `S` -- singleton
+
+### Output
+
+`true` iff ``x ∈ S``.
+
+### Notes
+
+This implementation performs an exact comparison, which may be insufficient with
+floating point computations.
+
+### Examples
+
+```jldoctest
+julia> S = Singleton([1., 1.]);
+
+julia> ∈([0.9, 1.1], S)
+false
+julia> ∈([1.0, 1.0], S)
+true
+```
+"""
+function ∈(x::AbstractVector{N}, S::Singleton{N})::Bool where {N<:Real}
+    return x == S.element
 end

--- a/src/VPolygon.jl
+++ b/src/VPolygon.jl
@@ -176,16 +176,12 @@ true
 function ∈(x::AbstractVector{N}, P::VPolygon{N})::Bool where {N<:Real}
     @assert length(x) == 2
 
-    @inline function side(x, u, v)
-        return (v[2] - u[2]) * (x[1] - u[1]) + (u[1] - v[1]) * (x[2] - u[2])
-    end
-
     zero_N = zero(N)
-    if side(x, P.vertices_list[1], P.vertices_list[end]) < zero_N
+    if right_turn(P.vertices_list[1], x, P.vertices_list[end]) < zero_N
         return false
     end
     for i in 2:length(P.vertices_list)
-        if side(x, P.vertices_list[i], P.vertices_list[i-1]) < zero_N
+        if right_turn(P.vertices_list[i], x, P.vertices_list[i-1]) < zero_N
             return false
         end
     end

--- a/src/ZeroSet.jl
+++ b/src/ZeroSet.jl
@@ -1,9 +1,11 @@
+import Base.∈
+
 export ZeroSet
 
 """
     ZeroSet <: LazySet
 
-Type that represents the zero set, i.e. the set which only contains the origin.
+Type that represents the zero set, i.e., the set that only contains the origin.
 
 ### Fields
 
@@ -20,9 +22,15 @@ Return the ambient dimension of this zero set.
 
 ### Input
 
-- `Z` -- a zero set, i.e. a set which only contains the origin
+- `Z` -- a zero set, i.e., a set that only contains the origin
+
+### Output
+
+The ambient dimension of the zero set.
 """
-dim(Z::ZeroSet)::Int = Z.dim
+function dim(Z::ZeroSet)::Int
+    return Z.dim
+end
 
 """
     σ(d, Z)
@@ -31,13 +39,45 @@ Return the support vector of a zero set.
 
 ### Input
 
-- `Z` -- a zero set, i.e. a set which only contains the origin
+- `Z` -- a zero set, i.e., a set that only contains the origin
 
 ### Output
 
-The returned value is the origin since it's the only point that belongs to this
+The returned value is the origin since it is the only point that belongs to this
 set.
 """
-function σ(d::AbstractVector{<:Real}, Z::ZeroSet)::Vector{<:Real}
+function σ(d::AbstractVector{N}, Z::ZeroSet)::Vector{N} where {N<:Real}
     return zeros(d)
+end
+
+"""
+    ∈(x::AbstractVector, Z::ZeroSet)::Bool
+
+Check whether a given point is contained in a zero set.
+
+### Input
+
+- `x` -- point/vector
+- `Z` -- zero set
+
+### Output
+
+`true` iff ``x ∈ Z``.
+
+### Examples
+
+```jldoctest
+julia> Z = ZeroSet(2);
+
+julia> ∈([1.0, 0.0], Z)
+false
+julia> ∈([0.0, 0.0], Z)
+true
+```
+"""
+function ∈(x::AbstractVector{N}, Z::ZeroSet)::Bool where {N<:Real}
+    @assert length(x) == dim(Z)
+
+    zero_N = zero(N)
+    return all(i -> x[i] == zero_N, eachindex(x))
 end

--- a/src/Zonotope.jl
+++ b/src/Zonotope.jl
@@ -22,10 +22,11 @@ Mathematically, a zonotope is defined as the set
 Z = \\left\\{ c + ∑_{i=1}^p ξ_i g_i,~~ ξ_i \\in [-1, 1]~~ ∀ i = 1,…, p \\right\\},
 ```
 where ``c \\in \\mathbb{R}^n`` is its *center* and ``\\{g_i\\}_{i=1}^p``,
-``g_i \\in \\mathbb{R}^n``, is the set of *generators*. This characterization
-defines a zonotope as the finite Minkowski sum of line elements. Zonotopes can
-be equivalently described as the image of a unit infinity-norm ball in
-``\\mathbb{R}^n`` by an affine transformation.
+``g_i \\in \\mathbb{R}^n``, is the set of *generators*.
+This characterization defines a zonotope as the finite Minkowski sum of line
+elements.
+Zonotopes can be equivalently described as the image of a unit infinity-norm
+ball in ``\\mathbb{R}^n`` by an affine transformation.
 
 - `Zonotope(center::AbstractVector{N},
             generators::AbstractMatrix{N}) where {N<:Real}`
@@ -197,6 +198,8 @@ A zonotope centered in the origin with generators ``g_i`` contains a point ``x``
 iff ``x = ∑_{i=1}^p ξ_i g_i`` for some ``ξ_i \\in [-1, 1]~~ ∀ i = 1,…, p``.
 Thus, we first ask for a solution and then check if it is in this Cartesian
 product of intervals.
+
+Other algorithms exist which test the feasibility of an LP.
 
 ### Examples
 

--- a/src/Zonotope.jl
+++ b/src/Zonotope.jl
@@ -1,3 +1,5 @@
+import Base.∈
+
 export Zonotope,
        vertices_list,
        order
@@ -17,7 +19,7 @@ Type that represents a zonotope.
 Mathematically, a zonotope is defined as the set
 
 ```math
-Z = \\left\\{ c + \\sum_{i=1}^p ξ_i g_i,~~ ξ_i \\in [-1, 1]~~ ∀ i = 1,…, p \\right\\},
+Z = \\left\\{ c + ∑_{i=1}^p ξ_i g_i,~~ ξ_i \\in [-1, 1]~~ ∀ i = 1,…, p \\right\\},
 ```
 where ``c \\in \\mathbb{R}^n`` is its *center* and ``\\{g_i\\}_{i=1}^p``,
 ``g_i \\in \\mathbb{R}^n``, is the set of *generators*. This characterization
@@ -171,4 +173,66 @@ and its dimension.
 """
 function order(Z::Zonotope)::Rational
     return size(Z.generators, 2) // dim(Z)
+end
+
+"""
+    ∈(x::AbstractVector{N}, Z::Zonotope{N})::Bool where {N<:Real}
+
+Check whether a given point is contained in a zonotope.
+
+### Input
+
+- `x` -- point/vector
+- `Z` -- zonotope
+
+### Output
+
+`true` iff ``x ∈ Z``.
+
+### Algorithm
+
+This implementation poses the problem as a linear equality system and solves it
+using `Base.:\`.
+A zonotope centered in the origin with generators ``g_i`` contains a point ``x``
+iff ``x = ∑_{i=1}^p ξ_i g_i`` for some ``ξ_i \\in [-1, 1]~~ ∀ i = 1,…, p``.
+Thus, we first ask for a solution and then check if it is in this Cartesian
+product of intervals.
+
+### Examples
+
+```jldoctest
+julia> Z = Zonotope([1.0, 0.0], 0.1*eye(2));
+
+julia> ∈([1.0, 0.2], Z)
+false
+julia> ∈([1.0, 0.1], Z)
+true
+```
+"""
+function ∈(x::AbstractVector{N}, Z::Zonotope{N})::Bool where {N<:Real}
+    @assert length(x) == dim(Z)
+
+    k = length(x)
+    b = similar(x)
+    one_N = one(N)
+    minus_one_N = -one_N
+    for i in 1:k
+        # normalize by moving the zonotope to the origin
+        b[i] = x[i] - Z.center[i]
+    end
+    # matrix A is just Z.generators
+
+    try
+        # results in LAPACKException or SingularException if not solvable
+        res = Z.generators \ b
+
+        for xi in res
+            if xi > one_N || xi < minus_one_N
+                return false
+            end
+        end
+        return true
+    catch
+        return false
+    end
 end


### PR DESCRIPTION
Discussion in #68.

Already available: HPolygons, CartesianProduct

Added:
* all Balls, Hyperrectangle, Singleton, VPolygon, LinearMap, Zonotope, ExponentialMap, ZeroSet, EmptySet
* conversion function for `Singleton` instead of `AbstractVector`

Missing and dismissed (outsourced to #77):
* MinkowskiSum (I have thought about it and it seems very complicated. One could subtract one set from the point and check for nonempty intersection with the other set. There is literature for the case that the sum consists of polytopes only, this could be interesting.)
* ConvexHull (I have thought about it and it seems too complicated. A sufficient test is to check containment in both generating sets, but for negative answers one has to continue, e.g., checking ray intersection from some vertex of one set in the other set.)
* ExponentialProjectionMap (I am not familiar with this type.)
* Polyhedron (We currently do not support them, so I will ignore them.)