### PR TITLE
Default interval decomposition

### DIFF
--- a/test/unit_decompose.jl
+++ b/test/unit_decompose.jl
@@ -62,4 +62,7 @@ for N in [Float64, Float32] # TODO Rational{Int}
     # odd dimension
     b = BallInf(zeros(N, 7), one(N))
     d = decompose(b)
+    # 1D intervals
+    d = decompose(b, set_type=LazySets.Interval)
+    @test d isa CartesianProductArray{N,LazySets.Interval{N,IN} where IN<:IntervalArithmetic.AbstractInterval{N}}
 end


### PR DESCRIPTION
Modifies `default_block_structure` such that one can `decompose(S, set_type=Interval)`.