### PR TITLE
Remove MkDocs deps from docs/make.jl

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -29,6 +29,6 @@ deploydocs(
     target = "build",
     osname = "linux",
     julia  = "0.6",
-    deps = Deps.pip("mkdocs", "python-markdown-math"),
+    deps = nothing,
     make = nothing
 )


### PR DESCRIPTION
Since the docs are rendered with Documenter's native HTML renderer, MkDocs-related deps are not necessary. Just something that caught my eye.