### PR TITLE
delete sign_cadlag helper func export

### DIFF
--- a/src/helper_functions.jl
+++ b/src/helper_functions.jl
@@ -1,5 +1,3 @@
-export sign_cadlag
-
 """
     sign_cadlag(x::N)::N where {N<:Real}
 
@@ -22,6 +20,8 @@ It can be used with vector-valued arguments via the dot operator.
 ### Examples
 
 ```jldoctest
+julia> import LazySets.sign_cadlag
+
 julia> sign_cadlag.([-0.6, 1.3, 0.0])
 3-element Array{Float64,1}:
  -1.0


### PR DESCRIPTION
The same as for other "utility functions": in a typical session these will be rarely used, thus we can opt to not clutter the namespace and search-by-tab-completion with those exports.