### PR TITLE
Merge conditions in compat.jl

### DIFF
--- a/src/compat.jl
+++ b/src/compat.jl
@@ -5,21 +5,18 @@ different Julia versions.
 
 using Compat
 import Compat.String
+export _At_mul_B
 
 if VERSION < v"0.7-"
     import Base.LinAlg:norm, checksquare
     import Base: eye, ×
+    @inline function _At_mul_B(A, B)
+        return At_mul_B(A, B)
+    end
 else
     using SparseArrays, LinearAlgebra
     import LinearAlgebra:norm, checksquare, eye, ×
-end
-
-export _At_mul_B
-
-@inline function _At_mul_B(A, B)
-    if VERSION > v"0.7-"
-        transpose(A) * B
-    else
-        At_mul_B(A, B)
+    @inline function _At_mul_B(A, B)
+        return transpose(A) * B
     end
 end


### PR DESCRIPTION
We had the condition `VERSION < v"0.7-"` and `VERSION > v"0.7-"`, which I found inconsistent. My original motivation for this PR was to unify these conditions.
In the end I merged everything into one if-then-else. I can also undo that if preferred.