### PR TITLE
#402 - Split travis command into two commands again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,8 @@ matrix:
 #  - julia -e 'Pkg.clone(pwd()); Pkg.build("LazySets"); Pkg.test("LazySets"; coverage=true)'
 after_success:
   # documentation (restrict Documenter to release version 0.18.0 due to problems, see #402)
-  - julia -e 'Pkg.add("Documenter"); Pkd.pin("Documenter", v"0.18.0"); cd(Pkg.dir("LazySets")); include(joinpath("docs", "make.jl"))'
+  - julia -e 'Pkg.add("Documenter"); Pkg.pin("Documenter", v"0.18.0")'
+  - julia -e 'cd(Pkg.dir("LazySets")); include(joinpath("docs", "make.jl"))'
   # code coverage (for both Coveralls and Codecov)
   - julia -e 'Pkg.add("Coverage")'
   # push coverage results to Coveralls


### PR DESCRIPTION
See #402.

Fix typo, and also try it with two commands again (even though this should not help).