### PR TITLE
#402 - Deploy docs from julia 0.6.0

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -37,7 +37,7 @@ deploydocs(
     repo = "github.com/JuliaReach/LazySets.jl.git",
     target = "build",
     osname = "linux",
-    julia  = "0.6",
+    julia  = "0.6.0",
     deps = nothing,
     make = nothing
 )


### PR DESCRIPTION
See #402.

This is yet another try, should #441 not work.