### PR TITLE
#159, #72 - Restructuring of docs

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -20,7 +20,8 @@ makedocs(
         "Operations on Sets" => "man/set_operations.md",
         "A Reachability Algorithm" => "man/reach_zonotopes.md",
         "A Hybrid Reachability Algorithm" => "man/reach_zonotopes_hybrid.md",
-        "Concrete Polyhedra" => "man/concrete_polyhedra.md"],
+        "Concrete Polyhedra" => "man/concrete_polyhedra.md",
+        ],
         "Library" => Any[
         "Set Interfaces" => "lib/interfaces.md",
         "Common Set Representations" => "lib/representations.md",
@@ -28,7 +29,9 @@ makedocs(
         "Conversion between set representations" => "lib/conversion.md",
         "Binary Functions on Sets" => "lib/binary_functions.md",
         "Approximations" => "lib/approximations.md",
-        "Utility Functions" => "lib/utils.md"],
+        "Utility Functions" => "lib/utils.md",
+#         "Methods Collection" => "lib/methods_fix.md",
+        ],
         "About" => "about.md"
     ]
 )

--- a/docs/src/lib/approximations.md
+++ b/docs/src/lib/approximations.md
@@ -44,14 +44,6 @@ symmetric_interval_hull
 box_approximation_helper
 ```
 
-### Metric properties of sets
-
-```@docs
-norm(::LazySet, ::Real)
-radius(::LazySet, ::Real)
-diameter(::LazySet, ::Real)
-```
-
 ## Iterative refinement
 
 ```@docs

--- a/docs/src/lib/binary_functions.md
+++ b/docs/src/lib/binary_functions.md
@@ -17,36 +17,38 @@ end
 ## Subset check
 
 ```@docs
-⊆(::LazySet{Float64}, ::AbstractHyperrectangle{Float64})
-⊆(::AbstractPolytope{Float64}, ::AbstractHyperrectangle{Float64})
-⊆(::AbstractHyperrectangle{Float64}, ::AbstractHyperrectangle{Float64})
-⊆(::AbstractPolytope{Float64}, ::LazySet{Float64})
-⊆(::AbstractSingleton{Float64}, ::LazySet{Float64})
-⊆(::AbstractSingleton{Float64}, ::AbstractHyperrectangle{Float64})
-⊆(::AbstractSingleton{Float64}, ::AbstractSingleton{Float64})
-⊆(::Ball2{Float64}, ::Ball2{Float64})
-⊆(::Ball2{Float64}, ::AbstractSingleton{Float64})
+⊆(::LazySet{N}, ::AbstractHyperrectangle{N}, ::Bool=false) where {N<:Real}
+⊆(::AbstractPolytope{N}, ::LazySet{N}, ::Bool=false) where {N<:Real}
+⊆(::AbstractPolytope{N}, ::AbstractHyperrectangle, ::Bool=false) where {N<:Real}
+⊆(::AbstractHyperrectangle{N}, ::AbstractHyperrectangle{N}, ::Bool=false) where {N<:Real}
+⊆(::AbstractSingleton{N}, ::LazySet{N}, ::Bool=false) where {N<:Real}
+⊆(::AbstractSingleton{N}, ::AbstractHyperrectangle{N}, ::Bool=false) where {N<:Real}
+⊆(::AbstractSingleton{N}, ::AbstractSingleton{N}, ::Bool=false) where {N<:Real}
+⊆(::Ball2{AbstractFloat}, ::Ball2{AbstractFloat}, ::Bool=false) where {N<:AbstractFloat}
+	⊆(::Union{Ball2{N}, Ballp{N}}, ::AbstractSingleton{N}, ::Bool=false) where {N<:Real}
+⊆(::LineSegment{N}, ::LazySet{N}, ::Bool=false) where {N<:Real}
+⊆(::LineSegment{N}, ::Hyperrectangle{N}, ::Bool=false) where {N<:Real}
 ⊆(::Interval, ::Interval)
 ```
 
 ## Check for emptiness of intersection
 
 ```@docs
-is_intersection_empty(::AbstractHyperrectangle{Float64}, ::AbstractHyperrectangle{Float64})
-is_intersection_empty(::AbstractSingleton{Float64}, ::AbstractHyperrectangle{Float64})
-is_intersection_empty(::AbstractHyperrectangle{Float64}, ::AbstractSingleton{Float64})
-is_intersection_empty(::AbstractSingleton{Float64}, ::LazySet{Float64})
-is_intersection_empty(::LazySet{Float64}, ::AbstractSingleton{Float64})
-is_intersection_empty(::AbstractSingleton{Float64}, ::AbstractSingleton{Float64})
-is_intersection_empty(::Zonotope{Float64}, ::Hyperplane{Float64})
-is_intersection_empty(::Hyperplane{Float64}, ::Zonotope{Float64})
-is_intersection_empty(::Ball2{Float64}, ::Ball2{Float64})
-is_intersection_empty(::LineSegment{Float64}, ::LineSegment{Float64})
+is_intersection_empty(::AbstractHyperrectangle{N}, ::AbstractHyperrectangle{N}, ::Bool=false) where {N<:Real}
+is_intersection_empty(::AbstractHyperrectangle{N}, ::AbstractSingleton{N}, ::Bool=false) where {N<:Real}
+is_intersection_empty(::AbstractSingleton{N}, ::LazySet{N}, ::Bool=false) where {N<:Real}
+is_intersection_empty(::AbstractSingleton{N}, ::AbstractHyperrectangle{N}, ::Bool=false) where {N<:Real}
+is_intersection_empty(::AbstractSingleton{N}, ::AbstractSingleton{N}, ::Bool=false) where {N<:Real}
+is_intersection_empty(::LazySet{N}, ::AbstractSingleton{N}, ::Bool=false) where {N<:Real}
+is_intersection_empty(::Zonotope{N}, ::Hyperplane{N}, ::Bool=false) where {N<:Real}
+is_intersection_empty(::Hyperplane{N}, ::Zonotope{N}, ::Bool=false) where {N<:Real}
+is_intersection_empty(::Ball2{N}, ::Ball2{N}, ::Bool=false) where {N<:AbstractFloat}
+is_intersection_empty(::LineSegment{N}, ::LineSegment{N}, ::Bool=false) where {N<:Real}
 ```
 
 ## Intersection of two sets
 
 ```@docs
-intersection(::Line{Float64}, ::Line{Float64})
-intersection(::Hyperrectangle{Float64}, ::Hyperrectangle{Float64})
+intersection(::Line{N}, ::Line{N}) where {N<:Real}
+intersection(::Hyperrectangle{N}, ::Hyperrectangle{N}) where {N<:Real}
 ```

--- a/docs/src/lib/interfaces.md
+++ b/docs/src/lib/interfaces.md
@@ -138,6 +138,9 @@ This interface defines the following functions:
 ```@docs
 norm(::AbstractHyperrectangle, ::Real)
 radius(::AbstractHyperrectangle, ::Real)
+σ(::AbstractVector{Real}, ::AbstractHyperrectangle{Real})
+∈(::AbstractVector{Real}, ::AbstractHyperrectangle{Real})
+vertices_list(::AbstractHyperrectangle{Real})
 ```
 
 #### Singleton

--- a/docs/src/lib/interfaces.md
+++ b/docs/src/lib/interfaces.md
@@ -154,5 +154,12 @@ AbstractSingleton
 This interface defines the following functions:
 
 ```@docs
-linear_map(::AbstractMatrix, ::AbstractSingleton)
+σ(::AbstractVector{N}, ::AbstractSingleton{N}) where {N<:Real}
+∈(::AbstractVector{N}, ::AbstractSingleton{N}) where {N<:Real}
+an_element(::AbstractSingleton{N}) where {N<:Real}
+center(::AbstractSingleton{Real})
+vertices_list(::AbstractSingleton{N}) where {N<:Real}
+radius_hyperrectangle(::AbstractSingleton{Real})
+radius_hyperrectangle(::AbstractSingleton{Real}, ::Int)
+linear_map(::AbstractMatrix, ::AbstractSingleton{N}) where {N<:Real}
 ```

--- a/docs/src/lib/interfaces.md
+++ b/docs/src/lib/interfaces.md
@@ -115,6 +115,18 @@ An HPolygon is a polygon in H-representation (or constraint representation).
 AbstractHPolygon
 ```
 
+This interface defines the following functions:
+
+```@docs
+an_element(::AbstractHPolygon{N}) where {N<:Real}
+∈(::AbstractVector{Real}, ::AbstractHPolygon{Real})
+vertices_list(::AbstractHPolygon{Real})
+tohrep(::AbstractHPolygon{Real})
+tovrep(::AbstractHPolygon{Real})
+addconstraint!(::AbstractHPolygon{Real}, ::LinearConstraint{Real})
+constraints_list(::AbstractHPolygon{Real})
+```
+
 ### Point symmetric polytope
 
 A point symmetric polytope is a combination of two other interfaces:

--- a/docs/src/lib/interfaces.md
+++ b/docs/src/lib/interfaces.md
@@ -118,6 +118,13 @@ A point symmetric polytope is a combination of two other interfaces:
 AbstractPointSymmetricPolytope
 ```
 
+This interface defines the following functions:
+
+```@docs
+dim(::AbstractPointSymmetricPolytope)
+an_element(::AbstractPointSymmetricPolytope{N}) where {N<:Real}
+```
+
 #### Hyperrectangle
 
 A hyperrectangle is a special point symmetric polytope with axis-aligned facets.

--- a/docs/src/lib/interfaces.md
+++ b/docs/src/lib/interfaces.md
@@ -101,6 +101,12 @@ A polygon is a two-dimensional polytope.
 AbstractPolygon
 ```
 
+This interface defines the following functions:
+
+```@docs
+dim(P::AbstractPolygon)
+```
+
 #### HPolygon
 
 An HPolygon is a polygon in H-representation (or constraint representation).

--- a/docs/src/lib/interfaces.md
+++ b/docs/src/lib/interfaces.md
@@ -44,13 +44,16 @@ Every `LazySet` type must define a function `σ` to compute the support vector.
 
 ```@docs
 support_vector
-ρ
+ρ(::AbstractVector{Real}, ::LazySet{Real})
 support_function
 ```
 
 ### Other globally defined set functions
 
 ```@docs
+norm(::LazySet{Float64}, ::Real)
+radius(::LazySet{Float64}, ::Real)
+diameter(::LazySet{Float64}, ::Real)
 an_element(S::LazySet{Float64})
 ```
 
@@ -79,7 +82,8 @@ AbstractPolytope
 This interface defines the following functions:
 
 ```@docs
-linear_map(M::AbstractMatrix, P::AbstractPolytope{Float64})
+singleton_list(::AbstractPolytope)
+linear_map(::AbstractMatrix, ::AbstractPolytope)
 ```
 
 ### Polygon
@@ -126,5 +130,5 @@ AbstractSingleton
 This interface defines the following functions:
 
 ```@docs
-linear_map(M::AbstractMatrix, S::AbstractSingleton{Float64})
+linear_map(::AbstractMatrix, ::AbstractSingleton)
 ```

--- a/docs/src/lib/interfaces.md
+++ b/docs/src/lib/interfaces.md
@@ -51,10 +51,10 @@ support_function
 ### Other globally defined set functions
 
 ```@docs
-norm(::LazySet{Float64}, ::Real)
-radius(::LazySet{Float64}, ::Real)
-diameter(::LazySet{Float64}, ::Real)
-an_element(S::LazySet{Float64})
+norm(::LazySet, ::Real)
+radius(::LazySet, ::Real)
+diameter(::LazySet, ::Real)
+an_element(::LazySet{Real})
 ```
 
 ## Point symmetric set
@@ -117,6 +117,13 @@ A hyperrectangle is a special point symmetric polytope with axis-aligned facets.
 
 ```@docs
 AbstractHyperrectangle
+```
+
+This interface defines the following functions:
+
+```@docs
+norm(::AbstractHyperrectangle, ::Real)
+radius(::AbstractHyperrectangle, ::Real)
 ```
 
 #### Singleton

--- a/docs/src/lib/interfaces.md
+++ b/docs/src/lib/interfaces.md
@@ -68,6 +68,13 @@ Note that there is a special interface combination
 AbstractPointSymmetric
 ```
 
+This interface defines the following functions:
+
+```@docs
+dim(::AbstractPointSymmetric)
+an_element(::AbstractPointSymmetric{N}) where {N<:Real}
+```
+
 ## Polytope
 
 A polytope has finitely many vertices (*V-representation*) resp. facets

--- a/docs/src/lib/methods_fix.md
+++ b/docs/src/lib/methods_fix.md
@@ -1,0 +1,40 @@
+# Functions with several methods
+
+```@meta
+CurrentModule = LazySets
+DocTestSetup = quote
+    using RecipesBase, LazySets
+end
+```
+
+```@docs
+RecipesBase.apply_recipe
+addconstraint!
+an_element
+array
+center
+constraints_list
+convert
+diameter
+dim
+element
+halfspace_left
+halfspace_right
+high
+intersection
+low
+norm
+is_intersection_empty
+linear_map
+radius
+radius_hyperrectangle
+tohrep
+tovrep
+vertices_list
+*
++
+<=
+σ
+∈
+⊆
+```

--- a/docs/src/lib/operations.md
+++ b/docs/src/lib/operations.md
@@ -247,5 +247,7 @@ Inherited from [`AbstractPointSymmetricPolytope`](@ref):
 * `an_element`
 
 Inherited from [`AbstractHyperrectangle`](@ref):
+* [`∈`](@ref ∈(::AbstractVector{Real}, ::AbstractHyperrectangle{Real}))
 * [`norm`](@ref norm(::AbstractHyperrectangle, ::Real))
 * [`radius`](@ref radius(::AbstractHyperrectangle, ::Real))
+* [`vertices_list`](@ref vertices_list(::AbstractHyperrectangle{Real}))

--- a/docs/src/lib/operations.md
+++ b/docs/src/lib/operations.md
@@ -233,9 +233,7 @@ Inherited from [`LazySet`](@ref):
 
 ```@docs
 SymmetricIntervalHull
-dim(::SymmetricIntervalHull)
 σ(::V, ::SymmetricIntervalHull{N}) where {N<:Real, V<:AbstractVector{N}}
-an_element(::SymmetricIntervalHull{Float64, LazySet{Float64}})
 ```
 Inherited from [`LazySet`](@ref):
 * [`diameter`](@ref diameter(::LazySet, ::Real))
@@ -243,6 +241,10 @@ Inherited from [`LazySet`](@ref):
 Inherited from [`AbstractPolytope`](@ref):
 * [`singleton_list`](@ref singleton_list(::AbstractPolytope))
 * [`linear_map`](@ref linear_map(::AbstractMatrix, ::AbstractPolytope))
+
+Inherited from [`AbstractPointSymmetricPolytope`](@ref):
+* [`dim`](@ref dim(::AbstractPointSymmetricPolytope))
+* `an_element`
 
 Inherited from [`AbstractHyperrectangle`](@ref):
 * [`norm`](@ref norm(::AbstractHyperrectangle, ::Real))

--- a/docs/src/lib/operations.md
+++ b/docs/src/lib/operations.md
@@ -27,6 +27,11 @@ dim(::CartesianProduct)
 σ(::AbstractVector{Real}, ::CartesianProduct{Real})
 ∈(::AbstractVector{Real}, ::CartesianProduct{Real})
 ```
+Inherited from [`LazySet`](@ref):
+* [`norm`](@ref norm(::LazySet, ::Real))
+* [`radius`](@ref radius(::LazySet, ::Real))
+* [`diameter`](@ref diameter(::LazySet, ::Real))
+* [`an_element`](@ref an_element(::LazySet{Real}))
 
 ### ``n``-ary Cartesian Product
 
@@ -37,6 +42,11 @@ dim(::CartesianProductArray)
 ∈(::AbstractVector{Real}, ::CartesianProductArray{Real})
 array(::CartesianProductArray)
 ```
+Inherited from [`LazySet`](@ref):
+* [`norm`](@ref norm(::LazySet, ::Real))
+* [`radius`](@ref radius(::LazySet, ::Real))
+* [`diameter`](@ref diameter(::LazySet, ::Real))
+* [`an_element`](@ref an_element(::LazySet{Real}))
 
 ## Convex Hull
 
@@ -48,6 +58,11 @@ CH
 dim(::ConvexHull)
 σ(::AbstractVector{Real}, ::ConvexHull{Real})
 ```
+Inherited from [`LazySet`](@ref):
+* [`norm`](@ref norm(::LazySet, ::Real))
+* [`radius`](@ref radius(::LazySet, ::Real))
+* [`diameter`](@ref diameter(::LazySet, ::Real))
+* [`an_element`](@ref an_element(::LazySet{Real}))
 
 ### ``n``-ary Convex Hull
 
@@ -58,6 +73,11 @@ dim(::ConvexHullArray)
 σ(::AbstractVector{Real}, ::ConvexHullArray{Real})
 array(::ConvexHullArray)
 ```
+Inherited from [`LazySet`](@ref):
+* [`norm`](@ref norm(::LazySet, ::Real))
+* [`radius`](@ref radius(::LazySet, ::Real))
+* [`diameter`](@ref diameter(::LazySet, ::Real))
+* [`an_element`](@ref an_element(::LazySet{Real}))
 
 ### Convex Hull Algorithms
 
@@ -80,6 +100,11 @@ dim(::Intersection)
 ∈(::AbstractVector{Real}, ::Intersection{Real})
 isempty(::Intersection)
 ```
+Inherited from [`LazySet`](@ref):
+* [`norm`](@ref norm(::LazySet, ::Real))
+* [`radius`](@ref radius(::LazySet, ::Real))
+* [`diameter`](@ref diameter(::LazySet, ::Real))
+* [`an_element`](@ref an_element(::LazySet{Real}))
 
 ### ``n``-ary Intersection
 
@@ -89,6 +114,11 @@ dim(::IntersectionArray)
 σ(::AbstractVector{Real}, ::IntersectionArray{Real})
 array(::IntersectionArray)
 ```
+Inherited from [`LazySet`](@ref):
+* [`norm`](@ref norm(::LazySet, ::Real))
+* [`radius`](@ref radius(::LazySet, ::Real))
+* [`diameter`](@ref diameter(::LazySet, ::Real))
+* [`an_element`](@ref an_element(::LazySet{Real}))
 
 ## Minkowski Sum
 
@@ -101,6 +131,11 @@ MinkowskiSum
 dim(::MinkowskiSum)
 σ(::AbstractVector{Real}, ::MinkowskiSum{Real})
 ```
+Inherited from [`LazySet`](@ref):
+* [`norm`](@ref norm(::LazySet, ::Real))
+* [`radius`](@ref radius(::LazySet, ::Real))
+* [`diameter`](@ref diameter(::LazySet, ::Real))
+* [`an_element`](@ref an_element(::LazySet{Real}))
 
 ### ``n``-ary Minkowski Sum
 
@@ -110,6 +145,11 @@ dim(::MinkowskiSumArray)
 σ(::AbstractVector{Real}, ::MinkowskiSumArray{Real})
 array(::MinkowskiSumArray)
 ```
+Inherited from [`LazySet`](@ref):
+* [`norm`](@ref norm(::LazySet, ::Real))
+* [`radius`](@ref radius(::LazySet, ::Real))
+* [`diameter`](@ref diameter(::LazySet, ::Real))
+* [`an_element`](@ref an_element(::LazySet{Real}))
 
 ### ``n``-ary Minkowski Sum with cache
 
@@ -120,6 +160,11 @@ dim(::CacheMinkowskiSum)
 array(::CacheMinkowskiSum)
 forget_sets!(::CacheMinkowskiSum)
 ```
+Inherited from [`LazySet`](@ref):
+* [`norm`](@ref norm(::LazySet, ::Real))
+* [`radius`](@ref radius(::LazySet, ::Real))
+* [`diameter`](@ref diameter(::LazySet, ::Real))
+* [`an_element`](@ref an_element(::LazySet{Real}))
 
 ## Maps
 
@@ -134,6 +179,10 @@ dim(::LinearMap)
 ∈(::AbstractVector{Real}, ::LinearMap{Real, Real})
 an_element(::LinearMap)
 ```
+Inherited from [`LazySet`](@ref):
+* [`norm`](@ref norm(::LazySet, ::Real))
+* [`radius`](@ref radius(::LazySet, ::Real))
+* [`diameter`](@ref diameter(::LazySet, ::Real))
 
 ### Exponential Map
 
@@ -143,22 +192,42 @@ dim(::ExponentialMap)
 σ(::AbstractVector{Real}, ::ExponentialMap{Real})
 ∈(::AbstractVector{Real}, ::ExponentialMap{Real})
 ```
+Inherited from [`LazySet`](@ref):
+* [`norm`](@ref norm(::LazySet, ::Real))
+* [`radius`](@ref radius(::LazySet, ::Real))
+* [`diameter`](@ref diameter(::LazySet, ::Real))
+* [`an_element`](@ref an_element(::LazySet{Real}))
 
 ```@docs
 ExponentialProjectionMap
 dim(::ExponentialProjectionMap)
 σ(::AbstractVector{Real}, ::ExponentialProjectionMap{Real})
 ```
+Inherited from [`LazySet`](@ref):
+* [`norm`](@ref norm(::LazySet, ::Real))
+* [`radius`](@ref radius(::LazySet, ::Real))
+* [`diameter`](@ref diameter(::LazySet, ::Real))
+* [`an_element`](@ref an_element(::LazySet{Real}))
 
 ```@docs
 SparseMatrixExp
 *(::SparseMatrixExp, ::LazySet)
 ```
+Inherited from [`LazySet`](@ref):
+* [`norm`](@ref norm(::LazySet, ::Real))
+* [`radius`](@ref radius(::LazySet, ::Real))
+* [`diameter`](@ref diameter(::LazySet, ::Real))
+* [`an_element`](@ref an_element(::LazySet{Real}))
 
 ```@docs
 ProjectionSparseMatrixExp
 *(::ProjectionSparseMatrixExp, ::LazySet)
 ```
+Inherited from [`LazySet`](@ref):
+* [`norm`](@ref norm(::LazySet, ::Real))
+* [`radius`](@ref radius(::LazySet, ::Real))
+* [`diameter`](@ref diameter(::LazySet, ::Real))
+* [`an_element`](@ref an_element(::LazySet{Real}))
 
 ## Symmetric Interval Hull
 
@@ -168,3 +237,9 @@ dim(::SymmetricIntervalHull)
 σ(::V, ::SymmetricIntervalHull{N}) where {N<:Real, V<:AbstractVector{N}}
 an_element(::SymmetricIntervalHull{Float64, LazySet{Float64}})
 ```
+Inherited from [`LazySet`](@ref):
+* [`diameter`](@ref diameter(::LazySet, ::Real))
+
+Inherited from [`AbstractHyperrectangle`](@ref):
+* [`norm`](@ref norm(::AbstractHyperrectangle, ::Real))
+* [`radius`](@ref radius(::AbstractHyperrectangle, ::Real))

--- a/docs/src/lib/operations.md
+++ b/docs/src/lib/operations.md
@@ -240,6 +240,10 @@ an_element(::SymmetricIntervalHull{Float64, LazySet{Float64}})
 Inherited from [`LazySet`](@ref):
 * [`diameter`](@ref diameter(::LazySet, ::Real))
 
+Inherited from [`AbstractPolytope`](@ref):
+* [`singleton_list`](@ref singleton_list(::AbstractPolytope))
+* [`linear_map`](@ref linear_map(::AbstractMatrix, ::AbstractPolytope))
+
 Inherited from [`AbstractHyperrectangle`](@ref):
 * [`norm`](@ref norm(::AbstractHyperrectangle, ::Real))
 * [`radius`](@ref radius(::AbstractHyperrectangle, ::Real))

--- a/docs/src/lib/operations.md
+++ b/docs/src/lib/operations.md
@@ -21,20 +21,21 @@ end
 
 ```@docs
 CartesianProduct
-Base.:*(::LazySet{Float64}, ::LazySet{Float64})
-dim(::CartesianProduct{Float64, LazySet{Float64}, LazySet{Float64}})
-σ(::AbstractVector{Float64}, ::CartesianProduct{Float64, LazySet{Float64}, LazySet{Float64}})
-∈(::AbstractVector{Float64}, ::CartesianProduct{Float64, LazySet{Float64}, LazySet{Float64}})
+×(::LazySet, ::LazySet)
+*(::LazySet, ::LazySet)
+dim(::CartesianProduct)
+σ(::AbstractVector{Real}, ::CartesianProduct{Real})
+∈(::AbstractVector{Real}, ::CartesianProduct{Real})
 ```
 
 ### ``n``-ary Cartesian Product
 
 ```@docs
-CartesianProductArray{Float64, LazySet{Float64}}
-array(::CartesianProductArray{Float64, LazySet{Float64}})
-dim(::CartesianProductArray{Float64, LazySet{Float64}})
-σ(::AbstractVector{Float64}, ::CartesianProductArray{Float64, LazySet{Float64}})
-∈(::AbstractVector{Float64}, ::CartesianProductArray{Float64, LazySet{Float64}})
+CartesianProductArray
+dim(::CartesianProductArray)
+σ(::AbstractVector{Real}, ::CartesianProductArray{Real})
+∈(::AbstractVector{Real}, ::CartesianProductArray{Real})
+array(::CartesianProductArray)
 ```
 
 ## Convex Hull
@@ -44,8 +45,8 @@ dim(::CartesianProductArray{Float64, LazySet{Float64}})
 ```@docs
 ConvexHull
 CH
-dim(::ConvexHull{Float64, LazySet{Float64}, LazySet{Float64}})
-σ(::AbstractVector{Float64}, ::ConvexHull{Float64, LazySet{Float64}, LazySet{Float64}})
+dim(::ConvexHull)
+σ(::AbstractVector{Real}, ::ConvexHull{Real})
 ```
 
 ### ``n``-ary Convex Hull
@@ -53,9 +54,9 @@ dim(::ConvexHull{Float64, LazySet{Float64}, LazySet{Float64}})
 ```@docs
 ConvexHullArray
 CHArray
-array(::ConvexHullArray{Float64, LazySet{Float64}})
-dim(cha::ConvexHullArray)
-σ(d::AbstractVector{Float64}, cha::ConvexHullArray)
+dim(::ConvexHullArray)
+σ(::AbstractVector{Real}, ::ConvexHullArray{Real})
+array(::ConvexHullArray)
 ```
 
 ### Convex Hull Algorithms
@@ -74,19 +75,19 @@ monotone_chain!
 ```@docs
 Intersection
 ∩(::LazySet, ::LazySet)
-dim(::Intersection{Float64, LazySet{Float64}, LazySet{Float64}})
-σ(::AbstractVector{Float64}, ::Intersection{Float64, LazySet{Float64}, LazySet{Float64}})
-∈(::AbstractVector{Float64}, ::Intersection{Float64, LazySet{Float64}, LazySet{Float64}})
-isempty(::Intersection{Float64, LazySet{Float64}, LazySet{Float64}})
+dim(::Intersection)
+σ(::AbstractVector{Real}, ::Intersection{Real})
+∈(::AbstractVector{Real}, ::Intersection{Real})
+isempty(::Intersection)
 ```
 
 ### ``n``-ary Intersection
 
 ```@docs
 IntersectionArray
-array(::IntersectionArray{Float64, LazySet{Float64}})
-dim(::IntersectionArray{Float64, LazySet{Float64}})
-σ(::AbstractVector{Float64}, ::IntersectionArray{Float64, LazySet{Float64}})
+dim(::IntersectionArray)
+σ(::AbstractVector{Real}, ::IntersectionArray{Real})
+array(::IntersectionArray)
 ```
 
 ## Minkowski Sum
@@ -95,28 +96,28 @@ dim(::IntersectionArray{Float64, LazySet{Float64}})
 
 ```@docs
 MinkowskiSum
-Base.:+(::LazySet{Float64}, ::LazySet{Float64})
-⊕
-dim(::MinkowskiSum{Float64, LazySet{Float64}, LazySet{Float64}})
-σ(::AbstractVector{Float64}, ::MinkowskiSum{Float64, LazySet{Float64}, LazySet{Float64}})
+⊕(::LazySet, ::LazySet)
++(::LazySet, ::LazySet)
+dim(::MinkowskiSum)
+σ(::AbstractVector{Real}, ::MinkowskiSum{Real})
 ```
 
 ### ``n``-ary Minkowski Sum
 
 ```@docs
 MinkowskiSumArray
-array(::MinkowskiSumArray{Float64, LazySet{Float64}})
-dim(::MinkowskiSumArray{Float64, LazySet{Float64}})
-σ(::AbstractVector{Float64}, ::MinkowskiSumArray{Float64, LazySet{Float64}})
+dim(::MinkowskiSumArray)
+σ(::AbstractVector{Real}, ::MinkowskiSumArray{Real})
+array(::MinkowskiSumArray)
 ```
 
 ### ``n``-ary Minkowski Sum with cache
 
 ```@docs
 CacheMinkowskiSum
-array(::CacheMinkowskiSum{Float64, LazySet{Float64}})
-dim(::CacheMinkowskiSum{Float64, LazySet{Float64}})
-σ(::AbstractVector{Float64}, ::CacheMinkowskiSum{Float64, LazySet{Float64}})
+dim(::CacheMinkowskiSum)
+σ(::AbstractVector{Real}, ::CacheMinkowskiSum{Real})
+array(::CacheMinkowskiSum)
 forget_sets!(::CacheMinkowskiSum)
 ```
 
@@ -126,44 +127,44 @@ forget_sets!(::CacheMinkowskiSum)
 
 ```@docs
 LinearMap
-dim(::LinearMap{Float64, Float64})
-σ(::AbstractVector{Float64}, ::LinearMap{Float64, Float64})
 *(::AbstractMatrix, ::LazySet)
-*(::Float64, ::LazySet)
-∈(x::AbstractVector{Float64}, ::LinearMap{Float64, Float64})
-an_element(lm::LinearMap)
+*(::Real, ::LazySet)
+dim(::LinearMap)
+σ(::AbstractVector{Real}, ::LinearMap{Real, Real})
+∈(::AbstractVector{Real}, ::LinearMap{Real, Real})
+an_element(::LinearMap)
 ```
 
 ### Exponential Map
 
 ```@docs
 ExponentialMap
-dim(::ExponentialMap{Float64, LazySet{Float64}})
-σ(::AbstractVector{Float64}, ::ExponentialMap{Float64, LazySet{Float64}})
-∈(::AbstractVector{Float64}, ::ExponentialMap{Float64, LazySet{Float64}})
+dim(::ExponentialMap)
+σ(::AbstractVector{Real}, ::ExponentialMap{Real})
+∈(::AbstractVector{Real}, ::ExponentialMap{Real})
 ```
 
 ```@docs
 ExponentialProjectionMap
-dim(::ExponentialProjectionMap{Float64, LazySet{Float64}})
-σ(::AbstractVector{Float64}, ::ExponentialProjectionMap{Float64, LazySet{Float64}})
+dim(::ExponentialProjectionMap)
+σ(::AbstractVector{Real}, ::ExponentialProjectionMap{Real})
 ```
 
 ```@docs
 SparseMatrixExp
-*(::SparseMatrixExp{Float64}, ::LazySet{Float64})
+*(::SparseMatrixExp, ::LazySet)
 ```
 
 ```@docs
 ProjectionSparseMatrixExp
-*(::ProjectionSparseMatrixExp{Float64}, ::LazySet{Float64})
+*(::ProjectionSparseMatrixExp, ::LazySet)
 ```
 
 ## Symmetric Interval Hull
 
 ```@docs
 SymmetricIntervalHull
-dim(::SymmetricIntervalHull{Float64, LazySet{Float64}})
-σ(::AbstractVector{Float64}, ::SymmetricIntervalHull{Float64, LazySet{Float64}})
+dim(::SymmetricIntervalHull)
+σ(::V, ::SymmetricIntervalHull{N}) where {N<:Real, V<:AbstractVector{N}}
 an_element(::SymmetricIntervalHull{Float64, LazySet{Float64}})
 ```

--- a/docs/src/lib/representations.md
+++ b/docs/src/lib/representations.md
@@ -20,16 +20,18 @@ end
 
 ```@docs
 Ball2
-dim(::Ball2)
 σ(::AbstractVector{AbstractFloat}, ::Ball2{AbstractFloat})
 ∈(::AbstractVector{AbstractFloat}, ::Ball2{AbstractFloat})
-an_element(::Ball2)
 center(::Ball2)
 ```
 Inherited from [`LazySet`](@ref):
 * [`norm`](@ref norm(::LazySet, ::Real))
 * [`radius`](@ref radius(::LazySet, ::Real))
 * [`diameter`](@ref diameter(::LazySet, ::Real))
+
+Inherited from [`AbstractPointSymmetric`](@ref):
+* [`dim`](@ref dim(::AbstractPointSymmetric))
+* `an_element`
 
 ### Infinity norm ball
 
@@ -79,10 +81,8 @@ Inherited from [`AbstractPolytope`](@ref):
 
 ```@docs
 Ballp
-dim(::Ballp)
 σ(::AbstractVector{AbstractFloat}, ::Ballp{AbstractFloat})
 ∈(::AbstractVector{AbstractFloat}, ::Ballp{AbstractFloat})
-an_element(::Ballp)
 center(::Ballp)
 ```
 Inherited from [`LazySet`](@ref):
@@ -90,20 +90,26 @@ Inherited from [`LazySet`](@ref):
 * [`radius`](@ref radius(::LazySet, ::Real))
 * [`diameter`](@ref diameter(::LazySet, ::Real))
 
+Inherited from [`AbstractPointSymmetric`](@ref):
+* [`dim`](@ref dim(::AbstractPointSymmetric))
+* `an_element`
+
 ## Ellipsoid
 
 ```@docs
 Ellipsoid
-dim(::Ellipsoid)
 σ(::AbstractVector{AbstractFloat}, ::Ellipsoid{AbstractFloat})
 ∈(::AbstractVector{AbstractFloat}, ::Ellipsoid{AbstractFloat})
-an_element(::Ellipsoid)
 center(::Ellipsoid)
 ```
 Inherited from [`LazySet`](@ref):
 * [`norm`](@ref norm(::LazySet, ::Real))
 * [`radius`](@ref radius(::LazySet, ::Real))
 * [`diameter`](@ref diameter(::LazySet, ::Real))
+
+Inherited from [`AbstractPointSymmetric`](@ref):
+* [`dim`](@ref dim(::AbstractPointSymmetric))
+* `an_element`
 
 ## Empty set
 

--- a/docs/src/lib/representations.md
+++ b/docs/src/lib/representations.md
@@ -257,12 +257,6 @@ Inherited from [`LazySet`](@ref):
 ```@docs
 HPolygon
 σ(::AbstractVector{Real}, ::HPolygon{Real})
-∈(::AbstractVector{Real}, ::HPolygon{Real})
-an_element(::HPolygon)
-vertices_list(::HPolygon)
-tohrep(::HPolygon)
-tovrep(::HPolygon)
-addconstraint!(::HPolygon{Real}, ::LinearConstraint{Real})
 ```
 Inherited from [`LazySet`](@ref):
 * [`norm`](@ref norm(::LazySet, ::Real))
@@ -275,18 +269,21 @@ Inherited from [`AbstractPolytope`](@ref):
 
 Inherited from [`AbstractPolygon`](@ref):
 * [`dim`](@ref dim(P::AbstractPolygon))
+
+Inherited from [`AbstractHPolygon`](@ref):
+* `an_element`
+* [`∈`](@ref ∈(::AbstractVector{Real}, ::AbstractHPolygon{Real}))
+* [`vertices_list`](@ref vertices_list(::AbstractHPolygon{Real}))
+* [`tohrep`](@ref tohrep(::AbstractHPolygon{Real}))
+* [`tovrep`](@ref tovrep(::AbstractHPolygon{Real}))
+* [`addconstraint!`](@ref addconstraint!(::AbstractHPolygon{Real}, ::LinearConstraint{Real}))
+* [`constraints_list`](@ref constraints_list(::AbstractHPolygon{Real}))
 
 ### Optimized constraint representation
 
 ```@docs
 HPolygonOpt
 σ(::AbstractVector{Real}, ::HPolygonOpt{Real})
-∈(::AbstractVector{Real}, ::HPolygonOpt{Real})
-an_element(::HPolygonOpt)
-vertices_list(::HPolygonOpt)
-tohrep(::HPolygonOpt)
-tovrep(::HPolygonOpt)
-addconstraint!(::HPolygonOpt{Real}, ::LinearConstraint{Real})
 ```
 Inherited from [`LazySet`](@ref):
 * [`norm`](@ref norm(::LazySet, ::Real))
@@ -299,6 +296,15 @@ Inherited from [`AbstractPolytope`](@ref):
 
 Inherited from [`AbstractPolygon`](@ref):
 * [`dim`](@ref dim(P::AbstractPolygon))
+
+Inherited from [`AbstractHPolygon`](@ref):
+* `an_element`
+* [`∈`](@ref ∈(::AbstractVector{Real}, ::AbstractHPolygon{Real}))
+* [`vertices_list`](@ref vertices_list(::AbstractHPolygon{Real}))
+* [`tohrep`](@ref tohrep(::AbstractHPolygon{Real}))
+* [`tovrep`](@ref tovrep(::AbstractHPolygon{Real}))
+* [`addconstraint!`](@ref addconstraint!(::AbstractHPolygon{Real}, ::LinearConstraint{Real}))
+* [`constraints_list`](@ref constraints_list(::AbstractHPolygon{Real}))
 
 ### Vertex representation
 

--- a/docs/src/lib/representations.md
+++ b/docs/src/lib/representations.md
@@ -48,6 +48,10 @@ radius_hyperrectangle(::BallInf, ::Int)
 Inherited from [`LazySet`](@ref):
 * [`diameter`](@ref diameter(::LazySet, ::Real))
 
+Inherited from [`AbstractPolytope`](@ref):
+* [`singleton_list`](@ref singleton_list(::AbstractPolytope))
+* [`linear_map`](@ref linear_map(::AbstractMatrix, ::AbstractPolytope))
+
 Inherited from [`AbstractHyperrectangle`](@ref):
 * [`norm`](@ref norm(::AbstractHyperrectangle, ::Real))
 
@@ -66,6 +70,10 @@ Inherited from [`LazySet`](@ref):
 * [`norm`](@ref norm(::LazySet, ::Real))
 * [`radius`](@ref radius(::LazySet, ::Real))
 * [`diameter`](@ref diameter(::LazySet, ::Real))
+
+Inherited from [`AbstractPolytope`](@ref):
+* [`singleton_list`](@ref singleton_list(::AbstractPolytope))
+* [`linear_map`](@ref linear_map(::AbstractMatrix, ::AbstractPolytope))
 
 ### p-norm ball
 
@@ -165,6 +173,10 @@ low(::Hyperrectangle)
 Inherited from [`LazySet`](@ref):
 * [`diameter`](@ref diameter(::LazySet, ::Real))
 
+Inherited from [`AbstractPolytope`](@ref):
+* [`singleton_list`](@ref singleton_list(::AbstractPolytope))
+* [`linear_map`](@ref linear_map(::AbstractMatrix, ::AbstractPolytope))
+
 Inherited from [`AbstractHyperrectangle`](@ref):
 * [`norm`](@ref norm(::AbstractHyperrectangle, ::Real))
 * [`radius`](@ref radius(::AbstractHyperrectangle, ::Real))
@@ -188,6 +200,10 @@ high(::Interval)
 ```
 Inherited from [`LazySet`](@ref):
 * [`diameter`](@ref diameter(::LazySet, ::Real))
+
+Inherited from [`AbstractPolytope`](@ref):
+* [`singleton_list`](@ref singleton_list(::AbstractPolytope))
+* [`linear_map`](@ref linear_map(::AbstractMatrix, ::AbstractPolytope))
 
 Inherited from [`AbstractHyperrectangle`](@ref):
 * [`norm`](@ref norm(::AbstractHyperrectangle, ::Real))
@@ -242,6 +258,10 @@ Inherited from [`LazySet`](@ref):
 * [`radius`](@ref radius(::LazySet, ::Real))
 * [`diameter`](@ref diameter(::LazySet, ::Real))
 
+Inherited from [`AbstractPolytope`](@ref):
+* [`singleton_list`](@ref singleton_list(::AbstractPolytope))
+* [`linear_map`](@ref linear_map(::AbstractMatrix, ::AbstractPolytope))
+
 ### Optimized constraint representation
 
 ```@docs
@@ -260,6 +280,10 @@ Inherited from [`LazySet`](@ref):
 * [`radius`](@ref radius(::LazySet, ::Real))
 * [`diameter`](@ref diameter(::LazySet, ::Real))
 
+Inherited from [`AbstractPolytope`](@ref):
+* [`singleton_list`](@ref singleton_list(::AbstractPolytope))
+* [`linear_map`](@ref linear_map(::AbstractMatrix, ::AbstractPolytope))
+
 ### Vertex representation
 
 ```@docs
@@ -276,6 +300,10 @@ Inherited from [`LazySet`](@ref):
 * [`norm`](@ref norm(::LazySet, ::Real))
 * [`radius`](@ref radius(::LazySet, ::Real))
 * [`diameter`](@ref diameter(::LazySet, ::Real))
+
+Inherited from [`AbstractPolytope`](@ref):
+* [`singleton_list`](@ref singleton_list(::AbstractPolytope))
+* [`linear_map`](@ref linear_map(::AbstractMatrix, ::AbstractPolytope))
 
 ### Sorting directions
 
@@ -303,6 +331,10 @@ Inherited from [`LazySet`](@ref):
 * [`radius`](@ref radius(::LazySet, ::Real))
 * [`diameter`](@ref diameter(::LazySet, ::Real))
 
+Inherited from [`AbstractPolytope`](@ref):
+* [`singleton_list`](@ref singleton_list(::AbstractPolytope))
+* [`linear_map`](@ref linear_map(::AbstractMatrix, ::AbstractPolytope))
+
 ### Vertex representation
 
 ```@docs
@@ -315,6 +347,10 @@ Inherited from [`LazySet`](@ref):
 * [`norm`](@ref norm(::LazySet, ::Real))
 * [`radius`](@ref radius(::LazySet, ::Real))
 * [`diameter`](@ref diameter(::LazySet, ::Real))
+
+Inherited from [`AbstractPolytope`](@ref):
+* [`singleton_list`](@ref singleton_list(::AbstractPolytope))
+* [`linear_map`](@ref linear_map(::AbstractMatrix, ::AbstractPolytope))
 
 ## Singleton
 
@@ -333,6 +369,10 @@ element(::Singleton, ::Int)
 ```
 Inherited from [`LazySet`](@ref):
 * [`diameter`](@ref diameter(::LazySet, ::Real))
+
+Inherited from [`AbstractPolytope`](@ref):
+* [`singleton_list`](@ref singleton_list(::AbstractPolytope))
+* [`linear_map`](@ref linear_map(::AbstractMatrix, ::AbstractPolytope))
 
 Inherited from [`AbstractHyperrectangle`](@ref):
 * [`norm`](@ref norm(::AbstractHyperrectangle, ::Real))
@@ -356,6 +396,9 @@ linear_map(::AbstractMatrix, ::ZeroSet{N}) where {N<:Real}
 ```
 Inherited from [`LazySet`](@ref):
 * [`diameter`](@ref diameter(::LazySet, ::Real))
+
+Inherited from [`AbstractPolytope`](@ref):
+* [`singleton_list`](@ref singleton_list(::AbstractPolytope))
 
 Inherited from [`AbstractHyperrectangle`](@ref):
 * [`norm`](@ref norm(::AbstractHyperrectangle, ::Real))
@@ -382,3 +425,6 @@ Inherited from [`LazySet`](@ref):
 * [`norm`](@ref norm(::LazySet, ::Real))
 * [`radius`](@ref radius(::LazySet, ::Real))
 * [`diameter`](@ref diameter(::LazySet, ::Real))
+
+Inherited from [`AbstractPolytope`](@ref):
+* [`singleton_list`](@ref singleton_list(::AbstractPolytope))

--- a/docs/src/lib/representations.md
+++ b/docs/src/lib/representations.md
@@ -37,10 +37,8 @@ Inherited from [`AbstractPointSymmetric`](@ref):
 
 ```@docs
 BallInf
-dim(::BallInf)
 σ(::AbstractVector{Real}, ::BallInf{Real})
 ∈(::AbstractVector{Real}, ::BallInf{Real})
-an_element(::BallInf)
 vertices_list(::BallInf)
 center(::BallInf)
 radius(::BallInf, ::Real)
@@ -54,6 +52,10 @@ Inherited from [`AbstractPolytope`](@ref):
 * [`singleton_list`](@ref singleton_list(::AbstractPolytope))
 * [`linear_map`](@ref linear_map(::AbstractMatrix, ::AbstractPolytope))
 
+Inherited from [`AbstractPointSymmetricPolytope`](@ref):
+* [`dim`](@ref dim(::AbstractPointSymmetricPolytope))
+* `an_element`
+
 Inherited from [`AbstractHyperrectangle`](@ref):
 * [`norm`](@ref norm(::AbstractHyperrectangle, ::Real))
 
@@ -61,10 +63,8 @@ Inherited from [`AbstractHyperrectangle`](@ref):
 
 ```@docs
 Ball1
-dim(::Ball1)
 σ(::AbstractVector{Real}, ::Ball1{Real})
 ∈(::AbstractVector{Real}, ::Ball1{Real})
-an_element(::Ball1)
 vertices_list(::Ball1)
 center(::Ball1)
 ```
@@ -76,6 +76,10 @@ Inherited from [`LazySet`](@ref):
 Inherited from [`AbstractPolytope`](@ref):
 * [`singleton_list`](@ref singleton_list(::AbstractPolytope))
 * [`linear_map`](@ref linear_map(::AbstractMatrix, ::AbstractPolytope))
+
+Inherited from [`AbstractPointSymmetricPolytope`](@ref):
+* [`dim`](@ref dim(::AbstractPointSymmetricPolytope))
+* `an_element`
 
 ### p-norm ball
 
@@ -165,10 +169,8 @@ Inherited from [`LazySet`](@ref):
 ```@docs
 Hyperrectangle
 Hyperrectangle(;kwargs...)
-dim(::Hyperrectangle)
 σ(::AbstractVector{Real}, ::Hyperrectangle{Real})
 ∈(::AbstractVector{Real}, ::Hyperrectangle{Real})
-an_element(::Hyperrectangle)
 vertices_list(::Hyperrectangle)
 center(::Hyperrectangle)
 radius_hyperrectangle(::Hyperrectangle)
@@ -182,6 +184,10 @@ Inherited from [`LazySet`](@ref):
 Inherited from [`AbstractPolytope`](@ref):
 * [`singleton_list`](@ref singleton_list(::AbstractPolytope))
 * [`linear_map`](@ref linear_map(::AbstractMatrix, ::AbstractPolytope))
+
+Inherited from [`AbstractPointSymmetricPolytope`](@ref):
+* [`dim`](@ref dim(::AbstractPointSymmetricPolytope))
+* `an_element`
 
 Inherited from [`AbstractHyperrectangle`](@ref):
 * [`norm`](@ref norm(::AbstractHyperrectangle, ::Real))
@@ -362,10 +368,8 @@ Inherited from [`AbstractPolytope`](@ref):
 
 ```@docs
 Singleton
-dim(::Singleton)
 σ(::AbstractVector{Real}, ::Singleton{Real})
 ∈(::AbstractVector{Real}, ::Singleton{Real})
-an_element(::Singleton)
 vertices_list(::Singleton)
 center(::Singleton)
 radius_hyperrectangle(::Singleton)
@@ -380,6 +384,10 @@ Inherited from [`AbstractPolytope`](@ref):
 * [`singleton_list`](@ref singleton_list(::AbstractPolytope))
 * [`linear_map`](@ref linear_map(::AbstractMatrix, ::AbstractPolytope))
 
+Inherited from [`AbstractPointSymmetricPolytope`](@ref):
+* [`dim`](@ref dim(::AbstractPointSymmetricPolytope))
+* `an_element`
+
 Inherited from [`AbstractHyperrectangle`](@ref):
 * [`norm`](@ref norm(::AbstractHyperrectangle, ::Real))
 * [`radius`](@ref radius(::AbstractHyperrectangle, ::Real))
@@ -391,7 +399,6 @@ ZeroSet
 dim(::ZeroSet)
 σ(::AbstractVector{N}, ::ZeroSet) where {N<:Real}
 ∈(::AbstractVector{N}, ::ZeroSet{N}) where {N<:Real}
-an_element(::ZeroSet)
 vertices_list(::ZeroSet)
 center(::ZeroSet)
 radius_hyperrectangle(::ZeroSet)
@@ -406,6 +413,9 @@ Inherited from [`LazySet`](@ref):
 Inherited from [`AbstractPolytope`](@ref):
 * [`singleton_list`](@ref singleton_list(::AbstractPolytope))
 
+Inherited from [`AbstractPointSymmetricPolytope`](@ref):
+* `an_element`
+
 Inherited from [`AbstractHyperrectangle`](@ref):
 * [`norm`](@ref norm(::AbstractHyperrectangle, ::Real))
 * [`radius`](@ref radius(::AbstractHyperrectangle, ::Real))
@@ -414,10 +424,8 @@ Inherited from [`AbstractHyperrectangle`](@ref):
 
 ```@docs
 Zonotope
-dim(::Zonotope)
 σ(::AbstractVector{Real}, ::Zonotope{Real})
 ∈(::AbstractVector{Real}, ::Zonotope{Real})
-an_element(::Zonotope)
 vertices_list(::Zonotope)
 center(::Zonotope)
 order(::Zonotope)
@@ -434,3 +442,7 @@ Inherited from [`LazySet`](@ref):
 
 Inherited from [`AbstractPolytope`](@ref):
 * [`singleton_list`](@ref singleton_list(::AbstractPolytope))
+
+Inherited from [`AbstractPointSymmetricPolytope`](@ref):
+* [`dim`](@ref dim(::AbstractPointSymmetricPolytope))
+* `an_element`

--- a/docs/src/lib/representations.md
+++ b/docs/src/lib/representations.md
@@ -368,12 +368,6 @@ Inherited from [`AbstractPolytope`](@ref):
 
 ```@docs
 Singleton
-σ(::AbstractVector{Real}, ::Singleton{Real})
-∈(::AbstractVector{Real}, ::Singleton{Real})
-vertices_list(::Singleton)
-center(::Singleton)
-radius_hyperrectangle(::Singleton)
-radius_hyperrectangle(::Singleton, ::Int)
 element(::Singleton)
 element(::Singleton, ::Int)
 ```
@@ -382,15 +376,23 @@ Inherited from [`LazySet`](@ref):
 
 Inherited from [`AbstractPolytope`](@ref):
 * [`singleton_list`](@ref singleton_list(::AbstractPolytope))
-* [`linear_map`](@ref linear_map(::AbstractMatrix, ::AbstractPolytope))
 
 Inherited from [`AbstractPointSymmetricPolytope`](@ref):
 * [`dim`](@ref dim(::AbstractPointSymmetricPolytope))
-* `an_element`
 
 Inherited from [`AbstractHyperrectangle`](@ref):
 * [`norm`](@ref norm(::AbstractHyperrectangle, ::Real))
 * [`radius`](@ref radius(::AbstractHyperrectangle, ::Real))
+
+Inherited from [`AbstractSingleton`](@ref):
+* `σ`
+* `∈`
+* `an_element`
+* [`center`](@ref center(::AbstractSingleton{Real}))
+* `vertices_list`
+* [`radius_hyperrectangle`](@ref radius_hyperrectangle(::AbstractSingleton{Real}))
+* [`radius_hyperrectangle`](@ref radius_hyperrectangle(::AbstractSingleton{Real}, ::Int))
+* `linear_map`
 
 ## Zero set
 
@@ -399,10 +401,6 @@ ZeroSet
 dim(::ZeroSet)
 σ(::AbstractVector{N}, ::ZeroSet) where {N<:Real}
 ∈(::AbstractVector{N}, ::ZeroSet{N}) where {N<:Real}
-vertices_list(::ZeroSet)
-center(::ZeroSet)
-radius_hyperrectangle(::ZeroSet)
-radius_hyperrectangle(::ZeroSet, ::Int)
 element(::ZeroSet)
 element(::ZeroSet, ::Int)
 linear_map(::AbstractMatrix, ::ZeroSet{N}) where {N<:Real}
@@ -413,12 +411,16 @@ Inherited from [`LazySet`](@ref):
 Inherited from [`AbstractPolytope`](@ref):
 * [`singleton_list`](@ref singleton_list(::AbstractPolytope))
 
-Inherited from [`AbstractPointSymmetricPolytope`](@ref):
-* `an_element`
-
 Inherited from [`AbstractHyperrectangle`](@ref):
 * [`norm`](@ref norm(::AbstractHyperrectangle, ::Real))
 * [`radius`](@ref radius(::AbstractHyperrectangle, ::Real))
+
+Inherited from [`AbstractSingleton`](@ref):
+* [`radius_hyperrectangle`](@ref radius_hyperrectangle(::AbstractSingleton{Real}))
+* [`radius_hyperrectangle`](@ref radius_hyperrectangle(::AbstractSingleton{Real}, ::Int))
+* `vertices_list`
+* [`center`](@ref center(::AbstractSingleton{Real}))
+* `an_element`
 
 ## Zonotope
 

--- a/docs/src/lib/representations.md
+++ b/docs/src/lib/representations.md
@@ -26,6 +26,10 @@ dim(::Ball2)
 an_element(::Ball2)
 center(::Ball2)
 ```
+Inherited from [`LazySet`](@ref):
+* [`norm`](@ref norm(::LazySet, ::Real))
+* [`radius`](@ref radius(::LazySet, ::Real))
+* [`diameter`](@ref diameter(::LazySet, ::Real))
 
 ### Infinity norm ball
 
@@ -41,6 +45,11 @@ radius(::BallInf, ::Real)
 radius_hyperrectangle(::BallInf)
 radius_hyperrectangle(::BallInf, ::Int)
 ```
+Inherited from [`LazySet`](@ref):
+* [`diameter`](@ref diameter(::LazySet, ::Real))
+
+Inherited from [`AbstractHyperrectangle`](@ref):
+* [`norm`](@ref norm(::AbstractHyperrectangle, ::Real))
 
 ### Manhattan norm ball
 
@@ -53,6 +62,10 @@ an_element(::Ball1)
 vertices_list(::Ball1)
 center(::Ball1)
 ```
+Inherited from [`LazySet`](@ref):
+* [`norm`](@ref norm(::LazySet, ::Real))
+* [`radius`](@ref radius(::LazySet, ::Real))
+* [`diameter`](@ref diameter(::LazySet, ::Real))
 
 ### p-norm ball
 
@@ -64,6 +77,10 @@ dim(::Ballp)
 an_element(::Ballp)
 center(::Ballp)
 ```
+Inherited from [`LazySet`](@ref):
+* [`norm`](@ref norm(::LazySet, ::Real))
+* [`radius`](@ref radius(::LazySet, ::Real))
+* [`diameter`](@ref diameter(::LazySet, ::Real))
 
 ## Ellipsoid
 
@@ -75,6 +92,10 @@ dim(::Ellipsoid)
 an_element(::Ellipsoid)
 center(::Ellipsoid)
 ```
+Inherited from [`LazySet`](@ref):
+* [`norm`](@ref norm(::LazySet, ::Real))
+* [`radius`](@ref radius(::LazySet, ::Real))
+* [`diameter`](@ref diameter(::LazySet, ::Real))
 
 ## Empty set
 
@@ -89,6 +110,10 @@ norm(::EmptySet, ::Real)
 radius(::EmptySet, ::Real)
 diameter(::EmptySet, ::Real)
 ```
+Inherited from [`LazySet`](@ref):
+* [`norm`](@ref norm(::LazySet, ::Real))
+* [`radius`](@ref radius(::LazySet, ::Real))
+* [`diameter`](@ref diameter(::LazySet, ::Real))
 
 ## Half-Space
 
@@ -102,6 +127,10 @@ an_element(::HalfSpace{N}) where {N<:Real}
 LazySets.halfspace_left(::AbstractVector{Real}, ::AbstractVector{Real})
 LazySets.halfspace_right(::AbstractVector{Real}, ::AbstractVector{Real})
 ```
+Inherited from [`LazySet`](@ref):
+* [`norm`](@ref norm(::LazySet, ::Real))
+* [`radius`](@ref radius(::LazySet, ::Real))
+* [`diameter`](@ref diameter(::LazySet, ::Real))
 
 ## Hyperplane
 
@@ -112,6 +141,10 @@ dim(::Hyperplane)
 ∈(::AbstractVector{Real}, ::Hyperplane{Real})
 an_element(::Hyperplane{N}) where {N<:Real}
 ```
+Inherited from [`LazySet`](@ref):
+* [`norm`](@ref norm(::LazySet, ::Real))
+* [`radius`](@ref radius(::LazySet, ::Real))
+* [`diameter`](@ref diameter(::LazySet, ::Real))
 
 ## Hyperrectangle
 
@@ -129,6 +162,12 @@ radius_hyperrectangle(::Hyperrectangle, ::Int)
 high(::Hyperrectangle)
 low(::Hyperrectangle)
 ```
+Inherited from [`LazySet`](@ref):
+* [`diameter`](@ref diameter(::LazySet, ::Real))
+
+Inherited from [`AbstractHyperrectangle`](@ref):
+* [`norm`](@ref norm(::AbstractHyperrectangle, ::Real))
+* [`radius`](@ref radius(::AbstractHyperrectangle, ::Real))
 
 ## Interval
 
@@ -147,6 +186,12 @@ high(::Interval)
 -(::Interval, ::Interval)
 *(::Interval, ::Interval)
 ```
+Inherited from [`LazySet`](@ref):
+* [`diameter`](@ref diameter(::LazySet, ::Real))
+
+Inherited from [`AbstractHyperrectangle`](@ref):
+* [`norm`](@ref norm(::AbstractHyperrectangle, ::Real))
+* [`radius`](@ref radius(::AbstractHyperrectangle, ::Real))
 
 ## Line
 
@@ -157,6 +202,10 @@ dim(::Line)
 ∈(::AbstractVector{Real}, ::Line{Real})
 an_element(::Line{N}) where {N<:Real}
 ```
+Inherited from [`LazySet`](@ref):
+* [`norm`](@ref norm(::LazySet, ::Real))
+* [`radius`](@ref radius(::LazySet, ::Real))
+* [`diameter`](@ref diameter(::LazySet, ::Real))
 
 ## Line segment
 
@@ -168,6 +217,10 @@ dim(::LineSegment)
 LazySets.halfspace_left(::LineSegment)
 LazySets.halfspace_right(::LineSegment)
 ```
+Inherited from [`LazySet`](@ref):
+* [`norm`](@ref norm(::LazySet, ::Real))
+* [`radius`](@ref radius(::LazySet, ::Real))
+* [`diameter`](@ref diameter(::LazySet, ::Real))
 
 ## Polygons
 
@@ -184,6 +237,10 @@ tohrep(::HPolygon)
 tovrep(::HPolygon)
 addconstraint!(::HPolygon{Real}, ::LinearConstraint{Real})
 ```
+Inherited from [`LazySet`](@ref):
+* [`norm`](@ref norm(::LazySet, ::Real))
+* [`radius`](@ref radius(::LazySet, ::Real))
+* [`diameter`](@ref diameter(::LazySet, ::Real))
 
 ### Optimized constraint representation
 
@@ -198,6 +255,10 @@ tohrep(::HPolygonOpt)
 tovrep(::HPolygonOpt)
 addconstraint!(::HPolygonOpt{Real}, ::LinearConstraint{Real})
 ```
+Inherited from [`LazySet`](@ref):
+* [`norm`](@ref norm(::LazySet, ::Real))
+* [`radius`](@ref radius(::LazySet, ::Real))
+* [`diameter`](@ref diameter(::LazySet, ::Real))
 
 ### Vertex representation
 
@@ -211,6 +272,10 @@ vertices_list(::VPolygon)
 tohrep(::VPolygon)
 tovrep(::VPolygon)
 ```
+Inherited from [`LazySet`](@ref):
+* [`norm`](@ref norm(::LazySet, ::Real))
+* [`radius`](@ref radius(::LazySet, ::Real))
+* [`diameter`](@ref diameter(::LazySet, ::Real))
 
 ### Sorting directions
 
@@ -233,6 +298,10 @@ addconstraint!(::HPolytope{Real}, ::LinearConstraint{Real})
 constraints_list(::HPolytope)
 tosimplehrep(::HPolytope)
 ```
+Inherited from [`LazySet`](@ref):
+* [`norm`](@ref norm(::LazySet, ::Real))
+* [`radius`](@ref radius(::LazySet, ::Real))
+* [`diameter`](@ref diameter(::LazySet, ::Real))
 
 ### Vertex representation
 
@@ -242,6 +311,10 @@ dim(::VPolytope)
 σ(::AbstractVector{Real}, ::VPolytope{Real})
 vertices_list(::VPolytope)
 ```
+Inherited from [`LazySet`](@ref):
+* [`norm`](@ref norm(::LazySet, ::Real))
+* [`radius`](@ref radius(::LazySet, ::Real))
+* [`diameter`](@ref diameter(::LazySet, ::Real))
 
 ## Singleton
 
@@ -258,6 +331,12 @@ radius_hyperrectangle(::Singleton, ::Int)
 element(::Singleton)
 element(::Singleton, ::Int)
 ```
+Inherited from [`LazySet`](@ref):
+* [`diameter`](@ref diameter(::LazySet, ::Real))
+
+Inherited from [`AbstractHyperrectangle`](@ref):
+* [`norm`](@ref norm(::AbstractHyperrectangle, ::Real))
+* [`radius`](@ref radius(::AbstractHyperrectangle, ::Real))
 
 ## Zero set
 
@@ -275,6 +354,12 @@ element(::ZeroSet)
 element(::ZeroSet, ::Int)
 linear_map(::AbstractMatrix, ::ZeroSet{N}) where {N<:Real}
 ```
+Inherited from [`LazySet`](@ref):
+* [`diameter`](@ref diameter(::LazySet, ::Real))
+
+Inherited from [`AbstractHyperrectangle`](@ref):
+* [`norm`](@ref norm(::AbstractHyperrectangle, ::Real))
+* [`radius`](@ref radius(::AbstractHyperrectangle, ::Real))
 
 ## Zonotope
 
@@ -293,3 +378,7 @@ scale(::Real, ::Zonotope)
 ngens(::Zonotope)
 reduce_order(::Zonotope, r)
 ```
+Inherited from [`LazySet`](@ref):
+* [`norm`](@ref norm(::LazySet, ::Real))
+* [`radius`](@ref radius(::LazySet, ::Real))
+* [`diameter`](@ref diameter(::LazySet, ::Real))

--- a/docs/src/lib/representations.md
+++ b/docs/src/lib/representations.md
@@ -20,73 +20,74 @@ end
 
 ```@docs
 Ball2
-dim(::Ball2{Float64})
-σ(::AbstractVector{Float64}, ::Ball2{Float64})
-∈(::AbstractVector{Float64}, ::Ball2{Float64})
-an_element(::Ball2{Float64})
-center(::Ball2{Float64})
+dim(::Ball2)
+σ(::AbstractVector{AbstractFloat}, ::Ball2{AbstractFloat})
+∈(::AbstractVector{AbstractFloat}, ::Ball2{AbstractFloat})
+an_element(::Ball2)
+center(::Ball2)
 ```
 
 ### Infinity norm ball
 
 ```@docs
 BallInf
-dim(::BallInf{Float64})
-σ(::AbstractVector{Float64}, ::BallInf{Float64})
-∈(::AbstractVector{Float64}, ::BallInf{Float64})
-an_element(::BallInf{Float64})
-norm(::BallInf{Float64}, ::Real)
-radius(::BallInf{Float64}, ::Real)
-diameter(::BallInf{Float64}, ::Real)
-vertices_list(::BallInf{Float64})
-singleton_list(::BallInf{Float64})
-center(::BallInf{Float64})
-radius_hyperrectangle(::BallInf{Float64})
-radius_hyperrectangle(::BallInf{Float64}, ::Int)
+dim(::BallInf)
+σ(::AbstractVector{Real}, ::BallInf{Real})
+∈(::AbstractVector{Real}, ::BallInf{Real})
+an_element(::BallInf)
+vertices_list(::BallInf)
+center(::BallInf)
+radius(::BallInf, ::Real)
+radius_hyperrectangle(::BallInf)
+radius_hyperrectangle(::BallInf, ::Int)
 ```
 
 ### Manhattan norm ball
 
 ```@docs
 Ball1
-dim(::Ball1{Float64})
-σ(::AbstractVector{Float64}, ::Ball1{Float64})
-∈(::AbstractVector{Float64}, ::Ball1{Float64})
-an_element(::Ball1{Float64})
-vertices_list(::Ball1{Float64})
-singleton_list(::Ball1{Float64})
-center(::Ball1{Float64})
+dim(::Ball1)
+σ(::AbstractVector{Real}, ::Ball1{Real})
+∈(::AbstractVector{Real}, ::Ball1{Real})
+an_element(::Ball1)
+vertices_list(::Ball1)
+center(::Ball1)
 ```
 
 ### p-norm ball
 
 ```@docs
 Ballp
-dim(::Ballp{Float64})
-σ(::AbstractVector{Float64}, ::Ballp{Float64})
-∈(::AbstractVector{Float64}, ::Ballp{Float64})
-an_element(::Ballp{Float64})
-center(::Ballp{Float64})
+dim(::Ballp)
+σ(::AbstractVector{AbstractFloat}, ::Ballp{AbstractFloat})
+∈(::AbstractVector{AbstractFloat}, ::Ballp{AbstractFloat})
+an_element(::Ballp)
+center(::Ballp)
 ```
 
 ## Ellipsoid
 
 ```@docs
 Ellipsoid
-σ(::AbstractVector{Float64}, ::Ellipsoid{Float64})
-center(::Ellipsoid{Float64})
-∈(::AbstractVector{Float64}, ::Ellipsoid{Float64})
+dim(::Ellipsoid)
+σ(::AbstractVector{AbstractFloat}, ::Ellipsoid{AbstractFloat})
+∈(::AbstractVector{AbstractFloat}, ::Ellipsoid{AbstractFloat})
+an_element(::Ellipsoid)
+center(::Ellipsoid)
 ```
 
-## EmptySet
+## Empty set
 
 ```@docs
 EmptySet
 ∅
-dim(::EmptySet{Float64})
-σ(::AbstractVector{Float64}, ::EmptySet{Float64})
-∈(::AbstractVector{Float64}, ::EmptySet{Float64})
-an_element(::EmptySet{Float64})
+dim(::EmptySet)
+σ(::AbstractVector{Real}, ::EmptySet{Real})
+∈(::AbstractVector{Real}, ::EmptySet{Real})
+an_element(::EmptySet)
+norm(::EmptySet, ::Real)
+radius(::EmptySet, ::Real)
+diameter(::EmptySet, ::Real)
 ```
 
 ## Half-Space
@@ -94,79 +95,76 @@ an_element(::EmptySet{Float64})
 ```@docs
 HalfSpace
 LinearConstraint
-dim(::HalfSpace{Float64})
-σ(::AbstractVector{Float64}, ::HalfSpace{Float64})
-an_element(::HalfSpace{Float64})
-∈(::AbstractVector{Float64}, ::HalfSpace{Float64})
-LazySets.halfspace_left(::AbstractVector{Float64}, ::AbstractVector{Float64})
-LazySets.halfspace_right(::AbstractVector{Float64}, ::AbstractVector{Float64})
+dim(::HalfSpace)
+σ(::AbstractVector{Real}, ::HalfSpace{Real})
+∈(::AbstractVector{Real}, ::HalfSpace{Real})
+an_element(::HalfSpace{N}) where {N<:Real}
+LazySets.halfspace_left(::AbstractVector{Real}, ::AbstractVector{Real})
+LazySets.halfspace_right(::AbstractVector{Real}, ::AbstractVector{Real})
 ```
 
 ## Hyperplane
 
 ```@docs
 Hyperplane
-dim(::Hyperplane{Float64})
-σ(::AbstractVector{Float64}, ::Hyperplane{Float64})
-an_element(::Hyperplane{Float64})
-∈(::AbstractVector{Float64}, ::Hyperplane{Float64})
+dim(::Hyperplane)
+σ(::AbstractVector{Real}, ::Hyperplane{Real})
+∈(::AbstractVector{Real}, ::Hyperplane{Real})
+an_element(::Hyperplane{N}) where {N<:Real}
 ```
 
-## Hyperrectangles
+## Hyperrectangle
 
 ```@docs
 Hyperrectangle
 Hyperrectangle(;kwargs...)
-dim(::Hyperrectangle{Float64})
-σ(::AbstractVector{Float64}, ::Hyperrectangle{Float64})
-∈(::AbstractVector{Float64}, ::Hyperrectangle{Float64})
-an_element(::Hyperrectangle{Float64})
-norm(::Hyperrectangle{Float64}, ::Real)
-radius(::Hyperrectangle{Float64}, ::Real)
-diameter(::Hyperrectangle{Float64}, ::Real)
-vertices_list(::Hyperrectangle{Float64})
-singleton_list(::Hyperrectangle{Float64})
-center(::Hyperrectangle{Float64})
-radius_hyperrectangle(::Hyperrectangle{Float64})
-radius_hyperrectangle(::Hyperrectangle{Float64}, ::Int)
-high(::Hyperrectangle{Float64})
-low(::Hyperrectangle{Float64})
+dim(::Hyperrectangle)
+σ(::AbstractVector{Real}, ::Hyperrectangle{Real})
+∈(::AbstractVector{Real}, ::Hyperrectangle{Real})
+an_element(::Hyperrectangle)
+vertices_list(::Hyperrectangle)
+center(::Hyperrectangle)
+radius_hyperrectangle(::Hyperrectangle)
+radius_hyperrectangle(::Hyperrectangle, ::Int)
+high(::Hyperrectangle)
+low(::Hyperrectangle)
 ```
 
-## Intervals
+## Interval
 
 ```@docs
 Interval
 dim(::Interval)
-σ(::AbstractVector{Float64}, ::Interval{Float64, IntervalArithmetic.AbstractInterval{Float64}})
+σ(::AbstractVector{Real}, ::Interval{Real, IntervalArithmetic.AbstractInterval{Real}})
+∈(::AbstractVector, ::Interval)
+∈(::Real, ::Interval)
+an_element(::Interval)
+vertices_list(::Interval)
 center(::Interval)
 low(::Interval)
 high(::Interval)
-vertices_list(::Interval)
 +(::Interval, ::Interval)
 -(::Interval, ::Interval)
 *(::Interval, ::Interval)
-∈(::AbstractVector, ::Interval)
-∈(::Float64, ::Interval)
 ```
 
 ## Line
 
 ```@docs
 Line
-dim(::Line{Float64})
-σ(::AbstractVector{Float64}, ::Line{Float64})
-∈(::AbstractVector, ::Line)
-an_element(::Line)
+dim(::Line)
+σ(::AbstractVector{Real}, ::Line{Real})
+∈(::AbstractVector{Real}, ::Line{Real})
+an_element(::Line{N}) where {N<:Real}
 ```
 
 ## Line segment
 
 ```@docs
 LineSegment
-dim(::LineSegment{Float64})
-σ(::AbstractVector{Float64}, ::LineSegment{Float64})
-∈(::AbstractVector{Float64}, ::LineSegment{Float64})
+dim(::LineSegment)
+σ(::AbstractVector{Real}, ::LineSegment{Real})
+∈(::AbstractVector{Real}, ::LineSegment{Real})
 LazySets.halfspace_left(::LineSegment)
 LazySets.halfspace_right(::LineSegment)
 ```
@@ -177,119 +175,121 @@ LazySets.halfspace_right(::LineSegment)
 
 ```@docs
 HPolygon
-dim(::HPolygon{Float64})
-σ(::AbstractVector{Float64}, ::HPolygon{Float64})
-∈(::AbstractVector{Float64}, ::HPolygon{Float64})
-an_element(::HPolygon{Float64})
-vertices_list(::HPolygon{Float64})
-singleton_list(::HPolygon{Float64})
-tohrep(::HPolygon{Float64})
-tovrep(::HPolygon{Float64})
-addconstraint!(::HPolygon{Float64}, ::LinearConstraint{Float64})
+dim(::HPolygon)
+σ(::AbstractVector{Real}, ::HPolygon{Real})
+∈(::AbstractVector{Real}, ::HPolygon{Real})
+an_element(::HPolygon)
+vertices_list(::HPolygon)
+tohrep(::HPolygon)
+tovrep(::HPolygon)
+addconstraint!(::HPolygon{Real}, ::LinearConstraint{Real})
 ```
 
 ### Optimized constraint representation
 
 ```@docs
 HPolygonOpt
-dim(::HPolygonOpt{Float64})
-σ(::AbstractVector{Float64}, ::HPolygonOpt{Float64})
-∈(::AbstractVector{Float64}, ::HPolygonOpt{Float64})
-an_element(::HPolygonOpt{Float64})
-vertices_list(::HPolygonOpt{Float64})
-singleton_list(::HPolygonOpt{Float64})
-tohrep(::HPolygonOpt{Float64})
-tovrep(::HPolygonOpt{Float64})
-addconstraint!(::HPolygonOpt{Float64}, ::LinearConstraint{Float64})
+dim(::HPolygonOpt)
+σ(::AbstractVector{Real}, ::HPolygonOpt{Real})
+∈(::AbstractVector{Real}, ::HPolygonOpt{Real})
+an_element(::HPolygonOpt)
+vertices_list(::HPolygonOpt)
+tohrep(::HPolygonOpt)
+tovrep(::HPolygonOpt)
+addconstraint!(::HPolygonOpt{Real}, ::LinearConstraint{Real})
 ```
 
 ### Vertex representation
 
 ```@docs
 VPolygon
-dim(::VPolygon{Float64})
-σ(::AbstractVector{Float64}, ::VPolygon{Float64})
-∈(::AbstractVector{Float64}, ::VPolygon{Float64})
-an_element(::VPolygon{Float64})
-vertices_list(::VPolygon{Float64})
-singleton_list(::VPolygon{Float64})
-tohrep(::VPolygon{Float64})
-tovrep(::VPolygon{Float64})
+dim(::VPolygon)
+σ(::AbstractVector{Real}, ::VPolygon{Real})
+∈(::AbstractVector{Real}, ::VPolygon{Real})
+an_element(::VPolygon{N}) where {N<:Real}
+vertices_list(::VPolygon)
+tohrep(::VPolygon)
+tovrep(::VPolygon)
 ```
 
 ### Sorting directions
 
 ```@docs
 LazySets.jump2pi
-<=(::AbstractVector{Float64}, ::AbstractVector{Float64})
-LazySets.quadrant(w::AbstractVector{Float64})
+<=(::AbstractVector{AbstractFloat}, ::AbstractVector{AbstractFloat})
+LazySets.quadrant(::AbstractVector{Real})
 ```
 
 ## Polytopes
 
+### Constraint representation
+
 ```@docs
 HPolytope
-dim(P::HPolytope)
-addconstraint!(P::HPolytope{Float64}, constraint::LinearConstraint{Float64})
-constraints_list(P::HPolytope{Float64})
-σ(d::AbstractVector{Float64}, P::HPolytope)
-∈(::AbstractVector{Float64}, ::HPolytope{Float64})
+dim(::HPolytope)
+σ(::AbstractVector{Real}, ::HPolytope{Real})
+∈(::AbstractVector{Real}, ::HPolytope{Real})
+addconstraint!(::HPolytope{Real}, ::LinearConstraint{Real})
+constraints_list(::HPolytope)
+tosimplehrep(::HPolytope)
 ```
 
-## Singletons
+### Vertex representation
+
+```@docs
+VPolytope
+dim(::VPolytope)
+σ(::AbstractVector{Real}, ::VPolytope{Real})
+vertices_list(::VPolytope)
+```
+
+## Singleton
 
 ```@docs
 Singleton
-dim(::Singleton{Float64})
-σ(::AbstractVector{Float64}, ::Singleton{Float64})
-∈(::AbstractVector{Float64}, ::Singleton{Float64})
-norm(::Singleton{Float64}, ::Real)
-diameter(::Singleton{Float64}, ::Real)
-vertices_list(::Singleton{Float64})
-singleton_list(::Singleton{Float64})
-center(::Singleton{Float64})
-radius_hyperrectangle(::Singleton{Float64})
-radius_hyperrectangle(::Singleton{Float64}, ::Int)
-an_element(::Singleton{Float64})
-element(::Singleton{Float64})
-element(::Singleton{Float64}, ::Int)
+dim(::Singleton)
+σ(::AbstractVector{Real}, ::Singleton{Real})
+∈(::AbstractVector{Real}, ::Singleton{Real})
+an_element(::Singleton)
+vertices_list(::Singleton)
+center(::Singleton)
+radius_hyperrectangle(::Singleton)
+radius_hyperrectangle(::Singleton, ::Int)
+element(::Singleton)
+element(::Singleton, ::Int)
 ```
 
-## ZeroSet
+## Zero set
 
 ```@docs
 ZeroSet
-dim(::ZeroSet{Float64})
-σ(::AbstractVector{Float64}, ::ZeroSet{Float64})
-∈(::AbstractVector{Float64}, ::ZeroSet{Float64})
-norm(::ZeroSet{Float64}, ::Real)
-diameter(::ZeroSet{Float64}, ::Real)
-vertices_list(::ZeroSet{Float64})
-singleton_list(::ZeroSet{Float64})
-center(::ZeroSet{Float64})
-radius_hyperrectangle(::ZeroSet{Float64})
-radius_hyperrectangle(::ZeroSet{Float64}, ::Int)
-an_element(::ZeroSet{Float64})
-element(::ZeroSet{Float64})
-element(::ZeroSet{Float64}, ::Int)
-linear_map(M::AbstractMatrix, Z::ZeroSet{Float64})
+dim(::ZeroSet)
+σ(::AbstractVector{N}, ::ZeroSet) where {N<:Real}
+∈(::AbstractVector{N}, ::ZeroSet{N}) where {N<:Real}
+an_element(::ZeroSet)
+vertices_list(::ZeroSet)
+center(::ZeroSet)
+radius_hyperrectangle(::ZeroSet)
+radius_hyperrectangle(::ZeroSet, ::Int)
+element(::ZeroSet)
+element(::ZeroSet, ::Int)
+linear_map(::AbstractMatrix, ::ZeroSet{N}) where {N<:Real}
 ```
 
-## Zonotopes
+## Zonotope
 
 ```@docs
 Zonotope
-dim(::Zonotope{Float64})
-σ(::AbstractVector{Float64}, ::Zonotope{Float64})
-∈(::AbstractVector{Float64}, ::Zonotope{Float64})
-an_element(::Zonotope{Float64})
-center(::Zonotope{Float64})
-vertices_list(::Zonotope{Float64})
-singleton_list(::Zonotope{Float64})
-order(::Zonotope{Float64})
+dim(::Zonotope)
+σ(::AbstractVector{Real}, ::Zonotope{Real})
+∈(::AbstractVector{Real}, ::Zonotope{Real})
+an_element(::Zonotope)
+vertices_list(::Zonotope)
+center(::Zonotope)
+order(::Zonotope)
 minkowski_sum(::Zonotope, ::Zonotope)
 linear_map(::AbstractMatrix, ::Zonotope)
 scale(::Real, ::Zonotope)
 ngens(::Zonotope)
-reduce_order(::Zonotope{Float64}, r)
+reduce_order(::Zonotope, r)
 ```

--- a/docs/src/lib/representations.md
+++ b/docs/src/lib/representations.md
@@ -37,9 +37,6 @@ Inherited from [`AbstractPointSymmetric`](@ref):
 
 ```@docs
 BallInf
-σ(::AbstractVector{Real}, ::BallInf{Real})
-∈(::AbstractVector{Real}, ::BallInf{Real})
-vertices_list(::BallInf)
 center(::BallInf)
 radius(::BallInf, ::Real)
 radius_hyperrectangle(::BallInf)
@@ -57,7 +54,10 @@ Inherited from [`AbstractPointSymmetricPolytope`](@ref):
 * `an_element`
 
 Inherited from [`AbstractHyperrectangle`](@ref):
+* [`σ`](@ref σ(::AbstractVector{Real}, ::AbstractHyperrectangle{Real}))
+* [`∈`](@ref ∈(::AbstractVector{Real}, ::AbstractHyperrectangle{Real}))
 * [`norm`](@ref norm(::AbstractHyperrectangle, ::Real))
+* [`vertices_list`](@ref vertices_list(::AbstractHyperrectangle{Real}))
 
 ### Manhattan norm ball
 
@@ -169,9 +169,6 @@ Inherited from [`LazySet`](@ref):
 ```@docs
 Hyperrectangle
 Hyperrectangle(;kwargs...)
-σ(::AbstractVector{Real}, ::Hyperrectangle{Real})
-∈(::AbstractVector{Real}, ::Hyperrectangle{Real})
-vertices_list(::Hyperrectangle)
 center(::Hyperrectangle)
 radius_hyperrectangle(::Hyperrectangle)
 radius_hyperrectangle(::Hyperrectangle, ::Int)
@@ -190,8 +187,11 @@ Inherited from [`AbstractPointSymmetricPolytope`](@ref):
 * `an_element`
 
 Inherited from [`AbstractHyperrectangle`](@ref):
+* [`σ`](@ref σ(::AbstractVector{Real}, ::AbstractHyperrectangle{Real}))
+* [`∈`](@ref ∈(::AbstractVector{Real}, ::AbstractHyperrectangle{Real}))
 * [`norm`](@ref norm(::AbstractHyperrectangle, ::Real))
 * [`radius`](@ref radius(::AbstractHyperrectangle, ::Real))
+* [`vertices_list`](@ref vertices_list(::AbstractHyperrectangle{Real}))
 
 ## Interval
 

--- a/docs/src/lib/representations.md
+++ b/docs/src/lib/representations.md
@@ -256,7 +256,6 @@ Inherited from [`LazySet`](@ref):
 
 ```@docs
 HPolygon
-dim(::HPolygon)
 σ(::AbstractVector{Real}, ::HPolygon{Real})
 ∈(::AbstractVector{Real}, ::HPolygon{Real})
 an_element(::HPolygon)
@@ -274,11 +273,13 @@ Inherited from [`AbstractPolytope`](@ref):
 * [`singleton_list`](@ref singleton_list(::AbstractPolytope))
 * [`linear_map`](@ref linear_map(::AbstractMatrix, ::AbstractPolytope))
 
+Inherited from [`AbstractPolygon`](@ref):
+* [`dim`](@ref dim(P::AbstractPolygon))
+
 ### Optimized constraint representation
 
 ```@docs
 HPolygonOpt
-dim(::HPolygonOpt)
 σ(::AbstractVector{Real}, ::HPolygonOpt{Real})
 ∈(::AbstractVector{Real}, ::HPolygonOpt{Real})
 an_element(::HPolygonOpt)
@@ -296,11 +297,13 @@ Inherited from [`AbstractPolytope`](@ref):
 * [`singleton_list`](@ref singleton_list(::AbstractPolytope))
 * [`linear_map`](@ref linear_map(::AbstractMatrix, ::AbstractPolytope))
 
+Inherited from [`AbstractPolygon`](@ref):
+* [`dim`](@ref dim(P::AbstractPolygon))
+
 ### Vertex representation
 
 ```@docs
 VPolygon
-dim(::VPolygon)
 σ(::AbstractVector{Real}, ::VPolygon{Real})
 ∈(::AbstractVector{Real}, ::VPolygon{Real})
 an_element(::VPolygon{N}) where {N<:Real}
@@ -316,6 +319,9 @@ Inherited from [`LazySet`](@ref):
 Inherited from [`AbstractPolytope`](@ref):
 * [`singleton_list`](@ref singleton_list(::AbstractPolytope))
 * [`linear_map`](@ref linear_map(::AbstractMatrix, ::AbstractPolytope))
+
+Inherited from [`AbstractPolygon`](@ref):
+* [`dim`](@ref dim(P::AbstractPolygon))
 
 ### Sorting directions
 

--- a/docs/src/lib/utils.md
+++ b/docs/src/lib/utils.md
@@ -14,10 +14,23 @@ sign_cadlag
 @declare_array_version
 ```
 
-## Helper functions for internal use only
+## Helpers for internal use only
+
+### Functions and Macros
 
 ```@docs
 @neutral_absorbing
 @array_neutral
 @array_absorbing
+
+get_radius!
+an_element_helper
+σ_helper
+```
+
+### Types
+
+```@docs
+CachedPair
+Approximations.UnitVector
 ```

--- a/src/LazySets.jl
+++ b/src/LazySets.jl
@@ -1,8 +1,6 @@
 __precompile__(true)
 
-"""
-Main module for `LazySets.jl` -- a Julia package for calculus with convex sets.
-"""
+# main module for `LazySets.jl`
 module LazySets
 
 include("compat.jl")

--- a/src/VPolytope.jl
+++ b/src/VPolytope.jl
@@ -45,13 +45,17 @@ If it is empty, the result is ``-1``.
 ### Examples
 
 ```jldoctest
-julia> v = VPolytope()
+julia> v = VPolytope();
+
 julia> dim(v) > 0
 false
+
 julia> v = VPolytope([ones(3)])
 LazySets.VPolytope{Float64}(Array{Float64,1}[[1.0, 1.0, 1.0]])
+
 julia> dim(v) == 3
 true
+
 ```
 """
 function dim(P::VPolytope)::Int

--- a/src/plot_recipes.jl
+++ b/src/plot_recipes.jl
@@ -2,6 +2,8 @@
 # Plot recipes for an abstract LazySet
 # ====================================
 
+import RecipesBase.apply_recipe
+
 """
     plot_lazyset(S::LazySet; ...)
 

--- a/src/plot_recipes.jl
+++ b/src/plot_recipes.jl
@@ -17,8 +17,11 @@ Plot a convex set in two dimensions using an axis-aligned approximation.
 
 ```jldoctest
 julia> using LazySets, Plots
-julia> B = BallInf(ones(2), 0.1)
-julia> plot(2.0 * B)
+
+julia> B = BallInf(ones(2), 0.1);
+
+julia> plot(2.0 * B);
+
 ```
 
 ### Algorithm
@@ -60,10 +63,14 @@ approximation.
 ### Examples
 
 ```jldoctest
-julia> using LazySets, Plots
-julia> B1 = BallInf(zeros(2), 0.4)
-julia> B2 = BallInf(ones(2), 0.4)
-julia> plot([B1, B2])
+julia> using LazySets, Plots;
+
+julia> B1 = BallInf(zeros(2), 0.4);
+
+julia> B2 = BallInf(ones(2), 0.4);
+
+julia> plot([B1, B2]);
+
 ```
 
 ### Algorithm
@@ -99,9 +106,12 @@ Plot a lazy set in two dimensions using iterative refinement.
 ### Examples
 
 ```jldoctest
-julia> using LazySets, Plots
-julia> B = BallInf(ones(2), 0.1)
-julia> plot(randn(2, 2) * B, 1e-3)
+julia> using LazySets, Plots;
+
+julia> B = BallInf(ones(2), 0.1);
+
+julia> plot(randn(2, 2) * B, 1e-3);
+
 ```
 """
 @recipe function plot_lazyset(S::LazySet, ε::Float64;
@@ -129,10 +139,14 @@ Plot an array of lazy sets in two dimensions using iterative refinement.
 ### Examples
 
 ```jldoctest
-julia> using LazySets, Plots
-julia> B1 = BallInf(zeros(2), 0.4)
-julia> B2 = Ball2(ones(2), 0.4)
-julia> plot([B1, B2], 1e-4)
+julia> using LazySets, Plots;
+
+julia> B1 = BallInf(zeros(2), 0.4);
+
+julia> B2 = Ball2(ones(2), 0.4);
+
+julia> plot([B1, B2], 1e-4);
+
 ```
 """
 @recipe function plot_lazyset(arr::Vector{<:LazySet}, ε::Float64;
@@ -164,12 +178,15 @@ Plot a polygon in constraint representation.
 ### Examples
 
 ```jldoctest
-julia> using LazySets, Plots
+julia> using LazySets, Plots;
+
 julia> P = HPolygon([LinearConstraint([1.0, 0.0], 0.6),
                      LinearConstraint([0.0, 1.0], 0.6),
                      LinearConstraint([-1.0, 0.0], -0.4),
-                     LinearConstraint([0.0, -1.0], -0.4)])
-julia> plot(P)
+                     LinearConstraint([0.0, -1.0], -0.4)]);
+
+julia> plot(P);
+
 ```
 """
 @recipe function plot_polygon(P::Union{HPolygon, HPolygonOpt};
@@ -195,16 +212,20 @@ Plot an array of polygons in constraint representation.
 ### Examples
 
 ```jldoctest
-julia> using LazySets, Plots
+julia> using LazySets, Plots;
+
 julia> P1 = HPolygon([LinearConstraint([1.0, 0.0], 0.6),
                       LinearConstraint([0.0, 1.0], 0.6),
                       LinearConstraint([-1.0, 0.0], -0.4),
-                      LinearConstraint([0.0, -1.0], -0.4)])
+                      LinearConstraint([0.0, -1.0], -0.4)]);
+
 julia> P2 = HPolygon([LinearConstraint([2.0, 0.0], 0.6),
                       LinearConstraint([0.0, 2.0], 0.6),
                       LinearConstraint([-2.0, 0.0], -0.4),
-                      LinearConstraint([0.0, -2.0], -0.4)])
-julia> plot([P1, P2])
+                      LinearConstraint([0.0, -2.0], -0.4)]);
+
+julia> plot([P1, P2]);
+
 ```
 """
 @recipe function plot_polygons(P::Vector{<:AbstractHPolygon};
@@ -231,9 +252,12 @@ Plot a polygon in vertex representation.
 ### Examples
 
 ```jldoctest
-julia> using LazySets, Plots
-julia> P = VPolygon([[0.6, 0.6], [0.4, 0.6], [0.4, 0.4], [0.6, 0.4]])
-julia> plot(P)
+julia> using LazySets, Plots;
+
+julia> P = VPolygon([[0.6, 0.6], [0.4, 0.6], [0.4, 0.4], [0.6, 0.4]]);
+
+julia> plot(P);
+
 ```
 """
 @recipe function plot_polygon(P::VPolygon;
@@ -259,10 +283,14 @@ Plot an array of polygons in vertex representation.
 ### Examples
 
 ```jldoctest
-julia> using LazySets, Plots
-julia> P1 = VPolygon([[0.6, 0.6], [0.4, 0.6], [0.4, 0.4], [0.6, 0.4]])
-julia> P2 = VPolygon([[0.3, 0.3], [0.2, 0.3], [0.2, 0.2], [0.3, 0.2]])
-julia> plot([P1, P2])
+julia> using LazySets, Plots;
+
+julia> P1 = VPolygon([[0.6, 0.6], [0.4, 0.6], [0.4, 0.4], [0.6, 0.4]]);
+
+julia> P2 = VPolygon([[0.3, 0.3], [0.2, 0.3], [0.2, 0.2], [0.3, 0.2]]);
+
+julia> plot([P1, P2]);
+
 ```
 """
 @recipe function plot_polygons(P::Vector{<:VPolygon};
@@ -293,8 +321,10 @@ Plot a singleton.
 ### Examples
 
 ```jldoctest
-julia> using LazySets, Plots
-julia> plot(Singleton([0.5, 1.0]))
+julia> using LazySets, Plots;
+
+julia> plot(Singleton([0.5, 1.0]));
+
 ```
 """
 @recipe function plot_singleton(point::AbstractSingleton;
@@ -318,16 +348,21 @@ Plot a list of singletons.
 ### Examples
 
 ```jldoctest
-julia> using LazySets, Plots
-julia> plot([Singleton([0.0, 0.0]), Singleton([1., 0]), Singleton([0.5, .5])])
+julia> using LazySets, Plots;
+
+julia> plot([Singleton([0.0, 0.0]), Singleton([1., 0]), Singleton([0.5, .5])]);
+
 ```
 
 Three-dimensional singletons can be plotted as well:
 
 ```jldoctest
-julia> using LazySets, Plots
+julia> using LazySets, Plots;
+
 julia> a, b, c = zeros(3), [1.0, 0, 0], [0.0, 1., 0];
-julia> plot([Singleton(a), Singleton(b), Singleton(c)])
+
+julia> plot([Singleton(a), Singleton(b), Singleton(c)]);
+
 ```
 """
 @recipe function plot_singleton(arr::Vector{<:AbstractSingleton};
@@ -354,9 +389,12 @@ Plot a zonotope by enumerating its vertices.
 ### Examples
 
 ```jldoctest
-julia> using LazySets, Plots
-julia> Z = Zonotope(ones(2), 0.2*[[1., 0], [0., 1], [1, 1]])
-julia> plot(Z)
+julia> using LazySets, Plots;
+
+julia> Z = Zonotope(ones(2), 0.2*[[1., 0], [0., 1], [1, 1]]);
+
+julia> plot(Z);
+
 ```
 """
 @recipe function plot_zonotope(Z::Zonotope;
@@ -383,10 +421,14 @@ Plot an array of zonotopes.
 ### Examples
 
 ```jldoctest
-julia> using LazySets, Plots
-julia> Z1 = Zonotope(zeros(2), [[0.6, 0.6], [0.4, 0.6], [0.4, 0.4], [0.6, 0.4]])
-julia> Z2 = Zonotope(zeros(2), [[0.3, 0.3], [0.2, 0.3], [0.2, 0.2], [0.3, 0.2]])
-julia> plot([Z1, Z2])
+julia> using LazySets, Plots;
+
+julia> Z1 = Zonotope(zeros(2), [[0.6, 0.6], [0.4, 0.6], [0.4, 0.4], [0.6, 0.4]]);
+
+julia> Z2 = Zonotope(zeros(2), [[0.3, 0.3], [0.2, 0.3], [0.2, 0.2], [0.3, 0.2]]);
+
+julia> plot([Z1, Z2]);
+
 ```
 """
 @recipe function plot_zonotopes(Z::Vector{<:Zonotope};
@@ -418,9 +460,12 @@ Plot a line segment.
 ### Examples
 
 ```jldoctest
-julia> using LazySets, Plots
-julia> L = LineSegment([0., 0.], [1., 1.])
-julia> plot(L)
+julia> using LazySets, Plots;
+
+julia> L = LineSegment([0., 0.], [1., 1.]);
+
+julia> plot(L);
+
 ```
 """
 @recipe function plot_linesegment(L::LineSegment; color="blue", label="",
@@ -447,10 +492,14 @@ Plot an array of line segments.
 ### Examples
 
 ```jldoctest
-julia> using LazySets, Plots
-julia> L1 = LineSegment([0., 0.], [1., 1.])
-julia> L2 = LineSegment([1., 0.], [0., 1.])
-julia> plot([L1, L2])
+julia> using LazySets, Plots;
+
+julia> L1 = LineSegment([0., 0.], [1., 1.]);
+
+julia> L2 = LineSegment([1., 0.], [0., 1.]);
+
+julia> plot([L1, L2]);
+
 ```
 """
 @recipe function plot_linesegments(L::Vector{<:LineSegment}; color="blue",
@@ -479,9 +528,12 @@ Plot an interval.
 ### Examples
 
 ```jldoctest
-julia> using LazySets, Plots
-julia> I = Interval(0.0, 1.0)
-julia> plot(I)
+julia> using LazySets, Plots;
+
+julia> I = Interval(0.0, 1.0);
+
+julia> plot(I);
+
 ```
 """
 @recipe function plot_linesegment(I::Interval; color=:auto, label="",
@@ -508,10 +560,14 @@ Plot an array of intervals.
 ### Examples
 
 ```jldoctest
-julia> using LazySets, Plots
-julia> I1 = Interval([0., 1.])
-julia> I2 = Interval([0.5, 2.])
-julia> plot(I1, I2])
+julia> using LazySets, Plots;
+
+julia> I1 = Interval([0., 1.]);
+
+julia> I2 = Interval([0.5, 2.]);
+
+julia> plot([I1, I2]);
+
 ```
 """
 @recipe function plot_intervals(I::Vector{<:Interval}; color=:auto,


### PR DESCRIPTION
Closes #159. Workaround for #72.

* [x] Add missing documentation.
* [x] Add workaround for #72. The only warnings that are still printed are the ones for functions only defined in presence of `Polyhedra.jl`. Should we remove them as well?
* [x] Have interface documentation at one place and link to it (#159).
  * There are still some problems with `Documenter` in case of multiple methods. As a workaround, I omit the hyperlinks when there are conflicts.
  * To elaborate:
    * default values (e.g., `p::Real=Inf`): This simply does not work.
    * type parameters: On the lowest interface level we can use an instantiation of the type parameters, like `an_element(::LazySet{Real})`; for this case one can also create a hyperlink reference. On higher (interface/type) levels, one has to use the `where` syntax in order to use the correct method; for this case there are no hyperlinks.
* [x] Remove duplicate documentation for concrete types.
  * See above (`where` syntax).
  * I did not find a way to make the `array` function for array types (probably due to nested type parameters) and the functions with default values (`norm`/`radius`/`diameter`) work.
* [x] Check that each implementation occurs in the docs.
* [x] Check that workaround for #72 is not created by default.
  * The page is not created, but the warnings are absorbed.
* [x] Fix broken doctests.
  * I have never seen those broken ones so far. Apparently up to now the doctests never executed for `VPolytope.jl` and `plot_recipes.jl`, probably because the documentation was not used before.