### PR TITLE
#117 - invert behavior of 'is_intersection_empty'

### DIFF
--- a/src/AbstractHyperrectangle.jl
+++ b/src/AbstractHyperrectangle.jl
@@ -306,8 +306,8 @@ end
                           witness::Bool=false
                          )::Union{Bool,Tuple{Bool,Vector{N}}} where {N<:Real}
 
-Check whether two hyperrectangles intersect, and if so, optionally compute a
-witness.
+Check whether two hyperrectangles do not intersect, and otherwise optionally
+compute a witness.
 
 ### Input
 
@@ -317,10 +317,10 @@ witness.
 
 ### Output
 
-* If `witness` option is deactivated: `true` iff ``H1 ∩ H2 ≠ ∅``
+* If `witness` option is deactivated: `true` iff ``H1 ∩ H2 = ∅``
 * If `witness` option is activated:
-  * `(true, v)` iff ``H1 ∩ H2 ≠ ∅`` and ``v ∈ H1 ∩ H2``
-  * `(false, [])` iff ``H1 ∩ H2 = ∅``
+  * `(true, [])` iff ``H1 ∩ H2 = ∅``
+  * `(false, v)` iff ``H1 ∩ H2 ≠ ∅`` and ``v ∈ H1 ∩ H2``
 
 ### Algorithm
 
@@ -336,33 +336,33 @@ function is_intersection_empty(H1::AbstractHyperrectangle{N},
                                H2::AbstractHyperrectangle{N},
                                witness::Bool=false
                               )::Union{Bool,Tuple{Bool,Vector{N}}} where {N<:Real}
-    intersection = true
+    empty_intersection = false
     center_diff = center(H2) - center(H1)
     for i in eachindex(center_diff)
         if abs(center_diff[i]) >
                 radius_hyperrectangle(H1, i) + radius_hyperrectangle(H2, i)
-            intersection = false
+            empty_intersection = true
             break
         end
     end
 
     if !witness
-        return intersection
-    elseif !intersection
-        return (false, N[])
+        return empty_intersection
+    elseif empty_intersection
+        return (true, N[])
     end
 
-    # compute a witness 'p' in the intersection
-    p = copy(center(H1))
+    # compute a witness 'v' in the intersection
+    v = copy(center(H1))
     c2 = center(H2)
     for i in eachindex(center_diff)
-        if p[i] <= c2[i]
+        if v[i] <= c2[i]
             # second center is right of first center
-            p[i] += min(radius_hyperrectangle(H1, i), center_diff[i])
+            v[i] += min(radius_hyperrectangle(H1, i), center_diff[i])
         else
             # second center is left of first center
-            p[i] -= max(radius_hyperrectangle(H1, i), -center_diff[i])
+            v[i] -= max(radius_hyperrectangle(H1, i), -center_diff[i])
         end
     end
-    return (true, p)
+    return (false, v)
 end

--- a/src/AbstractSingleton.jl
+++ b/src/AbstractSingleton.jl
@@ -247,8 +247,8 @@ end
                           witness::Bool=false
                          )::Union{Bool,Tuple{Bool,Vector{N}}} where {N<:Real}
 
-Check whether a singleton and a convex set intersect, and if so, optionally
-compute a witness.
+Check whether a singleton and a convex set do not intersect, and otherwise
+optionally compute a witness.
 
 ### Input
 
@@ -258,24 +258,25 @@ compute a witness.
 
 ### Output
 
-* If `witness` option is deactivated: `true` iff ``S ∩ \\operatorname{set} ≠ ∅``
+* If `witness` option is deactivated: `true` iff ``S ∩ \\operatorname{set} = ∅``
 * If `witness` option is activated:
-  * `(true, v)` iff ``S ∩ \\operatorname{set} ≠ ∅`` and `v` = `element(S)`
-  * `(false, [])` iff ``S ∩ \\operatorname{set} = ∅``
+  * `(true, [])` iff ``S ∩ \\operatorname{set} = ∅``
+  * `(false, v)` iff ``S ∩ \\operatorname{set} ≠ ∅`` and
+    `v` = `element(S)` ``∈ S ∩ \\operatorname{set}``
 
 ### Algorithm
 
-``S ∩ \\operatorname{set} ≠ ∅`` iff `element(S)` ``∈ \\operatorname{set}``.
+``S ∩ \\operatorname{set} = ∅`` iff `element(S)` ``\notin \\operatorname{set}``.
 """
 function is_intersection_empty(S::AbstractSingleton{N},
                                set::LazySet,
                                witness::Bool=false
                               )::Union{Bool,Tuple{Bool,Vector{N}}} where {N<:Real}
-    intersection = ∈(element(S), set)
+    empty_intersection = !∈(element(S), set)
     if witness
-        return (intersection, intersection ? element(S) : N[])
+        return (empty_intersection, empty_intersection ? N[] : element(S))
     else
-        return intersection
+        return empty_intersection
     end
 end
 
@@ -285,8 +286,8 @@ end
                           witness::Bool=false
                          )::Union{Bool,Tuple{Bool,Vector{N}}} where {N<:Real}
 
-Check whether a convex set and a singleton intersect, and if so, optionally
-compute a witness.
+Check whether a convex set and a singleton do not intersect, and otherwise
+optionally compute a witness.
 
 ### Input
 
@@ -296,25 +297,21 @@ compute a witness.
 
 ### Output
 
-* If `witness` option is deactivated: `true` iff ``S ∩ \\operatorname{set} ≠ ∅``
+* If `witness` option is deactivated: `true` iff ``S ∩ \\operatorname{set} = ∅``
 * If `witness` option is activated:
-  * `(true, v)` iff ``S ∩ \\operatorname{set} ≠ ∅`` and `v` = `element(S)`
-  * `(false, [])` iff ``S ∩ \\operatorname{set} = ∅``
+  * `(true, [])` iff ``S ∩ \\operatorname{set} = ∅``
+  * `(false, v)` iff ``S ∩ \\operatorname{set} ≠ ∅`` and
+    `v` = `element(S)` ``∈ S ∩ \\operatorname{set}``
 
 ### Algorithm
 
-``S ∩ \\operatorname{set} ≠ ∅`` iff `element(S)` ``∈ \\operatorname{set}``.
+``S ∩ \\operatorname{set} = ∅`` iff `element(S)` ``\notin \\operatorname{set}``.
 """
 function is_intersection_empty(set::LazySet,
                                S::AbstractSingleton{N},
                                witness::Bool=false
                               )::Union{Bool,Tuple{Bool,Vector{N}}} where {N<:Real}
-    intersection = ∈(element(S), set)
-    if witness
-        return (intersection, intersection ? element(S) : N[])
-    else
-        return intersection
-    end
+    return is_intersection_empty(S, set, witness)
 end
 
 """
@@ -323,7 +320,8 @@ end
                           witness::Bool=false
                          )::Union{Bool,Tuple{Bool,Vector{N}}} where {N<:Real}
 
-Check whether two singletons intersect, and if so, optionally compute a witness.
+Check whether two singletons do not intersect, and otherwise optionally compute
+a witness.
 
 ### Input
 
@@ -333,23 +331,23 @@ Check whether two singletons intersect, and if so, optionally compute a witness.
 
 ### Output
 
-* If `witness` option is deactivated: `true` iff ``S1 ∩ S2 ≠ ∅``
+* If `witness` option is deactivated: `true` iff ``S1 ∩ S2 = ∅``
 * If `witness` option is activated:
-  * `(true, v)` iff ``S1 ∩ S2 ≠ ∅`` and `v` = `element(S1)`
-  * `(false, [])` iff ``S1 ∩ S2 = ∅``
+  * `(true, [])` iff ``S1 ∩ S2 = ∅``
+  * `(false, v)` iff ``S1 ∩ S2 ≠ ∅`` and `v` = `element(S1)` ``∈ S1 ∩ S2``
 
 ### Algorithm
 
-``S1 ∩ S2 ≠ ∅`` iff ``S1 = S2``.
+``S1 ∩ S2 = ∅`` iff ``S1 ≠ S2``.
 """
 function is_intersection_empty(S1::AbstractSingleton{N},
                                S2::AbstractSingleton{N},
                                witness::Bool=false
                               )::Union{Bool,Tuple{Bool,Vector{N}}} where {N<:Real}
-    intersection = element(S1) == element(S2)
+    empty_intersection = element(S1) != element(S2)
     if witness
-        return (intersection, intersection ? element(S1) : N[])
+        return (empty_intersection, empty_intersection ? N[] : element(S1))
     else
-        return intersection
+        return empty_intersection
     end
 end

--- a/src/Ball2.jl
+++ b/src/Ball2.jl
@@ -257,8 +257,8 @@ end
                           witness::Bool=false
                          )::Union{Bool, Tuple{Bool,Vector{N}}} where {N<:Real}
 
-Check whether two balls in the 2-norm intersect, and if so, optionally compute a
-witness.
+Check whether two balls in the 2-norm do not intersect, and otherwise optionally
+compute a witness.
 
 ### Input
 
@@ -268,14 +268,14 @@ witness.
 
 ### Output
 
-* If `witness` option is deactivated: `true` iff ``B1 ∩ B2 ≠ ∅``
+* If `witness` option is deactivated: `true` iff ``B1 ∩ B2 = ∅``
 * If `witness` option is activated:
-  * `(true, v)` iff ``B1 ∩ B2 ≠ ∅`` and ``v ∈ B1 ∩ B2``
-  * `(false, [])` iff ``B1 ∩ B2 = ∅``
+  * `(true, [])` iff ``B1 ∩ B2 = ∅``
+  * `(false, v)` iff ``B1 ∩ B2 ≠ ∅`` and ``v ∈ B1 ∩ B2``
 
 ### Algorithm
 
-``B1 ∩ B2 ≠ ∅`` iff ``‖ c_2 - c_1 ‖_2 ≤ r_1 + r_2``.
+``B1 ∩ B2 = ∅`` iff ``‖ c_2 - c_1 ‖_2 > r_1 + r_2``.
 
 A witness is computed depending on the smaller/bigger ball (to break ties,
 choose `B1` for the smaller ball) as follows.
@@ -290,12 +290,12 @@ function is_intersection_empty(B1::Ball2{N},
                                witness::Bool=false
                               )::Union{Bool, Tuple{Bool,Vector{N}}} where {N<:Real}
     center_diff_normed = norm(center(B2) - center(B1), 2)
-    intersection = center_diff_normed <= B1.radius + B2.radius
+    empty_intersection = center_diff_normed > B1.radius + B2.radius
 
     if !witness
-        return intersection
-    elseif !intersection
-        return (false, N[])
+        return empty_intersection
+    elseif empty_intersection
+        return (true, N[])
     end
 
     # compute a witness 'v' in the intersection
@@ -314,5 +314,5 @@ function is_intersection_empty(B1::Ball2{N},
 	direction = (bigger.center - smaller.center)
         v = smaller.center + direction / center_diff_normed * smaller.radius
     end
-    return (true, v)
+    return (false, v)
 end

--- a/test/unit_Ball2.jl
+++ b/test/unit_Ball2.jl
@@ -72,6 +72,6 @@ subset, point = ⊆(b1, b3, true)
 b1 = Ball2([0., 0.], 2.)
 b2 = Ball2([2., 2.], 2.)
 b3 = Ball2([4., 4.], 2.)
-intersecting, point = is_intersection_empty(b1, b2, true)
-@test is_intersection_empty(b1, b2) && intersecting && point ∈ b1 && point ∈ b2
-@test !is_intersection_empty(b1, b3) && !is_intersection_empty(b1, b3, true)[1]
+intersection_empty, point = is_intersection_empty(b1, b2, true)
+@test !is_intersection_empty(b1, b2) && !intersection_empty && point ∈ b1 && point ∈ b2
+@test is_intersection_empty(b1, b3) && is_intersection_empty(b1, b3, true)[1]

--- a/test/unit_Hyperrectangle.jl
+++ b/test/unit_Hyperrectangle.jl
@@ -121,7 +121,7 @@ subset, point = ⊆(H1, H3, true)
 H1 = Hyperrectangle([1.0, 1.0], [2.0, 2.0])
 H2 = Hyperrectangle([3.0, 3.0], [2.0, 2.0])
 B1 = BallInf([2.0, 4.0], 0.5)
-@test is_intersection_empty(H1, H2)
-intersection, point = is_intersection_empty(H1, H2, true)
-@test intersection && point ∈ H1 && point ∈ H2
-@test !is_intersection_empty(H1, B1) && !is_intersection_empty(H1, B1, true)[1]
+intersection_empty, point = is_intersection_empty(H1, H2, true)
+@test !is_intersection_empty(H1, H2) &&
+    !intersection_empty && point ∈ H1 && point ∈ H2
+@test is_intersection_empty(H1, B1) && is_intersection_empty(H1, B1, true)[1]

--- a/test/unit_Singleton.jl
+++ b/test/unit_Singleton.jl
@@ -40,6 +40,7 @@ subset, point = ⊆(s1, s2, true)
 S1 = Singleton([1.0, 1.0])
 S2 = Singleton([0.0, 0.0])
 S3 = ZeroSet(2)
-@test !is_intersection_empty(S1, S2) && !is_intersection_empty(S1, S2, true)[1]
-intersection, point = is_intersection_empty(S2, S3, true)
-@test is_intersection_empty(S2, S3) && intersection && point ∈ S2 && point ∈ S3
+@test is_intersection_empty(S1, S2) && is_intersection_empty(S1, S2, true)[1]
+intersection_empty, point = is_intersection_empty(S2, S3, true)
+@test !is_intersection_empty(S2, S3) &&
+    !intersection_empty && point ∈ S2 && point ∈ S3


### PR DESCRIPTION
See #117.

I also saved a duplicate implementation for a symmetric case - could just swap the operands 👍
  