### PR TITLE
#55 - Revise diameter function

### DIFF
--- a/src/AbstractHyperrectangle.jl
+++ b/src/AbstractHyperrectangle.jl
@@ -126,31 +126,6 @@ function radius(H::AbstractHyperrectangle, p::Real=Inf)::Real
 end
 
 """
-    diameter(H::AbstractHyperrectangle, [p]::Real=Inf)::Real
-
-Return the diameter of a hyperrectangular set.
-
-### Input
-
-- `H` -- hyperrectangular set
-- `p` -- (optional, default: `Inf`) norm
-
-### Output
-
-A real number representing the diameter.
-
-### Notes
-
-The diameter is defined as the maximum distance in the given ``p``-norm between
-any two elements of the set.
-Equivalently, it is the diameter of the enclosing ball of the given ``p``-norm
-of minimal volume with the same center.
-"""
-function diameter(H::AbstractHyperrectangle, p::Real=Inf)::Real
-    return radius(H, p) * 2
-end
-
-"""
     ∈(x::AbstractVector{N}, H::AbstractHyperrectangle{N})::Bool where {N<:Real}
 
 Check whether a given point is contained in a hyperrectangular set.

--- a/src/LazySet.jl
+++ b/src/LazySet.jl
@@ -162,11 +162,7 @@ minimal volume with the same center.
 A real number representing the diameter.
 """
 function diameter(S::LazySet, p::Real=Inf)
-    if p == Inf
-        return radius(S, p) * 2
-    else
-        error("the diameter for this value of p=$p is not implemented")
-    end
+    return radius(S, p) * 2
 end
 
 


### PR DESCRIPTION
Closes #55.

@mforets: Please check that these changes are correct:
1. The diameter is *always* two times the radius (of the respective norm). So there is no need to throw an error, because it will be thrown by `radius`.
2. The diameter of a `Hyperrectangle` is defined in the same way, so we can just use the default implementation.