### PR TITLE
#44 - Parametric numeric type of a LazySet 

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -96,7 +96,7 @@ formulation:
 
 ```jldoctest index_label
 julia> typeof(Y)
-LazySets.ConvexHull{LazySets.MinkowskiSum{LazySets.ExponentialMap{LazySets.Ball2{Float64}},LazySets.LinearMap{LazySets.BallInf{Float64},Float64}},LazySets.Ball2{Float64}}
+LazySets.ConvexHull{Float64,LazySets.MinkowskiSum{Float64,LazySets.ExponentialMap{Float64,LazySets.Ball2{Float64}},LazySets.LinearMap{Float64,LazySets.BallInf{Float64}}},LazySets.Ball2{Float64}}
 ```
 
 Now suppose that we are interested in observing the projection of $\mathcal{Y}$

--- a/docs/src/lib/operations.md
+++ b/docs/src/lib/operations.md
@@ -21,9 +21,9 @@ end
 
 ```@docs
 MinkowskiSum
-dim(::MinkowskiSum)
-σ(::AbstractVector{Float64}, ::MinkowskiSum)
-Base.:+(::LazySet, ::LazySet)
+dim(::MinkowskiSum{Float64, LazySet{Float64}, LazySet{Float64}})
+σ(::AbstractVector{Float64}, ::MinkowskiSum{Float64, LazySet{Float64}, LazySet{Float64}})
+Base.:+(::LazySet{Float64}, ::LazySet{Float64})
 ⊕
 ```
 
@@ -31,12 +31,12 @@ Base.:+(::LazySet, ::LazySet)
 
 ```@docs
 MinkowskiSumArray
-dim(::MinkowskiSumArray)
-σ(::AbstractVector{Float64}, ::MinkowskiSumArray)
-Base.:+(::MinkowskiSumArray, ::LazySet)
-Base.:+(::LazySet, ::MinkowskiSumArray)
-Base.:+(::MinkowskiSumArray, ::MinkowskiSumArray)
-Base.:+(::MinkowskiSumArray, ::ZeroSet)
+dim(::MinkowskiSumArray{Float64, LazySet{Float64}})
+σ(::AbstractVector{Float64}, ::MinkowskiSumArray{Float64, LazySet{Float64}})
+Base.:+(::MinkowskiSumArray{Float64, LazySet{Float64}}, ::LazySet{Float64})
+Base.:+(::LazySet{Float64}, ::MinkowskiSumArray{Float64, LazySet{Float64}})
+Base.:+(::MinkowskiSumArray{Float64, LazySet{Float64}}, ::MinkowskiSumArray{Float64, LazySet{Float64}})
+Base.:+(::MinkowskiSumArray{Float64, LazySet{Float64}}, ::ZeroSet{Float64})
 ```
 
 ## Cartesian Product
@@ -45,22 +45,22 @@ Base.:+(::MinkowskiSumArray, ::ZeroSet)
 
 ```@docs
 CartesianProduct
-dim(::CartesianProduct)
-σ(::AbstractVector{Float64}, ::CartesianProduct)
-Base.:*(::LazySet, ::LazySet)
-∈(::AbstractVector{Float64}, ::CartesianProduct)
+dim(::CartesianProduct{Float64, LazySet{Float64}, LazySet{Float64}})
+σ(::AbstractVector{Float64}, ::CartesianProduct{Float64, LazySet{Float64}, LazySet{Float64}})
+Base.:*(::LazySet{Float64}, ::LazySet{Float64})
+∈(::AbstractVector{Float64}, ::CartesianProduct{Float64, LazySet{Float64}, LazySet{Float64}})
 ```
 
 ### ``n``-ary Cartesian Product
 
 ```@docs
-CartesianProductArray
-dim(::CartesianProductArray)
-σ(::AbstractVector{Float64}, ::CartesianProductArray)
-Base.:*(::CartesianProductArray, ::LazySet)
-Base.:*(::LazySet, ::CartesianProductArray)
-Base.:*(::CartesianProductArray, ::CartesianProductArray)
-∈(::AbstractVector{Float64}, ::CartesianProductArray)
+CartesianProductArray{Float64, LazySet{Float64}}
+dim(::CartesianProductArray{Float64, LazySet{Float64}})
+σ(::AbstractVector{Float64}, ::CartesianProductArray{Float64, LazySet{Float64}})
+Base.:*(::CartesianProductArray{Float64, LazySet{Float64}}, ::LazySet{Float64})
+Base.:*(::LazySet{Float64}, ::CartesianProductArray{Float64, LazySet{Float64}})
+Base.:*(::CartesianProductArray{Float64, LazySet{Float64}}, ::CartesianProductArray{Float64, LazySet{Float64}})
+∈(::AbstractVector{Float64}, ::CartesianProductArray{Float64, LazySet{Float64}})
 ```
 
 ## Maps
@@ -69,36 +69,36 @@ Base.:*(::CartesianProductArray, ::CartesianProductArray)
 
 ```@docs
 LinearMap
-dim(::LinearMap)
-σ(::AbstractVector{Float64}, ::LinearMap)
-*(::AbstractMatrix{Float64}, ::LazySet)
-*(::Real, ::LazySet)
-∈(::AbstractVector{Float64}, ::LinearMap{<:LazySet, Float64})
+dim(::LinearMap{Float64, LazySet{Float64}})
+σ(::AbstractVector{Float64}, ::LinearMap{Float64, LazySet{Float64}})
+*(::AbstractMatrix{Float64}, ::LazySet{Float64})
+*(::Float64, ::LazySet{Float64})
+∈(::AbstractVector{Float64}, ::LinearMap{Float64, LazySet{Float64}})
 ```
 
 ### Exponential Map
 
 ```@docs
 ExponentialMap
-dim(::ExponentialMap)
-σ(::AbstractVector{Float64}, ::ExponentialMap)
-∈(::AbstractVector{Float64}, ::ExponentialMap{<:LazySet})
+dim(::ExponentialMap{Float64, LazySet{Float64}})
+σ(::AbstractVector{Float64}, ::ExponentialMap{Float64, LazySet{Float64}})
+∈(::AbstractVector{Float64}, ::ExponentialMap{Float64, LazySet{Float64}})
 ```
 
 ```@docs
 ExponentialProjectionMap
-dim(::ExponentialProjectionMap)
-σ(::AbstractVector{Float64}, ::ExponentialProjectionMap)
+dim(::ExponentialProjectionMap{Float64, LazySet{Float64}})
+σ(::AbstractVector{Float64}, ::ExponentialProjectionMap{Float64, LazySet{Float64}})
 ```
 
 ```@docs
 SparseMatrixExp
-*(::SparseMatrixExp, ::LazySet)
+*(::SparseMatrixExp{Float64}, ::LazySet{Float64})
 ```
 
 ```@docs
 ProjectionSparseMatrixExp
-*(::ProjectionSparseMatrixExp, ::LazySet)
+*(::ProjectionSparseMatrixExp{Float64}, ::LazySet{Float64})
 ```
 
 ## Convex Hull
@@ -106,8 +106,8 @@ ProjectionSparseMatrixExp
 ```@docs
 ConvexHull
 CH
-dim(::ConvexHull)
-σ(::AbstractVector{Float64}, ::ConvexHull)
+dim(::ConvexHull{Float64, LazySet{Float64}, LazySet{Float64}})
+σ(::AbstractVector{Float64}, ::ConvexHull{Float64, LazySet{Float64}, LazySet{Float64}})
 ```
 
 ### Convex Hull Algorithms

--- a/docs/src/lib/representations.md
+++ b/docs/src/lib/representations.md
@@ -29,12 +29,12 @@ support_vector
 
 ```@docs
 Ball2
-dim(::Ball2)
-σ(::AbstractVector{Float64}, ::Ball2)
+dim(::Ball2{Float64})
+σ(::AbstractVector{Float64}, ::Ball2{Float64})
 ∈(::AbstractVector{Float64}, ::Ball2{Float64})
 an_element(::Ball2{Float64})
-⊆(::Ball2, ::Singleton)
-⊆(::Ball2, ::AbstractHyperrectangle)
+⊆(::Ball2{Float64}, ::Singleton{Float64})
+⊆(::Ball2{Float64}, ::AbstractHyperrectangle{Float64})
 is_intersection_empty(::Ball2{Float64}, ::Ball2{Float64}, ::Bool)
 center(::Ball2{Float64})
 ```
@@ -43,16 +43,16 @@ center(::Ball2{Float64})
 
 ```@docs
 BallInf
-dim(::BallInf)
+dim(::BallInf{Float64})
 σ(::AbstractVector{Float64}, ::BallInf{Float64})
 ∈(::AbstractVector{Float64}, ::BallInf{Float64})
 an_element(::BallInf{Float64})
-⊆(::BallInf, ::AbstractHyperrectangle)
-⊆(::BallInf, ::LazySet)
+⊆(::BallInf{Float64}, ::AbstractHyperrectangle{Float64})
+⊆(::BallInf{Float64}, ::LazySet{Float64})
 is_intersection_empty(::BallInf{Float64}, ::AbstractHyperrectangle{Float64}, ::Bool)
-norm(::BallInf, ::Real=Inf)
-radius(::BallInf, ::Real=Inf)
-diameter(::BallInf, ::Real=Inf)
+norm(::BallInf{Float64}, ::Real)
+radius(::BallInf{Float64}, ::Real)
+diameter(::BallInf{Float64}, ::Real)
 vertices_list(::BallInf{Float64})
 singleton_list(::BallInf{Float64})
 center(::BallInf{Float64})
@@ -64,11 +64,11 @@ radius_hyperrectangle(::BallInf{Float64}, ::Int)
 
 ```@docs
 Ball1
-dim(::Ball1)
+dim(::Ball1{Float64})
 σ(::AbstractVector{Float64}, ::Ball1{Float64})
 ∈(::AbstractVector{Float64}, ::Ball1{Float64})
 an_element(::Ball1{Float64})
-⊆(::Ball1, ::LazySet)
+⊆(::Ball1{Float64}, ::LazySet{Float64})
 vertices_list(::Ball1{Float64})
 singleton_list(::Ball1{Float64})
 center(::Ball1{Float64})
@@ -78,12 +78,12 @@ center(::Ball1{Float64})
 
 ```@docs
 Ballp
-dim(::Ballp)
-σ(::AbstractVector{Float64}, ::Ballp)
+dim(::Ballp{Float64})
+σ(::AbstractVector{Float64}, ::Ballp{Float64})
 ∈(::AbstractVector{Float64}, ::Ballp{Float64})
 an_element(::Ballp{Float64})
-⊆(::Ballp, ::Singleton)
-⊆(::Ballp, ::AbstractHyperrectangle)
+⊆(::Ballp{Float64}, ::Singleton{Float64})
+⊆(::Ballp{Float64}, ::AbstractHyperrectangle{Float64})
 center(::Ballp{Float64})
 ```
 
@@ -93,11 +93,11 @@ center(::Ballp{Float64})
 
 ```@docs
 HPolygon
-dim(::HPolygon)
+dim(::HPolygon{Float64})
 σ(::AbstractVector{Float64}, ::HPolygon{Float64})
 ∈(::AbstractVector{Float64}, ::HPolygon{Float64})
 an_element(::HPolygon{Float64})
-⊆(::HPolygon, ::LazySet)
+⊆(::HPolygon{Float64}, ::LazySet{Float64})
 vertices_list(::HPolygon{Float64})
 singleton_list(::HPolygon{Float64})
 tohrep(::HPolygon{Float64})
@@ -109,11 +109,11 @@ addconstraint!(::HPolygon{Float64}, ::LinearConstraint{Float64})
 
 ```@docs
 HPolygonOpt
-dim(::HPolygonOpt)
+dim(::HPolygonOpt{Float64})
 σ(::AbstractVector{Float64}, ::HPolygonOpt{Float64})
 ∈(::AbstractVector{Float64}, ::HPolygonOpt{Float64})
 an_element(::HPolygonOpt{Float64})
-⊆(::HPolygonOpt, ::LazySet)
+⊆(::HPolygonOpt{Float64}, ::LazySet{Float64})
 vertices_list(::HPolygonOpt{Float64})
 singleton_list(::HPolygonOpt{Float64})
 tohrep(::HPolygonOpt{Float64})
@@ -125,11 +125,11 @@ addconstraint!(::HPolygonOpt{Float64}, ::LinearConstraint{Float64})
 
 ```@docs
 VPolygon
-dim(::VPolygon)
+dim(::VPolygon{Float64})
 σ(::AbstractVector{Float64}, ::VPolygon{Float64})
 ∈(::AbstractVector{Float64}, ::VPolygon{Float64})
 an_element(::VPolygon{Float64})
-⊆(::VPolygon, ::LazySet)
+⊆(::VPolygon{Float64}, ::LazySet{Float64})
 vertices_list(::VPolygon{Float64})
 singleton_list(::VPolygon{Float64})
 tohrep(::VPolygon{Float64})
@@ -149,49 +149,49 @@ intersection(::Line{Float64}, L2::Line{Float64})
 ```@docs
 Hyperrectangle
 Hyperrectangle(;kwargs...)
-dim(::Hyperrectangle)
+dim(::Hyperrectangle{Float64})
 σ(::AbstractVector{Float64}, ::Hyperrectangle{Float64})
 ∈(::AbstractVector{Float64}, ::Hyperrectangle{Float64})
 an_element(::Hyperrectangle{Float64})
-⊆(::Hyperrectangle, ::AbstractHyperrectangle)
-⊆(::Hyperrectangle, ::LazySet)
+⊆(::Hyperrectangle{Float64}, ::AbstractHyperrectangle{Float64})
+⊆(::Hyperrectangle{Float64}, ::LazySet{Float64})
 is_intersection_empty(::Hyperrectangle{Float64}, ::AbstractHyperrectangle{Float64}, ::Bool)
-norm(::Hyperrectangle, ::Real=Inf)
-radius(::Hyperrectangle, ::Real=Inf)
-diameter(::Hyperrectangle, ::Real=Inf)
+norm(::Hyperrectangle{Float64}, ::Real)
+radius(::Hyperrectangle{Float64}, ::Real)
+diameter(::Hyperrectangle{Float64}, ::Real)
 vertices_list(::Hyperrectangle{Float64})
 singleton_list(::Hyperrectangle{Float64})
 center(::Hyperrectangle{Float64})
 radius_hyperrectangle(::Hyperrectangle{Float64})
 radius_hyperrectangle(::Hyperrectangle{Float64}, ::Int)
-high(::Hyperrectangle)
-low(::Hyperrectangle)
+high(::Hyperrectangle{Float64})
+low(::Hyperrectangle{Float64})
 ```
 
 ## EmptySet
 
 ```@docs
 EmptySet
-dim(::EmptySet)
-σ(::AbstractVector{Float64}, ::EmptySet)
-∈(::AbstractVector{Float64}, ::EmptySet)
-an_element(::EmptySet)
+dim(::EmptySet{Float64})
+σ(::AbstractVector{Float64}, ::EmptySet{Float64})
+∈(::AbstractVector{Float64}, ::EmptySet{Float64})
+an_element(::EmptySet{Float64})
 ```
 
 ## Singletons
 
 ```@docs
 Singleton
-dim(::Singleton)
+dim(::Singleton{Float64})
 σ(::AbstractVector{Float64}, ::Singleton{Float64})
 ∈(::AbstractVector{Float64}, ::Singleton{Float64})
-⊆(::Singleton, ::AbstractSingleton)
-⊆(::Singleton, ::LazySet)
-is_intersection_empty(::Singleton{Float64}, ::LazySet, ::Bool)
-is_intersection_empty(::LazySet, ::Singleton{Float64}, ::Bool)
+⊆(::Singleton{Float64}, ::AbstractSingleton{Float64})
+⊆(::Singleton{Float64}, ::LazySet{Float64})
+is_intersection_empty(::Singleton{Float64}, ::LazySet{Float64}, ::Bool)
+is_intersection_empty(::LazySet{Float64}, ::Singleton{Float64}, ::Bool)
 is_intersection_empty(::Singleton{Float64}, ::Singleton{Float64}, ::Bool)
-norm(::Singleton, ::Real=Inf)
-diameter(::Singleton, ::Real=Inf)
+norm(::Singleton{Float64}, ::Real)
+diameter(::Singleton{Float64}, ::Real)
 vertices_list(::Singleton{Float64})
 singleton_list(::Singleton{Float64})
 center(::Singleton{Float64})
@@ -206,16 +206,16 @@ element(::Singleton{Float64}, ::Int)
 
 ```@docs
 ZeroSet
-dim(::ZeroSet)
-σ(::AbstractVector{Float64}, ::ZeroSet)
+dim(::ZeroSet{Float64})
+σ(::AbstractVector{Float64}, ::ZeroSet{Float64})
 ∈(::AbstractVector{Float64}, ::ZeroSet{Float64})
-⊆(::ZeroSet, ::AbstractSingleton)
-⊆(::ZeroSet, ::LazySet)
-is_intersection_empty(::ZeroSet{Float64}, ::LazySet, ::Bool)
-is_intersection_empty(::LazySet, ::ZeroSet{Float64}, ::Bool)
+⊆(::ZeroSet{Float64}, ::AbstractSingleton{Float64})
+⊆(::ZeroSet{Float64}, ::LazySet{Float64})
+is_intersection_empty(::ZeroSet{Float64}, ::LazySet{Float64}, ::Bool)
+is_intersection_empty(::LazySet{Float64}, ::ZeroSet{Float64}, ::Bool)
 is_intersection_empty(::ZeroSet{Float64}, ::ZeroSet{Float64}, ::Bool)
-norm(::ZeroSet, ::Real=Inf)
-diameter(::ZeroSet, ::Real=Inf)
+norm(::ZeroSet{Float64}, ::Real)
+diameter(::ZeroSet{Float64}, ::Real)
 vertices_list(::ZeroSet{Float64})
 singleton_list(::ZeroSet{Float64})
 center(::ZeroSet{Float64})
@@ -230,13 +230,13 @@ element(::ZeroSet{Float64}, ::Int)
 
 ```@docs
 Zonotope
-dim(::Zonotope)
-σ(::AbstractVector{Float64}, Z::Zonotope)
+dim(::Zonotope{Float64})
+σ(::AbstractVector{Float64}, ::Zonotope{Float64})
 ∈(::AbstractVector{Float64}, ::Zonotope{Float64})
 an_element(::Zonotope{Float64})
-⊆(::Zonotope, ::LazySet)
+⊆(::Zonotope{Float64}, ::LazySet{Float64})
 center(::Zonotope{Float64})
 vertices_list(::Zonotope{Float64})
 singleton_list(::Zonotope{Float64})
-order(::Zonotope)
+order(::Zonotope{Float64})
 ```

--- a/src/AbstractHyperrectangle.jl
+++ b/src/AbstractHyperrectangle.jl
@@ -163,7 +163,7 @@ function ∈(x::AbstractVector{N},
 end
 
 """
-    ⊆(S::LazySet, H::AbstractHyperrectangle{N}, witness::Bool=false
+    ⊆(S::LazySet{N}, H::AbstractHyperrectangle{N}, witness::Bool=false
      )::Union{Bool,Tuple{Bool,Vector{N}}} where {N<:Real}
 
 Check whether a convex set is contained in a hyperrectangle, and if not,
@@ -187,7 +187,7 @@ optionally compute a witness.
 ``S ⊆ H`` iff ``\\operatorname{ihull}(S) ⊆ H``, where  ``\\operatorname{ihull}``
 is the interval hull operator.
 """
-function ⊆(S::LazySet, H::AbstractHyperrectangle{N}, witness::Bool=false
+function ⊆(S::LazySet{N}, H::AbstractHyperrectangle{N}, witness::Bool=false
           )::Union{Bool,Tuple{Bool,Vector{N}}} where {N<:Real}
     return ⊆(Approximations.interval_hull(S), H, witness)
 end

--- a/src/AbstractPointSymmetric.jl
+++ b/src/AbstractPointSymmetric.jl
@@ -3,7 +3,7 @@ export AbstractPointSymmetric,
        an_element
 
 """
-    AbstractPointSymmetric{N<:Real} <: LazySet
+    AbstractPointSymmetric{N<:Real} <: LazySet{N}
 
 Abstract type for point symmetric sets.
 
@@ -19,7 +19,7 @@ julia> subtypes(AbstractPointSymmetric)
  LazySets.Ballp                   
 ```
 """
-abstract type AbstractPointSymmetric{N<:Real} <: LazySet end
+abstract type AbstractPointSymmetric{N<:Real} <: LazySet{N} end
 
 
 """

--- a/src/AbstractPolytope.jl
+++ b/src/AbstractPolytope.jl
@@ -5,7 +5,7 @@ export AbstractPolytope,
        singleton_list
 
 """
-    AbstractPolytope{N<:Real} <: LazySet
+    AbstractPolytope{N<:Real} <: LazySet{N}
 
 Abstract type for polytopic sets, i.e., sets with finitely many flat facets, or
 equivalently, sets defined as an intersection of a finite number of halfspaces,
@@ -24,14 +24,14 @@ julia> subtypes(AbstractPolytope)
  LazySets.AbstractPolygon
 ```
 """
-abstract type AbstractPolytope{N<:Real} <: LazySet end
+abstract type AbstractPolytope{N<:Real} <: LazySet{N} end
 
 
 # --- LazySet interface functions ---
 
 
 """
-    ⊆(P::AbstractPolytope{N}, S::LazySet, witness::Bool=false
+    ⊆(P::AbstractPolytope{N}, S::LazySet{N}, witness::Bool=false
      )::Union{Bool,Tuple{Bool,Vector{N}}} where {N<:Real}
 
 Check whether a polytope is contained in a convex set, and if not, optionally
@@ -55,7 +55,7 @@ compute a witness.
 Since ``S`` is convex, ``P ⊆ S`` iff ``v_i ∈ S`` for all vertices ``v_i`` of
 ``P``.
 """
-function ⊆(P::AbstractPolytope{N}, S::LazySet, witness::Bool=false
+function ⊆(P::AbstractPolytope{N}, S::LazySet{N}, witness::Bool=false
           )::Union{Bool,Tuple{Bool,Vector{N}}} where {N<:Real}
     @assert dim(P) == dim(S)
 

--- a/src/AbstractSingleton.jl
+++ b/src/AbstractSingleton.jl
@@ -178,7 +178,7 @@ end
 
 
 """
-    ⊆(S::AbstractSingleton{N}, set::LazySet, witness::Bool=false
+    ⊆(S::AbstractSingleton{N}, set::LazySet{N}, witness::Bool=false
      )::Union{Bool,Tuple{Bool,Vector{N}}} where {N<:Real}
 
 Check whether a given set with a single value is contained in a convex set, and
@@ -198,7 +198,7 @@ if not, optionally compute a witness.
   * `(false, v)` iff ``S \\not\\subseteq \\text{set}`` and
     ``v ∈ S \\setminus \\text{set}``
 """
-function ⊆(S::AbstractSingleton{N}, set::LazySet, witness::Bool=false
+function ⊆(S::AbstractSingleton{N}, set::LazySet{N}, witness::Bool=false
           )::Union{Bool,Tuple{Bool,Vector{N}}} where {N<:Real}
     result = ∈(element(S), set)
     if witness
@@ -243,7 +243,7 @@ end
 
 """
     is_intersection_empty(S::AbstractSingleton{N},
-                          set::LazySet,
+                          set::LazySet{N},
                           witness::Bool=false
                          )::Union{Bool,Tuple{Bool,Vector{N}}} where {N<:Real}
 
@@ -269,7 +269,7 @@ optionally compute a witness.
 ``S ∩ \\operatorname{set} = ∅`` iff `element(S)` ``\notin \\operatorname{set}``.
 """
 function is_intersection_empty(S::AbstractSingleton{N},
-                               set::LazySet,
+                               set::LazySet{N},
                                witness::Bool=false
                               )::Union{Bool,Tuple{Bool,Vector{N}}} where {N<:Real}
     empty_intersection = !∈(element(S), set)
@@ -281,7 +281,7 @@ function is_intersection_empty(S::AbstractSingleton{N},
 end
 
 """
-    is_intersection_empty(set::LazySet,
+    is_intersection_empty(set::LazySet{N},
                           S::AbstractSingleton{N},
                           witness::Bool=false
                          )::Union{Bool,Tuple{Bool,Vector{N}}} where {N<:Real}
@@ -307,7 +307,7 @@ optionally compute a witness.
 
 ``S ∩ \\operatorname{set} = ∅`` iff `element(S)` ``\notin \\operatorname{set}``.
 """
-function is_intersection_empty(set::LazySet,
+function is_intersection_empty(set::LazySet{N},
                                S::AbstractSingleton{N},
                                witness::Bool=false
                               )::Union{Bool,Tuple{Bool,Vector{N}}} where {N<:Real}

--- a/src/Approximations/2D_approximations.jl
+++ b/src/Approximations/2D_approximations.jl
@@ -1,5 +1,5 @@
 """
-    overapproximate(S::LazySet, ::Type{HPolygon})::HPolygon
+    overapproximate(S::LazySet, ::Type{<:HPolygon})::HPolygon
 
 Return an approximation of a given 2D convex set as a box-shaped polygon.
 
@@ -12,7 +12,7 @@ Return an approximation of a given 2D convex set as a box-shaped polygon.
 
 A box-shaped polygon in constraint representation.
 """
-function overapproximate(S::LazySet, ::Type{HPolygon})::HPolygon
+function overapproximate(S::LazySet, ::Type{<:HPolygon})::HPolygon
     @assert dim(S) == 2
     pe, pn, pw, ps = box_bounds(S)
     constraints = Vector{LinearConstraint{eltype(pe)}}(4)
@@ -31,7 +31,7 @@ Alias for `overapproximate(S, HPolygon)`.
 overapproximate(S::LazySet)::HPolygon = overapproximate(S, HPolygon)
 
 """
-    overapproximate(S::LazySet, Type{Hyperrectangle})::Hyperrectangle
+    overapproximate(S::LazySet, Type{<:Hyperrectangle})::Hyperrectangle
 
 Return an approximation of a given 2D convex set as a hyperrectangle.
 
@@ -44,7 +44,7 @@ Return an approximation of a given 2D convex set as a hyperrectangle.
 
 A hyperrectangle.
 """
-function overapproximate(S::LazySet, ::Type{Hyperrectangle})::Hyperrectangle
+function overapproximate(S::LazySet, ::Type{<:Hyperrectangle})::Hyperrectangle
     @assert dim(S) == 2
     pe, pn, pw, ps = box_bounds(S)
     radius = [(pe[1] - pw[1]) / 2, (pn[2] - ps[2]) / 2]

--- a/src/Approximations/decompositions.jl
+++ b/src/Approximations/decompositions.jl
@@ -1,5 +1,5 @@
 """
-    decompose(S::LazySet, [set_type]::Type=HPolygon
+    decompose(S::LazySet, [set_type]::Type=HPolygon{Float64}
              )::CartesianProductArray
 
 Compute an overapproximation of the projections of the given convex set over
@@ -20,7 +20,7 @@ two-dimensional sets of type `set_type`.
 For each 2D block a specific `decompose_2D` method is called, dispatched on the
 `set_type` argument.
 """
-function decompose(S::LazySet, set_type::Type=HPolygon
+function decompose(S::LazySet, set_type::Type=HPolygon{Float64}
                   )::CartesianProductArray
     n = dim(S)
     b = div(n, 2)
@@ -33,7 +33,7 @@ end
 
 # polygon with box directions
 @inline function decompose_2D(S::LazySet, n::Int, bi::Int,
-                              set_type::Type{HPolygon})::HPolygon
+                              set_type::Type{<:HPolygon})::HPolygon
     pe, pn, pw, ps = box_bounds(S, n, bi)
     block = 2*bi-1:2*bi
     pe_bi = dot(DIR_EAST, view(pe, block))
@@ -49,7 +49,7 @@ end
 
 # hyperrectangle
 @inline function decompose_2D(S::LazySet, n::Int, bi::Int,
-                              set_type::Type{Hyperrectangle})::Hyperrectangle
+                              set_type::Type{<:Hyperrectangle})::Hyperrectangle
     pe, pn, pw, ps = box_bounds(S, n, bi)
     radius = [(pe[1] - pw[1]) / 2, (pn[2] - ps[2]) / 2]
     center = [pw[1] + radius[1], ps[2] + radius[2]]
@@ -109,7 +109,7 @@ function decompose(S::LazySet, ɛi::Vector{Float64})::CartesianProductArray
 end
 
 """
-    decompose(S::LazySet, ɛ::Float64, [set_type]::Type=HPolygon
+    decompose(S::LazySet, ɛ::Float64, [set_type]::Type=HPolygon{Float64}
              )::CartesianProductArray
 
 Compute an overapproximation of the projections of the given convex set over
@@ -133,7 +133,7 @@ bound for each block is assumed.
 
 The `set_type` argument is ignored if ``ɛ ≠ \\text{Inf}``.
 """
-function decompose(S::LazySet, ɛ::Float64, set_type::Type=HPolygon
+function decompose(S::LazySet, ɛ::Float64, set_type::Type=HPolygon{Float64}
                   )::CartesianProductArray
     if ɛ == Inf
         return decompose(S, set_type)

--- a/src/CartesianProduct.jl
+++ b/src/CartesianProduct.jl
@@ -326,7 +326,8 @@ function dim(cpa::CartesianProductArray)::Int
 end
 
 """
-    σ(d::AbstractVector{<:Real}, cpa::CartesianProductArray)::AbstractVector{<:Real}
+    σ(d::AbstractVector{N}, cpa::CartesianProductArray{N, <:LazySet{N}}
+     )::AbstractVector{N} where {N<:Real}
 
 Support vector of a Cartesian product.
 
@@ -340,8 +341,8 @@ Support vector of a Cartesian product.
 The support vector in the given direction.
 If the direction has norm zero, the result depends on the product sets.
 """
-function σ(d::AbstractVector{<:Real},
-           cpa::CartesianProductArray)::AbstractVector{<:Real}
+function σ(d::AbstractVector{N}, cpa::CartesianProductArray{N, <:LazySet{N}}
+          )::AbstractVector{N} where {N<:Real}
     svec = similar(d)
     jinit = 1
     for sj in cpa.sfarray
@@ -353,7 +354,8 @@ function σ(d::AbstractVector{<:Real},
 end
 
 """
-    ∈(x::AbstractVector{<:Real}, cpa::CartesianProductArray)::Bool
+    ∈(x::AbstractVector{N}, cpa::CartesianProductArray{N, <:LazySet{N}}
+     )::Bool  where {N<:Real}
 
 Check whether a given point is contained in a Cartesian product of a finite
 number of sets.
@@ -367,7 +369,8 @@ number of sets.
 
 `true` iff ``x ∈ \\text{cpa}``.
 """
-function ∈(x::AbstractVector{<:Real}, cpa::CartesianProductArray)::Bool
+function ∈(x::AbstractVector{N}, cpa::CartesianProductArray{N, <:LazySet{N}}
+          )::Bool  where {N<:Real}
     @assert length(x) == dim(cpa)
 
     jinit = 1

--- a/src/CartesianProduct.jl
+++ b/src/CartesianProduct.jl
@@ -4,7 +4,7 @@ export CartesianProduct,
        CartesianProductArray
 
 """
-    CartesianProduct{S1<:LazySet,S2<:LazySet} <: LazySet
+    CartesianProduct{N<:Real, S1<:LazySet{N}, S2<:LazySet{N}} <: LazySet{N}
 
 Type that represents a Cartesian product of two convex sets.
 
@@ -19,18 +19,24 @@ The Cartesian product of three elements is obtained recursively.
 See also `CartesianProductArray` for an implementation of a Cartesian product of
 many sets without recursion, instead using an array.
 
-- `CartesianProduct{S1<:LazySet,S2<:LazySet}`            -- default constructor
+- `CartesianProduct{N<:Real, S1<:LazySet{N}, S2<:LazySet{N}}(X1::S1, X2::S2)`
+  -- default constructor
 
-- `CartesianProduct(Xarr::Vector{S}) where {S<:LazySet}` -- constructor from an
-                                                            array of convex sets
+- `CartesianProduct(Xarr::Vector{S}) where {S<:LazySet}`
+  -- constructor from an array of convex sets
 """
-struct CartesianProduct{S1<:LazySet,S2<:LazySet} <: LazySet
+struct CartesianProduct{N<:Real, S1<:LazySet{N}, S2<:LazySet{N}} <: LazySet{N}
     X::S1
     Y::S2
 end
-CartesianProduct(Xarr::Vector{S}) where {S<:LazySet} =
+# type-less convenience constructor
+CartesianProduct(X1::S1, X2::S2
+                ) where {S1<:LazySet{N}, S2<:LazySet{N}} where {N<:Real} =
+    CartesianProduct{N, S1, S2}(X1, X2)
+# constructor from an array
+CartesianProduct(Xarr::Vector{S}) where {S<:LazySet{N}} where {N<:Real} =
     (length(Xarr) == 0
-        ? ∅
+        ? EmptySet{N}()
         : length(Xarr) == 1
             ? Xarr[1]
             : length(Xarr) == 2
@@ -54,59 +60,51 @@ Return the Cartesian product of two convex sets.
 
 The Cartesian product of the two convex sets.
 """
-function *(X::LazySet, Y::LazySet)::CartesianProduct
-    CartesianProduct(X, Y)
-end
+*(X::LazySet, Y::LazySet)::CartesianProduct = CartesianProduct(X, Y)
 
 """
     ×
 
 Alias for the binary Cartesian product.
 """
-×(X::LazySet, Y::LazySet) = CartesianProduct(X, Y)
+×(X::LazySet, Y::LazySet) = *(X, Y)
 
 """
-```
-    *(X::LazySet, E::EmptySet)
-```
+    X × ∅
 
 Right multiplication of a set by an empty set.
 
 ### Input
 
 - `X` -- a convex set
-- `E` -- an empty set
+- `∅` -- an empty set
 
 ### Output
 
 An empty set, because the empty set is the absorbing element for the
 Cartesian product.
 """
-*(X::LazySet, E::EmptySet) = ∅
-
-*(::EmptySet, ::EmptySet) = ∅
-
-×(X::LazySet, E::EmptySet) = ∅
+*(::LazySet, ∅::EmptySet) = ∅
 
 """
-```
-    *(E::EmptySet, X::LazySet)
-```
+    ∅ × X
+
 Left multiplication of a set by an empty set.
 
 ### Input
 
 - `X` -- a convex set
-- `E` -- an empty set
+- `∅` -- an empty set
 
 ### Output
 
 An empty set, because the empty set is the absorbing element for the
 Cartesian product.
 """
-*(E::EmptySet, X::LazySet) = ∅
+*(∅::EmptySet, ::LazySet) = ∅
 
-×(E::EmptySet, X::LazySet) = ∅
+# special case: pure empty set multiplication (we require the same numeric type)
+(*(∅::E, ::E)) where {E<:EmptySet} = ∅
 
 """
     dim(cp::CartesianProduct)::Int
@@ -171,7 +169,7 @@ end
 #  Cartesian product of an array of sets
 # ======================================
 """
-    CartesianProductArray{S<:LazySet} <: LazySet
+    CartesianProductArray{N<:Real, S<:LazySet{N}} <: LazySet{N}
 
 Type that represents the Cartesian product of a finite number of convex sets.
 
@@ -185,17 +183,21 @@ Type that represents the Cartesian product of a finite number of convex sets.
 
 - `CartesianProductArray()` -- constructor for an empty Cartesian product
 
-- `CartesianProductArray(n::Int)`
-  -- constructor for an empty Cartesian product with size hint
+- `CartesianProductArray(n::Int, [N]::Type=Float64)`
+  -- constructor for an empty Cartesian product with size hint and numeric type
 """
-struct CartesianProductArray{S<:LazySet} <: LazySet
+struct CartesianProductArray{N<:Real, S<:LazySet{N}} <: LazySet{N}
     sfarray::Vector{S}
 end
-# constructor for an empty Cartesian product
-CartesianProductArray() = CartesianProductArray{LazySet}(Vector{LazySet}(0))
-# constructor for an empty Cartesian product with size hint
-function CartesianProductArray(n::Int)::CartesianProductArray
-    arr = Vector{LazySet}(0)
+# type-less convenience constructor
+CartesianProductArray(arr::Vector{S}) where {S<:LazySet{N}} where {N<:Real} =
+    CartesianProductArray{N, S}(arr)
+# constructor for an empty Cartesian product of floats
+CartesianProductArray() =
+    CartesianProductArray{Float64, LazySet{Float64}}(Vector{LazySet{Float64}}(0))
+# constructor for an empty Cartesian product with size hint and numeric type
+function CartesianProductArray(n::Int, N::Type=Float64)::CartesianProductArray
+    arr = Vector{LazySet{N}}(0)
     sizehint!(arr, n)
     return CartesianProductArray(arr)
 end
@@ -246,23 +248,22 @@ end
 
 """
 ```
-    *(cpa::CartesianProductArray, E::EmptySet)
+    *(cpa::CartesianProductArray, ∅::EmptySet)
 ```
+
 Right multiplication of a `CartesianProductArray` by an empty set.
 
 ### Input
 
 - `cpa` -- Cartesian product array
-- `E`   -- an empty set
+- `∅`   -- an empty set
 
 ### Output
 
 An empty set, because the empty set is the absorbing element for the
 Cartesian product.
 """
-*(cpa::CartesianProductArray, E::EmptySet) = ∅
-
-×(cpa::CartesianProductArray, E::EmptySet) = ∅
+*(::CartesianProductArray, ∅::EmptySet) = ∅
 
 """
 ```
@@ -274,16 +275,14 @@ Left multiplication of a set by an empty set.
 ### Input
 
 - `X` -- a convex set
-- `E` -- an empty set
+- `∅` -- an empty set
 
 ### Output
 
 An empty set, because the empty set is the absorbing element for the
 Cartesian product.
 """
-*(S::EmptySet, cpa::CartesianProductArray) = ∅
-
-×(S::EmptySet, cpa::CartesianProductArray) = ∅
+*(∅::EmptySet, ::CartesianProductArray) = ∅
 
 """
 ```
@@ -303,12 +302,6 @@ product.
 The modified first Cartesian product.
 """
 function *(cpa1::CartesianProductArray,
-           cpa2::CartesianProductArray)::CartesianProductArray
-    append!(cpa1.sfarray, cpa2.sfarray)
-    return cpa1
-end
-
-function ×(cpa1::CartesianProductArray,
            cpa2::CartesianProductArray)::CartesianProductArray
     append!(cpa1.sfarray, cpa2.sfarray)
     return cpa1

--- a/src/ConvexHull.jl
+++ b/src/ConvexHull.jl
@@ -48,7 +48,7 @@ Convex hull of a set with the empty set from the right.
 
 The given set because the empty set is neutral for the convex hull.
 """
-ConvexHull(X::LazySet, ::EmptySet) = X
+ConvexHull(X::LazySet{N}, ::EmptySet{N}) where {N<:Real} = X
 
 """
     ConvexHull(∅, X)
@@ -64,7 +64,6 @@ Convex hull of a set with the empty set from the left.
 
 The given set because the empty set is neutral for the convex hull.
 """
-ConvexHull(X::LazySet{N}, ::EmptySet{N}) where {N<:Real} = X
 ConvexHull(::EmptySet{N}, X::LazySet{N}) where {N<:Real} = X
 
 # special case: pure empty set convex hull (we require the same numeric type)

--- a/src/ConvexHull.jl
+++ b/src/ConvexHull.jl
@@ -5,7 +5,7 @@ export ConvexHull, CH,
        convex_hull!
 
 """
-    ConvexHull{S1<:LazySet, S2<:LazySet} <: LazySet
+    ConvexHull{N<:Real, S1<:LazySet{N}, S2<:LazySet{N}} <: LazySet{N}
 
 Type that represents the convex hull of the union of two convex sets.
 
@@ -14,27 +14,28 @@ Type that represents the convex hull of the union of two convex sets.
 - `X` -- convex set
 - `Y` -- convex set
 """
-struct ConvexHull{S1<:LazySet, S2<:LazySet} <: LazySet
+struct ConvexHull{N<:Real, S1<:LazySet{N}, S2<:LazySet{N}} <: LazySet{N}
     X::S1
     Y::S2
 
     # default constructor with dimension check
-    ConvexHull{S1,S2}(X::S1, Y::S2) where {S1<:LazySet, S2<:LazySet} =
-        dim(X) != dim(Y) ? throw(DimensionMismatch) : new(X, Y)
+    ConvexHull{N, S1, S2}(X::S1, Y::S2) where
+        {S1<:LazySet{N}, S2<:LazySet{N}} where {N<:Real} =
+            dim(X) != dim(Y) ? throw(DimensionMismatch) : new(X, Y)
 end
 # type-less convenience constructor
-ConvexHull(X::S1, Y::S2) where {S1<:LazySet, S2<:LazySet} =
-    ConvexHull{S1, S2}(X, Y)
+ConvexHull(X::S1, Y::S2) where {S1<:LazySet{N}, S2<:LazySet{N}} where {N<:Real} =
+    ConvexHull{N, S1, S2}(X, Y)
 
 """
     CH
 
 Alias for `ConvexHull`.
 """
-CH = ConvexHull
+const CH = ConvexHull
 
 """
-    ConvexHull(X::LazySet, ∅::EmptySet)::LazySet
+    ConvexHull(X, ∅)
 
 Convex hull of a set with the empty set from the right.
 
@@ -47,10 +48,10 @@ Convex hull of a set with the empty set from the right.
 
 The given set because the empty set is neutral for the convex hull.
 """
-ConvexHull(X::LazySet, ∅::EmptySet)::LazySet = X
+ConvexHull(X::LazySet, ::EmptySet) = X
 
 """
-    ConvexHull(∅::EmptySet, X::LazySet)::LazySet
+    ConvexHull(∅, X)
 
 Convex hull of a set with the empty set from the left.
 
@@ -63,9 +64,10 @@ Convex hull of a set with the empty set from the left.
 
 The given set because the empty set is neutral for the convex hull.
 """
-ConvexHull(∅::EmptySet, X::LazySet)::LazySet = X
+ConvexHull(::EmptySet, X::LazySet) = X
 
-ConvexHull(::EmptySet, ::EmptySet)::LazySet = ∅
+# special case: pure empty set convex hull (we require the same numeric type)
+(ConvexHull(∅::E, ::E)) where {E<:EmptySet} = ∅
 
 """
     dim(ch::ConvexHull)::Int

--- a/src/ConvexHull.jl
+++ b/src/ConvexHull.jl
@@ -64,10 +64,13 @@ Convex hull of a set with the empty set from the left.
 
 The given set because the empty set is neutral for the convex hull.
 """
-ConvexHull(::EmptySet, X::LazySet) = X
+ConvexHull(X::LazySet{N}, ::EmptySet{N}) where {N<:Real} = X
+ConvexHull(::EmptySet{N}, X::LazySet{N}) where {N<:Real} = X
 
 # special case: pure empty set convex hull (we require the same numeric type)
 (ConvexHull(∅::E, ::E)) where {E<:EmptySet} = ∅
+
+
 
 """
     dim(ch::ConvexHull)::Int

--- a/src/EmptySet.jl
+++ b/src/EmptySet.jl
@@ -4,18 +4,18 @@ export EmptySet, ∅,
        an_element
 
 """
-    EmptySet <: LazySet
+    EmptySet{N<:Real} <: LazySet{N}
 
 Type that represents the empty set, i.e., the set with no elements.
 """
-struct EmptySet <: LazySet end
+struct EmptySet{N<:Real} <: LazySet{N} end
 
 """
     ∅
 
-An `EmptySet` instance.
+An `EmptySet` instance of type `Float64`.
 """
-const ∅ = EmptySet()
+const ∅ = EmptySet{Float64}()
 
 """
     dim(∅::EmptySet)

--- a/src/ExponentialMap.jl
+++ b/src/ExponentialMap.jl
@@ -85,7 +85,7 @@ function get_rows(spmexp::SparseMatrixExp,
 end
 
 """
-    ExponentialMap{S<:LazySet} <: LazySet
+    ExponentialMap{N<:Real, S<:LazySet{N}} <: LazySet{N}
 
 Type that represents the action of an exponential map on a convex set.
 
@@ -94,10 +94,13 @@ Type that represents the action of an exponential map on a convex set.
 - `spmexp` -- sparse matrix exponential
 - `X`      -- convex set
 """
-struct ExponentialMap{S<:LazySet} <: LazySet
+struct ExponentialMap{N<:Real, S<:LazySet{N}} <: LazySet{N}
     spmexp::SparseMatrixExp
     X::S
 end
+# type-less convenience constructor
+ExponentialMap(spmexp::SparseMatrixExp, X::S) where {S<:LazySet{N}} where {N<:Real} =
+    ExponentialMap{N, S}(spmexp, X)
 
 """
 ```
@@ -163,7 +166,7 @@ function σ(d::AbstractVector{Float64},
 end
 
 """
-    ∈(x::AbstractVector{<:Real}, em::ExponentialMap{<:LazySet})::Bool
+    ∈(x::AbstractVector{N}, em::ExponentialMap{<:LazySet{N}})::Bool where {N<:Real}
 
 Check whether a given point is contained in an exponential map of a convex set.
 
@@ -193,7 +196,8 @@ julia> ∈([1.0, 1.0], em)
 true
 ```
 """
-function ∈(x::AbstractVector{<:Real}, em::ExponentialMap{<:LazySet})::Bool
+function ∈(x::AbstractVector{N}, em::ExponentialMap{N, <:LazySet{N}}
+          )::Bool where {N<:Real}
     @assert length(x) == dim(em)
     return ∈(exp.(-em.spmexp.M) * x, em.X)
 end
@@ -217,7 +221,7 @@ struct ProjectionSparseMatrixExp{N<:Real}
 end
 
 """
-    ExponentialProjectionMap{S<:LazySet} <: LazySet
+    ExponentialProjectionMap{N<:Real, S<:LazySet{N}} <: LazySet{N}
 
 Type that represents the application of a projection of a sparse matrix
 exponential to a convex set.
@@ -227,14 +231,19 @@ exponential to a convex set.
 - `spmexp` -- projection of a sparse matrix exponential
 - `X`      -- convex set
 """
-struct ExponentialProjectionMap{S<:LazySet} <: LazySet
+struct ExponentialProjectionMap{N<:Real, S<:LazySet{N}} <: LazySet{N}
     projspmexp::ProjectionSparseMatrixExp
     X::S
 end
+# type-less convenience constructor
+ExponentialProjectionMap(projspmexp::ProjectionSparseMatrixExp, X::S
+                        ) where {S<:LazySet{N}} where {N<:Real} =
+    ExponentialProjectionMap{N, S}(projspmexp, X)
 
 """
 ```
-    *(projspmexp::ProjectionSparseMatrixExp, X::LazySet)::ExponentialProjectionMap
+    *(projspmexp::ProjectionSparseMatrixExp,
+      X::LazySet)::ExponentialProjectionMap
 ```
 
 Return the application of a projection of a sparse matrix exponential to a

--- a/src/LazySets.jl
+++ b/src/LazySets.jl
@@ -17,7 +17,7 @@ export LazySet,
        Approximations
 
 """
-    LazySet
+    LazySet{N<:Real}
 
 Abstract type for a lazy set.
 
@@ -31,7 +31,7 @@ Every concrete `LazySet` must define the following functions:
 `LazySet` types should be parameterized with a type `N`, typically `N<:Real`, to
 support computations with different numeric types.
 """
-abstract type LazySet end
+abstract type LazySet{N<:Real} end
 
 # ============================
 # Auxiliary types or functions

--- a/src/LazySets.jl
+++ b/src/LazySets.jl
@@ -31,7 +31,7 @@ Every concrete `LazySet` must define the following functions:
 `LazySet` types should be parameterized with a type `N`, typically `N<:Real`, to
 support computations with different numeric types.
 """
-abstract type LazySet{N<:Real} end
+abstract type LazySet{N} end
 
 # ============================
 # Auxiliary types or functions

--- a/src/LazySets.jl
+++ b/src/LazySets.jl
@@ -17,7 +17,7 @@ export LazySet,
        Approximations
 
 """
-    LazySet{N<:Real}
+    LazySet{N}
 
 Abstract type for a lazy set.
 
@@ -28,8 +28,8 @@ Every concrete `LazySet` must define the following functions:
     of `S` in a given direction `d`
 - `dim(S::LazySet)::Int` -- the ambient dimension of `S`
 
-`LazySet` types should be parameterized with a type `N`, typically `N<:Real`, to
-support computations with different numeric types.
+`LazySet` types should be parameterized with a type `N`, typically `N<:Real`,
+for using different numeric types.
 """
 abstract type LazySet{N} end
 

--- a/src/LinearMap.jl
+++ b/src/LinearMap.jl
@@ -61,7 +61,7 @@ Return a linear map of a convex set by a scalar value.
 The linear map of the convex set.
 """
 function *(a::Real, S::LazySet)::LinearMap
-    return LinearMap(sparse(a*I, dim(S)), S)
+    return LinearMap(a * speye(typeof(a), dim(S)), S)
 end
 
 """

--- a/src/LinearMap.jl
+++ b/src/LinearMap.jl
@@ -3,7 +3,7 @@ import Base: *, ∈
 export LinearMap
 
 """
-    LinearMap{S<:LazySet, N<:Real} <: LazySet
+    LinearMap{N<:Real, S<:LazySet{N}} <: LazySet{N}
 
 Type that represents a linear transformation ``M⋅S`` of a convex set ``S``.
 
@@ -12,13 +12,14 @@ Type that represents a linear transformation ``M⋅S`` of a convex set ``S``.
 - `M`  -- matrix/linear map
 - `sf` -- convex set
 """
-struct LinearMap{S<:LazySet, N<:Real} <: LazySet
+struct LinearMap{N<:Real, S<:LazySet{N}} <: LazySet{N}
     M::AbstractMatrix{N}
     sf::S
 end
 # constructor from a linear map: perform the matrix multiplication immediately
-LinearMap(M::AbstractMatrix{N}, map::LinearMap{S}) where {S<:LazySet, N<:Real} =
-    LinearMap{S,N}(M * map.M, map.sf)
+LinearMap(M::AbstractMatrix{N}, map::LinearMap{N, S}
+         ) where {S<:LazySet{N}} where {N<:Real} =
+    LinearMap{N, S}(M * map.M, map.sf)
 
 """
 ```
@@ -46,7 +47,7 @@ end
 
 """
 ```
-    *(a::Real, S::LazySet)::LinearMap
+    *(a::N, X::S)::LinearMap{N, S} where {S<:LazySet{N}} where {N<:Real}
 ```
 
 Return a linear map of a convex set by a scalar value.
@@ -60,8 +61,8 @@ Return a linear map of a convex set by a scalar value.
 
 The linear map of the convex set.
 """
-function *(a::Real, S::LazySet)::LinearMap
-    return LinearMap(a * speye(typeof(a), dim(S)), S)
+function *(a::N, X::S)::LinearMap{N, S} where {S<:LazySet{N}} where {N<:Real}
+    return LinearMap(a * speye(N, dim(X)), X)
 end
 
 """
@@ -126,7 +127,7 @@ function σ(d::AbstractVector{<:Real}, lm::LinearMap)::AbstractVector{<:Real}
 end
 
 """
-    ∈(x::AbstractVector{N}, lm::LinearMap{<:LazySet, N})::Bool where {N<:Real}
+    ∈(x::AbstractVector{N}, lm::LinearMap{N, <:LazySet})::Bool where {N<:Real}
 
 Check whether a given point is contained in a linear map of a convex set.
 
@@ -167,6 +168,6 @@ true
 ```
 """
 function ∈(x::AbstractVector{N},
-           lm::LinearMap{<:LazySet, N})::Bool where {N<:Real}
+           lm::LinearMap{N, <:LazySet})::Bool where {N<:Real}
     return ∈(lm.M \ x, lm.sf)
 end

--- a/src/UnionSet.jl
+++ b/src/UnionSet.jl
@@ -3,7 +3,7 @@ import Base.∈
 export UnionSet
 
 """
-    UnionSet{S<:LazySet} <: LazySet
+    UnionSet{N<:Real, S<:LazySet{N}}
 
 Type that represents a union of convex sets.
 
@@ -11,7 +11,7 @@ Type that represents a union of convex sets.
 
 - `sets` --  a list of convex sets
 """
-struct UnionSet{S<:LazySet} <: LazySet
+struct UnionSet{N<:Real, S<:LazySet{N}}
     sets::Vector{S}
 end
 

--- a/src/plot_recipes.jl
+++ b/src/plot_recipes.jl
@@ -168,7 +168,7 @@ julia> plot(P)
 end
 
 """
-    plot_polygons(P::Union{Vector{HPolygon}, Vector{HPolygonOpt}}; ...)
+    plot_polygons(P::Vector{<:AbstractHPolygon}; ...)
 
 Plot an array of polygons in constraint representation.
 
@@ -191,7 +191,7 @@ julia> P2 = HPolygon([LinearConstraint([2.0, 0.0], 0.6),
 julia> plot([P1, P2])
 ```
 """
-@recipe function plot_polygons(P::Union{Vector{HPolygon}, Vector{HPolygonOpt}};
+@recipe function plot_polygons(P::Vector{<:AbstractHPolygon};
                                seriescolor="blue", label="", grid=true,
                                alpha=0.5)
 
@@ -232,7 +232,7 @@ julia> plot(P)
 end
 
 """
-    plot_polygons(P::Vector{VPolygon}; ...)
+    plot_polygons(P::Vector{<:VPolygon}; ...)
 
 Plot an array of polygons in vertex representation.
 
@@ -249,7 +249,7 @@ julia> P2 = VPolygon([[0.3, 0.3], [0.2, 0.3], [0.2, 0.2], [0.3, 0.2]])
 julia> plot([P1, P2])
 ```
 """
-@recipe function plot_polygons(P::Vector{VPolygon};
+@recipe function plot_polygons(P::Vector{<:VPolygon};
                                seriescolor="blue", label="", grid=true,
                                alpha=0.5)
 
@@ -356,7 +356,7 @@ julia> plot(Z)
 end
 
 """
-    plot_zonotopes(Z::Vector{Zonotope}; ...)
+    plot_zonotopes(Z::Vector{<:Zonotope}; ...)
 
 Plot an array of zonotopes.
 
@@ -373,7 +373,7 @@ julia> Z2 = Zonotope(zeros(2), [[0.3, 0.3], [0.2, 0.3], [0.2, 0.2], [0.3, 0.2]])
 julia> plot([Z1, Z2])
 ```
 """
-@recipe function plot_zonotopes(V::Vector{Zonotope};
+@recipe function plot_zonotopes(V::Vector{<:Zonotope};
                                 seriescolor="blue", label="", grid=true,
                                 alpha=0.5)
 

--- a/src/support_function.jl
+++ b/src/support_function.jl
@@ -3,7 +3,7 @@
 # =============================
 
 """
-    ρ(d::AbstractVector{N}, S::LazySet)::N where {N<:Real}
+    ρ(d::AbstractVector{N}, S::LazySet{N})::N where {N<:Real}
 
 Evaluate the support function of a set in a given direction.
 
@@ -16,7 +16,7 @@ Evaluate the support function of a set in a given direction.
 
 The support function of the set `S` for the direction `d`.
 """
-function ρ(d::AbstractVector{N}, S::LazySet)::N where {N<:Real}
+function ρ(d::AbstractVector{N}, S::LazySet{N})::N where {N<:Real}
     return dot(d, σ(d, S))
 end
 

--- a/test/unit_CartesianProduct.jl
+++ b/test/unit_CartesianProduct.jl
@@ -61,15 +61,15 @@ cs2 = s * ∅
 
 # Test Cartesian Product of an array
 # 0-elements
-as = LazySet[]
+as = LazySet{Float64}[]
 cs = CartesianProduct(as)
 @test cs isa EmptySet
 # 1-element
-as = LazySet[Singleton([1.])]
+as = [Singleton([1.])]
 cs = CartesianProduct(as)
 @test cs.element == [1.]
 # 3-elements
-as = LazySet[Singleton([1.]), Singleton([2.]), Singleton([3.])]
+as = [Singleton([1.]), Singleton([2.]), Singleton([3.])]
 cs = CartesianProduct(as)
 @test cs.X.element == [1.]
 @test cs.Y.X.element == [2.]

--- a/test/unit_EmptySet.jl
+++ b/test/unit_EmptySet.jl
@@ -1,4 +1,4 @@
-E = EmptySet()
+E = ∅
 B = BallInf(ones(2), 1.)
 
 # testing that the empty set is an absorbing element for the cartesian product
@@ -8,7 +8,7 @@ B = BallInf(ones(2), 1.)
 # test ∅ alias
 @test B × E isa EmptySet
 
-cpa = CartesianProductArray([B, 2.*B, 3.*B])
+cpa = CartesianProductArray([B, 2. * B, 3. * B])
 @test cpa * E isa EmptySet && E * cpa isa EmptySet
 @test cpa × E isa EmptySet && E × cpa isa EmptySet
 
@@ -20,7 +20,7 @@ cpa = CartesianProductArray([B, 2.*B, 3.*B])
 # testing the mathematical alias ⊕ 
 @test B ⊕ E isa EmptySet && E ⊕ B isa EmptySet
 
-msa = MinkowskiSumArray([B, 2.*B, 3.*B])
+msa = MinkowskiSumArray([B, 2. * B, 3. * B])
 @test msa + E isa EmptySet && E + msa isa EmptySet
 @test msa ⊕ E isa EmptySet && E ⊕ msa isa EmptySet
 

--- a/test/unit_ZeroSet.jl
+++ b/test/unit_ZeroSet.jl
@@ -4,7 +4,7 @@ B = BallInf(ones(2), 1.)
 # testing that the zero set is neutral element for the Minkowski sum
 @test B ⊕ Z == B && Z ⊕ B == B
 
-cpa = MinkowskiSumArray([B, 2.*B, 3.*B])
+cpa = MinkowskiSumArray([B, 2. * B, 3. * B])
 @test cpa ⊕ Z == cpa && Z ⊕ cpa == cpa
 
 # test M-sum of zero set with itself


### PR DESCRIPTION
See #44.

This took way longer than I expected, and unfortunately there is a caveat:
I needed to introduce an additional numeric type parameter to the composite types (`CartesianProduct`, `MinkowskiSum`, `ConvexHull`, `LinearMap`, `ExponentialMap`) because I did not find a way how to write the signature with nested type parameters (I searched **a lot** in documentations) like this:
```julia
CartesianProduct(s::S1 where S1<:LazySet{N<:Real}, s::S2 where S2<:LazySet{N}) <: LazySet{N}
```
The problem is that `N` is not visible outside. The outer `where` syntax is only meant for functions.

@mforets: There were hidden problems in the unit tests. Let `B` be a `BallInf`. Then `2.*B` is interpreted as `2 .* B` instead of the intended `2. * B`. I changed this in a separate commit, please note this for the future.

**EDIT: All known errors are fixed now.**
The unit tests were priceless. This typing stuff is hard to do right (at least for me 🤕). We might want to test a bit more. We should also run the reachability examples for additional testing.

I also took the liberty to:
* remove the `<: LazySet`from `UnionSet`
* remove some redundant function definitions
* remove some output types for simple functions where they are crystal clear
* fix the plot recipes for vectors of types different from `AbstractSingleton` (this was recently fixed for `AbstractSingleton` in #119)
* fix subtype problems in the recent #110 (not sure why they did not trigger before)
* fix a type conversion bug in `LinearMap` with a constant (was always a matrix of type `Int`)
* add type parameters to the doc files (creates more warnings, but should be the correct way to do it; for some this was even required due to the changes here)