### PR TITLE
#86 - restrict Ball2/Ballp numeric type to AbstractFloat

### DIFF
--- a/src/Ball2.jl
+++ b/src/Ball2.jl
@@ -3,7 +3,7 @@ import Base.∈
 export Ball2
 
 """
-    Ball2{N<:Real} <: AbstractPointSymmetric{N}
+    Ball2{N<:AbstractFloat} <: AbstractPointSymmetric{N}
 
 Type that represents a ball in the 2-norm.
 
@@ -48,7 +48,7 @@ julia> σ([1.,2.,3.,4.,5.], B)
  0.3371
 ```
 """
-struct Ball2{N<:Real} <: AbstractPointSymmetric{N}
+struct Ball2{N<:AbstractFloat} <: AbstractPointSymmetric{N}
     center::Vector{N}
     radius::N
 
@@ -57,14 +57,15 @@ struct Ball2{N<:Real} <: AbstractPointSymmetric{N}
         radius < zero(N) ? throw(DomainError()) : new(center, radius)
 end
 # type-less convenience constructor
-Ball2(center::Vector{N}, radius::N) where {N<:Real} = Ball2{N}(center, radius)
+Ball2(center::Vector{N}, radius::N) where {N<:AbstractFloat} =
+    Ball2{N}(center, radius)
 
 
 # --- AbstractPointSymmetric interface functions ---
 
 
 """
-    center(B::Ball2{N})::Vector{N} where {N<:Real}
+    center(B::Ball2{N})::Vector{N} where {N<:AbstractFloat}
 
 Return the center of a ball in the 2-norm.
 
@@ -76,7 +77,7 @@ Return the center of a ball in the 2-norm.
 
 The center of the ball in the 2-norm.
 """
-function center(B::Ball2{N})::Vector{N} where {N<:Real}
+function center(B::Ball2{N})::Vector{N} where {N<:AbstractFloat}
     return B.center
 end
 
@@ -121,7 +122,7 @@ function σ(d::AbstractVector{N},
 end
 
 """
-    ∈(x::AbstractVector{N}, B::Ball2{N})::Bool where {N<:Real}
+    ∈(x::AbstractVector{N}, B::Ball2{N})::Bool where {N<:AbstractFloat}
 
 Check whether a given point is contained in a ball in the 2-norm.
 
@@ -159,7 +160,7 @@ julia> ∈([.5, 1.5], B)
 true
 ```
 """
-function ∈(x::AbstractVector{N}, B::Ball2{N})::Bool where {N<:Real}
+function ∈(x::AbstractVector{N}, B::Ball2{N})::Bool where {N<:AbstractFloat}
     @assert length(x) == dim(B)
     sum = zero(N)
     for i in eachindex(x)

--- a/src/Ballp.jl
+++ b/src/Ballp.jl
@@ -3,7 +3,7 @@ import Base.∈
 export Ballp
 
 """
-    Ballp{N<:Real} <: AbstractPointSymmetric{N}
+    Ballp{N<:AbstractFloat} <: AbstractPointSymmetric{N}
 
 Type that represents a ball in the p-norm, for ``1 ≤ p ≤ ∞``.
 
@@ -52,8 +52,8 @@ julia> σ(1.:5, B)
  0.3379
 ```
 """
-struct Ballp{N<:Real} <: AbstractPointSymmetric{N}
-    p::Real
+struct Ballp{N<:AbstractFloat} <: AbstractPointSymmetric{N}
+    p::N
     center::Vector{N}
     radius::N
 
@@ -75,7 +75,7 @@ struct Ballp{N<:Real} <: AbstractPointSymmetric{N}
     end
 end
 # type-less convenience constructor
-Ballp(p::Real, center::Vector{N}, radius::N) where {N<:Real} =
+Ballp(p::N, center::Vector{N}, radius::N) where {N<:AbstractFloat} =
     Ballp{N}(p, center, radius)
 
 
@@ -83,7 +83,7 @@ Ballp(p::Real, center::Vector{N}, radius::N) where {N<:Real} =
 
 
 """
-    center(B::Ballp{N})::Vector{N} where {N<:Real}
+    center(B::Ballp{N})::Vector{N} where {N<:AbstractFloat}
 
 Return the center of a ball in the p-norm.
 
@@ -95,7 +95,7 @@ Return the center of a ball in the p-norm.
 
 The center of the ball in the p-norm.
 """
-function center(B::Ballp{N})::Vector{N} where {N<:Real}
+function center(B::Ballp{N})::Vector{N} where {N<:AbstractFloat}
     return B.center
 end
 
@@ -151,7 +151,7 @@ function σ(d::AbstractVector{N},
 end
 
 """
-    ∈(x::AbstractVector{N}, B::Ballp{N})::Bool where {N<:Real}
+    ∈(x::AbstractVector{N}, B::Ballp{N})::Bool where {N<:AbstractFloat}
 
 Check whether a given point is contained in a ball in the p-norm.
 
@@ -189,8 +189,7 @@ julia> ∈([.5, 1.5], B)
 true
 ```
 """
-function ∈(x::AbstractVector{<:Real},
-           B::Ballp{N})::Bool where {N<:AbstractFloat}
+function ∈(x::AbstractVector{N}, B::Ballp{N})::Bool where {N<:AbstractFloat}
     @assert length(x) == dim(B)
     sum = zero(N)
     for i in eachindex(x)


### PR DESCRIPTION
See #86.