### PR TITLE
#132 - unit tests for different numeric types

### DIFF
--- a/docs/src/lib/approximations.md
+++ b/docs/src/lib/approximations.md
@@ -40,9 +40,9 @@ box_approximation_helper
 ### Metric properties of sets
 
 ```@docs
-norm(::LazySet, ::Real=Inf)
-radius(::LazySet, ::Real=Inf)
-diameter(::LazySet, ::Real=Inf)
+norm(::LazySet, ::Real)
+radius(::LazySet, ::Real)
+diameter(::LazySet, ::Real)
 ```
 
 ## Iterative refinement
@@ -50,11 +50,11 @@ diameter(::LazySet, ::Real=Inf)
 ```@docs
 LocalApproximation
 PolygonalOverapproximation
-new_approx(S::LazySet, p1::Vector{Float64}, d1::Vector{Float64}, p2::Vector{Float64}, d2::Vector{Float64})
-addapproximation!(Ω::PolygonalOverapproximation, p1::Vector{Float64}, d1::Vector{Float64}, p2::Vector{Float64}, d2::Vector{Float64})
-refine(Ω::PolygonalOverapproximation, i::Int)
-tohrep(Ω::PolygonalOverapproximation)
-approximate(S::LazySet, ɛ::Float64)
+new_approx(::LazySet, ::Vector{Float64}, ::Vector{Float64}, ::Vector{Float64}, ::Vector{Float64})
+addapproximation!(::PolygonalOverapproximation, ::Vector{Float64}, ::Vector{Float64}, ::Vector{Float64}, ::Vector{Float64})
+refine(::PolygonalOverapproximation, ::Int)
+tohrep(::PolygonalOverapproximation)
+approximate(::LazySet{Float64}, ::Float64)
 ```
 
 See [Iterative Refinement](@ref) for more details.

--- a/src/ExponentialMap.jl
+++ b/src/ExponentialMap.jl
@@ -41,7 +41,7 @@ end
 
 function get_column(spmexp::SparseMatrixExp{N}, j::Int)::Vector{N} where {N}
     n = size(spmexp, 1)
-    aux = zeros(n)
+    aux = zeros(N, n)
     aux[j] = one(N)
     return expmv(one(N), spmexp.M, aux)
 end
@@ -49,8 +49,8 @@ end
 function get_columns(spmexp::SparseMatrixExp{N},
                      J::AbstractArray)::SparseMatrixCSC{N, Int} where {N}
     n = size(spmexp, 1)
-    aux = zeros(n)
-    ans = spzeros(n, length(J))
+    aux = zeros(N, n)
+    ans = spzeros(N, n, length(J))
     count = 1
     one_N = one(N)
     zero_N = zero(N)
@@ -65,7 +65,7 @@ end
 
 function get_row(spmexp::SparseMatrixExp{N}, i::Int)::Matrix{N} where {N}
     n = size(spmexp, 1)
-    aux = zeros(n)
+    aux = zeros(N, n)
     aux[i] = one(N)
     return transpose(expmv(one(N), spmexp.M.', aux))
 end
@@ -73,8 +73,8 @@ end
 function get_rows(spmexp::SparseMatrixExp{N},
                   I::AbstractArray{Int})::SparseMatrixCSC{N, Int} where {N}
     n = size(spmexp, 1)
-    aux = zeros(n)
-    ans = spzeros(length(I), n)
+    aux = zeros(N, n)
+    ans = spzeros(N, length(I), n)
     Mtranspose = spmexp.M.'
     count = 1
     one_N = one(N)

--- a/src/helper_functions.jl
+++ b/src/helper_functions.jl
@@ -39,7 +39,7 @@ function sign_cadlag(x::N)::N where {N<:Real}
 end
 
 """
-    jump2pi(x::Float64)::Float64
+    jump2pi(x::N)::N where {N<:AbstractFloat}
 
 Return ``x + 2π`` if ``x`` is negative, otherwise return ``x``.
 
@@ -62,12 +62,12 @@ julia> jump2pi(0.5)
 0.5
 ```
 """
-function jump2pi(x::Float64)::Float64
-    x < 0.0 ? 2.0 * pi + x : x
+function jump2pi(x::N)::N where {N<:AbstractFloat}
+    x < zero(N) ? 2 * pi + x : x
 end
 
 """
-    <=(u::AbstractVector{Float64}, v::AbstractVector{Float64})::Bool
+    <=(u::AbstractVector{N}, v::AbstractVector{N})::Bool where {N<:AbstractFloat}
 
 Compares two 2D vectors by their direction.
 
@@ -85,7 +85,8 @@ True iff ``\\arg(u) [2π] ≤ \\arg(v) [2π]``
 The argument is measured in counter-clockwise fashion, with the 0 being the
 direction (1, 0).
 """
-function <=(u::AbstractVector{Float64}, v::AbstractVector{Float64})::Bool
+function <=(u::AbstractVector{N},
+            v::AbstractVector{N})::Bool where {N<:AbstractFloat}
     return jump2pi(atan2(u[2], u[1])) <= jump2pi(atan2(v[2], v[1]))
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,9 @@
 #!/usr/bin/env julia
 using LazySets, Base.Test
 
+# conversion between numeric types
+include("to_N.jl")
+
 # ====================================
 # Testing common API of all interfaces
 # ====================================

--- a/test/to_N.jl
+++ b/test/to_N.jl
@@ -1,0 +1,62 @@
+# numbers
+
+function to_N(N::Type{NUM}, v::NUM) where {NUM<:Real}
+    return v
+end
+
+function to_N(N::Type{<:Real}, v::Real)
+    return N(v)
+end
+
+function to_N(N::Type{<:Rational{NUM}}, v::Real) where {NUM}
+    return rationalize(NUM, v)
+end
+
+# arrays
+
+function to_N(N::Type{NUM}, a::AbstractVector{NUM}) where {NUM<:Real}
+    return a
+end
+
+function to_N(N::Type{<:Real}, a::AbstractVector{<:Real})
+    r = Vector{N}(length(a))
+    for i in eachindex(a)
+        r[i] = to_N(N, a[i])
+    end
+    return r
+end
+
+# matrices
+
+function to_N(N::Type{NUM}, m::AbstractMatrix{NUM}) where {NUM<:Real}
+    return m
+end
+
+function to_N(N::Type{<:Real}, m::AbstractMatrix{<:Real})
+    r = Matrix{N}(size(m))
+    for j = 1:size(m,2)
+        for i = 1:size(m,1)
+            r[i, j] = to_N(N, m[i, j])
+        end
+    end
+    return r
+end
+
+# arrays of arrays
+
+function to_N(N::Type{NUM}, a::AbstractVector{<:AbstractVector{NUM}}) where {NUM<:Real}
+    return a
+end
+
+function to_N(N::Type{<:Real}, a::AbstractVector{<:AbstractVector{<:Real}})
+    r = Vector{Vector{N}}(length(a))
+    for i in eachindex(a)
+        v = a[i]
+        b = Vector{N}(length(v))
+        for j in eachindex(v)
+            b[j] = to_N(N, v[j])
+        end
+        r[i] = b
+    end
+    return r
+end

--- a/test/unit_Ball2.jl
+++ b/test/unit_Ball2.jl
@@ -1,77 +1,79 @@
-# 1D Ball2
-b = Ball2([0.], 1.)
-# Test Dimension
-@test dim(b) == 1
-# Test Support Vector
-d = [1.]
-@test σ(d, b) == [1.]
-d = [-1.]
-@test σ(d, b) == [-1.]
+for N in [Float64, Float32]
+    # 1D Ball2
+    b = Ball2(N[0.], N(1.))
+    # Test Dimension
+    @test dim(b) == 1
+    # Test Support Vector
+    d = N[1.]
+    @test σ(d, b) == N[1.]
+    d = N[-1.]
+    @test σ(d, b) == N[-1.]
 
-# 2D Ball2
-b = Ball2([0., 0.], 1.)
-# Test Dimension
-@test dim(b) == 2
-# Test Support Vector
-d = [1., 0.]
-@test σ(d, b) == [1., 0.]
-d = [-1., 0.]
-@test σ(d, b) == [-1., 0.]
-d = [0., 1.]
-@test σ(d, b) == [0., 1.]
-d = [0., -1.]
-@test σ(d, b) == [0., -1.]
+    # 2D Ball2
+    b = Ball2(N[0., 0.], N(1.))
+    # Test Dimension
+    @test dim(b) == 2
+    # Test Support Vector
+    d = N[1., 0.]
+    @test σ(d, b) == N[1., 0.]
+    d = N[-1., 0.]
+    @test σ(d, b) == N[-1., 0.]
+    d = N[0., 1.]
+    @test σ(d, b) == N[0., 1.]
+    d = N[0., -1.]
+    @test σ(d, b) == N[0., -1.]
 
-# 2D Ball2 not 0-centered
-b = Ball2([1., 2.], 1.)
-# Test Dimension
-@test dim(b) == 2
-# Test Support Vector
-d = [1., 0.]
-@test σ(d, b) == [2., 2.]
-d = [-1., 0.]
-@test σ(d, b) == [0., 2.]
-d = [0., 1.]
-@test σ(d, b) == [1., 3.]
-d = [0., -1.]
-@test σ(d, b) == [1., 1.]
+    # 2D Ball2 not 0-centered
+    b = Ball2(N[1., 2.], N(1.))
+    # Test Dimension
+    @test dim(b) == 2
+    # Test Support Vector
+    d = N[1., 0.]
+    @test σ(d, b) == N[2., 2.]
+    d = N[-1., 0.]
+    @test σ(d, b) == N[0., 2.]
+    d = N[0., 1.]
+    @test σ(d, b) == N[1., 3.]
+    d = N[0., -1.]
+    @test σ(d, b) == N[1., 1.]
 
-# 2D Ball2 radius =/= 1
-b = Ball2([0., 0.], 2.)
-# Test Dimension
-@test dim(b) == 2
-# Test Support Vector
-d = [1., 0.]
-@test σ(d, b) == [2., 0.]
-d = [-1., 0.]
-@test σ(d, b) == [-2., 0.]
-d = [0., 1.]
-@test σ(d, b) == [0., 2.]
-d = [0., -1.]
-@test σ(d, b) == [0., -2.]
+    # 2D Ball2 radius =/= 1
+    b = Ball2(N[0., 0.], N(2.))
+    # Test Dimension
+    @test dim(b) == 2
+    # Test Support Vector
+    d = N[1., 0.]
+    @test σ(d, b) == N[2., 0.]
+    d = N[-1., 0.]
+    @test σ(d, b) == N[-2., 0.]
+    d = N[0., 1.]
+    @test σ(d, b) == N[0., 2.]
+    d = N[0., -1.]
+    @test σ(d, b) == N[0., -2.]
 
-# an_element function
-b = Ball2([1., 2.], 2.)
-@test an_element(b) ∈ b
+    # an_element function
+    b = Ball2(N[1., 2.], N(2.))
+    @test an_element(b) ∈ b
 
-# subset
-b1 = Ball2([1., 2.], 2.)
-b2 = Ball2([1., 2.], 0.)
-b3 = Ball2([1.7, 2.7], 1.)
-s = Singleton([1., 2.])
-subset, point = ⊆(b1, s, true)
-@test !⊆(b1, s) && !subset && point ∈ b1 && !(point ∈ s)
-@test ⊆(b2, s) && ⊆(b2, s, true)[1]
-@test !⊆(b1, BallInf([1., 2.], 1.))
-@test ⊆(b2, BallInf([1., 2.], 2.))
-subset, point = ⊆(b1, b3, true)
-@test !⊆(b1, b3) && !subset && point ∈ b1 && !(point ∈ b3)
-@test ⊆(b3, b1) && ⊆(b3, b1, true)[1]
+    # subset
+    b1 = Ball2(N[1., 2.], N(2.))
+    b2 = Ball2(N[1., 2.], N(0.))
+    b3 = Ball2(N[1.7, 2.7], N(1.))
+    s = Singleton(N[1., 2.])
+    subset, point = ⊆(b1, s, true)
+    @test !⊆(b1, s) && !subset && point ∈ b1 && !(point ∈ s)
+    @test ⊆(b2, s) && ⊆(b2, s, true)[1]
+    @test !⊆(b1, BallInf(N[1., 2.], N(1.)))
+    @test ⊆(b2, BallInf(N[1., 2.], N(2.)))
+    subset, point = ⊆(b1, b3, true)
+    @test !⊆(b1, b3) && !subset && point ∈ b1 && !(point ∈ b3)
+    @test ⊆(b3, b1) && ⊆(b3, b1, true)[1]
 
-# intersection
-b1 = Ball2([0., 0.], 2.)
-b2 = Ball2([2., 2.], 2.)
-b3 = Ball2([4., 4.], 2.)
-intersection_empty, point = is_intersection_empty(b1, b2, true)
-@test !is_intersection_empty(b1, b2) && !intersection_empty && point ∈ b1 && point ∈ b2
-@test is_intersection_empty(b1, b3) && is_intersection_empty(b1, b3, true)[1]
+    # intersection
+    b1 = Ball2(N[0., 0.], N(2.))
+    b2 = Ball2(N[2., 2.], N(2.))
+    b3 = Ball2(N[4., 4.], N(2.))
+    intersection_empty, point = is_intersection_empty(b1, b2, true)
+    @test !is_intersection_empty(b1, b2) && !intersection_empty && point ∈ b1 && point ∈ b2
+    @test is_intersection_empty(b1, b3) && is_intersection_empty(b1, b3, true)[1]
+end

--- a/test/unit_BallInf.jl
+++ b/test/unit_BallInf.jl
@@ -1,60 +1,62 @@
-# 1D BallInf
-b = BallInf([0.], 1.)
-# Test Dimension
-@test dim(b) == 1
-# Test Support Vector
-d = [1.]
-@test σ(d, b) == [1.]
-d = [-1.]
-@test σ(d, b) == [-1.]
+for N in [Float64, Rational{Int}, Float32]
+    # 1D BallInf
+    b = BallInf(N[0.], N(1.))
+    # Test Dimension
+    @test dim(b) == 1
+    # Test Support Vector
+    d = N[1.]
+    @test σ(d, b) == N[1.]
+    d = N[-1.]
+    @test σ(d, b) == N[-1.]
 
-# 2D BallInf
-b = BallInf([0., 0.], 1.)
-# Test Dimension
-@test dim(b) == 2
-# Test Support Vector
-d = [1., 1.]
-@test σ(d, b) == [1., 1.]
-d = [-1., 1.]
-@test σ(d, b) == [-1., 1.]
-d = [-1., -1.]
-@test σ(d, b) == [-1., -1.]
-d = [1., -1.]
-@test σ(d, b) == [1., -1.]
+    # 2D BallInf
+    b = BallInf(N[0., 0.], N(1.))
+    # Test Dimension
+    @test dim(b) == 2
+    # Test Support Vector
+    d = N[1., 1.]
+    @test σ(d, b) == N[1., 1.]
+    d = N[-1., 1.]
+    @test σ(d, b) == N[-1., 1.]
+    d = N[-1., -1.]
+    @test σ(d, b) == N[-1., -1.]
+    d = N[1., -1.]
+    @test σ(d, b) == N[1., -1.]
 
-# 2D BallInf not 0-centered
-b = BallInf([1., 2.], 1.)
-# Test Dimension
-@test dim(b) == 2
-# Test Support Vector
-d = [1., 1.]
-@test σ(d, b) == [2., 3.]
-d = [-1., 1.]
-@test σ(d, b) == [0., 3.]
-d = [-1., -1.]
-@test σ(d, b) == [0., 1.]
-d = [0., -1.]
-@test σ(d, b) == [2., 1.]
+    # 2D BallInf not 0-centered
+    b = BallInf(N[1., 2.], N(1.))
+    # Test Dimension
+    @test dim(b) == 2
+    # Test Support Vector
+    d = N[1., 1.]
+    @test σ(d, b) == N[2., 3.]
+    d = N[-1., 1.]
+    @test σ(d, b) == N[0., 3.]
+    d = N[-1., -1.]
+    @test σ(d, b) == N[0., 1.]
+    d = N[0., -1.]
+    @test σ(d, b) == N[2., 1.]
 
-# 2D BallInf radius =/= 1
-b = BallInf([0., 0.], 2.)
-# Test Dimension
-@test dim(b) == 2
-# Test Support Vector
-d = [1., 1.]
-@test σ(d, b) == [2., 2.]
-d = [-1., 1.]
-@test σ(d, b) == [-2., 2.]
-d = [-1., -1.]
-@test σ(d, b) == [-2., -2.]
-d = [1., -1.]
-@test σ(d, b) == [2., -2.]
+    # 2D BallInf radius =/= 1
+    b = BallInf(N[0., 0.], N(2.))
+    # Test Dimension
+    @test dim(b) == 2
+    # Test Support Vector
+    d = N[1., 1.]
+    @test σ(d, b) == N[2., 2.]
+    d = N[-1., 1.]
+    @test σ(d, b) == N[-2., 2.]
+    d = N[-1., -1.]
+    @test σ(d, b) == N[-2., -2.]
+    d = N[1., -1.]
+    @test σ(d, b) == N[2., -2.]
 
-# membership
-b = BallInf([1., 1.], 1.)
-@test !∈([.5, -.5], b)
-@test ∈([.5, 1.5], b)
+    # membership
+    b = BallInf(N[1., 1.], N(1.))
+    @test !∈(N[.5, -.5], b)
+    @test ∈(N[.5, 1.5], b)
 
-# an_element function
-b = BallInf([1.0, 2.0], 3.0)
-@test an_element(b) ∈ b
+    # an_element function
+    b = BallInf(N[1., 2.], N(3.))
+    @test an_element(b) ∈ b
+end

--- a/test/unit_CartesianProduct.jl
+++ b/test/unit_CartesianProduct.jl
@@ -1,106 +1,108 @@
-# Cartesian Product of a centered 1D BallInf and a centered 2D BallInf
-# Here a 3D BallInf
-b1 = BallInf([0.], 1.)
-b2 = BallInf([0., 0.], 1.)
-# Test Construction
-c1 = CartesianProduct(b1, b2)
-@test c1.X == b1
-@test c1.Y == b2
-# Test Dimension
-@test dim(c1) == 3
-# Test Support Vector
-d = [1., 1., 1.]
-@test σ(d, c1) == [1., 1., 1.]
-d = [1., 1., -1.]
-@test σ(d, c1) == [1., 1., -1.]
-d = [1., -1., 1.]
-@test σ(d, c1) == [1., -1., 1.]
-d = [1., -1., -1.]
-@test σ(d, c1) == [1., -1., -1.]
-d = [-1., 1., 1.]
-@test σ(d, c1) == [-1., 1., 1.]
-d = [-1., 1., -1.]
-@test σ(d, c1) == [-1., 1., -1.]
-d = [-1., -1., 1.]
-@test σ(d, c1) == [-1., -1., 1.]
-d = [-1., -1., -1.]
-@test σ(d, c1) == [-1., -1., -1.]
+for N in [Float64, Float32] # TODO Rational{Int}
+    # Cartesian Product of a centered 1D BallInf and a centered 2D BallInf
+    # Here a 3D BallInf
+    b1 = BallInf(N[0.], N(1.))
+    b2 = BallInf(N[0., 0.], N(1.))
+    # Test Construction
+    c1 = CartesianProduct(b1, b2)
+    @test c1.X == b1
+    @test c1.Y == b2
+    # Test Dimension
+    @test dim(c1) == 3
+    # Test Support Vector
+    d = N[1., 1., 1.]
+    @test σ(d, c1) == N[1., 1., 1.]
+    d = N[1., 1., -1.]
+    @test σ(d, c1) == N[1., 1., -1.]
+    d = N[1., -1., 1.]
+    @test σ(d, c1) == N[1., -1., 1.]
+    d = N[1., -1., -1.]
+    @test σ(d, c1) == N[1., -1., -1.]
+    d = N[-1., 1., 1.]
+    @test σ(d, c1) == N[-1., 1., 1.]
+    d = N[-1., 1., -1.]
+    @test σ(d, c1) == N[-1., 1., -1.]
+    d = N[-1., -1., 1.]
+    @test σ(d, c1) == N[-1., -1., 1.]
+    d = N[-1., -1., -1.]
+    @test σ(d, c1) == N[-1., -1., -1.]
 
-# Cartesian Product of a not-centered 1D BallInf and a not-centered 2D BallInf
-# Here a Hyperrectangle where c = [1., -3., 4.] and r = [3., 2., 2.]
-b1 = BallInf([1.], 3.)
-b2 = BallInf([-3., 4.], 2.)
-# Test Construction
-c = CartesianProduct(b1, b2)
-# Test Dimension
-@test dim(c) == 3
-# Test Support Vector
-d = [1., 1., 1.]
-@test σ(d, c) == [4., -1., 6.]
-d = [1., 1., -1.]
-@test σ(d, c) == [4., -1., 2.]
-d = [1., -1., 1.]
-@test σ(d, c) == [4., -5., 6.]
-d = [1., -1., -1.]
-@test σ(d, c) == [4., -5., 2.]
-d = [-1., 1., 1.]
-@test σ(d, c) == [-2., -1., 6.]
-d = [-1., 1., -1.]
-@test σ(d, c) == [-2., -1., 2.]
-d = [-1., -1., 1.]
-@test σ(d, c) == [-2., -5., 6.]
-d = [-1., -1., -1.]
-@test σ(d, c) == [-2., -5., 2.]
+    # Cartesian Product of a not-centered 1D BallInf and a not-centered 2D BallInf
+    # Here a Hyperrectangle where c = [1., -3., 4.] and r = [3., 2., 2.]
+    b1 = BallInf(N[1.], N(3.))
+    b2 = BallInf(N[-3., 4.], N(2.))
+    # Test Construction
+    c = CartesianProduct(b1, b2)
+    # Test Dimension
+    @test dim(c) == 3
+    # Test Support Vector
+    d = N[1., 1., 1.]
+    @test σ(d, c) == N[4., -1., 6.]
+    d = N[1., 1., -1.]
+    @test σ(d, c) == N[4., -1., 2.]
+    d = N[1., -1., 1.]
+    @test σ(d, c) == N[4., -5., 6.]
+    d = N[1., -1., -1.]
+    @test σ(d, c) == N[4., -5., 2.]
+    d = N[-1., 1., 1.]
+    @test σ(d, c) == N[-2., -1., 6.]
+    d = N[-1., 1., -1.]
+    @test σ(d, c) == N[-2., -1., 2.]
+    d = N[-1., -1., 1.]
+    @test σ(d, c) == N[-2., -5., 6.]
+    d = N[-1., -1., -1.]
+    @test σ(d, c) == N[-2., -5., 2.]
 
-# Test Cartesian Product with EmptySet
-s = Singleton([1.])
-cs1 = ∅ * s
-cs2 = s * ∅
-@test cs1 isa EmptySet
-@test cs2 isa EmptySet
+    # Test Cartesian Product with EmptySet
+    s = Singleton(N[1.])
+    cs1 = ∅ * s
+    cs2 = s * ∅
+    @test cs1 isa EmptySet
+    @test cs2 isa EmptySet
 
-# Test Cartesian Product of an array
-# 0-elements
-as = LazySet{Float64}[]
-cs = CartesianProduct(as)
-@test cs isa EmptySet
-# 1-element
-as = [Singleton([1.])]
-cs = CartesianProduct(as)
-@test cs.element == [1.]
-# 3-elements
-as = [Singleton([1.]), Singleton([2.]), Singleton([3.])]
-cs = CartesianProduct(as)
-@test cs.X.element == [1.]
-@test cs.Y.X.element == [2.]
-@test cs.Y.Y.element == [3.]
+    # Test Cartesian Product of an array
+    # 0-elements
+    as = LazySet{N}[]
+    cs = CartesianProduct(as)
+    @test cs isa EmptySet
+    # 1-element
+    as = [Singleton(N[1.])]
+    cs = CartesianProduct(as)
+    @test cs.element == N[1.]
+    # 3-elements
+    as = [Singleton(N[1.]), Singleton(N[2.]), Singleton(N[3.])]
+    cs = CartesianProduct(as)
+    @test cs.X.element == N[1.]
+    @test cs.Y.X.element == N[2.]
+    @test cs.Y.Y.element == N[3.]
 
-# Test containment with respect to CartesianProduct
-p1 = HPolygon()
-addconstraint!(p1, LinearConstraint([2., 2.], 12.))
-addconstraint!(p1, LinearConstraint([-3., 3.], 6.))
-addconstraint!(p1, LinearConstraint([-1., -1.], 0.))
-addconstraint!(p1, LinearConstraint([2., -4.], 0.))
-p2 = HPolygon()
-addconstraint!(p2, LinearConstraint([1., 0.], 1.))
-addconstraint!(p2, LinearConstraint([-1., 0.], 1.))
-addconstraint!(p2, LinearConstraint([0., 1.], 1.))
-addconstraint!(p2, LinearConstraint([0., -1.], 1.))
-cp = CartesianProduct(p1, p2)
+    # Test containment with respect to CartesianProduct
+    p1 = HPolygon{N}()
+    addconstraint!(p1, LinearConstraint(N[2., 2.], N(12.)))
+    addconstraint!(p1, LinearConstraint(N[-3., 3.], N(6.)))
+    addconstraint!(p1, LinearConstraint(N[-1., -1.], N(0.)))
+    addconstraint!(p1, LinearConstraint(N[2., -4.], N(0.)))
+    p2 = HPolygon{N}()
+    addconstraint!(p2, LinearConstraint(N[1., 0.], N(1.)))
+    addconstraint!(p2, LinearConstraint(N[-1., 0.], N(1.)))
+    addconstraint!(p2, LinearConstraint(N[0., 1.], N(1.)))
+    addconstraint!(p2, LinearConstraint(N[0., -1.], N(1.)))
+    cp = CartesianProduct(p1, p2)
 
-@test ∈([0., 0., 0., 0.], cp)
-@test ∈([4., 2., 1., 0.], cp)
-@test ∈([2., 4., -1., 0.], cp)
-@test ∈([-1., 1., .5, .7], cp)
-@test ∈([2., 3., -.8, .9], cp)
-@test ∈([1., 1., -1., 0.], cp)
-@test ∈([3., 2., 0., 1.], cp)
-@test ∈([5./4., 7./4., 1., 1.], cp)
-@test !∈([4., 1., 0., 0.], cp)
-@test !∈([5., 2., 0., 0.], cp)
-@test !∈([3., 4., 0., 0.], cp)
-@test !∈([-1., 5., 0., 0.], cp)
-@test !∈([4., 2., 3., 1.], cp)
-@test !∈([2., 3., 3., 1.], cp)
-@test !∈([0., 0., 3., 1.], cp)
-@test !∈([1., 1., 3., 1.], cp)
+    @test ∈(N[0., 0., 0., 0.], cp)
+    @test ∈(N[4., 2., 1., 0.], cp)
+    @test ∈(N[2., 4., -1., 0.], cp)
+    @test ∈(N[-1., 1., .5, .7], cp)
+    @test ∈(N[2., 3., -.8, .9], cp)
+    @test ∈(N[1., 1., -1., 0.], cp)
+    @test ∈(N[3., 2., 0., 1.], cp)
+    @test ∈(N[5./4., 7./4., 1., 1.], cp)
+    @test !∈(N[4., 1., 0., 0.], cp)
+    @test !∈(N[5., 2., 0., 0.], cp)
+    @test !∈(N[3., 4., 0., 0.], cp)
+    @test !∈(N[-1., 5., 0., 0.], cp)
+    @test !∈(N[4., 2., 3., 1.], cp)
+    @test !∈(N[2., 3., 3., 1.], cp)
+    @test !∈(N[0., 0., 3., 1.], cp)
+    @test !∈(N[1., 1., 3., 1.], cp)
+end

--- a/test/unit_ConvexHull.jl
+++ b/test/unit_ConvexHull.jl
@@ -1,48 +1,50 @@
-# ConvexHull of two 2D Ball2
-b1 = Ball2([0., 0.], 1.)
-b2 = Ball2([1., 2.], 1.)
-# Test Construction
-ch1 = ConvexHull(b1, b2)
-ch2 = CH(b1, b2)
-@test ch1 == ch2
-# Test Dimension
-@test dim(ch1) == 2
-# Test Support Vector
-d = [1., 0.]
-@test σ(d, ch1) == [2., 2.]
-d = [-1., 0.]
-@test σ(d, ch1) == [-1., 0.]
-d = [0., 1.]
-@test σ(d, ch1) == [1., 3.]
-d = [0., -1.]
-@test σ(d, ch1) == [0., -1.]
+for N in [Float64, Rational{Int}, Float32]
+    # ConvexHull of two 2D Ball1
+    b1 = Ball1(to_N(N, [0., 0.]), to_N(N, 1.))
+    b2 = Ball1(to_N(N, [1., 2.]), to_N(N, 1.))
+    # Test Construction
+    ch1 = ConvexHull(b1, b2)
+    ch2 = CH(b1, b2)
+    @test ch1 == ch2
+    # Test Dimension
+    @test dim(ch1) == 2
+    # Test Support Vector
+    d = to_N(N, [1., 0.])
+    @test σ(d, ch1) == to_N(N, [2., 2.])
+    d = to_N(N, [-1., 0.])
+    @test σ(d, ch1) == to_N(N, [-1., 0.])
+    d = to_N(N, [0., 1.])
+    @test σ(d, ch1) == to_N(N, [1., 3.])
+    d = to_N(N, [0., -1.])
+    @test σ(d, ch1) == to_N(N, [0., -1.])
 
-# test convex hull of a set of points using the default algorithm
-points = [[0.9,0.2], [0.4,0.6], [0.2,0.1], [0.1,0.3], [0.3,0.28]]
-@test convex_hull(points) == [ [0.1,0.3],[0.2,0.1], [0.9,0.2],[0.4,0.6] ]
+    # test convex hull of a set of points using the default algorithm
+    points = to_N(N, [[0.9,0.2], [0.4,0.6], [0.2,0.1], [0.1,0.3], [0.3,0.28]])
+    @test convex_hull(points) == to_N(N, [[0.1,0.3],[0.2,0.1], [0.9,0.2],[0.4,0.6]])
 
-# convex hull array of 2 sets
-C = ConvexHullArray([b1, b2])
-# test alias
-@test CHArray([b1, b2]) isa ConvexHullArray
-# test dimension
-@test dim(C) == 2
-# test support vector
-d = [1., 0.]
-@test σ(d, C) == [2., 2.]
-d = [-1., 0.]
-@test σ(d, C) == [-1., 0.]
-d = [0., 1.]
-@test σ(d, C) == [1., 3.]
-d = [0., -1.]
-@test σ(d, C) == [0., -1.]
-# test convex hull array of singleton
-C = ConvexHullArray([Singleton([1.0, 0.5]), Singleton([1.1, 0.2]), Singleton([1.4, 0.3]), Singleton([1.7, 0.5]), Singleton([1.4, 0.8])])
+    # convex hull array of 2 sets
+    C = ConvexHullArray([b1, b2])
+    # test alias
+    @test CHArray([b1, b2]) isa ConvexHullArray
+    # test dimension
+    @test dim(C) == 2
+    # test support vector
+    d = to_N(N, [1., 0.])
+    @test σ(d, C) == to_N(N, [2., 2.])
+    d = to_N(N, [-1., 0.])
+    @test σ(d, C) == to_N(N, [-1., 0.])
+    d = to_N(N, [0., 1.])
+    @test σ(d, C) == to_N(N, [1., 3.])
+    d = to_N(N, [0., -1.])
+    @test σ(d, C) == to_N(N, [0., -1.])
+    # test convex hull array of singleton
+    C = ConvexHullArray([Singleton(to_N(N, [1.0, 0.5])), Singleton(to_N(N, [1.1, 0.2])), Singleton(to_N(N, [1.4, 0.3])), Singleton(to_N(N, [1.7, 0.5])), Singleton(to_N(N, [1.4, 0.8]))])
 
-# empty set is neutral for CH
-a = ConvexHullArray([Ball2(ones(2), 1.)])
-@test CH(a, ∅) == a
-@test CH(∅, a) == a
+    # empty set is neutral for CH
+    a = ConvexHullArray([Ball1(ones(N, 2), to_N(N, 1.))])
+    @test CH(a, ∅) == a
+    @test CH(∅, a) == a
 
-# concatenation of two convex hull arrays
-@test CH(a, a) isa ConvexHullArray
+    # concatenation of two convex hull arrays
+    @test CH(a, a) isa ConvexHullArray
+end

--- a/test/unit_Ellipsoid.jl
+++ b/test/unit_Ellipsoid.jl
@@ -1,56 +1,58 @@
-# 1D ellipsoid
-E = Ellipsoid([0.], diagm(1.))
-# Test Dimension
-@test dim(E) == 1
-# Test Support Vector
-d = [1.]
-@test σ(d, E) == [1.]
-d = [-1.]
-@test σ(d, E) == [-1.]
-# test constructor
-E = Ellipsoid(diagm(1.))
-@test E.center == [0.]
+for N in [Float64, Float32]
+    # 1D ellipsoid
+    E = Ellipsoid(N[0.], diagm(N[1.]))
+    # Test Dimension
+    @test dim(E) == 1
+    # Test Support Vector
+    d = N[1.]
+    @test σ(d, E) == N[1.]
+    d = N[-1.]
+    @test σ(d, E) == N[-1.]
+    # test constructor
+    E = Ellipsoid(diagm(N[1.]))
+    @test E.center == N[0.]
 
-# 2D Ellipsoid
-E = Ellipsoid([0., 0.], diagm([1., 1.]))
-# Test Dimension
-@test dim(E) == 2
-# Test Support Vector
-d = [1., 0.]
-@test σ(d, E) == [1., 0.]
-d = [-1., 0.]
-@test σ(d, E) == [-1., 0.]
-d = [0., 1.]
-@test σ(d, E) == [0., 1.]
-d = [0., -1.]
-@test σ(d, E) == [0., -1.]
+    # 2D Ellipsoid
+    E = Ellipsoid(N[0., 0.], diagm(N[1., 1.]))
+    # Test Dimension
+    @test dim(E) == 2
+    # Test Support Vector
+    d = N[1., 0.]
+    @test σ(d, E) == N[1., 0.]
+    d = N[-1., 0.]
+    @test σ(d, E) == N[-1., 0.]
+    d = N[0., 1.]
+    @test σ(d, E) == N[0., 1.]
+    d = N[0., -1.]
+    @test σ(d, E) == N[0., -1.]
 
-# 2D Ellipsoid not 0-centered
-E = Ellipsoid([1., 2.], diagm([1., 1.]))
-# Test Dimension
-@test dim(E) == 2
-# Test Support Vector
-d = [1., 0.]
-@test σ(d, E) == [2., 2.]
-d = [-1., 0.]
-@test σ(d, E) == [0., 2.]
-d = [0., 1.]
-@test σ(d, E) == [1., 3.]
-d = [0., -1.]
-@test σ(d, E) == [1., 1.]
+    # 2D Ellipsoid not 0-centered
+    E = Ellipsoid(N[1., 2.], diagm(N[1., 1.]))
+    # Test Dimension
+    @test dim(E) == 2
+    # Test Support Vector
+    d = N[1., 0.]
+    @test σ(d, E) == N[2., 2.]
+    d = N[-1., 0.]
+    @test σ(d, E) == N[0., 2.]
+    d = N[0., 1.]
+    @test σ(d, E) == N[1., 3.]
+    d = N[0., -1.]
+    @test σ(d, E) == N[1., 1.]
 
-# another shape matrix
-E = Ellipsoid([1., 2.], diagm([.5, 2.]))
-# Test Support Vector
-d = [1., 0.]
-@test σ(d, E) ≈ [1+sqrt(.5), 2.]
-d = [-1., 0.]
-@test σ(d, E) ≈ [1-sqrt(.5), 2.]
-d = [0., 1.]
-@test σ(d, E) ≈ [1., 2. + sqrt(2)]
-d = [0., -1.]
-@test σ(d, E) ≈ [1., 2. - sqrt(2)]
+    # another shape matrix
+    E = Ellipsoid(N[1., 2.], diagm(N[.5, 2.]))
+    # Test Support Vector
+    d = N[1., 0.]
+    @test σ(d, E) ≈ N[1+sqrt(.5), 2.]
+    d = N[-1., 0.]
+    @test σ(d, E) ≈ N[1-sqrt(.5), 2.]
+    d = N[0., 1.]
+    @test σ(d, E) ≈ N[1., 2. + sqrt(2)]
+    d = N[0., -1.]
+    @test σ(d, E) ≈ N[1., 2. - sqrt(2)]
 
-# an_element and set membership functions
-E = Ellipsoid([1., 2.], 2*eye(2))
-@test an_element(E) ∈ E
+    # an_element and set membership functions
+    E = Ellipsoid(N[1., 2.], 2*eye(N, 2))
+    @test an_element(E) ∈ E
+end

--- a/test/unit_EmptySet.jl
+++ b/test/unit_EmptySet.jl
@@ -1,38 +1,43 @@
+for N in [Float64, Rational{Int}, Float32]
+    E = EmptySet{N}()
+    B = BallInf(ones(N, 2), N(1.))
+
+    # testing that the empty set is an absorbing element for the cartesian product
+    @test B * E isa EmptySet && E * B isa EmptySet
+    # testing the mathematical alias ×
+    @test B × E isa EmptySet && E × B isa EmptySet
+    # test ∅ alias
+    @test B × E isa EmptySet
+
+    cpa = CartesianProductArray([B, N(2.) * B, N(3.) * B])
+    @test cpa * E isa EmptySet && E * cpa isa EmptySet
+    @test cpa × E isa EmptySet && E × cpa isa EmptySet
+
+    # testing cp of empty set with itself
+    @test E * E == E
+
+    # testing that the empty set is an absorbing element for the Minkowski sum
+    @test B + E isa EmptySet && E + B isa EmptySet
+    # testing the mathematical alias ⊕
+    @test B ⊕ E isa EmptySet && E ⊕ B isa EmptySet
+
+    msa = MinkowskiSumArray([B, N(2.) * B, N(3.) * B])
+    @test msa + E isa EmptySet && E + msa isa EmptySet
+    @test msa ⊕ E isa EmptySet && E ⊕ msa isa EmptySet
+
+    # testing M-sum of empty set with itself
+    @test E + E == E
+
+    # testing that the emptyset is neutral for the convex hull
+    @test CH(B, E) == B
+    @test CH(E, B) == B
+
+    # test convex hull of empty set with itself
+    @test CH(E, E) == E
+
+    # an_element function
+    @test_throws ErrorException an_element(E)
+end
+
+# default Float64 constructor
 E = ∅
-B = BallInf(ones(2), 1.)
-
-# testing that the empty set is an absorbing element for the cartesian product
-@test B * E isa EmptySet && E * B isa EmptySet
-# testing the mathematical alias ×
-@test B × E isa EmptySet && E × B isa EmptySet
-# test ∅ alias
-@test B × E isa EmptySet
-
-cpa = CartesianProductArray([B, 2. * B, 3. * B])
-@test cpa * E isa EmptySet && E * cpa isa EmptySet
-@test cpa × E isa EmptySet && E × cpa isa EmptySet
-
-# testing cp of empty set with itself
-@test ∅ * ∅ == ∅
-
-# testing that the empty set is an absorbing element for the Minkowski sum
-@test B + E isa EmptySet && E + B isa EmptySet
-# testing the mathematical alias ⊕ 
-@test B ⊕ E isa EmptySet && E ⊕ B isa EmptySet
-
-msa = MinkowskiSumArray([B, 2. * B, 3. * B])
-@test msa + E isa EmptySet && E + msa isa EmptySet
-@test msa ⊕ E isa EmptySet && E ⊕ msa isa EmptySet
-
-# testing M-sum of empty set with itself
-@test ∅ + ∅ == ∅
-
-# testing that the emptyset is neutral for the convex hull
-@test CH(B, ∅) == B
-@test CH(∅, B) == B
-
-# test convex hull of empty set with itself
-@test CH(∅, ∅) == ∅
-
-# an_element function
-@test_throws ErrorException an_element(∅)

--- a/test/unit_ExponentialMap.jl
+++ b/test/unit_ExponentialMap.jl
@@ -71,13 +71,4 @@ for N in [Float64] # TODO Float32
     P = L * expm(full(m)) * R
     svec_explicit = σ(d, P*b)
     @test svec ≈ svec_explicit
-
-    # product of a matrix exponential times a matrix << is a GeneralMapArray
-    #MatrixExpSp(m) * m  # left mult
-
-    #m * MatrixExpSp(m)  # right mult
-
-    # using the general map array
-    #m1 = sprandn(10, 10, 0.1); m2 = sprandn(10, 10, 0.1);
-    #mpa = GeneralMapArray([m1, me, m2])
 end

--- a/test/unit_ExponentialMap.jl
+++ b/test/unit_ExponentialMap.jl
@@ -1,79 +1,83 @@
-# dimension for this benchs (choose a multiple of 3)
-n = 3*2
+for N in [Float64] # TODO Float32
+    # dimension (choose a multiple of 3)
+    n = 3*2
 
-# occupation probability for these benchs
-p = 0.4
+    # occupation probability for these benchs
+    p = 0.4
 
-# sparse matrix
-m = sprandn(n, n, p);
+    # sparse matrix
+    m = sprandn(n, n, p)
+    m = convert(SparseMatrixCSC{N,Int}, m)
 
-# a set
-b = BallInf(ones(n), 0.1);
+    # a set
+    b = BallInf(ones(N, n), to_N(N, 0.1))
 
-# linear map
-lm = m * b
+    # linear map
+    lm = m * b
 
-# the (lazy) exponential of a sparse matrix
-me = SparseMatrixExp(m)
+    # the (lazy) exponential of a sparse matrix
+    me = SparseMatrixExp(m)
 
-# size
-@test size(me, 1) == n
-@test size(me) == (n, n)
-# product of the exponential maps of two commuting matrices
-# WARNING: assuming commutativity of matrix exponents
-#me * me
+    # size
+    @test size(me, 1) == n
+    @test size(me) == (n, n)
+    # product of the exponential maps of two commuting matrices
+    # WARNING: assuming commutativity of matrix exponents
+    #me * me
 
-# the exponential map of a convex set, same as ExponentialMap(me, b)
-emap = me * b
+    # the exponential map of a convex set, same as ExponentialMap(me, b)
+    emap = me * b
 
-# the support vector of an exponential map
-d = randn(n)
-svec = σ(d, emap)
+    # the support vector of an exponential map
+    d = randn(n)
+    d = convert(Vector{N}, d)
+    svec = σ(d, emap)
 
-# check consistency with respect to explicit computation of the matrix exponential
-svec_explicit = σ(d, expm(full(m)) * b)
-@test svec ≈ svec_explicit
+    # check consistency with respect to explicit computation of the matrix exponential
+    svec_explicit = σ(d, expm(full(m)) * b)
+    @test svec ≈ svec_explicit
 
-# construct an exponential map where we only pass the matrix
-#ExponentialMap(m, b) # ExponentialMap
+    # construct an exponential map where we only pass the matrix
+    #ExponentialMap(m, b) # ExponentialMap
 
-# the exponential map of an exponential map falls back to a Cartesian product
-cpem = emap * emap # CartesianProduct of ExponentialMap
+    # the exponential map of an exponential map falls back to a Cartesian product
+    cpem = emap * emap # CartesianProduct of ExponentialMap
 
-# the exponential map applied to an exponential map
-emap2 = ExponentialMap(SparseMatrixExp(2*m), emap)
+    # the exponential map applied to an exponential map
+    emap2 = ExponentialMap(SparseMatrixExp(2*m), emap)
 
-# for projection tests, let's assume that n is divisible by three
-assert(mod(n, 3) == 0)
-nb = div(n, 3)
-# the projection of exp(A) on the (m, m)-dimensional right-most upper block
-R = [spzeros(nb, nb); spzeros(nb, nb); speye(nb, nb)]
-L = [speye(nb, nb) spzeros(nb, nb) spzeros(nb, nb)]
-proj = ProjectionSparseMatrixExp(L, me, R)
+    # for projection tests, let's assume that n is divisible by three
+    assert(mod(n, 3) == 0)
+    nb = div(n, 3)
+    # the projection of exp(A) on the (m, m)-dimensional right-most upper block
+    R = [spzeros(N, nb, nb); spzeros(N, nb, nb); speye(N, nb, nb)]
+    L = [speye(N, nb, nb) spzeros(N, nb, nb) spzeros(N, nb, nb)]
+    proj = ProjectionSparseMatrixExp(L, me, R)
 
-# build an exponential projection map : it is the application of the projection
-# of exp(A) over a given set
-b = BallInf(ones(nb), 0.1);
-projmap = proj * b
+    # build an exponential projection map : it is the application of the projection
+    # of exp(A) over a given set
+    b = BallInf(ones(N, nb), to_N(N, 0.1))
+    projmap = proj * b
 
-# query the ambient dimension of projmap (hint: it is the output dimension)
-@test dim(projmap) == nb
+    # query the ambient dimension of projmap (hint: it is the output dimension)
+    @test dim(projmap) == nb
 
-#compute the support vector of the projection of an exponential map
-d = randn(nb)
-svec = σ(d, projmap)
+    #compute the support vector of the projection of an exponential map
+    d = randn(nb)
+    d = convert(Vector{N}, d)
+    svec = σ(d, projmap)
 
-# check consistency with respect to explicit computation of the matrix exponential
-P = L * expm(full(m)) * R
-svec_explicit = σ(d, P*b)
-@test svec ≈ svec_explicit
+    # check consistency with respect to explicit computation of the matrix exponential
+    P = L * expm(full(m)) * R
+    svec_explicit = σ(d, P*b)
+    @test svec ≈ svec_explicit
 
-# product of a matrix exponential times a matrix << is a GeneralMapArray
-#MatrixExpSp(m) * m  # left mult
+    # product of a matrix exponential times a matrix << is a GeneralMapArray
+    #MatrixExpSp(m) * m  # left mult
 
-#m * MatrixExpSp(m)  # right mult
+    #m * MatrixExpSp(m)  # right mult
 
-# using the general map array
-#m1 = sprandn(10, 10, 0.1); m2 = sprandn(10, 10, 0.1);
-#mpa = GeneralMapArray([m1, me, m2])
-
+    # using the general map array
+    #m1 = sprandn(10, 10, 0.1); m2 = sprandn(10, 10, 0.1);
+    #mpa = GeneralMapArray([m1, me, m2])
+end

--- a/test/unit_HalfSpace.jl
+++ b/test/unit_HalfSpace.jl
@@ -1,27 +1,29 @@
-# normal constructor
-normal = ones(3)
-hs = HalfSpace(normal, 5.)
+for N in [Float64, Rational{Int}, Float32]
+    # normal constructor
+    normal = ones(N, 3)
+    hs = HalfSpace(normal, N(5.))
 
-# dimension
-@test dim(hs) == 3
+    # dimension
+    @test dim(hs) == 3
 
-# support vector and membership function
-function test_svec(hs, d)
-    @test σ(d, hs) ∈ hs
-    @test σ(2. * d, hs) ∈ hs
-    d2 = [1., 0., 0.]
-    @test_throws ErrorException σ(d2, hs)
-    d2 = zeros(3)
-    @test σ(d2, hs) ∈ hs
+    # support vector and membership function
+    function test_svec(hs, d)
+        @test σ(d, hs) ∈ hs
+        @test σ(N(2.) * d, hs) ∈ hs
+        d2 = N[1., 0., 0.]
+        @test_throws ErrorException σ(d2, hs)
+        d2 = zeros(N, 3)
+        @test σ(d2, hs) ∈ hs
+    end
+    # tests 1
+    normal = ones(N, 3)
+    d = ones(N, 3)
+    test_svec(HalfSpace(normal, N(5.)), d)
+    # tests 2
+    normal = zeros(N, 3); normal[3] = N(1.)
+    d = zeros(N, 3); d[3] = 1.
+    test_svec(HalfSpace(normal, N(5.)), d)
+
+    # an_element function and membership function
+    @test an_element(hs) ∈ hs
 end
-# tests 1
-normal = ones(3)
-d = ones(3)
-test_svec(HalfSpace(normal, 5.), d)
-# tests 2
-normal = zeros(3); normal[3] = 1.
-d = zeros(3); d[3] = 1.
-test_svec(HalfSpace(normal, 5.), d)
-
-# an_element function and membership function
-@test an_element(hs) ∈ hs

--- a/test/unit_Hyperplane.jl
+++ b/test/unit_Hyperplane.jl
@@ -1,27 +1,29 @@
-# normal constructor
-normal = ones(3)
-hp = Hyperplane(normal, 5.)
+for N in [Float64, Rational{Int}, Float32]
+    # normal constructor
+    normal = ones(N, 3)
+    hp = Hyperplane(normal, N(5.))
 
-# dimension
-@test dim(hp) == 3
+    # dimension
+    @test dim(hp) == 3
 
-# support vector and membership function
-function test_svec(hp, d)
-    @test σ(d, hp) ∈ hp
-    @test σ(2. * d, hp) ∈ hp
-    d2 = [1., 0., 0.]
-    @test_throws ErrorException σ(d2, hp)
-    d2 = zeros(3)
-    @test σ(d2, hp) ∈ hp
+    # support vector and membership function
+    function test_svec(hp, d)
+        @test σ(d, hp) ∈ hp
+        @test σ(N(2.) * d, hp) ∈ hp
+        d2 = N[1., 0., 0.]
+        @test_throws ErrorException σ(d2, hp)
+        d2 = zeros(N, 3)
+        @test σ(d2, hp) ∈ hp
+    end
+    # tests 1
+    normal = ones(N, 3)
+    d = ones(N, 3)
+    test_svec(Hyperplane(normal, N(5.)), d)
+    # tests 2
+    normal = zeros(N, 3); normal[3] = N(1.)
+    d = zeros(N, 3); d[3] = N(1.)
+    test_svec(Hyperplane(normal, N(5.)), d)
+
+    # an_element function and membership function
+    @test an_element(hp) ∈ hp
 end
-# tests 1
-normal = ones(3)
-d = ones(3)
-test_svec(Hyperplane(normal, 5.), d)
-# tests 2
-normal = zeros(3); normal[3] = 1.
-d = zeros(3); d[3] = 1.
-test_svec(Hyperplane(normal, 5.), d)
-
-# an_element function and membership function
-@test an_element(hp) ∈ hp

--- a/test/unit_Hyperrectangle.jl
+++ b/test/unit_Hyperrectangle.jl
@@ -1,127 +1,129 @@
-# 1D Hyperrectangle
-h = Hyperrectangle([0.], [1.])
-# Test Dimension
-@test dim(h) == 1
-# Test Support Vector
-d = [1.]
-@test σ(d, h) == [1.]
-d = [-1.]
-@test σ(d, h) == [-1.]
+for N in [Float64, Rational{Int}, Float32]
+    # 1D Hyperrectangle
+    h = Hyperrectangle(N[0.], N[1.])
+    # Test Dimension
+    @test dim(h) == 1
+    # Test Support Vector
+    d = N[1.]
+    @test σ(d, h) == N[1.]
+    d = N[-1.]
+    @test σ(d, h) == N[-1.]
 
-# 2D Hyperrectangle
-h = Hyperrectangle([0., 0.], [1., 1.])
-# Test Dimension
-@test dim(h) == 2
-# Test Support Vector
-d = [1., 1.]
-@test σ(d, h) == [1., 1.]
-d = [-1., 1.]
-@test σ(d, h) == [-1., 1.]
-d = [-1., -1.]
-@test σ(d, h) == [-1., -1.]
-d = [1., -1.]
-@test σ(d, h) == [1., -1.]
+    # 2D Hyperrectangle
+    h = Hyperrectangle(N[0., 0.], N[1., 1.])
+    # Test Dimension
+    @test dim(h) == 2
+    # Test Support Vector
+    d = N[1., 1.]
+    @test σ(d, h) == N[1., 1.]
+    d = N[-1., 1.]
+    @test σ(d, h) == N[-1., 1.]
+    d = N[-1., -1.]
+    @test σ(d, h) == N[-1., -1.]
+    d = N[1., -1.]
+    @test σ(d, h) == N[1., -1.]
 
-# 2D Hyperrectangle not 0-centered
-h = Hyperrectangle([1., 2.], [1., 1.])
-# Test Dimension
-@test dim(h) == 2
-# Test Support Vector
-d = [1., 1.]
-@test σ(d, h) == [2., 3.]
-d = [-1., 1.]
-@test σ(d, h) == [0., 3.]
-d = [-1., -1.]
-@test σ(d, h) == [0., 1.]
-d = [0., -1.]
-@test σ(d, h) == [2., 1.]
+    # 2D Hyperrectangle not 0-centered
+    h = Hyperrectangle(N[1., 2.], N[1., 1.])
+    # Test Dimension
+    @test dim(h) == 2
+    # Test Support Vector
+    d = N[1., 1.]
+    @test σ(d, h) == N[2., 3.]
+    d = N[-1., 1.]
+    @test σ(d, h) == N[0., 3.]
+    d = N[-1., -1.]
+    @test σ(d, h) == N[0., 1.]
+    d = N[0., -1.]
+    @test σ(d, h) == N[2., 1.]
 
-# 2D Hyperrectangle not same radius in each direction
-h = Hyperrectangle([0., 0.], [1., 2.])
-# Test Dimension
-@test dim(h) == 2
-# Test Support Vector
-d = [1., 1.]
-@test σ(d, h) == [1., 2.]
-d = [-1., 1.]
-@test σ(d, h) == [-1., 2.]
-d = [-1., -1.]
-@test σ(d, h) == [-1., -2.]
-d = [1., -1.]
-@test σ(d, h) == [1., -2.]
+    # 2D Hyperrectangle not same radius in each direction
+    h = Hyperrectangle(N[0., 0.], N[1., 2.])
+    # Test Dimension
+    @test dim(h) == 2
+    # Test Support Vector
+    d = N[1., 1.]
+    @test σ(d, h) == N[1., 2.]
+    d = N[-1., 1.]
+    @test σ(d, h) == N[-1., 2.]
+    d = N[-1., -1.]
+    @test σ(d, h) == N[-1., -2.]
+    d = N[1., -1.]
+    @test σ(d, h) == N[1., -2.]
 
-function isin(e, list)
+    function isin(e, list)
     for x in list
         if x == e
-            return true
+        return true
         end
     end
     return false
-end
+    end
 
-# 2D Hyperrectangle not centered, not same radius, for vertex representation,
-# radius, and diameter
-h = Hyperrectangle([3., 2.], [2., 1.])
-vl = vertices_list(h)
-# Test Vertices
-@test length(vl) == 4
-@test isin([1., 1.], vl) == true
-@test isin([1., 3.], vl) == true
-@test isin([5., 1.], vl) == true
-@test isin([5., 3.], vl) == true
-# norm
-@test norm(h) == norm([5., 3.], Inf)
-# radius
-@test radius(h) == norm([2., 1.], Inf)
-# diameter
-@test diameter(h) == norm([5., 3.] - [1., 1.], Inf)
+    # 2D Hyperrectangle not centered, not same radius, for vertex representation,
+    # radius, and diameter
+    h = Hyperrectangle(N[3., 2.], N[2., 1.])
+    vl = vertices_list(h)
+    # Test Vertices
+    @test length(vl) == 4
+    @test isin(N[1., 1.], vl) == true
+    @test isin(N[1., 3.], vl) == true
+    @test isin(N[5., 1.], vl) == true
+    @test isin(N[5., 3.], vl) == true
+    # norm
+    @test norm(h) == norm(N[5., 3.], Inf)
+    # radius
+    @test radius(h) == norm(N[2., 1.], Inf)
+    # diameter
+    @test diameter(h) == norm(N[5., 3.] - N[1., 1.], Inf)
 
-# alternative constructors
-c = ones(2)
-r = [0.1, 0.2]
-l = [0.9, 0.8]
-h = [1.1, 1.2]
-H1 = Hyperrectangle(c, r)
-H2 = Hyperrectangle(center=c, radius=r)
-H3 = Hyperrectangle(low=l, high=h)
-@test H1.center == H2.center
-@test H2.center ≈ H3.center
-@test H1.radius == H2.radius
-@test H2.radius ≈ H3.radius
+    # alternative constructors
+    c = ones(N, 2)
+    r = to_N(N, [0.1, 0.2])
+    l = to_N(N, [0.9, 0.8])
+    h = to_N(N, [1.1, 1.2])
+    H1 = Hyperrectangle(c, r)
+    H2 = Hyperrectangle(center=c, radius=r)
+    H3 = Hyperrectangle(low=l, high=h)
+    @test H1.center == H2.center
+    @test H2.center ≈ H3.center
+    @test H1.radius == H2.radius
+    @test H2.radius ≈ H3.radius
 
-# Test low and high methods for a hyperrectangle
-H = Hyperrectangle(center=[-2.1, 5.6, 0.9], radius=fill(0.5, 3))
-@test low(H) == [-2.6, 5.1, 0.4]
-@test high(H) == [-1.6, 6.1, 1.4]
+    # Test low and high methods for a hyperrectangle
+    H = Hyperrectangle(center=to_N(N, [-2.1, 5.6, 0.9]), radius=fill(to_N(N, 0.5), 3))
+    @test low(H) ≈ to_N(N, [-2.6, 5.1, 0.4])
+    @test high(H) ≈ to_N(N, [-1.6, 6.1, 1.4])
 
-# membership
-H = Hyperrectangle([1.0, 1.0], [2.0, 3.0])
-@test !∈([-1.1, 4.1], H)
-@test ∈([-1.0, 4.0], H)
+    # membership
+    H = Hyperrectangle(N[1.0, 1.0], N[2.0, 3.0])
+    @test !∈(N[-1.1, 4.1], H)
+    @test ∈(N[-1.0, 4.0], H)
 
-# an_element function
-H = Hyperrectangle([1.0, 2.0], [3.0, 4.0])
-@test an_element(H) ∈ H
+    # an_element function
+    H = Hyperrectangle(N[1.0, 2.0], N[3.0, 4.0])
+    @test an_element(H) ∈ H
 
-# subset
-H1 = Hyperrectangle([1.5, 1.5], [0.5, 0.5])
-H2 = Hyperrectangle([2.0, 2.5], [0.5, 0.5])
-H3 = Hyperrectangle([2.0, 2.0], [2.0, 3.0])
-B1 = BallInf([2.0, 2.5], 0.5)
-B2 = BallInf([2.0, 2.0], 1.0)
-@test !⊆(H1, H2) && ⊆(H1, H3) && ⊆(H2, H3)
-subset, point = ⊆(H1, H2, true)
-@test !subset && point ∈ H1 && !(point ∈ H2)
-subset, point = ⊆(H1, H3, true)
-@test subset
-@test ⊆(H2, B1) && ⊆(B1, H2)
-@test ⊆(B1, B2) && !⊆(B2, B1)
+    # subset
+    H1 = Hyperrectangle(N[1.5, 1.5], N[0.5, 0.5])
+    H2 = Hyperrectangle(N[2.0, 2.5], N[0.5, 0.5])
+    H3 = Hyperrectangle(N[2.0, 2.0], N[2.0, 3.0])
+    B1 = BallInf(N[2.0, 2.5], N(0.5))
+    B2 = BallInf(N[2.0, 2.0], N(1.0))
+    @test !⊆(H1, H2) && ⊆(H1, H3) && ⊆(H2, H3)
+    subset, point = ⊆(H1, H2, true)
+    @test !subset && point ∈ H1 && !(point ∈ H2)
+    subset, point = ⊆(H1, H3, true)
+    @test subset
+    @test ⊆(H2, B1) && ⊆(B1, H2)
+    @test ⊆(B1, B2) && !⊆(B2, B1)
 
-# intersection emptiness
-H1 = Hyperrectangle([1.0, 1.0], [2.0, 2.0])
-H2 = Hyperrectangle([3.0, 3.0], [2.0, 2.0])
-B1 = BallInf([2.0, 4.0], 0.5)
-intersection_empty, point = is_intersection_empty(H1, H2, true)
-@test !is_intersection_empty(H1, H2) &&
+    # intersection emptiness
+    H1 = Hyperrectangle(N[1.0, 1.0], N[2.0, 2.0])
+    H2 = Hyperrectangle(N[3.0, 3.0], N[2.0, 2.0])
+    B1 = BallInf(N[2.0, 4.0], N(0.5))
+    intersection_empty, point = is_intersection_empty(H1, H2, true)
+    @test !is_intersection_empty(H1, H2) &&
     !intersection_empty && point ∈ H1 && point ∈ H2
-@test is_intersection_empty(H1, B1) && is_intersection_empty(H1, B1, true)[1]
+    @test is_intersection_empty(H1, B1) && is_intersection_empty(H1, B1, true)[1]
+end

--- a/test/unit_Intersection.jl
+++ b/test/unit_Intersection.jl
@@ -1,15 +1,17 @@
-B = BallInf(ones(2), 3.)
-H = Hyperrectangle(ones(2), ones(2))
-I = Intersection(B, H)
+for N in [Float64, Rational{Int}, Float32]
+    B = BallInf(ones(N, 2), N(3.))
+    H = Hyperrectangle(ones(N, 2), ones(N, 2))
+    I = Intersection(B, H)
 
-# dim
-@test dim(I) == 2
+    # dim
+    @test dim(I) == 2
 
-# support vector (error)
-@test_throws ErrorException σ(ones(2), I)
+    # support vector (error)
+    @test_throws ErrorException σ(ones(N, 2), I)
 
-# membership
-@test ∈(ones(2), I) && !∈([5., 5.], I)
+    # membership
+    @test ∈(ones(N, 2), I) && !∈(N[5., 5.], I)
 
-# emptiness of intersection
-@test !isempty(I)
+    # emptiness of intersection
+    @test !isempty(I)
+end

--- a/test/unit_LinearMap.jl
+++ b/test/unit_LinearMap.jl
@@ -1,50 +1,52 @@
-# π/2 trigonometric rotation
-b = BallInf([1., 2.], 1.)
-M = [0. -1. ; 1. 0.]
-# Test Construction
-lm1 = LinearMap(M, b)
-@test lm1.M == M
-@test lm1.sf == b
-# Test Dimension
-@test dim(lm1) == 2
-# Test Support Vector
-d = [1., 1.]
-@test σ(d, lm1) == [-1., 2.]
-d = [-1., 1.]
-@test σ(d, lm1) == [-3., 2.]
-d = [-1., -1.]
-@test σ(d, lm1) == [-3., 0.]
-d = [1., -1.]
-@test σ(d, lm1) == [-1., 0.]
+for N in [Float64, Rational{Int}, Float32]
+    # π/2 trigonometric rotation
+    b = BallInf(N[1., 2.], N(1.))
+    M = N[0. -1. ; 1. 0.]
+    # Test Construction
+    lm1 = LinearMap(M, b)
+    @test lm1.M == M
+    @test lm1.sf == b
+    # Test Dimension
+    @test dim(lm1) == 2
+    # Test Support Vector
+    d = N[1., 1.]
+    @test σ(d, lm1) == N[-1., 2.]
+    d = N[-1., 1.]
+    @test σ(d, lm1) == N[-3., 2.]
+    d = N[-1., -1.]
+    @test σ(d, lm1) == N[-3., 0.]
+    d = N[1., -1.]
+    @test σ(d, lm1) == N[-1., 0.]
 
-# 2D -> 1D Projection
-b = BallInf([1., 2.], 1.)
-M = [1. 0.]
-lm = M*b
-# Test Dimension
-@test dim(lm) == 1
-# Test Support Vector
-d = [1.]
-@test σ(d, lm) == [2.]
-d = [-1.]
-@test σ(d, lm) == [0.]
+    # 2D -> 1D Projection
+    b = BallInf(N[1., 2.], N(1.))
+    M = N[1. 0.]
+    lm = M*b
+    # Test Dimension
+    @test dim(lm) == 1
+    # Test Support Vector
+    d = N[1.]
+    @test σ(d, lm) == N[2.]
+    d = N[-1.]
+    @test σ(d, lm) == N[0.]
 
-# scalar multiplication
-b = BallInf([0., 0.], 1.)
-lm = 2.0*b
-# Test Dimension
-@test dim(lm) == 2
-# Test Support Vector
-d = [1., 1.]
-@test σ(d, lm) == [2., 2.]
-d = [-1., 1.]
-@test σ(d, lm) == [-2., 2.]
-d = [-1., -1.]
-@test σ(d, lm) == [-2., -2.]
-d = [1., -1.]
-@test σ(d, lm) == [2., -2.]
+    # scalar multiplication
+    b = BallInf(N[0., 0.], N(1.))
+    lm = N(2.) * b
+    # Test Dimension
+    @test dim(lm) == 2
+    # Test Support Vector
+    d = N[1., 1.]
+    @test σ(d, lm) == N[2., 2.]
+    d = N[-1., 1.]
+    @test σ(d, lm) == N[-2., 2.]
+    d = N[-1., -1.]
+    @test σ(d, lm) == N[-2., -2.]
+    d = N[1., -1.]
+    @test σ(d, lm) == N[2., -2.]
 
-# Nested construction
-lm1_copy = LinearMap(eye(2), lm1)
-@test lm1_copy.M == lm1.M
-@test lm1_copy.sf == lm1.sf
+    # Nested construction
+    lm1_copy = LinearMap(eye(N, 2), lm1)
+    @test lm1_copy.M == lm1.M
+    @test lm1_copy.sf == lm1.sf
+end

--- a/test/unit_MinkowskiSum.jl
+++ b/test/unit_MinkowskiSum.jl
@@ -1,50 +1,52 @@
-# Sum of 2D centered balls in norm 2 and infinity
-b1 = BallInf([0., 0.], 2.)
-b2 = Ball2([0., 0.], 1.)
-# Test Construction
-X = MinkowskiSum(b1, b2)
-@test X.X == b1
-@test X.Y == b2
-# Test Dimension
-@test dim(X) == 2
-# Test Support Vector
-d = [1., 0.]
-v = σ(d, X)
-@test v[1] == 3.
-d = [-1., 0.]
-v = σ(d, X)
-@test v[1] == -3.
-d = [0., 1.]
-v = σ(d, X)
-@test v[2] == 3.
-d = [0., -1.]
-v = σ(d, X)
-@test v[2] == -3.
+for N in [Float64, Rational{Int}, Float32]
+    # Sum of 2D centered balls in norm 1 and infinity
+    b1 = BallInf(N[0., 0.], N(2.))
+    b2 = Ball1(N[0., 0.], N(1.))
+    # Test Construction
+    X = MinkowskiSum(b1, b2)
+    @test X.X == b1
+    @test X.Y == b2
+    # Test Dimension
+    @test dim(X) == 2
+    # Test Support Vector
+    d = N[1., 0.]
+    v = σ(d, X)
+    @test v[1] == N(3.)
+    d = N[-1., 0.]
+    v = σ(d, X)
+    @test v[1] == N(-3.)
+    d = N[0., 1.]
+    v = σ(d, X)
+    @test v[2] == N(3.)
+    d = N[0., -1.]
+    v = σ(d, X)
+    @test v[2] == N(-3.)
 
-# Sum of not-centered 2D balls in norm 2 and infinity
-b1 = BallInf([-1., 3.], 2.)
-b2 = Ball2([1., 2.], 1.)
-s = b1 + b2
-# Test Support Vector
-d = [1., 0.]
-v = σ(d, s)
-@test v[1] == 3.
-d = [-1., 0.]
-v = σ(d, s)
-@test v[1] == -3.
-d = [0., 1.]
-v = σ(d, s)
-@test v[2] == 8.
-d = [0., -1.]
-v = σ(d, s)
-@test v[2] == 2.
+    # Sum of not-centered 2D balls in norm 1 and infinity
+    b1 = BallInf(N[-1., 3.], N(2.))
+    b2 = Ball1(N[1., 2.], N(1.))
+    s = b1 + b2
+    # Test Support Vector
+    d = N[1., 0.]
+    v = σ(d, s)
+    @test v[1] == N(3.)
+    d = N[-1., 0.]
+    v = σ(d, s)
+    @test v[1] == N(-3.)
+    d = N[0., 1.]
+    v = σ(d, s)
+    @test v[2] == N(8.)
+    d = N[0., -1.]
+    v = σ(d, s)
+    @test v[2] == N(2.)
 
-# Sum of array of LazySet
-# 2-elements
-ms = MinkowskiSum(Singleton([1.]), Singleton([2.]))
-@test ρ([1.], ms) == 3.
-@test ρ([-1.], ms) == -3.
-# 3-elements
-ms = MinkowskiSum(Singleton([1.]), MinkowskiSum(Singleton([2.]), Singleton([3.])))
-@test ρ([1.], ms) == 6.
-@test ρ([-1.], ms) == -6.
+    # Sum of array of LazySet
+    # 2-elements
+    ms = MinkowskiSum(Singleton(N[1.]), Singleton(N[2.]))
+    @test ρ(N[1.], ms) == 3.
+    @test ρ(N[-1.], ms) == -3.
+    # 3-elements
+    ms = MinkowskiSum(Singleton(N[1.]), MinkowskiSum(Singleton(N[2.]), Singleton(N[3.])))
+    @test ρ(N[1.], ms) == N(6.)
+    @test ρ(N[-1.], ms) == N(-6.)
+end

--- a/test/unit_Polygon.jl
+++ b/test/unit_Polygon.jl
@@ -1,134 +1,109 @@
-# Empty polygon
-p = HPolygon()
+for N in [Float64, Float32] # TODO Rational{Int}
+    # Empty polygon
+    p = HPolygon{N}()
 
-# Test Dimension
-@test dim(p) == 2
+    # Test that constraints are automatically sorted
+    c1 = LinearConstraint(N[2., 2.], N(12.))
+    c2 = LinearConstraint(N[-3., 3.], N(6.))
+    c3 = LinearConstraint(N[-1., -1.], N(0.))
+    c4 = LinearConstraint(N[2., -4.], N(0.))
+    addconstraint!(p, c3)
+    addconstraint!(p, c1)
+    addconstraint!(p, c4)
+    addconstraint!(p, c2)
+    @test p.constraints_list[1] == c1
+    @test p.constraints_list[2] == c2
+    @test p.constraints_list[3] == c3
+    @test p.constraints_list[4] == c4
 
-# Test that constraints are automatically sorted
-c1 = LinearConstraint([2., 2.], 12.)
-c2 = LinearConstraint([-3., 3.], 6.)
-c3 = LinearConstraint([-1., -1.], 0.)
-c4 = LinearConstraint([2., -4.], 0.)
-addconstraint!(p, c3)
-addconstraint!(p, c1)
-addconstraint!(p, c4)
-addconstraint!(p, c2)
-@test p.constraints_list[1] == c1
-@test p.constraints_list[2] == c2
-@test p.constraints_list[3] == c3
-@test p.constraints_list[4] == c4
+    # Optimized polygon
+    po = HPolygonOpt(p)
 
-# Test Support Vector
-d = [1., 0.]
-@test σ(d, p) == [4., 2.]
-d = [0., 1.]
-@test σ(d, p) == [2., 4.]
-d = [-1., 0.]
-@test σ(d, p) == [-1., 1.]
-d = [0., -1.]
-@test σ(d, p) == [0., 0.]
+    # HPolygon/HPolygonOpt tests
+    for p in [p, po]
+        # Test Dimension
+        @test dim(p) == 2
 
-# Test containment
-@test ∈([0., 0.], p)
-@test ∈([4., 2.], p)
-@test ∈([2., 4.], p)
-@test ∈([-1., 1.], p)
-@test ∈([2., 3.], p)
-@test ∈([1., 1.], p)
-@test ∈([3., 2.], p)
-@test ∈([5./4., 7./4.], p)
-@test !∈([4., 1.], p)
-@test !∈([5., 2.], p)
-@test !∈([3., 4.], p)
-@test !∈([-1., 5.], p)
+        # Test Support Vector
+        d = N[1., 0.]
+        @test σ(d, p) == N[4., 2.]
+        d = N[0., 1.]
+        @test σ(d, p) == N[2., 4.]
+        d = N[-1., 0.]
+        @test σ(d, p) == N[-1., 1.]
+        d = N[0., -1.]
+        @test σ(d, p) == N[0., 0.]
 
-# an_element function
-@test an_element(p) ∈ p
+        # Test containment
+        @test ∈(N[0., 0.], p)
+        @test ∈(N[4., 2.], p)
+        @test ∈(N[2., 4.], p)
+        @test ∈(N[-1., 1.], p)
+        @test ∈(N[2., 3.], p)
+        @test ∈(N[1., 1.], p)
+        @test ∈(N[3., 2.], p)
+        @test ∈(N[5./4., 7./4.], p)
+        @test !∈(N[4., 1.], p)
+        @test !∈(N[5., 2.], p)
+        @test !∈(N[3., 4.], p)
+        @test !∈(N[-1., 5.], p)
 
-# Optimized Polygon
-po = HPolygonOpt(p)
+        # an_element function
+        @test an_element(p) ∈ p
+    end
 
-# Test Dimension
-@test dim(po) == 2
+    # Test VRepresentation
+    vp = tovrep(p)
+    @test N[2., 4.] ∈ vp.vertices_list
+    @test N[-1., 1.] ∈ vp.vertices_list
+    @test N[0., 0.] ∈ vp.vertices_list
+    @test N[4., 2.] ∈ vp.vertices_list
 
-# Test Support Vector
-d = [1., 0.]
-@test σ(d, po) == [4., 2.]
-d = [0., 1.]
-@test σ(d, po) == [2., 4.]
-d = [-1., 0.]
-@test σ(d, po) == [-1., 1.]
-d = [0., -1.]
-@test σ(d, po) == [0., 0.]
+    # test convex hull of a set of points using the default algorithm
+    points = [N[0.9,0.2], N[0.4,0.6], N[0.2,0.1], N[0.1,0.3], N[0.3,0.28]]
+    vp = VPolygon(points) # by default, a convex hull is run
+    @test vertices_list(vp) == [ N[0.1,0.3],N[0.2,0.1], N[0.9,0.2],N[0.4,0.6] ]
 
-# Test containment
-@test ∈([0., 0.], po)
-@test ∈([4., 2.], po)
-@test ∈([2., 4.], po)
-@test ∈([-1., 1.], po)
-@test ∈([2., 3.], po)
-@test ∈([1., 1.], po)
-@test ∈([3., 2.], po)
-@test ∈([5./4., 7./4.], po)
-@test !∈([4., 1.], po)
-@test !∈([5., 2.], po)
-@test !∈([3., 4.], po)
-@test !∈([-1., 5.], po)
+    vp = VPolygon(points, apply_convex_hull=false) # we can turn it off
+    @test vertices_list(vp) == [N[0.9,0.2], N[0.4,0.6], N[0.2,0.1], N[0.1,0.3], N[0.3,0.28]]
 
-# an_element function
-@test an_element(po) ∈ po
+    # test for pre-sorted points
+    points = [N[0.1, 0.3], N[0.2, 0.1], N[0.4, 0.3], N[0.4, 0.6], N[0.9, 0.2]]
+    vp = VPolygon(points, algorithm="monotone_chain_sorted")
+    @test vertices_list(vp) == [N[0.1, 0.3], N[0.2, 0.1], N[0.9, 0.2], N[0.4, 0.6]]
 
-# Test VRepresentation
-vp = tovrep(p)
-@test [2., 4.] ∈ vp.vertices_list
-@test [-1., 1.] ∈ vp.vertices_list
-@test [0., 0.] ∈ vp.vertices_list
-@test [4., 2.] ∈ vp.vertices_list
-
-# test convex hull of a set of points using the default algorithm
-points = [[0.9,0.2], [0.4,0.6], [0.2,0.1], [0.1,0.3], [0.3,0.28]]
-vp = VPolygon(points) # by default, a convex hull is run
-@test vertices_list(vp) == [ [0.1,0.3],[0.2,0.1], [0.9,0.2],[0.4,0.6] ]
-
-vp = VPolygon(points, apply_convex_hull=false) # we can turn it off
-@test vertices_list(vp) == [[0.9,0.2], [0.4,0.6], [0.2,0.1], [0.1,0.3], [0.3,0.28]]
-
-# test for pre-sorted points
-points = [[0.1, 0.3], [0.2, 0.1], [0.4, 0.3], [0.4, 0.6], [0.9, 0.2]]
-vp = VPolygon(points, algorithm="monotone_chain_sorted")
-@test vertices_list(vp) == [[0.1, 0.3], [0.2, 0.1], [0.9, 0.2], [0.4, 0.6]]
-
-# test support vector of a VPolygon
-p = HPolygon()
-for ci in [c1, c2, c3, c4]
+    # test support vector of a VPolygon
+    p = HPolygon{N}()
+    for ci in [c1, c2, c3, c4]
     addconstraint!(p, ci)
+    end
+    p = tovrep(p)
+
+    # Test Support Vector
+    d = N[1., 0.]
+    @test σ(d, p) == N[4., 2.]
+    d = N[0., 1.]
+    @test σ(d, p) == N[2., 4.]
+    d = N[-1., 0.]
+    @test σ(d, p) == N[-1., 1.]
+    d = N[0., -1.]
+    @test σ(d, p) == N[0., 0.]
+
+    # test that #83 is fixed
+    v = VPolygon([N[2.0, 3.0]])
+    @test N[2.0, 3.0] ∈ v
+    @test !(N[3.0, 2.0] ∈ v)
+    v = VPolygon([N[2.0, 3.0], N[-1.0, -3.4]])
+    @test N[-1.0, -3.4] ∈ v
+
+    # an_element function
+    v = VPolygon([N[2., 3.]])
+    @test an_element(v) ∈ v
+
+    # subset
+    p1 = VPolygon([N[0., 0.],N[2., 0.]])
+    p2 = VPolygon([N[1., 0.]])
+    @test ⊆(p2, p1) && ⊆(p2, p1, true)[1]
+    @test ⊆(HPolygon{N}(), p1)
+    @test ⊆(p1, BallInf(N[1., 0.], N(1.)))
 end
-p = tovrep(p)
-
-# Test Support Vector
-d = [1., 0.]
-@test σ(d, p) == [4., 2.]
-d = [0., 1.]
-@test σ(d, p) == [2., 4.]
-d = [-1., 0.]
-@test σ(d, p) == [-1., 1.]
-d = [0., -1.]
-@test σ(d, p) == [0., 0.]
-
-# test that #83 is fixed
-v = VPolygon([[2.0, 3.0]])
-@test [2.0, 3.0] ∈ v
-@test !([3.0, 2.0] ∈ v)
-v = VPolygon([[2.0, 3.0], [-1.0, -3.4]])
-@test [-1.0, -3.4] ∈ v
-
-# an_element function
-v = VPolygon([[2., 3.]])
-@test an_element(v) ∈ v
-
-# subset
-p1 = VPolygon([[0., 0.],[2., 0.]])
-p2 = VPolygon([[1., 0.]])
-@test ⊆(p2, p1) && ⊆(p2, p1, true)[1]
-@test ⊆(HPolygon(), p1)
-@test ⊆(p1, BallInf([1., 0.], 1.))

--- a/test/unit_Polytope.jl
+++ b/test/unit_Polytope.jl
@@ -1,24 +1,26 @@
-# 2D polytope
-p = HPolytope()
-c1 = LinearConstraint([2., 2.], 12.)
-c2 = LinearConstraint([-3., 3.], 6.)
-c3 = LinearConstraint([-1., -1.], 0.)
-c4 = LinearConstraint([2., -4.], 0.)
-addconstraint!(p, c3)
-addconstraint!(p, c1)
-addconstraint!(p, c4)
-addconstraint!(p, c2)
+for N in [Float64, Rational{Int}, Float32]
+    # 2D polytope
+    p = HPolytope{N}()
+    c1 = LinearConstraint(N[2., 2.], N(12.))
+    c2 = LinearConstraint(N[-3., 3.], N(6.))
+    c3 = LinearConstraint(N[-1., -1.], N(0.))
+    c4 = LinearConstraint(N[2., -4.], N(0.))
+    addconstraint!(p, c3)
+    addconstraint!(p, c1)
+    addconstraint!(p, c4)
+    addconstraint!(p, c2)
 
-# support vector
-d = [1., 0.]
-@test σ(d, p) == [4., 2.]
-d = [0., 1.]
-@test σ(d, p) == [2., 4.]
-d = [-1., 0.]
-@test σ(d, p) == [-1., 1.]
-d = [0., -1.]
-@test σ(d, p) == [0., 0.]
+    # support vector
+    d = N[1., 0.]
+    @test σ(d, p) == N[4., 2.]
+    d = N[0., 1.]
+    @test σ(d, p) == N[2., 4.]
+    d = N[-1., 0.]
+    @test σ(d, p) == N[-1., 1.]
+    d = N[0., -1.]
+    @test σ(d, p) == N[0., 0.]
 
-# membership
-@test ∈([5./4., 7./4.], p)
-@test !∈([4., 1.], p)
+    # membership
+    @test ∈(N[5./4., 7./4.], p)
+    @test !∈(N[4., 1.], p)
+end

--- a/test/unit_Singleton.jl
+++ b/test/unit_Singleton.jl
@@ -1,46 +1,48 @@
-# 1D singleton
-s = Singleton([1.])
-d = [1.]
-@test σ(d, s) == [1.]
-d = [-1.]
-@test σ(d, s) == [1.]
-d = [0.]
-@test σ(d, s) == [1.]
+for N in [Float64, Rational{Int}, Float32]
+    # 1D singleton
+    s = Singleton(N[1.])
+    d = N[1.]
+    @test σ(d, s) == N[1.]
+    d = N[-1.]
+    @test σ(d, s) == N[1.]
+    d = N[0.]
+    @test σ(d, s) == N[1.]
 
-# 2D singleton
-s = Singleton([1., 2.])
-d = [1., 0.]
-@test σ(d, s) == [1., 2.]
-d = [-1., .5]
-@test σ(d, s) == [1., 2.]
-d = [0., 0.]
-@test σ(d, s) == [1., 2.]
+    # 2D singleton
+    s = Singleton(N[1., 2.])
+    d = N[1., 0.]
+    @test σ(d, s) == N[1., 2.]
+    d = N[-1., .5]
+    @test σ(d, s) == N[1., 2.]
+    d = N[0., 0.]
+    @test σ(d, s) == N[1., 2.]
 
-# membership
-S = Singleton([1., 1.])
-!∈([0.9, 1.1], S)
-∈([1.0, 1.0], S)
+    # membership
+    S = Singleton(N[1., 1.])
+    !∈(N[0.9, 1.1], S)
+    ∈(N[1.0, 1.0], S)
 
-# an_element function
-@test an_element(S) ∈ S
+    # an_element function
+    @test an_element(S) ∈ S
 
-# subset
-s1 = Singleton([0., 1.])
-s2 = Singleton([0., 3.])
-p1 = VPolygon([[0.,0.],[0., 2.]])
-p2 = VPolygon([[0.,0.],[0., 2.], [2., 0.]])
-@test ⊆(s1, p1) && ⊆(s1, p1, true)[1]
-subset, point = ⊆(s2, p2, true)
-@test !⊆(s2, p2) && !subset && point ∈ s2 && !(point ∈ p2)
-@test ⊆(s1, s1) && ⊆(s1, s1, true)[1]
-subset, point = ⊆(s1, s2, true)
-@test !⊆(s1, s2) && !subset && point ∈ s1 && !(point ∈ s2)
+    # subset
+    s1 = Singleton(N[0., 1.])
+    s2 = Singleton(N[0., 3.])
+    p1 = VPolygon([N[0.,0.], N[0., 2.]])
+    p2 = VPolygon([N[0.,0.], N[0., 2.], N[2., 0.]])
+    @test ⊆(s1, p1) && ⊆(s1, p1, true)[1]
+    subset, point = ⊆(s2, p2, true)
+    @test !⊆(s2, p2) && !subset && point ∈ s2 && !(point ∈ p2)
+    @test ⊆(s1, s1) && ⊆(s1, s1, true)[1]
+    subset, point = ⊆(s1, s2, true)
+    @test !⊆(s1, s2) && !subset && point ∈ s1 && !(point ∈ s2)
 
-# intersection emptiness
-S1 = Singleton([1.0, 1.0])
-S2 = Singleton([0.0, 0.0])
-S3 = ZeroSet(2)
-@test is_intersection_empty(S1, S2) && is_intersection_empty(S1, S2, true)[1]
-intersection_empty, point = is_intersection_empty(S2, S3, true)
-@test !is_intersection_empty(S2, S3) &&
+    # intersection emptiness
+    S1 = Singleton(N[1.0, 1.0])
+    S2 = Singleton(N[0.0, 0.0])
+    S3 = ZeroSet{N}(2)
+    @test is_intersection_empty(S1, S2) && is_intersection_empty(S1, S2, true)[1]
+    intersection_empty, point = is_intersection_empty(S2, S3, true)
+    @test !is_intersection_empty(S2, S3) &&
     !intersection_empty && point ∈ S2 && point ∈ S3
+end

--- a/test/unit_SymmetricIntervalHull.jl
+++ b/test/unit_SymmetricIntervalHull.jl
@@ -1,17 +1,20 @@
-# constructor from empty set
-@test SymmetricIntervalHull(∅) == ∅
+for N in [Float64, Rational{Int}, Float32]
+    # constructor from empty set
+    E = EmptySet{N}()
+    @test SymmetricIntervalHull(E) == E
 
-# normal constructor
-h = SymmetricIntervalHull(Ball2([2., 3.], 4.))
+    # normal constructor
+    h = SymmetricIntervalHull(Ball1(N[2., 3.], N(4.)))
 
-# dimension
-@test dim(h) == 2
+    # dimension
+    @test dim(h) == 2
 
-# support vector
-d = [1., 0.]
-@test σ(d, h)[1] == 6. && σ(-d, h)[1] == -6.
-d = [0., 1.]
-@test σ(d, h)[2] == 7. && σ(-d, h)[2] == -7.
+    # support vector
+    d = N[1., 0.]
+    @test σ(d, h)[1] == N(6.) && σ(-d, h)[1] == N(-6.)
+    d = N[0., 1.]
+    @test σ(d, h)[2] == N(7.) && σ(-d, h)[2] == N(-7.)
 
-# an_element function
-@test an_element(h) == [0., 0.]
+    # an_element function
+    @test an_element(h) == N[0., 0.]
+end

--- a/test/unit_UnionSet.jl
+++ b/test/unit_UnionSet.jl
@@ -1,38 +1,41 @@
-# UnionSet of Polygon
-# Union construction
-p1 = HPolygon()
-c = LinearConstraint([1., 0.], 1.)
-addconstraint!(p1, c)
-c = LinearConstraint([-1., 0.], 1.)
-addconstraint!(p1, c)
-c = LinearConstraint([0., 1.], 1.)
-addconstraint!(p1, c)
-c = LinearConstraint([0., -1.], 1.)
-addconstraint!(p1, c)
-p2 = HPolygon()
-v = [4., 5.]
-c = LinearConstraint([1., 0.], 1. + dot(v, [1., 0.]))
-addconstraint!(p2, c)
-c = LinearConstraint([-1., 0.], 1. + dot(v, [-1., 0.]))
-addconstraint!(p2, c)
-c = LinearConstraint([0., 1.], 1. + dot(v, [0., 1.]))
-addconstraint!(p2, c)
-c = LinearConstraint([0., -1.], 1. + dot(v, [0., -1.]))
-addconstraint!(p2, c)
-u = UnionSet([p1, p2])
-# In test
-@test in([0., 0.], u) == true
-@test in([1., 0.], u) == true
-@test in([-1., 0.], u) == true
-@test in([0., 1.], u) == true
-@test in([0., -1.], u) == true
-@test in([4., 5.], u) == true
-@test in([5., 5.], u) == true
-@test in([3., 5.], u) == true
-@test in([4., 6.], u) == true
-@test in([4., 4.], u) == true
-@test in([2., 2.], u) == false
-@test in([2., 5.], u) == false
-@test in([5., 2.], u) == false
-@test in([-1., 2.], u) == false
-@test in([-5., -5.], u) == false
+for N in [Float64, Rational{Int}, Float32]
+    # UnionSet of Polygon
+    # Union construction
+    p1 = HPolygon{N}()
+    c = LinearConstraint(N[1., 0.], N(1.))
+    addconstraint!(p1, c)
+    c = LinearConstraint(N[-1., 0.], N(1.))
+    addconstraint!(p1, c)
+    c = LinearConstraint(N[0., 1.], N(1.))
+    addconstraint!(p1, c)
+    c = LinearConstraint(N[0., -1.], N(1.))
+    addconstraint!(p1, c)
+    p2 = HPolygon{N}()
+    v = N[4., 5.]
+    c = LinearConstraint(N[1., 0.], N(1.9 + dot(v, N[1., 0.]))
+    addconstraint!(p2, c)
+    c = LinearConstraint(N[-1., 0.], N(1.) + dot(v, N[-1., 0.]))
+    addconstraint!(p2, c)
+    c = LinearConstraint(N[0., 1.], N(1.) + dot(v, N[0., 1.]))
+    addconstraint!(p2, c)
+    c = LinearConstraint(N[0., -1.], N(1.) + dot(v, N[0., -1.]))
+    addconstraint!(p2, c)
+    u = UnionSet([p1, p2])
+
+    # membership
+    @test ∈(N[0., 0.], u)
+    @test ∈(N[1., 0.], u)
+    @test ∈(N[-1., 0.], u)
+    @test ∈(N[0., 1.], u)
+    @test ∈(N[0., -1.], u)
+    @test ∈(N[4., 5.], u)
+    @test ∈(N[5., 5.], u)
+    @test ∈(N[3., 5.], u)
+    @test ∈(N[4., 6.], u)
+    @test ∈(N[4., 4.], u)
+    @test !∈(N[2., 2.], u)
+    @test !∈(N[2., 5.], u)
+    @test !∈(N[5., 2.], u)
+    @test !∈(N[-1., 2.], u)
+    @test !∈(N[-5., -5.], u)
+end

--- a/test/unit_ZeroSet.jl
+++ b/test/unit_ZeroSet.jl
@@ -1,23 +1,25 @@
-Z = ZeroSet(2)
-B = BallInf(ones(2), 1.)
+for N in [Float64, Rational{Int}, Float32]
+    Z = ZeroSet{N}(2)
+    B = BallInf(ones(N, 2), N(1.))
 
-# testing that the zero set is neutral element for the Minkowski sum
-@test B ⊕ Z == B && Z ⊕ B == B
+    # testing that the zero set is neutral element for the Minkowski sum
+    @test B ⊕ Z == B && Z ⊕ B == B
 
-cpa = MinkowskiSumArray([B, 2. * B, 3. * B])
-@test cpa ⊕ Z == cpa && Z ⊕ cpa == cpa
+    cpa = MinkowskiSumArray([B, N(2.) * B, N(3.) * B])
+    @test cpa ⊕ Z == cpa && Z ⊕ cpa == cpa
 
-# test M-sum of zero set with itself
-@test ZeroSet(2) ⊕ ZeroSet(2) == ZeroSet(2)
+    # test M-sum of zero set with itself
+    @test ZeroSet{N}(2) ⊕ ZeroSet{N}(2) == ZeroSet{N}(2)
 
-# an_element function
-@test an_element(Z) ∈ Z
+    # an_element function
+    @test an_element(Z) ∈ Z
 
-# subset
-z = ZeroSet(1)
-s1 = Singleton([0.])
-s2 = Singleton([2.])
-@test ⊆(z, s1) && ⊆(z, s1, true)[1]
-subset, point = ⊆(z, s2, true)
-@test !⊆(z, s2) && !subset && point ∈ z && !(point ∈ s2)
-@test ⊆(z, z) && !⊆(z, ZeroSet(2))
+    # subset
+    z = ZeroSet{N}(1)
+    s1 = Singleton(N[0.])
+    s2 = Singleton(N[2.])
+    @test ⊆(z, s1) && ⊆(z, s1, true)[1]
+    subset, point = ⊆(z, s2, true)
+    @test !⊆(z, s2) && !subset && point ∈ z && !(point ∈ s2)
+    @test ⊆(z, z) && !⊆(z, ZeroSet{N}(2))
+end

--- a/test/unit_Zonotope.jl
+++ b/test/unit_Zonotope.jl
@@ -1,58 +1,60 @@
-# 1D Zonotope
-z = Zonotope([0.], eye(1))
-# Test Dimension
-@test dim(z) == 1
-# Test Support Vector
-d = [1.]
-@test σ(d, z) == [1.]
-d = [-1.]
-@test σ(d, z) == [-1.]
+for N in [Float64, Rational{Int}, Float32]
+    # 1D Zonotope
+    z = Zonotope(N[0.], eye(N, 1))
+    # Test Dimension
+    @test dim(z) == 1
+    # Test Support Vector
+    d = N[1.]
+    @test σ(d, z) == N[1.]
+    d = N[-1.]
+    @test σ(d, z) == N[-1.]
 
-# 2D Zonotope
-z = Zonotope([0., 0.], 1. * eye(2))
-# Test Dimension
-@test dim(z) == 2
-# Test Support Vector
-d = [1., 0.]
-@test σ(d, z) == [1., 1.] || [1., -1]
-d = [-1., 0.]
-@test σ(d, z) == [-1., 1.] || [-1., -1]
-d = [0., 1.]
-@test σ(d, z) == [1., 1.] || [-1., 1]
-d = [0., -1.]
-@test σ(d, z) == [1., -1.] || [-1., -1]
+    # 2D Zonotope
+    z = Zonotope(N[0., 0.], N(1.) * eye(N, 2))
+    # Test Dimension
+    @test dim(z) == 2
+    # Test Support Vector
+    d = N[1., 0.]
+    @test σ(d, z) == N[1., 1.] || N[1., -1]
+    d = N[-1., 0.]
+    @test σ(d, z) == N[-1., 1.] || N[-1., -1]
+    d = N[0., 1.]
+    @test σ(d, z) == N[1., 1.] || N[-1., 1]
+    d = N[0., -1.]
+    @test σ(d, z) == N[1., -1.] || N[-1., -1]
 
-# 2D Zonotope not 0-centered
-z = Zonotope([1., 2.], 1. * eye(2))
-# Test Dimension
-@test dim(b) == 2
-# Test Support Vector
-d = [1., 0.]
-@test σ(d, z) == [2., 3]
-d = [-1., 0.]
-@test σ(d, z) == [0., 3]
-d = [0., 1.]
-@test σ(d, z) == [2., 3]
-d = [0., -1.]
-@test σ(d, z) == [2., 1.]
+    # 2D Zonotope not 0-centered
+    z = Zonotope(N[1., 2.], N(1.) * eye(N, 2))
+    # Test Dimension
+    @test dim(z) == 2
+    # Test Support Vector
+    d = N[1., 0.]
+    @test σ(d, z) == N[2., 3]
+    d = N[-1., 0.]
+    @test σ(d, z) == N[0., 3]
+    d = N[0., 1.]
+    @test σ(d, z) == N[2., 3]
+    d = N[0., -1.]
+    @test σ(d, z) == N[2., 1.]
 
-# an_element function
-@test an_element(z) ∈ z
+    # an_element function
+    @test an_element(z) ∈ z
 
-# concrete operations
-Z1 = Zonotope([1, 1.], [1 1; -1 1.])
-Z2 = Zonotope([-1, 1.], eye(2))
-A = [0.5 1; 1 0.5]
+    # concrete operations
+    Z1 = Zonotope(N[1, 1.], N[1 1; -1 1.])
+    Z2 = Zonotope(N[-1, 1.], eye(N, 2))
+    A = N[0.5 1; 1 0.5]
 
-# concrete Minkowski sum
-Z3 = minkowski_sum(Z1, Z2)
-@test Z3.center == [0, 2.]
-@test Z3.generators == [1 1 1 0; -1 1 0 1.]
+    # concrete Minkowski sum
+    Z3 = minkowski_sum(Z1, Z2)
+    @test Z3.center == N[0, 2.]
+    @test Z3.generators == N[1 1 1 0; -1 1 0 1.]
 
-# concrete linear map and scale
-Z4 = linear_map(A, Z3)
-@test Z4.center == [2, 1.]
-@test Z4.generators == [-0.5 1.5 0.5 1.0; 0.5 1.5 1.0 0.5]
-Z5 = scale(0.5, Z3)
-@test Z5.center == [0, 1.]
-@test Z5.generators == [0.5 0.5 0.5 0.0; -0.5 0.5 0.0 0.5]
+    # concrete linear map and scale
+    Z4 = linear_map(A, Z3)
+    @test Z4.center == N[2, 1.]
+    @test Z4.generators == N[-0.5 1.5 0.5 1.0; 0.5 1.5 1.0 0.5]
+    Z5 = scale(0.5, Z3)
+    @test Z5.center == N[0, 1.]
+    @test Z5.generators == N[0.5 0.5 0.5 0.0; -0.5 0.5 0.0 0.5]
+end

--- a/test/unit_ballinf_approximation.jl
+++ b/test/unit_ballinf_approximation.jl
@@ -1,20 +1,22 @@
 import LazySets.Approximations.ballinf_approximation
 
-# BallInf approximation of a 3D unit ball centered at [1,2,0] of radius 1
-b = Ball2([1., 2., 0.], 1.)
-bi = ballinf_approximation(b)
-biexp = BallInf([1., 2., 0.], 1.)
-@test bi.center ≈ biexp.center
-@test bi.radius ≈ biexp.radius
+for N in [Float64, Float32] # TODO Rational{Int}
+    # BallInf approximation of a 3D unit ball in the 1-norm centered at [1,2,0]
+    b = Ball1(N[1., 2., 0.], N(1.))
+    bi = ballinf_approximation(b)
+    biexp = BallInf(N[1., 2., 0.], N(1.))
+    @test bi.center ≈ biexp.center
+    @test bi.radius ≈ biexp.radius
 
-# BallInf approximation of a 2D polygon whose vertices are
-# (0,1), (1,1), (2,-1), (-1,0)
-p = HPolygon()
-addconstraint!(p, LinearConstraint([0., 1.], 1.))
-addconstraint!(p, LinearConstraint([-1., 1.], 1.))
-addconstraint!(p, LinearConstraint([-1., -3.], 1.))
-addconstraint!(p, LinearConstraint([2., 1.], 3.))
-bi = ballinf_approximation(p)
-biexp = BallInf([.5, 0.], 1.5)
-@test bi.center ≈ biexp.center
-@test bi.radius ≈ biexp.radius
+    # BallInf approximation of a 2D polygon whose vertices are
+    # (0,1), (1,1), (2,-1), (-1,0)
+    p = HPolygon{N}()
+    addconstraint!(p, LinearConstraint(N[0., 1.], N(1.)))
+    addconstraint!(p, LinearConstraint(N[-1., 1.], N(1.)))
+    addconstraint!(p, LinearConstraint(N[-1., -3.], N(1.)))
+    addconstraint!(p, LinearConstraint(N[2., 1.], N(3.)))
+    bi = ballinf_approximation(p)
+    biexp = BallInf(N[.5, 0.], N(1.5))
+    @test bi.center ≈ biexp.center
+    @test bi.radius ≈ biexp.radius
+end

--- a/test/unit_box_approximation.jl
+++ b/test/unit_box_approximation.jl
@@ -2,63 +2,64 @@ import LazySets.Approximations:box_approximation,
                                box_approximation_symmetric,
                                symmetric_interval_hull
 
-# ==============================
-# Testing box approximation
-# ==============================
-# Box approximation of a 2D square
-b = BallInf([1., 1.], 0.1)
-h = box_approximation(b)
-hexp = Hyperrectangle([1., 1.], [0.1, 0.1])
-@test h.center ≈ hexp.center
-@test h.radius ≈ hexp.radius
+for N in [Float64, Rational{Int}, Float32]
+    # ==============================
+    # Testing box approximation
+    # ==============================
+    # Box approximation of a 2D square
+    b = BallInf(to_N(N, [1., 1.]), to_N(N, 0.1))
+    h = box_approximation(b)
+    hexp = Hyperrectangle(to_N(N, [1., 1.]), to_N(N, [0.1, 0.1]))
+    @test h.center ≈ hexp.center
+    @test h.radius ≈ hexp.radius
 
-# Box approximation of a 2D unit ball
-b = Ball2([1., -2.], 0.2)
-h = box_approximation(b)
-hexp = Hyperrectangle([1., -2.], [0.2, 0.2])
-@test h.center ≈ hexp.center
-@test h.radius ≈ hexp.radius
-
-
-# Box approximation of a 3D unit ball
-b = Ball2([1., 2., 0.], 1.)
-h = box_approximation(b)
-hexp = Hyperrectangle([1., 2., 0.], [1., 1., 1.])
-@test h.center ≈ hexp.center
-@test h.radius ≈ hexp.radius
+    # Box approximation of a 2D unit ball in the 1-norm
+    b = Ball1(to_N(N, [1., -2.]), to_N(N, 0.2))
+    h = box_approximation(b)
+    hexp = Hyperrectangle(to_N(N, [1., -2.]), to_N(N, [0.2, 0.2]))
+    @test h.center ≈ hexp.center
+    @test h.radius ≈ hexp.radius
 
 
-# ===================================================================
-# Testing box_approximation_symmetric (= symmetric interval hull)
-# ===================================================================
-# Box approximation of a 2D square
-b = BallInf([1., 1.], 0.1)
-h = box_approximation_symmetric(b)
-hexp = Hyperrectangle([0.0, 0.0], [1.1, 1.1])
-@test h.center ≈ hexp.center
-@test h.radius ≈ hexp.radius
+    # Box approximation of a 3D unit ball in the 1-norm
+    b = Ball1(to_N(N, [1., 2., 0.]), to_N(N, 1.))
+    h = box_approximation(b)
+    hexp = Hyperrectangle(to_N(N, [1., 2., 0.]), to_N(N, [1., 1., 1.]))
+    @test h.center ≈ hexp.center
+    @test h.radius ≈ hexp.radius
 
-# Box approximation of a 2D unit ball
-b = Ball2([1., -2.], 0.2)
-h = box_approximation_symmetric(b)
-hexp = Hyperrectangle([0., 0.], [1.2, 2.2])
-@test h.center ≈ hexp.center
-@test h.radius ≈ hexp.radius
 
-# Box approximation of a 3D unit ball
-b = Ball2([1., 2., 0.], 0.1)
-h = box_approximation_symmetric(b)
-hexp = Hyperrectangle([0., 0., 0.], [1.1, 2.1, 0.1])
-@test h.center ≈ hexp.center
-@test h.radius ≈ hexp.radius
+    # ===================================================================
+    # Testing box_approximation_symmetric (= symmetric interval hull)
+    # ===================================================================
+    # Box approximation of a 2D square
+    b = BallInf(to_N(N, [1., 1.]), to_N(N, 0.1))
+    h = box_approximation_symmetric(b)
+    hexp = Hyperrectangle(to_N(N, [0.0, 0.0]), to_N(N, [1.1, 1.1]))
+    @test h.center ≈ hexp.center
+    @test h.radius ≈ hexp.radius
 
-# Box approximation of a 4D hyperrectangle
-b = Hyperrectangle([-1.5, -2.5, 2.4, -0.4], [0.1, 0.2, 0.3, 0.4])
-h = box_approximation_symmetric(b)
-hexp = Hyperrectangle(zeros(4), [1.6, 2.7, 2.7, 0.8])
-@test h.center ≈ hexp.center
-@test h.radius ≈ hexp.radius
+    # Box approximation of a 2D unit ball in the 1-norm
+    b = Ball1(to_N(N, [1., -2.]), to_N(N, 0.2))
+    h = box_approximation_symmetric(b)
+    hexp = Hyperrectangle(to_N(N, [0., 0.]), to_N(N, [1.2, 2.2]))
+    @test h.center ≈ hexp.center
+    @test h.radius ≈ hexp.radius
 
-# Testing alias symmetric_interval_hull
-h = symmetric_interval_hull(b)
+    # Box approximation of a 3D unit ball in the 1-norm
+    b = Ball1(to_N(N, [1., 2., 0.]), to_N(N, 0.1))
+    h = box_approximation_symmetric(b)
+    hexp = Hyperrectangle(to_N(N, [0., 0., 0.]), to_N(N, [1.1, 2.1, 0.1]))
+    @test h.center ≈ hexp.center
+    @test h.radius ≈ hexp.radius
 
+    # Box approximation of a 4D hyperrectangle
+    b = Hyperrectangle(to_N(N, [-1.5, -2.5, 2.4, -0.4]), to_N(N, [0.1, 0.2, 0.3, 0.4]))
+    h = box_approximation_symmetric(b)
+    hexp = Hyperrectangle(zeros(N, 4), to_N(N, [1.6, 2.7, 2.7, 0.8]))
+    @test h.center ≈ hexp.center
+    @test h.radius ≈ hexp.radius
+
+    # Testing alias symmetric_interval_hull
+    h = symmetric_interval_hull(b)
+end

--- a/test/unit_decompose.jl
+++ b/test/unit_decompose.jl
@@ -1,35 +1,39 @@
 import LazySets.Approximations.decompose
 
-# ==============================
-# Check that Issue #43 is fixed
-# ==============================
-const CPA = CartesianProductArray
-X = CPA([BallInf([0.767292, 0.936613], 0.1), BallInf([0.734104, 0.87296], 0.1)])
-Y = [1.92664 1.00674 1.0731 -0.995149;
-    -2.05704 3.48059 0.0317863 1.83481;
-    0.990993 -1.97754 0.754192 -0.807085;
-    -2.43723 0.782825 -3.99255 3.93324]
-Y = Y * CPA([BallInf([0.767292, 0.936613], 0.1), BallInf([0.734104, 0.87296], 0.1)])
-Ω0 = CH(X, Y)
-dec = decompose(Ω0)
-dec1 = dec.sfarray[1]
+for N in [Float64, Float32] # TODO Rational{Int}
+    # ==============================
+    # Check that Issue #43 is fixed
+    # ==============================
+    const CPA = CartesianProductArray
+    X = CPA([BallInf(to_N(N, [0.767292, 0.936613]), to_N(N, 0.1)),
+             BallInf(to_N(N, [0.734104, 0.87296]), to_N(N, 0.1))])
+    Y = to_N(N, [1.92664 1.00674 1.0731 -0.995149;
+        -2.05704 3.48059 0.0317863 1.83481;
+        0.990993 -1.97754 0.754192 -0.807085;
+        -2.43723 0.782825 -3.99255 3.93324])
+    Y = Y * CPA([BallInf(to_N(N, [0.767292, 0.936613]), to_N(N, 0.1)),
+                 BallInf(to_N(N, [0.734104, 0.87296]), to_N(N, 0.1))])
+    Ω0 = CH(X, Y)
+    dec = decompose(Ω0)
+    dec1 = dec.sfarray[1]
 
-@test dec1.constraints_list[1].b ≈ 2.84042586
-@test dec1.constraints_list[2].b ≈ 4.04708832
-@test dec1.constraints_list[3].b ≈ -0.667292
-@test dec1.constraints_list[4].b ≈ -0.836613
+    @test dec1.constraints_list[1].b ≈ to_N(N, 2.84042586)
+    @test dec1.constraints_list[2].b ≈ to_N(N, 4.04708832)
+    @test dec1.constraints_list[3].b ≈ to_N(N, -0.667292)
+    @test dec1.constraints_list[4].b ≈ to_N(N, -0.836613)
 
-# ======================================
-# Run decompose for different set types
-# ======================================
-b = BallInf(zeros(6), 1.)
-d = decompose(b, Inf, HPolygon)
-@test d.sfarray[1] isa HPolygon
-d = decompose(b, Inf, Hyperrectangle)
-@test d.sfarray[1] isa Hyperrectangle
-d = decompose(b, 1e-2, Hyperrectangle)
-@test d.sfarray[1] isa HPolygon  # with p not Inf the set type is ignored
-d = decompose(b, 1e-2) # by default uses HPolygon
-@test d.sfarray[1] isa HPolygon
-d = decompose(b, [1e-1, 1e-2, 1e-3])
-@test d.sfarray[1] isa HPolygon
+    # ======================================
+    # Run decompose for different set types
+    # ======================================
+    b = BallInf(zeros(N, 6), one(N))
+    d = decompose(b, Inf, HPolygon)
+    @test d.sfarray[1] isa HPolygon
+    d = decompose(b, Inf, Hyperrectangle)
+    @test d.sfarray[1] isa Hyperrectangle
+    d = decompose(b, to_N(N, 1e-2), Hyperrectangle)
+    @test d.sfarray[1] isa HPolygon  # with p not Inf the set type is ignored
+    d = decompose(b, to_N(N, 1e-2)) # by default uses HPolygon
+    @test d.sfarray[1] isa HPolygon
+    d = decompose(b, [to_N(N, 1e-1), to_N(N, 1e-2), to_N(N, 1e-3)])
+    @test d.sfarray[1] isa HPolygon
+end

--- a/test/unit_decompose.jl
+++ b/test/unit_decompose.jl
@@ -1,3 +1,5 @@
+import LazySets.Approximations.decompose
+
 # ==============================
 # Check that Issue #43 is fixed
 # ==============================
@@ -9,10 +11,25 @@ Y = [1.92664 1.00674 1.0731 -0.995149;
     -2.43723 0.782825 -3.99255 3.93324]
 Y = Y * CPA([BallInf([0.767292, 0.936613], 0.1), BallInf([0.734104, 0.87296], 0.1)])
 Ω0 = CH(X, Y)
-dec = Approximations.decompose(Ω0)
+dec = decompose(Ω0)
 dec1 = dec.sfarray[1]
 
 @test dec1.constraints_list[1].b ≈ 2.84042586
 @test dec1.constraints_list[2].b ≈ 4.04708832
 @test dec1.constraints_list[3].b ≈ -0.667292
 @test dec1.constraints_list[4].b ≈ -0.836613
+
+# ======================================
+# Run decompose for different set types
+# ======================================
+b = BallInf(zeros(6), 1.)
+d = decompose(b, Inf, HPolygon)
+@test d.sfarray[1] isa HPolygon
+d = decompose(b, Inf, Hyperrectangle)
+@test d.sfarray[1] isa Hyperrectangle
+d = decompose(b, 1e-2, Hyperrectangle)
+@test d.sfarray[1] isa HPolygon  # with p not Inf the set type is ignored
+d = decompose(b, 1e-2) # by default uses HPolygon
+@test d.sfarray[1] isa HPolygon
+d = decompose(b, [1e-1, 1e-2, 1e-3])
+@test d.sfarray[1] isa HPolygon

--- a/test/unit_overapproximation2D.jl
+++ b/test/unit_overapproximation2D.jl
@@ -1,55 +1,57 @@
 import LazySets.Approximations.overapproximate
 
-# Approximation of a 2D centered unit ball in norm 2
-# All vertices v should be like this:
-# ‖v‖ >= 1 and ‖v‖ <= 1+ɛ
-# Where ɛ is the given error bound
-b = Ball2([0., 0.], 1.)
-ɛ = .01
-p = tovrep(overapproximate(b, ɛ))
-for v in p.vertices_list
-    @test norm(v) >= 1.
-    @test norm(v) <= 1.+ɛ
+for N in [Float64, Float32] # TODO Rational{Int}
+    # Approximation of a 2D centered unit ball in norm 1
+    # All vertices v should be like this:
+    # ‖v‖ >= 1 and ‖v‖ <= 1+ɛ
+    # Where ɛ is the given error bound
+    b = Ball1(N[0., 0.], N(1.))
+    ɛ = N(.01)
+    p = tovrep(overapproximate(b, ɛ))
+    for v in p.vertices_list
+    @test norm(v) >= N(1.)
+    @test norm(v) <= N(1.+ɛ)
+    end
+
+    # Check that there are no redundant constraints for a ballinf
+    b = BallInf(N[0.5, 0.5], N(0.1))
+    lcl = overapproximate(b, N(.001)).constraints_list
+    @test length(lcl) == 4
+    @test lcl[1].a == N[1.0, 0.0]
+    @test lcl[1].b == N(0.6)
+    @test lcl[2].a == N[0.0, 1.0]
+    @test lcl[2].b == N(0.6)
+    @test lcl[3].a == N[-1.0, 0.0]
+    @test lcl[3].b == N(-0.4)
+    @test lcl[4].a == N[0.0, -1.0]
+    @test lcl[4].b == N(-0.4)
+
+    # Check that there are no redundant constraints for a HPolygon (octagon)
+    p = HPolygon{N}()
+    addconstraint!(p, LinearConstraint(N[1.0, 0.0], N(1.0)))
+    addconstraint!(p, LinearConstraint(N[0.0, 1.0], N(1.0)))
+    addconstraint!(p, LinearConstraint(N[-1.0, 0.0], N(1.0)))
+    addconstraint!(p, LinearConstraint(N[0.0, -1.0], N(1.0)))
+    addconstraint!(p, LinearConstraint(N[sqrt(2.0)/2.0, sqrt(2.0)/2.0], N(1.0)))
+    addconstraint!(p, LinearConstraint(N[-sqrt(2.0)/2.0, sqrt(2.0)/2.0], N(1.0)))
+    addconstraint!(p, LinearConstraint(N[sqrt(2.0)/2.0, -sqrt(2.0)/2.0], N(1.0)))
+    addconstraint!(p, LinearConstraint(N[-sqrt(2.0)/2.0, -sqrt(2.0)/2.0], N(1.0)))
+    lcl = overapproximate(p, N(.001)).constraints_list
+    @test length(lcl) == 8
+    @test lcl[1].a ≈ N[1.0, 0.0]
+    @test lcl[1].b ≈ N(1.0)
+    @test lcl[2].a ≈ N[sqrt(2.0)/2.0, sqrt(2.0)/2.0]
+    @test lcl[2].b ≈ N(1.0)
+    @test lcl[3].a ≈ N[0.0, 1.0]
+    @test lcl[3].b ≈ N(1.0)
+    @test lcl[4].a ≈ N[-sqrt(2.0)/2.0, sqrt(2.0)/2.0]
+    @test lcl[4].b ≈ N(1.0)
+    @test lcl[5].a ≈ N[-1.0, 0.0]
+    @test lcl[5].b ≈ N(1.0)
+    @test lcl[6].a ≈ N[-sqrt(2.0)/2.0, -sqrt(2.0)/2.0]
+    @test lcl[6].b ≈ N(1.0)
+    @test lcl[7].a ≈ N[0.0, -1.0]
+    @test lcl[7].b ≈ N(1.0)
+    @test lcl[8].a ≈ N[sqrt(2.0)/2.0, -sqrt(2.0)/2.0]
+    @test lcl[8].b ≈ N(1.0)
 end
-
-# Check that there are no redundant constraints for a ballinf
-b = BallInf([0.5,0.5],0.1)
-lcl = overapproximate(b, .001).constraints_list
-@test length(lcl) == 4
-@test lcl[1].a == [1.0,0.0]
-@test lcl[1].b == 0.6
-@test lcl[2].a == [0.0,1.0]
-@test lcl[2].b == 0.6
-@test lcl[3].a == [-1.0,0.0]
-@test lcl[3].b == -0.4
-@test lcl[4].a == [0.0,-1.0]
-@test lcl[4].b == -0.4
-
-# Check that there are no redundant constraints for a HPolygon (octagon)
-p = HPolygon()
-addconstraint!(p, LinearConstraint([1.0, 0.0], 1.0))
-addconstraint!(p, LinearConstraint([0.0, 1.0], 1.0))
-addconstraint!(p, LinearConstraint([-1.0, 0.0], 1.0))
-addconstraint!(p, LinearConstraint([0.0, -1.0], 1.0))
-addconstraint!(p, LinearConstraint([sqrt(2.0)/2.0, sqrt(2.0)/2.0], 1.0))
-addconstraint!(p, LinearConstraint([-sqrt(2.0)/2.0, sqrt(2.0)/2.0], 1.0))
-addconstraint!(p, LinearConstraint([sqrt(2.0)/2.0, -sqrt(2.0)/2.0], 1.0))
-addconstraint!(p, LinearConstraint([-sqrt(2.0)/2.0, -sqrt(2.0)/2.0], 1.0))
-lcl = overapproximate(p, .001).constraints_list
-@test length(lcl) == 8
-@test lcl[1].a ≈ [1.0,0.0]
-@test lcl[1].b ≈ 1.0
-@test lcl[2].a ≈ [sqrt(2.0)/2.0, sqrt(2.0)/2.0]
-@test lcl[2].b ≈ 1.0
-@test lcl[3].a ≈ [0.0,1.0]
-@test lcl[3].b ≈ 1.0
-@test lcl[4].a ≈ [-sqrt(2.0)/2.0, sqrt(2.0)/2.0]
-@test lcl[4].b ≈ 1.0
-@test lcl[5].a ≈ [-1.0,0.0]
-@test lcl[5].b ≈ 1.0
-@test lcl[6].a ≈ [-sqrt(2.0)/2.0, -sqrt(2.0)/2.0]
-@test lcl[6].b ≈ 1.0
-@test lcl[7].a ≈ [0.0,-1.0]
-@test lcl[7].b ≈ 1.0
-@test lcl[8].a ≈ [sqrt(2.0)/2.0, -sqrt(2.0)/2.0]
-@test lcl[8].b ≈ 1.0

--- a/test/unit_radiusdiameter.jl
+++ b/test/unit_radiusdiameter.jl
@@ -2,49 +2,51 @@ import LazySets.Approximations:norm,
                                radius,
                                diameter
 
-# =======
-#  Ball2
-# =======
+for N in [Float64, Rational{Int}, Float32]
+    # =======
+    #  Ball1
+    # =======
 
-# approximation of a centered unit Ball2
-b = Ball2([0., 0., 0.], 1.)
-@test norm(b) ≈ 1.  # in the infinity norm (default)
-@test radius(b) ≈ 1.  # in the infinity norm (default)
-@test diameter(b) ≈ 2.  # in the infinity norm (default)
+    # approximation of a centered unit Ball1
+    b = Ball1(N[0., 0., 0.], N(1.))
+    @test norm(b) ≈ N(1.)  # in the infinity norm (default)
+    @test radius(b) ≈ N(1.)  # in the infinity norm (default)
+    @test diameter(b) ≈ N(2.)  # in the infinity norm (default)
 
-# approximations of a non-centered unit Ball2
-b = Ball2([1., 2., 0.], 1.)
-@test norm(b) ≈ 3.  # in the infinity norm (default)
-@test radius(b) ≈ 1.  # in the infinity norm (default)
-@test diameter(b) ≈ 2.  # in the infinity norm (default)
+    # approximations of a non-centered unit Ball1
+    b = Ball1(N[1., 2., 0.], N(1.))
+    @test norm(b) ≈ N(3.)  # in the infinity norm (default)
+    @test radius(b) ≈ N(1.)  # in the infinity norm (default)
+    @test diameter(b) ≈ N(2.)  # in the infinity norm (default)
 
 
-# ================
-#  Hyperrectangle
-# ================
+    # ================
+    #  Hyperrectangle
+    # ================
 
-# metrics in the infinity norm (default)
-h = Hyperrectangle([-1., 2.], [0.2, 0.5])
-@test norm(h, Inf) ≈ 2.5
-@test radius(h, Inf) ≈ 0.5
-@test diameter(h, Inf) ≈ 1.
+    # metrics in the infinity norm (default)
+    h = Hyperrectangle(N[-1., 2.], N[0.2, 0.5])
+    @test norm(h, Inf) ≈ N(2.5)
+    @test radius(h, Inf) ≈ N(0.5)
+    @test diameter(h, Inf) ≈ N(1.)
 
-# metrics in the 2-norm
-@test norm(h, 2) ≈ sqrt(2.5^2 + 1.2^2)
-@test radius(h, 2) ≈ sqrt(.5^2 + .2^2)
-@test diameter(h, 2) ≈ 2*sqrt(.5^2 + .2^2)
+    # metrics in the 2-norm
+    @test norm(h, 2) ≈ N(sqrt(2.5^2 + 1.2^2))
+    @test radius(h, 2) ≈ N(sqrt(.5^2 + .2^2))
+    @test diameter(h, 2) ≈ N(2*sqrt(.5^2 + .2^2))
 
-# =========
-#  BallInf
-# =========
+    # =========
+    #  BallInf
+    # =========
 
-# metrics in the infinity norm (default)
-b = BallInf([-1., -2., -4], 0.2)
-@test norm(b, Inf) ≈ 4.2
-@test radius(b, Inf) ≈ 0.2
-@test diameter(b, Inf) ≈ 0.4
+    # metrics in the infinity norm (default)
+    b = BallInf(N[-1., -2., -4], N(0.2))
+    @test norm(b, Inf) ≈ N(4.2)
+    @test radius(b, Inf) ≈ N(0.2)
+    @test diameter(b, Inf) ≈ N(0.4)
 
-# metrics in the 2-norm
-@test norm(b, 2) ≈ sqrt(1.2^2 + 2.2^2 + 4.2^2)
-@test radius(b, 2) ≈ sqrt(0.2^2 * 3)
-@test diameter(b, 2) ≈ 2*sqrt(0.2^2 * 3)
+    # metrics in the 2-norm
+    @test norm(b, 2) ≈ N(sqrt(1.2^2 + 2.2^2 + 4.2^2))
+    @test radius(b, 2) ≈ N(sqrt(0.2^2 * 3))
+    @test diameter(b, 2) ≈ N(2*sqrt(0.2^2 * 3))
+end


### PR DESCRIPTION
Closes #132.

There are quite a few problems that prevent using different numeric types. When they are resolved, we have to add the numeric types to the unit tests (marked with "TODO").
* [x] `ExponentialMap` - `σ`
* [x] `ConvexHull` - imprecision
* [x] `Hyperrectangle` - imprecision
* [x] `ExponentialMap` - imprecision EDIT: There are random failures, so I deactivated the types here and created a new issue for the future.
* [x] `Polygon`/`CartesianProduct` - `<=` will be solved another time
* [x] `Approximations` - generalize numeric type EDIT: sometimes not possible because of `<=`
* [x] `ExponentialMap` - There are also some commented lines in the test file... EDIT: I removed them