### PR TITLE
#130 - increase code coverage

### DIFF
--- a/src/AbstractPolytope.jl
+++ b/src/AbstractPolytope.jl
@@ -45,5 +45,5 @@ List containing a singleton for each vertex.
 """
 function singleton_list(P::AbstractPolytope{N}
                        )::Vector{Singleton{N}} where {N<:Real}
-    return [Singleton(vi) for vi in P.vertices_list]
+    return [Singleton(vi) for vi in vertices_list(P)]
 end

--- a/src/Approximations/box_approximations.jl
+++ b/src/Approximations/box_approximations.jl
@@ -26,8 +26,12 @@ function box_approximation(S::LazySet)::Hyperrectangle
     return Hyperrectangle(c, r)
 end
 
+# special case: Hyperrectangle
 box_approximation(S::Hyperrectangle) = S
-box_approximation(S::BallInf) = Hyperrectangle(S.center, fill(S.radius, dim(S)))
+
+# special case: other rectangle
+box_approximation(S::AbstractHyperrectangle) =
+    Hyperrectangle(center(S), radius_hyperrectangle(S))
 
 """
     interval_hull

--- a/src/CartesianProduct.jl
+++ b/src/CartesianProduct.jl
@@ -332,7 +332,7 @@ function ∈(x::AbstractVector{N}, cpa::CartesianProductArray{N, <:LazySet{N}}
     @assert length(x) == dim(cpa)
 
     jinit = 1
-    for sj in cpa
+    for sj in cpa.array
         jend = jinit + dim(sj) - 1
         if !∈(x[jinit:jend], sj)
             return false

--- a/src/HPolytope.jl
+++ b/src/HPolytope.jl
@@ -86,6 +86,9 @@ This implementation uses `GLPKSolverLP` as linear programming backend.
 function σ(d::AbstractVector{<:Real}, P::HPolytope)::Vector{<:Real}
     c = -d
     m = length(constraints_list(P))
+    if m == 0
+        error("this polytope is empty")
+    end
     A = zeros(m, dim(P))
     b = zeros(m)
     for (i, Pi) in enumerate(constraints_list(P))

--- a/test/unit_Ball2.jl
+++ b/test/unit_Ball2.jl
@@ -22,6 +22,8 @@ for N in [Float64, Float32]
     @test σ(d, b) == N[0., 1.]
     d = N[0., -1.]
     @test σ(d, b) == N[0., -1.]
+    d = N[0., 0.]
+    @test σ(d, b) == N[0., 0.]
 
     # 2D Ball2 not 0-centered
     b = Ball2(N[1., 2.], N(1.))

--- a/test/unit_CartesianProduct.jl
+++ b/test/unit_CartesianProduct.jl
@@ -107,7 +107,18 @@ for N in [Float64, Float32, Rational{Int}]
     @test !∈(N[0., 0., 3., 1.], cp)
     @test !∈(N[1., 1., 3., 1.], cp)
 
+    # =====================
+    # CartesianProductArray
+    # =====================
+    v = Vector{LazySet{N}}(0)
+    push!(v, Singleton(N[1., 2.]))
+    push!(v, Singleton(N[3., 4.]))
+    cpa = CartesianProductArray(v)
+
     # array getter
-    v = Vector{N}(0)
-    @test array(CartesianProductArray()) == v
+    @test array(cpa) == v
+
+    # membership
+    @test ∈(N[1., 2., 3., 4.], cpa)
+    @test !∈(N[3., 4., 1., 2.], cpa)
 end

--- a/test/unit_Ellipsoid.jl
+++ b/test/unit_Ellipsoid.jl
@@ -25,6 +25,8 @@ for N in [Float64, Float32]
     @test σ(d, E) == N[0., 1.]
     d = N[0., -1.]
     @test σ(d, E) == N[0., -1.]
+    d = N[0., 0.]
+    @test σ(d, E) ∈ E
 
     # 2D Ellipsoid not 0-centered
     E = Ellipsoid(N[1., 2.], diagm(N[1., 1.]))

--- a/test/unit_EmptySet.jl
+++ b/test/unit_EmptySet.jl
@@ -33,6 +33,16 @@ for N in [Float64, Rational{Int}, Float32]
     # test convex hull of empty set with itself
     @test CH(E, E) == E
 
+    # dim
+    @test dim(E) == -1
+
+    # support vector
+    @test_throws ErrorException σ(N[0.], E)
+
+    # membership
+    @test !∈(N[0.], E)
+    @test !∈(N[0., 0.], E)
+
     # an_element function
     @test_throws ErrorException an_element(E)
 end

--- a/test/unit_LinearMap.jl
+++ b/test/unit_LinearMap.jl
@@ -51,4 +51,9 @@ for N in [Float64, Rational{Int}, Float32]
     lm1_copy = LinearMap(eye(N, 2), lm1)
     @test lm1_copy.M == lm1.M
     @test lm1_copy.X == lm1.X
+
+    # an_element function (default implementation)
+    lm = N(2.) * BallInf(N[0., 0.], N(1.))
+    an_element(lm)
+#     @test an_element(lm) ∈ lm # TODO results in an error for Rational
 end

--- a/test/unit_Polygon.jl
+++ b/test/unit_Polygon.jl
@@ -63,6 +63,16 @@ for N in [Float64, Float32, Rational{Int}]
 
         # an_element function
         @test an_element(p) ∈ p
+        p_shallow = HPolygon{N}()
+        @test_throws ErrorException an_element(p_shallow)
+        addconstraint!(p_shallow, c1)
+        @test_throws ErrorException an_element(p_shallow)
+
+        # hrep conversion
+        @test tohrep(p) == p
+
+        # constraints list getter
+        @test constraints_list(p) == p.constraints
     end
 
     # Test VRepresentation

--- a/test/unit_Polygon.jl
+++ b/test/unit_Polygon.jl
@@ -32,6 +32,11 @@ for N in [Float64, Float32, Rational{Int}]
     HPolytope(p)
     HPolytope(po)
 
+    # support vector of empty polygon
+    @test_throws ErrorException σ([0.], HPolygon())
+    @test_throws ErrorException σ([0.], HPolygonOpt(HPolygon()))
+    @test_throws ErrorException σ([0.], HPolytope())
+
     # HPolygon/HPolygonOpt tests
     for p in [p, po]
         # Test Dimension
@@ -46,6 +51,8 @@ for N in [Float64, Float32, Rational{Int}]
         @test σ(d, p) == N[-1., 1.]
         d = N[0., -1.]
         @test σ(d, p) == N[0., 0.]
+        d = N[1., -1.]
+        @test σ(d, p) == N[4., 2.]
 
         # Test containment
         @test ∈(N[0., 0.], p)
@@ -96,21 +103,14 @@ for N in [Float64, Float32, Rational{Int}]
     @test vertices_list(vp) == to_N(N, [[0.1, 0.3], [0.2, 0.1], [0.9, 0.2], [0.4, 0.6]])
 
     # test support vector of a VPolygon
-    p = HPolygon{N}()
-    for ci in [c1, c2, c3, c4]
-    addconstraint!(p, ci)
-    end
-    p = tovrep(p)
-
-    # Test Support Vector
     d = N[1., 0.]
-    @test σ(d, p) == N[4., 2.]
+    @test σ(d, vp) == points[5]
     d = N[0., 1.]
-    @test σ(d, p) == N[2., 4.]
+    @test σ(d, vp) == points[4]
     d = N[-1., 0.]
-    @test σ(d, p) == N[-1., 1.]
+    @test σ(d, vp) == points[1]
     d = N[0., -1.]
-    @test σ(d, p) == N[0., 0.]
+    @test σ(d, vp) == points[2]
 
     # test that #83 is fixed
     v = VPolygon(to_N(N, [[2.0, 3.0]]))
@@ -146,3 +146,6 @@ for N in [Float64, Float32, Rational{Int}]
         end
     end
 end
+
+# default Float64 constructor
+HPolygon()

--- a/test/unit_Polytope.jl
+++ b/test/unit_Polytope.jl
@@ -23,4 +23,7 @@ for N in [Float64, Rational{Int}, Float32]
     # membership
     @test ∈(N[5./4., 7./4.], p)
     @test !∈(N[4., 1.], p)
+
+    # singleton list (only available with Polyhedra library)
+    @test_throws MethodError singleton_list(p)
 end

--- a/test/unit_Singleton.jl
+++ b/test/unit_Singleton.jl
@@ -25,6 +25,12 @@ for N in [Float64, Rational{Int}, Float32]
     # an_element function
     @test an_element(S) ∈ S
 
+    # vertices_list
+    @test vertices_list(S)[1] ∈ S
+
+    # radius_hyperrectangle
+    @test iszero(radius_hyperrectangle(S))
+
     # subset
     s1 = Singleton(N[0., 1.])
     s2 = Singleton(N[0., 3.])

--- a/test/unit_box_approximation.jl
+++ b/test/unit_box_approximation.jl
@@ -20,7 +20,6 @@ for N in [Float64, Rational{Int}, Float32]
     @test h.center ≈ hexp.center
     @test h.radius ≈ hexp.radius
 
-
     # Box approximation of a 3D unit ball in the 1-norm
     b = Ball1(to_N(N, [1., 2., 0.]), to_N(N, 1.))
     h = box_approximation(b)
@@ -28,6 +27,11 @@ for N in [Float64, Rational{Int}, Float32]
     @test h.center ≈ hexp.center
     @test h.radius ≈ hexp.radius
 
+    # Box approximation of a Hyperrectangle
+    hexp = Hyperrectangle(N[0., 0.], N[1., 1.])
+    h = box_approximation(hexp)
+    @test h.center ≈ hexp.center
+    @test h.radius ≈ hexp.radius
 
     # ===================================================================
     # Testing box_approximation_symmetric (= symmetric interval hull)

--- a/test/unit_overapproximate.jl
+++ b/test/unit_overapproximate.jl
@@ -55,6 +55,31 @@ for N in [Float64, Float32] # TODO Rational{Int}
     @test lcl[8].a ≈ N[sqrt(2.0)/2.0, -sqrt(2.0)/2.0]
     @test lcl[8].b ≈ N(1.0)
 
+    # HPolygon approximation with box directions
+    c = N[0., 0.]
+    b = Ball1(c, N(1.))
+    p = overapproximate(b, HPolygon)
+    for d in to_N(N, [[1., 0.], [-1., 0.]])
+        @test σ(d, p)[1] ≈ σ(d, b)[1]
+    end
+    for d in to_N(N, [[0., 1.], [0., -1.]])
+        @test σ(d, p)[2] ≈ σ(d, b)[2]
+    end
+
+    # Hyperrectangle approximation
+    c = N[0., 0.]
+    b = Ball1(c, N(1.))
+    p = overapproximate(b, Hyperrectangle)
+    for d in to_N(N, [[1., 0.], [-1., 0.]])
+        @test σ(d, p)[1] ≈ σ(d, b)[1]
+    end
+    for d in to_N(N, [[0., 1.], [0., -1.]])
+        @test σ(d, p)[2] ≈ σ(d, b)[2]
+    end
+    @test p.center ≈ c
+    @test p.radius ≈ N[1., 1.]
+
+    # Zonotope approximation
     Z1 = Zonotope(ones(N, 2), [N[1., 0.], N[0., 1.], N[1., 1.]])
     Z2 = Zonotope(-ones(N, 2), [N[.5, 1.], N[-.1, .9], N[1., 4.]])
     Y = ConvexHull(Z1, Z2)

--- a/test/unit_radiusdiameter.jl
+++ b/test/unit_radiusdiameter.jl
@@ -45,4 +45,13 @@ for N in [Float64, Rational{Int}, Float32]
     @test norm(b, 2) ≈ N(sqrt(1.2^2 + 2.2^2 + 4.2^2))
     @test radius(b, 2) ≈ N(sqrt(0.2^2 * 3))
     @test diameter(b, 2) ≈ N(2*sqrt(0.2^2 * 3))
+
+    # ====================================
+    #  failing case (not implemented yet)
+    # ====================================
+
+    s = MinkowskiSum(b, b)
+    @test_throws ErrorException norm(s, 2)
+    @test_throws ErrorException radius(s, 2)
+    @test_throws ErrorException diameter(s, 2)
 end


### PR DESCRIPTION
Part of #130.
100% code coverage for the `Approximations` module, interfaces, and some set types (see below).
Coverage is shown [here](https://codecov.io/gh/JuliaReach/LazySets.jl/tree/516880e03240e149a393f2f24a155b9ac9a6c695/src).

* [x] `box_approximation`, including a generalization
* [x] `overapproximate`
* [x] `AbstractHPolygon`
* [x] `AbstractPolytope`, including a bugfix
* [x] `AbstractSingleton`
* [x] `LazySet`
* [x] `Ball2`
* [x] `CartesianProduct`, including a bugfix
* [x] `Ellipsoid`
* [x] `EmptySet`
* [x] `HPolygon`/`HPolygonOpt`
* [x] better error message for an empty `HPolytope`'s support vector