### PR TITLE
Fix deprecated isdefined signature

### DIFF
--- a/src/VPolytope.jl
+++ b/src/VPolytope.jl
@@ -76,7 +76,7 @@ The support vector in the given direction.
 """
 function σ(d::AbstractVector{<:Real}, P::VPolytope; algorithm="hrep")::Vector{<:Real}
     if algorithm == "hrep"
-        @assert isdefined(:Polyhedra) "you need to load Polyhedra for this algorithm"
+        @assert isdefined(@__MODULE__, :Polyhedra) "you need to load Polyhedra for this algorithm"
         return σ(d, tohrep(P))
     else
         error("the algorithm $(hrep) is not known")

--- a/src/helper_functions.jl
+++ b/src/helper_functions.jl
@@ -81,19 +81,19 @@ macro neutral(SET, NEUT)
         end
 
         # if the absorbing element has already been defined, create combinations
-        if isdefined(:absorbing) && hasmethod(absorbing, (Type{$SET},))
+        if isdefined(@__MODULE__, :absorbing) && hasmethod(absorbing, (Type{$SET},))
             @eval(@neutral_absorbing($(esc(SET)),
                                      $(esc(NEUT)),
                                      absorbing($(esc(SET)))))
         end
 
         # if the array set type has already been defined, create combinations
-        if isdefined(:array_constructor) &&
+        if isdefined(@__MODULE__, :array_constructor) &&
                 hasmethod(array_constructor, (Type{$SET},))
             @eval(@array_neutral($(esc(SET)),
                                  $(esc(NEUT)),
                                  array_constructor($(esc(SET)))))
-        elseif isdefined(:is_array_constructor) &&
+        elseif isdefined(@__MODULE__, :is_array_constructor) &&
                 hasmethod(is_array_constructor, (Type{$SET},))
             @eval(@array_neutral($(esc(SET)),
                                  $(esc(NEUT)),
@@ -151,19 +151,19 @@ macro absorbing(SET, ABS)
         end
 
         # if the neutral element has already been defined, create combinations
-        if isdefined(:neutral) && hasmethod(neutral, (Type{$SET},))
+        if isdefined(@__MODULE__, :neutral) && hasmethod(neutral, (Type{$SET},))
             @eval(@neutral_absorbing($(esc(SET)),
                                      neutral($(esc(SET))),
                                      $(esc(ABS))))
         end
 
         # if the array set type has already been defined, create combinations
-        if isdefined(:array_constructor) &&
+        if isdefined(@__MODULE__, :array_constructor) &&
                 hasmethod(array_constructor, (Type{$SET},))
             @eval(@array_absorbing($(esc(SET)),
                                    $(esc(ABS)),
                                    array_constructor($(esc(SET)))))
-        elseif isdefined(:is_array_constructor) &&
+        elseif isdefined(@__MODULE__, :is_array_constructor) &&
                 hasmethod(is_array_constructor, (Type{$SET},))
             @eval(@array_absorbing($(esc(SET)),
                                    $(esc(ABS)),
@@ -235,23 +235,23 @@ macro declare_array_version(SET, SETARR)
             return arr1
         end
         # handle method ambiguities with neutral elements
-        if isdefined(:neutral) && hasmethod(neutral, (Type{$SET},))
+        if isdefined(@__MODULE__, :neutral) && hasmethod(neutral, (Type{$SET},))
             @eval(@array_neutral($(esc(SET)),
                                  neutral($(esc(SET))),
                                  $(esc(SETARR))))
         end
-        if isdefined(:neutral) && hasmethod(neutral, (Type{$SETARR},))
+        if isdefined(@__MODULE__, :neutral) && hasmethod(neutral, (Type{$SETARR},))
             @eval(@array_neutral($(esc(SETARR)),
                                  neutral($(esc(SETARR))),
                                  $(esc(SETARR))))
         end
         # handle method ambiguities with absorbing elements
-        if isdefined(:absorbing) && hasmethod(absorbing, (Type{$SET},))
+        if isdefined(@__MODULE__, :absorbing) && hasmethod(absorbing, (Type{$SET},))
             @eval(@array_absorbing($(esc(SET)),
                                    absorbing($(esc(SET))),
                                    $(esc(SETARR))))
         end
-        if isdefined(:absorbing) && hasmethod(absorbing, (Type{$SETARR},))
+        if isdefined(@__MODULE__, :absorbing) && hasmethod(absorbing, (Type{$SETARR},))
             @eval(@array_absorbing($(esc(SETARR)),
                                    absorbing($(esc(SETARR))),
                                    $(esc(SETARR))))


### PR DESCRIPTION
In Julia v0.7 the signature `isdefined(::Symbol)` is deprecated in favor of `isdefined(module, ::Symbol)`. 

See https://discourse.julialang.org/t/how-to-refactor-isdefined-othermodule-field-to-isdefined-v0-7/11509/6