### PR TITLE
#130 - Increase code coverage

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,6 +10,7 @@ include("to_N.jl")
 # =======================================
 @time @testset "LazySets.Singleton" begin include("unit_Singleton.jl") end
 @time @testset "LazySets.Ball2" begin include("unit_Ball2.jl") end
+@time @testset "LazySets.Ballp" begin include("unit_Ballp.jl") end
 @time @testset "LazySets.BallInf" begin include("unit_BallInf.jl") end
 @time @testset "LazySets.Hyperrectangle" begin include("unit_Hyperrectangle.jl") end
 @time @testset "LazySets.Polygon" begin include("unit_Polygon.jl") end

--- a/test/unit_Ballp.jl
+++ b/test/unit_Ballp.jl
@@ -1,0 +1,39 @@
+for N in [Float64, Float32]
+    # 1D Ball3
+    b = Ballp(N(3.), N[0.], N(1.))
+    # dimension
+    @test dim(b) == 1
+    # support vector
+    d = N[1.]
+    @test σ(d, b) == N[1.]
+    d = N[-1.]
+    @test σ(d, b) == N[-1.]
+
+    # 2D Ball3
+    b = Ballp(N(3.), N[0., 0.], N(2.))
+    # dimension
+    @test dim(b) == 2
+    # support vector
+    d = N[1., 0.]
+    @test σ(d, b) == N[2., 0.]
+    d = N[-1., 0.]
+    @test σ(d, b) == N[-2., 0.]
+    d = N[0., 1.]
+    @test σ(d, b) == N[0., 2.]
+    d = N[0., -1.]
+    @test σ(d, b) == N[0., -2.]
+    d = N[0., 0.]
+    @test σ(d, b) == N[0., 0.]
+
+    # constructors that fall back to specialized set types
+    @test Ballp(N(1.), N[3.], N(4.)) isa Ball1
+    @test Ballp(N(2.), N[3.], N(4.)) isa Ball2
+    @test Ballp(N(Inf), N[3.], N(4.)) isa BallInf
+
+    # center
+    @test center(b) == b.center
+    @test an_element(b) isa AbstractVector{N}
+
+    # membership & an_element
+    @test an_element(b) ∈ b
+end

--- a/test/unit_CartesianProduct.jl
+++ b/test/unit_CartesianProduct.jl
@@ -110,10 +110,15 @@ for N in [Float64, Float32, Rational{Int}]
     # =====================
     # CartesianProductArray
     # =====================
+
+    # standard constructor
     v = Vector{LazySet{N}}(0)
     push!(v, Singleton(N[1., 2.]))
     push!(v, Singleton(N[3., 4.]))
     cpa = CartesianProductArray(v)
+
+    # constructor with size hint and type
+    CartesianProductArray(10, N)
 
     # array getter
     @test array(cpa) ≡ v

--- a/test/unit_ConvexHull.jl
+++ b/test/unit_ConvexHull.jl
@@ -24,6 +24,8 @@ for N in [Float64, Rational{Int}, Float32]
 
     # convex hull array of 2 sets
     C = ConvexHullArray([b1, b2])
+    # constructor with size hint and type
+    ConvexHullArray(10, N)
     # test alias
     @test CHArray([b1, b2]) isa ConvexHullArray
     # test dimension

--- a/test/unit_EmptySet.jl
+++ b/test/unit_EmptySet.jl
@@ -47,5 +47,6 @@ for N in [Float64, Rational{Int}, Float32]
     @test_throws ErrorException an_element(E)
 end
 
-# default Float64 constructor
+# default Float64 constructors
 @test ∅ == EmptySet{Float64}()
+@test EmptySet() == EmptySet{Float64}()

--- a/test/unit_Hyperplane.jl
+++ b/test/unit_Hyperplane.jl
@@ -1,28 +1,29 @@
 for N in [Float64, Rational{Int}, Float32]
     # normal constructor
-    normal = ones(N, 3)
-    hp = Hyperplane(normal, N(5.))
+    a = ones(N, 3)
+    hp = Hyperplane(a, N(5.))
 
     # dimension
     @test dim(hp) == 3
 
     # support vector and membership function
-    function test_svec(hp, d)
-        @test σ(d, hp) ∈ hp
-        @test σ(N(2.) * d, hp) ∈ hp
+    function test_svec(hp)
+        d1 = copy(hp.a)
+        @test σ(d1, hp) ∈ hp
+        @test σ(N(2.) * d1, hp) ∈ hp
         d2 = N[1., 0., 0.]
         @test_throws ErrorException σ(d2, hp)
-        d2 = zeros(N, 3)
-        @test σ(d2, hp) ∈ hp
+        d3 = N[1., 0., 0.]
+        @test_throws ErrorException σ(d3, hp)
+        d4 = zeros(N, 3)
+        @test σ(d4, hp) ∈ hp
     end
     # tests 1
-    normal = ones(N, 3)
-    d = ones(N, 3)
-    test_svec(Hyperplane(normal, N(5.)), d)
+    a = ones(N, 3)
+    test_svec(Hyperplane(a, N(5.)))
     # tests 2
-    normal = zeros(N, 3); normal[3] = N(1.)
-    d = zeros(N, 3); d[3] = N(1.)
-    test_svec(Hyperplane(normal, N(5.)), d)
+    a = zeros(N, 3); a[3] = N(1.)
+    test_svec(Hyperplane(a, N(5.)))
 
     # an_element function and membership function
     @test an_element(hp) ∈ hp

--- a/test/unit_Hyperrectangle.jl
+++ b/test/unit_Hyperrectangle.jl
@@ -89,6 +89,7 @@ for N in [Float64, Rational{Int}, Float32]
     @test H2.center ≈ H3.center
     @test H1.radius == H2.radius
     @test H2.radius ≈ H3.radius
+    @test_throws ArgumentError Hyperrectangle(xyz="zyx")
 
     # Test low and high methods for a hyperrectangle
     H = Hyperrectangle(center=to_N(N, [-2.1, 5.6, 0.9]), radius=fill(to_N(N, 0.5), 3))

--- a/test/unit_LineSegment.jl
+++ b/test/unit_LineSegment.jl
@@ -24,6 +24,9 @@ for N in [Float64, Rational{Int}, Float32]
     @test !∈(N[7., 4.], l)
     @test !∈(N[1.5, 1.6], l)
 
+    # an_element function
+    @test an_element(l) ∈ l
+
     # intersection emptiness
     l1 = LineSegment(N[1., 1.], N[2., 2.])
     l2 = LineSegment(N[2., 1.], N[1., 2.])

--- a/test/unit_Singleton.jl
+++ b/test/unit_Singleton.jl
@@ -17,6 +17,12 @@ for N in [Float64, Rational{Int}, Float32]
     d = N[0., 0.]
     @test σ(d, s) == N[1., 2.]
 
+    # element function
+    @test element(s) == s.element
+    for i in 1:2
+        @test element(s, i) == s.element[i]
+    end
+
     # membership
     S = Singleton(N[1., 1.])
     !∈(N[0.9, 1.1], S)


### PR DESCRIPTION
See #130.

* [x] `Ballp`
* [x] `CartesianProduct`
* [x] `ConvexHull`
* [x] `MinkowskiSum`
* [x] `EmptySet`
* [x] `Hyperrectangle`
* [x] `Hyperplane`
* [x] `Singleton`
* [x] `LazySet` (by using a default implementation for `LineSegment`)