### PR TITLE
#83 - fix one-vertex case for in(x, VPolygon)

### DIFF
--- a/src/VPolygon.jl
+++ b/src/VPolygon.jl
@@ -206,6 +206,13 @@ true
 function ∈(x::AbstractVector{N}, P::VPolygon{N})::Bool where {N<:Real}
     @assert length(x) == 2
 
+    # special cases: 0 or 1 vertex
+    if length(P.vertices_list) == 0
+        return false
+    elseif length(P.vertices_list) == 1
+        return x == P.vertices_list[1]
+    end
+
     zero_N = zero(N)
     if right_turn(P.vertices_list[1], x, P.vertices_list[end]) < zero_N
         return false

--- a/test/unit_Polygon.jl
+++ b/test/unit_Polygon.jl
@@ -118,6 +118,7 @@ d = [0., -1.]
 # test that #83 is fixed
 v = VPolygon([[2.0, 3.0]])
 @test [2.0, 3.0] ∈ v
+@test !([3.0, 2.0] ∈ v)
 v = VPolygon([[2.0, 3.0], [-1.0, -3.4]])
 @test [-1.0, -3.4] ∈ v
 


### PR DESCRIPTION
See #83.