### PR TITLE
update set_type in decompose and doctests

### DIFF
--- a/docs/src/man/reach_zonotopes.md
+++ b/docs/src/man/reach_zonotopes.md
@@ -43,7 +43,7 @@ function Algorithm1(A, X0, δ, μ, T)
     # discretized system
     n = size(A, 1)
     ϕ = expm(δ*A)
-    N = Int(div(T, δ))
+    N = floor(Int, T/δ)
 
     # preallocate arrays
     Q = Vector{LazySet}(N)

--- a/docs/src/man/reach_zonotopes.md
+++ b/docs/src/man/reach_zonotopes.md
@@ -86,9 +86,9 @@ X0 = Zonotope([1.0, 0.0], 0.1*eye(2))
 δ = 0.02
 T = 2.
 
-R = Algorithm1(A, δ, X0, μ, 2.*δ); # warm-up
+R = Algorithm1(A, X0, δ, μ, 2.*δ); # warm-up
 
-R = Algorithm1(A, δ, X0, μ, T)
+R = Algorithm1(A, X0, δ, μ, T)
 
 plot(R, 1e-2, fillalpha=0.1)
 ```
@@ -107,9 +107,9 @@ X0 = Zonotope([1.0, 0.0, 0.0, 0.0, 0.0], 0.1*eye(5))
 δ = 0.005
 T = 1.
 
-R = Algorithm1(A, δ, X0, μ, 2*δ); # warm-up
+R = Algorithm1(A, X0, δ, μ, 2*δ); # warm-up
 
-R = Algorithm1(A, δ, X0, μ, T)
+R = Algorithm1(A, X0, δ, μ, T)
 R = project(R, [1, 3], 5)
 
 plot(R, 1e-2, fillalpha=0.1, xlabel="x1", ylabel="x3")

--- a/docs/src/man/reach_zonotopes.md
+++ b/docs/src/man/reach_zonotopes.md
@@ -43,7 +43,7 @@ function Algorithm1(A, X0, δ, μ, T)
     # discretized system
     n = size(A, 1)
     ϕ = expm(δ*A)
-    N = div(T, δ)
+    N = Int(div(T, δ))
 
     # preallocate arrays
     Q = Vector{LazySet}(N)

--- a/src/AbstractPolytope.jl
+++ b/src/AbstractPolytope.jl
@@ -19,9 +19,10 @@ Every concrete `AbstractPolytope` must define the following functions:
 
 ```jldoctest
 julia> subtypes(AbstractPolytope)
-2-element Array{Union{DataType, UnionAll},1}:
+3-element Array{Union{DataType, UnionAll},1}:
  LazySets.AbstractPointSymmetricPolytope
  LazySets.AbstractPolygon
+ LazySets.HPolytope
 ```
 """
 abstract type AbstractPolytope{N<:Real} <: LazySet{N} end

--- a/src/Approximations/decompositions.jl
+++ b/src/Approximations/decompositions.jl
@@ -19,7 +19,7 @@ two-dimensional sets of type `set_type`.
 For each 2D block a specific `decompose_2D` method is called, dispatched on the
 `set_type` argument.
 """
-function decompose(S::LazySet{N}, set_type::Type=HPolygon{N})::CartesianProductArray where {N<:Real}
+function decompose(S::LazySet{N}, set_type::Type=HPolygon{Float64})::CartesianProductArray where {N<:Real}
     n = dim(S)
     b = div(n, 2)
     result = Vector{set_type{N}}(b)
@@ -96,10 +96,10 @@ The algorithm proceeds as follows:
    ``i = 1, …, b``,
 3. Return the result as a `CartesianProductArray`.
 """
-function decompose(S::LazySet, ɛi::Vector{Float64})::CartesianProductArray
+function decompose(S::LazySet{N}, ɛi::Vector{Float64})::CartesianProductArray where {N<:Real}
     n = dim(S)
     b = div(n, 2)
-    result = Vector{HPolygon}(b)
+    result = Vector{HPolygon{N}}(b)
     @inbounds for i in 1:b
         M = sparse([1, 2], [2*i-1, 2*i], [1., 1.], 2, n)
         result[i] = overapproximate(M * S, ɛi[i])

--- a/src/Approximations/decompositions.jl
+++ b/src/Approximations/decompositions.jl
@@ -1,5 +1,6 @@
 """
-    decompose(S::LazySet{N}, set_type::Type=HPolygon{N})::CartesianProductArray where {N<:Real}
+    decompose(S::LazySet{N}, set_type::Type=HPolygon
+             )::CartesianProductArray where {N<:Real}
 
 Compute an overapproximation of the projections of the given convex set over
 each two-dimensional subspace.
@@ -19,7 +20,8 @@ two-dimensional sets of type `set_type`.
 For each 2D block a specific `decompose_2D` method is called, dispatched on the
 `set_type` argument.
 """
-function decompose(S::LazySet{N}, set_type::Type=HPolygon{Float64})::CartesianProductArray where {N<:Real}
+function decompose(S::LazySet{N}, set_type::Type=HPolygon
+                  )::CartesianProductArray where {N<:Real}
     n = dim(S)
     b = div(n, 2)
     result = Vector{set_type{N}}(b)
@@ -108,7 +110,7 @@ function decompose(S::LazySet{N}, ɛi::Vector{Float64})::CartesianProductArray w
 end
 
 """
-    decompose(S::LazySet, ɛ::Float64, [set_type]::Type=HPolygon{Float64}
+    decompose(S::LazySet, ɛ::Float64, [set_type]::Type=HPolygon
              )::CartesianProductArray
 
 Compute an overapproximation of the projections of the given convex set over
@@ -132,7 +134,7 @@ bound for each block is assumed.
 
 The `set_type` argument is ignored if ``ɛ ≠ \\text{Inf}``.
 """
-function decompose(S::LazySet, ɛ::Float64, set_type::Type=HPolygon{Float64}
+function decompose(S::LazySet, ɛ::Float64, set_type::Type=HPolygon
                   )::CartesianProductArray
     if ɛ == Inf
         return decompose(S, set_type)

--- a/src/Approximations/decompositions.jl
+++ b/src/Approximations/decompositions.jl
@@ -1,6 +1,5 @@
 """
-    decompose(S::LazySet, [set_type]::Type=HPolygon{Float64}
-             )::CartesianProductArray
+    decompose(S::LazySet{N}, set_type::Type=HPolygon{N})::CartesianProductArray where {N<:Real}
 
 Compute an overapproximation of the projections of the given convex set over
 each two-dimensional subspace.
@@ -20,11 +19,10 @@ two-dimensional sets of type `set_type`.
 For each 2D block a specific `decompose_2D` method is called, dispatched on the
 `set_type` argument.
 """
-function decompose(S::LazySet, set_type::Type=HPolygon{Float64}
-                  )::CartesianProductArray
+function decompose(S::LazySet{N}, set_type::Type=HPolygon{N})::CartesianProductArray where {N<:Real}
     n = dim(S)
     b = div(n, 2)
-    result = Vector{set_type}(b)
+    result = Vector{set_type{N}}(b)
     @inbounds for bi in 1:b
         result[bi] = decompose_2D(S, n, bi, set_type)
     end


### PR DESCRIPTION
- [x] update AbstractPolytope subtypes
- [x] fix `reach_zonotope` error in Zonotope:

```julia
 !! failed to run code block.


MethodError(*, (LazySets.Zonotope{Float64}([1.0, 0.0], [0.1 0.0; 0.0 0.1]), 5.0), 0x0000000000005571) [src/man/reach_zonotopes.md]
 !! failed to run code block.

MethodError(*, (LazySets.Zonotope{Float64}([1.0, 0.0, 0.0, 0.0, 0.0], [0.1 0.0 0.0 0.0 0.0; 0.0 0.1 0.0 0.0 0.0; 0.0 0.0 0.1 0.0 0.0; 0.0 0.0 0.0 0.1 0.0; 0.0 0.0 0.0 0.0 0
.1]), 5.0), 0x0000000000005571) [src/man/reach_zonotopes.md]
```

- [x] fix constructor in `CartesianProductArray`, e.g.

```julia
using LazySets
import LazySets.Approximations:decompose

X = Ball2(zeros(4), 1.)
Y = Hyperrectangle(3. * ones(4), 2. * ones(4))
Z = ConvexHull(X, Y)
Hd = decompose(Z, Hyperrectangle)
```

```julia
MethodError: Cannot `convert` an object of type Array{LazySets.Hyperrectangle,1} to an object of type LazySets.CartesianProductArray
This may have arisen from a call to the constructor LazySets.CartesianProductArray(...),
since type constructors fall back to convert methods.
```