### PR TITLE
Remove temporary 'allow failure' of v0.6.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ git:
 ## allow failures (tests will run but not make your overall status red)
 matrix:
   allow_failures:
-    - julia: 0.6.4 # temporary fix for broken dependency
     - julia: nightly
 
 ## uncomment and modify the following lines to manually install system packages


### PR DESCRIPTION
`ErrorfreeArithmetic.jl`'s release got merged on `METADATA`.
Apparently the build already worked again some hours before that :confused: :question:
But anyway, now it works again.