### PR TITLE
#130 - Increase code coverage

### DIFF
--- a/src/Zonotope.jl
+++ b/src/Zonotope.jl
@@ -375,7 +375,7 @@ function reduce_order(Z::Zonotope{N}, r)::Zonotope{N} where {N<:Real}
 
     # interval hull computation of reduced generators
     Gbox = diagm(sum(abs.(rg), 2)[:])
-    if m+1 <= p
+    if m < p
         Gnotred = G[:, ind[m+1:end]]
         Gred = [Gnotred Gbox]
     else

--- a/test/unit_CartesianProduct.jl
+++ b/test/unit_CartesianProduct.jl
@@ -111,6 +111,10 @@ for N in [Float64, Float32, Rational{Int}]
     # CartesianProductArray
     # =====================
 
+    # relation to base type (internal helper functions)
+    @test LazySets.array_constructor(CartesianProduct) == CartesianProductArray
+    @test LazySets.is_array_constructor(CartesianProductArray)
+
     # standard constructor
     v = Vector{LazySet{N}}(0)
     push!(v, Singleton(N[1., 2.]))
@@ -138,4 +142,15 @@ for N in [Float64, Float32, Rational{Int}]
     @test res isa CartesianProductArray && length(array(cpa)) == 2
     res = CartesianProduct!(cpa, cpa)
     @test res isa CartesianProductArray && length(array(cpa)) == 4
+
+    # ================
+    # common functions
+    # ================
+
+    # absorbing element
+    e = EmptySet{N}()
+    b = BallInf(N[0., 0.], N(2.))
+    @test absorbing(CartesianProduct) == absorbing(CartesianProductArray) ==
+          EmptySet
+    @test b × e == e × b == cpa × e == e × cpa == e × e == e
 end

--- a/test/unit_ConvexHull.jl
+++ b/test/unit_ConvexHull.jl
@@ -22,6 +22,14 @@ for N in [Float64, Rational{Int}, Float32]
     points = to_N(N, [[0.9,0.2], [0.4,0.6], [0.2,0.1], [0.1,0.3], [0.3,0.28]])
     @test convex_hull(points) == to_N(N, [[0.1,0.3],[0.2,0.1], [0.9,0.2],[0.4,0.6]])
 
+    # ===============
+    # ConvexHullArray
+    # ===============
+
+    # relation to base type (internal helper functions)
+    @test LazySets.array_constructor(ConvexHull) == ConvexHullArray
+    @test LazySets.is_array_constructor(ConvexHullArray)
+
     # convex hull array of 2 sets
     C = ConvexHullArray([b1, b2])
     # constructor with size hint and type
@@ -42,31 +50,37 @@ for N in [Float64, Rational{Int}, Float32]
     # test convex hull array of singleton
     C = ConvexHullArray([Singleton(to_N(N, [1.0, 0.5])), Singleton(to_N(N, [1.1, 0.2])), Singleton(to_N(N, [1.4, 0.3])), Singleton(to_N(N, [1.7, 0.5])), Singleton(to_N(N, [1.4, 0.8]))])
 
-    # empty set is neutral for CH
-    b = BallInf(N[0., 0.], N(2.))
-    cha = ConvexHullArray([Ball1(ones(N, 2), to_N(N, 1.))])
-    E = EmptySet{N}()
-    @test CH(b, E) == CH(E, b) == b
-    @test CH(cha, E) == CH(E, cha) == cha
-
-    # concatenation of two convex hull arrays
-    @test CH(cha, cha) isa ConvexHull
-
     # array getter
     v = Vector{LazySet{N}}(0)
     @test array(ConvexHullArray(v)) ≡ v
 
     # in-place modification
     cha = ConvexHullArray(LazySet{N}[])
-    @test ConvexHull!(b, b) isa ConvexHull && length(array(cha)) == 0
-    res = ConvexHull!(b, cha)
+    @test ConvexHull!(b1, b1) isa ConvexHull && length(array(cha)) == 0
+    res = ConvexHull!(b1, cha)
     @test res isa ConvexHullArray && length(array(cha)) == 1
-    res = ConvexHull!(cha, b)
+    res = ConvexHull!(cha, b1)
     @test res isa ConvexHullArray && length(array(cha)) == 2
     res = ConvexHull!(cha, cha)
     @test res isa ConvexHullArray && length(array(cha)) == 4
 
+    # concatenation of two convex hull arrays
+    @test CH(cha, cha) isa ConvexHull
+
+    # ================
+    # common functions
+    # ================
+
+    # neutral element
+    e = EmptySet{N}()
+    @test neutral(ConvexHull) == neutral(ConvexHullArray) == EmptySet
+    @test CH(b1, e) == CH(e, b1) == b1
+    @test CH(cha, e) == CH(e, cha) == cha
+
+    # ==============================
     # concrete convex hull operation
+    # ==============================
+
     points = to_N(N, [[0.9,0.2], [0.4,0.6], [0.2,0.1], [0.1,0.3], [0.3,0.28]])
     sorted = to_N(N, [[0.1,0.3],[0.2,0.1], [0.9,0.2],[0.4,0.6]])
     @test convex_hull!(points, algorithm="monotone_chain") == sorted

--- a/test/unit_Hyperplane.jl
+++ b/test/unit_Hyperplane.jl
@@ -13,7 +13,7 @@ for N in [Float64, Rational{Int}, Float32]
         @test σ(N(2.) * d1, hp) ∈ hp
         d2 = N[1., 0., 0.]
         @test_throws ErrorException σ(d2, hp)
-        d3 = N[1., 1., 0.]
+        d3 = N[1., 1., 2.]
         @test_throws ErrorException σ(d3, hp)
         d4 = zeros(N, 3)
         @test σ(d4, hp) ∈ hp

--- a/test/unit_Intersection.jl
+++ b/test/unit_Intersection.jl
@@ -18,7 +18,13 @@ for N in [Float64, Rational{Int}, Float32]
     # emptiness of intersection
     @test !isempty(I)
 
-    # ---
+    # =================
+    # IntersectionArray
+    # =================
+
+    # relation to base type (internal helper functions)
+    @test LazySets.array_constructor(Intersection) == IntersectionArray
+    @test LazySets.is_array_constructor(IntersectionArray)
 
     # intersection of an array of sets
     IA = IntersectionArray([B, H])
@@ -39,8 +45,11 @@ for N in [Float64, Rational{Int}, Float32]
     # constructor with size hint and type
     IntersectionArray(10, N)
 
-    # ---
+    # ================
+    # common functions
+    # ================
 
     # absorbing element
+    @test absorbing(Intersection) == absorbing(IntersectionArray) == EmptySet
     @test I ∩ E == E ∩ I == IA ∩ E == E ∩ IA == E ∩ E == E
 end

--- a/test/unit_MinkowskiSum.jl
+++ b/test/unit_MinkowskiSum.jl
@@ -83,9 +83,9 @@ for N in [Float64, Rational{Int}, Float32]
 
     # support vector
     d = N[1., 1.]
-    @assert σ(d, ms) == σ(d, msa)
+    @test σ(d, ms) == σ(d, msa)
     d = N[-1., 1.]
-    @assert σ(d, ms) == σ(d, msa)
+    @test σ(d, ms) == σ(d, msa)
 
     # =================
     # CacheMinkowskiSum

--- a/test/unit_Polygon.jl
+++ b/test/unit_Polygon.jl
@@ -54,7 +54,7 @@ for N in [Float64, Float32, Rational{Int}]
         d = N[1., -1.]
         @test σ(d, p) == N[4., 2.]
 
-        # Test containment
+        # membership
         @test ∈(N[0., 0.], p)
         @test ∈(N[4., 2.], p)
         @test ∈(N[2., 4.], p)
@@ -88,6 +88,7 @@ for N in [Float64, Float32, Rational{Int}]
     @test N[-1., 1.] ∈ vertices_list(vp)
     @test N[0., 0.] ∈ vertices_list(vp)
     @test N[4., 2.] ∈ vertices_list(vp)
+    @test tovrep(vp) == vp
 
     # test convex hull of a set of points using the default algorithm
     points = to_N(N, [[0.9,0.2], [0.4,0.6], [0.2,0.1], [0.1,0.3], [0.3,0.28]])
@@ -123,6 +124,13 @@ for N in [Float64, Float32, Rational{Int}]
     v = VPolygon(to_N(N, [[2., 3.]]))
     @test an_element(v) ∈ v
 
+    # membership
+    point = N[0., 1.]
+    @test point ∉ VPolygon([N[]])
+    @test point ∉ VPolygon([N[0., 2.]])
+    @test point ∈ VPolygon([N[0., 0.], N[0., 2.]])
+    @test point ∉ VPolygon([N[1., 0.], N[1., 2.]])
+
     # subset
     p1 = VPolygon(to_N(N, [[0., 0.], [2., 0.]]))
     p2 = VPolygon(to_N(N, [[1., 0.]]))
@@ -151,8 +159,12 @@ for N in [Float64, Float32, Rational{Int}]
     v2 = to_N(N, [0.4, 0.6])
     v3 = to_N(N, [0.2, 0.1])
     v4 = to_N(N, [0.1, 0.3])
-    points5 = [v1, v2, v3, v4]
-    for i in [0, 1, 2, 4]
+    v5 = to_N(N, [0.7, 0.4])
+    v6 = to_N(N, [0.8, 0.3])
+    v7 = to_N(N, [0.3, 0.55])
+    v8 = to_N(N, [0.2, 0.45])
+    points5 = [v1, v2, v3, v4, v5, v6, v7, v8]
+    for i in [0, 1, 2, 4, 8]
         points = i == 0 ? Vector{Vector{N}}() : points5[1:i]
         vp = VPolygon(points, apply_convex_hull=i > 0)
         h1 = tohrep(vp)

--- a/test/unit_ZeroSet.jl
+++ b/test/unit_ZeroSet.jl
@@ -13,6 +13,7 @@ for N in [Float64, Rational{Int}, Float32]
 
     # element & an_element function
     @test element(Z) ∈ Z
+    @test element(Z, 1) == 0
     @test an_element(Z) ∈ Z
 
     # subset

--- a/test/unit_Zonotope.jl
+++ b/test/unit_Zonotope.jl
@@ -76,6 +76,10 @@ for N in [Float64, Rational{Int}, Float32]
     Zred2 = reduce_order(Z, 2)
     @test ngens(Zred2) == 4
     @test order(Zred2) == 2
+    Z = Zonotope(N[2, 1.], N[-0.5 1.5 0.5 1.0 0.0 1.0; 0.5 1.5 1.0 0.5 1.0 0.0])
+    Zred3 = reduce_order(Z, 2)
+    @test ngens(Zred3) == 4
+    @test order(Zred3) == 2
 
     # test conversion from hyperrectangular sets
     Z = convert(Zonotope, Hyperrectangle(N[2., 3.], N[4., 5.]))

--- a/test/unit_overapproximate.jl
+++ b/test/unit_overapproximate.jl
@@ -1,6 +1,12 @@
 import LazySets.Approximations.overapproximate
 
 for N in [Float64, Float32] # TODO Rational{Int}
+    # overapproximating a set of type T1 with an unsupported type T2 is the
+    # identity if T1 = T2
+    @test_throws MethodError overapproximate(ZeroSet{N}(2), EmptySet)
+    e = EmptySet{N}()
+    @test overapproximate(e, EmptySet) == e
+
     # Approximation of a 2D centered unit ball in norm 1
     # All vertices v should be like this:
     # ‖v‖ >= 1 and ‖v‖ <= 1+ε

--- a/test/unit_template_directions.jl
+++ b/test/unit_template_directions.jl
@@ -42,3 +42,8 @@ for N in [Float64, Float32, Rational{Int}]
               (n == 1 ? 2 : 2^n + 2*n)
     end
 end
+
+# default Float64 constructors
+BoxDirections(3)
+OctDirections(3)
+BoxDiagDirections(3)


### PR DESCRIPTION
See #130.

There is also a minor code simplification here.
I also replaced `@assert` by `@test` in the unit tests.

* [x] `Hyperplane`
* [x] `ZeroSet`
* [x] `Zonotope`
* [x] lazy operations (`CartesianProduct`, `ConvexHull`, `Intersection`, `MinkowskiSum`)
* [x] `VPolygon`
* [x] `overapproximate`
* [x] `template_directions`
* [x] `decompose`