### PR TITLE
#126 - Optional tolerance argument for containment checks

### DIFF
--- a/docs/src/lib/interfaces.md
+++ b/docs/src/lib/interfaces.md
@@ -52,6 +52,7 @@ support_function
 
 ```@docs
 an_element(S::LazySet{Float64})
+∈(::AbstractVector{Float64}, ::LazySet{Float64}, ::Float64)
 ```
 
 ## Point symmetric set

--- a/src/AbstractHyperrectangle.jl
+++ b/src/AbstractHyperrectangle.jl
@@ -154,7 +154,9 @@ function diameter(H::AbstractHyperrectangle, p::Real=Inf)::Real
 end
 
 """
-    ∈(x::AbstractVector{N}, H::AbstractHyperrectangle{N})::Bool where {N<:Real}
+    ∈(x::AbstractVector{N},
+      H::AbstractHyperrectangle{N},
+      tolerance::N=zero(N))::Bool where {N<:Real}
 
 Check whether a given point is contained in a hyperrectangular set.
 
@@ -162,10 +164,12 @@ Check whether a given point is contained in a hyperrectangular set.
 
 - `x` -- point/vector
 - `H` -- hyperrectangular set
+- `tolerance` -- (optional, default: `zero(N)`) tolerance for when a point is
+                 still considered inside the set
 
 ### Output
 
-`true` iff ``x ∈ H``.
+`true` iff ``x ∈ H'``, where ``H'`` is the set ``H`` bloated by `tolerance`.
 
 ### Algorithm
 
@@ -175,10 +179,12 @@ respectively.
 Then ``x ∈ H`` iff ``|c_i - x_i| ≤ r_i`` for all ``i=1,…,n``.
 """
 function ∈(x::AbstractVector{N},
-           H::AbstractHyperrectangle{N})::Bool where {N<:Real}
+           H::AbstractHyperrectangle{N},
+           tolerance::N=zero(N))::Bool where {N<:Real}
     @assert length(x) == dim(H)
+    @assert tolerance >= 0
     for i in eachindex(x)
-        if abs(center(H)[i] - x[i]) > radius_hyperrectangle(H, i)
+        if abs(center(H)[i] - x[i]) > radius_hyperrectangle(H, i) + tolerance
             return false
         end
     end

--- a/test/unit_Ball2.jl
+++ b/test/unit_Ball2.jl
@@ -55,6 +55,13 @@ for N in [Float64, Float32]
     b = Ball2(N[1., 2.], N(2.))
     @test an_element(b) ∈ b
 
+    # membership
+    x = N[0., 0.]
+    b = Ball2(N[1., 1.], N(0.9))
+    @test !in(x, b)
+    @test !in(x, b, N(0.5))
+    @test in(x, b, N(0.55))
+
     # subset
     b1 = Ball2(N[1., 2.], N(2.))
     b2 = Ball2(N[1., 2.], N(0.))

--- a/test/unit_BallInf.jl
+++ b/test/unit_BallInf.jl
@@ -55,6 +55,8 @@ for N in [Float64, Rational{Int}, Float32]
     b = BallInf(N[1., 1.], N(1.))
     @test !∈(N[.5, -.5], b)
     @test ∈(N[.5, 1.5], b)
+    @test !∈(N[.5, -.5], b, N(0.4))
+    @test ∈(N[.5, -.5], b, N(0.6))
 
     # an_element function
     b = BallInf(N[1., 2.], N(3.))

--- a/test/unit_Hyperrectangle.jl
+++ b/test/unit_Hyperrectangle.jl
@@ -99,6 +99,8 @@ for N in [Float64, Rational{Int}, Float32]
     H = Hyperrectangle(N[1.0, 1.0], N[2.0, 3.0])
     @test !∈(N[-1.1, 4.1], H)
     @test ∈(N[-1.0, 4.0], H)
+    @test !∈(N[-1.1, 4.1], H, N(0.09))
+    @test ∈(N[-1.1, 4.1], H, N(0.11))
 
     # an_element function
     H = Hyperrectangle(N[1.0, 2.0], N[3.0, 4.0])

--- a/test/unit_Polygon.jl
+++ b/test/unit_Polygon.jl
@@ -47,7 +47,7 @@ for N in [Float64, Float32, Rational{Int}]
         d = N[0., -1.]
         @test σ(d, p) == N[0., 0.]
 
-        # Test containment
+        # membership
         @test ∈(N[0., 0.], p)
         @test ∈(N[4., 2.], p)
         @test ∈(N[2., 4.], p)
@@ -60,6 +60,8 @@ for N in [Float64, Float32, Rational{Int}]
         @test !∈(N[5., 2.], p)
         @test !∈(N[3., 4.], p)
         @test !∈(N[-1., 5.], p)
+        @test !∈(N[-1., 0.], p, N(0.6))
+        @test ∈(N[-1., 0.], p, N(0.8))
 
         # an_element function
         @test an_element(p) ∈ p


### PR DESCRIPTION
Closes #126.

* [x] default implementation
* [x] `AbstractHyperrectangle`
* [x] `AbstractHPolygon`

The specialized implementations are **not** correct in the sense that at the corners the tolerance is bigger than allowed. I create a polytope of the same shape where all facets are pushed to the outside. On the other hand, a "usual" bloating with a Euclidean ball would produce rounded corners instead.

Is there a simple way to express the "usual" bloating? I can live with the not-correct bloating, but we should find a way to make it consistent.