### PR TITLE
#478 - "Safely" querying support vectors 

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -31,7 +31,7 @@ Concrete information is obtained through evaluating the set in specific
 directions.
 More precisely, each concrete subtype $\mathcal{X}$ of the abstract type
 `LazySet` exports a method to calculate its support vector
-$\sigma(d, \mathcal{X})$ in a given (arbitrary) direction $d \in \mathbb{R}^n$.
+$σ(d, \mathcal{X})$ in a given (arbitrary) direction $d \in \mathbb{R}^n$.
 Representing sets exactly but lazily has the advantage of being able to perform
 only the required operations on-demand.
 

--- a/docs/src/lib/operations.md
+++ b/docs/src/lib/operations.md
@@ -175,7 +175,7 @@ LinearMap
 *(::AbstractMatrix{Real}, ::LazySet{Real})
 *(::Real, ::LazySet{Real})
 dim(::LinearMap)
-σ(::AbstractVector{Real}, ::LinearMap{Real, LazySet{Real}, Real, Matrix{Real}})
+σ(::AbstractVector{Real}, ::LinearMap{Real})
 ∈(::AbstractVector{Real}, ::LinearMap{Real, LazySet{Real}, Real, Matrix{Real}})
 an_element(::LinearMap)
 ```
@@ -223,7 +223,7 @@ ProjectionSparseMatrixExp
 
 ```@docs
 SymmetricIntervalHull
-σ(::V, ::SymmetricIntervalHull{N}) where {N<:Real, V<:AbstractVector{N}}
+σ(::AbstractVector{N}, ::SymmetricIntervalHull{N}) where {N<:Real}
 ```
 Inherited from [`LazySet`](@ref):
 * [`diameter`](@ref diameter(::LazySet, ::Real))

--- a/docs/src/lib/representations.md
+++ b/docs/src/lib/representations.md
@@ -198,7 +198,7 @@ Inherited from [`AbstractHyperrectangle`](@ref):
 ```@docs
 Interval
 dim(::Interval)
-σ(::AbstractVector{Real}, ::Interval{Real, IntervalArithmetic.AbstractInterval{Real}})
+σ(::AbstractVector{Real}, ::Interval{Real})
 ∈(::AbstractVector, ::Interval)
 ∈(::Real, ::Interval)
 an_element(::Interval)
@@ -411,7 +411,7 @@ Inherited from [`AbstractSingleton`](@ref):
 ```@docs
 ZeroSet
 dim(::ZeroSet)
-σ(::AbstractVector{N}, ::ZeroSet) where {N<:Real}
+σ(::AbstractVector{N}, ::ZeroSet{N}) where {N<:Real}
 ∈(::AbstractVector{N}, ::ZeroSet{N}) where {N<:Real}
 element(::ZeroSet)
 element(::ZeroSet, ::Int)

--- a/src/AbstractHyperrectangle.jl
+++ b/src/AbstractHyperrectangle.jl
@@ -60,7 +60,7 @@ end
 
 
 """
-    σ(d::V, H::AbstractHyperrectangle{N}) where {N<:Real, V<:AbstractVector{N}}
+    σ(d::AbstractVector{N}, H::AbstractHyperrectangle{N}) where {N<:Real}
 
 Return the support vector of a hyperrectangular set in a given direction.
 
@@ -74,7 +74,7 @@ Return the support vector of a hyperrectangular set in a given direction.
 The support vector in the given direction.
 If the direction has norm zero, the vertex with biggest values is returned.
 """
-function σ(d::V, H::AbstractHyperrectangle{N}) where {N<:Real, V<:AbstractVector{N}}
+function σ(d::AbstractVector{N}, H::AbstractHyperrectangle{N}) where {N<:Real}
     return center(H) .+ sign_cadlag.(d) .* radius_hyperrectangle(H)
 end
 

--- a/src/AbstractSingleton.jl
+++ b/src/AbstractSingleton.jl
@@ -137,7 +137,7 @@ end
 
 
 """
-    σ(d::AbstractVector{N}, S::AbstractSingleton{N})::Vector{N} where {N<:Real}
+    σ(d::AbstractVector{N}, S::AbstractSingleton{N}) where {N<:Real}
 
 Return the support vector of a set with a single value.
 
@@ -151,8 +151,7 @@ Return the support vector of a set with a single value.
 The support vector, which is the set's vector itself, irrespective of the given
 direction.
 """
-function σ(d::AbstractVector{N},
-           S::AbstractSingleton{N})::Vector{N} where {N<:Real}
+function σ(d::AbstractVector{N}, S::AbstractSingleton{N}) where {N<:Real}
     return element(S)
 end
 

--- a/src/Ball1.jl
+++ b/src/Ball1.jl
@@ -110,7 +110,7 @@ end
 
 
 """
-    σ(d::V, B::Ball1{N}) where {N<:Real, V<:AbstractVector{N}}
+    σ(d::AbstractVector{N}, B::Ball1{N}) where {N<:Real}
 
 Return the support vector of a ball in the 1-norm in a given direction.
 
@@ -123,7 +123,7 @@ Return the support vector of a ball in the 1-norm in a given direction.
 
 Support vector in the given direction.
 """
-function σ(d::V, B::Ball1{N}) where {N<:Real, V<:AbstractVector{N}}
+function σ(d::AbstractVector{N}, B::Ball1{N}) where {N<:Real}
     res = copy(B.center)
     imax = indmax(abs.(d))
     res[imax] += sign(d[imax]) * B.radius

--- a/src/Ball2.jl
+++ b/src/Ball2.jl
@@ -88,7 +88,7 @@ end
 
 
 """
-    σ(d::V, B::Ball2{N}) where {N<:AbstractFloat, V<:AbstractVector{N}}
+    σ(d::AbstractVector{N}, B::Ball2{N}) where {N<:AbstractFloat}
 
 Return the support vector of a 2-norm ball in a given direction.
 
@@ -117,7 +117,7 @@ performed in the given precision of the numeric datatype of both the direction
 and the set.
 Exact inputs are not supported.
 """
-function σ(d::V, B::Ball2{N}) where {N<:AbstractFloat, V<:AbstractVector{N}}
+function σ(d::AbstractVector{N}, B::Ball2{N}) where {N<:AbstractFloat}
     dnorm = norm(d, 2)
     if dnorm <= zero(N)
         return zeros(eltype(d), length(d))

--- a/src/Ballp.jl
+++ b/src/Ballp.jl
@@ -102,7 +102,7 @@ end
 
 
 """
-    σ(d::V, B::Ballp) where {N<:AbstractFloat, V<:AbstractVector{N}}
+    σ(d::AbstractVector{N}, B::Ballp{N}) where {N<:AbstractFloat}
 
 Return the support vector of a `Ballp` in a given direction.
 
@@ -135,7 +135,7 @@ the support vector of ``\\mathcal{B}_p^n(c, r)`` is
 where ``v_i = c_i + r\\frac{|d_i|^q}{d_i}`` if ``d_i ≠ 0`` and ``v_i = 0``
 otherwise, for all ``i = 1, …, n``.
 """
-function σ(d::V, B::Ballp) where {N<:AbstractFloat, V<:AbstractVector{N}}
+function σ(d::AbstractVector{N}, B::Ballp{N}) where {N<:AbstractFloat}
     p = B.p
     q = p/(p-1)
     v = similar(d)

--- a/src/CartesianProduct.jl
+++ b/src/CartesianProduct.jl
@@ -87,7 +87,7 @@ function dim(cp::CartesianProduct)::Int
 end
 
 """
-    σ(d::V, cp::CartesianProduct) where {N<:Real, V<:AbstractVector{N}}
+    σ(d::AbstractVector{N}, cp::CartesianProduct{N}) where {N<:Real}
 
 Return the support vector of a Cartesian product.
 
@@ -105,7 +105,7 @@ If the direction has norm zero, the result depends on the product sets.
 
 
 """
-function σ(d::V, cp::CartesianProduct) where {N<:Real, V<:AbstractVector{N}}
+function σ(d::AbstractVector{N}, cp::CartesianProduct{N}) where {N<:Real}
     return [σ(d[1:dim(cp.X)], cp.X); σ(d[dim(cp.X)+1:length(d)], cp.Y)]
 end
 
@@ -212,7 +212,7 @@ function dim(cpa::CartesianProductArray)::Int
 end
 
 """
-    σ(d::V, cpa::CartesianProductArray{N, <:LazySet{N}}) where {N<:Real, V<:AbstractVector{N}}
+    σ(d::AbstractVector{N}, cpa::CartesianProductArray{N}) where {N<:Real}
 
 Support vector of a Cartesian product.
 
@@ -226,7 +226,7 @@ Support vector of a Cartesian product.
 The support vector in the given direction.
 If the direction has norm zero, the result depends on the product sets.
 """
-function σ(d::V, cpa::CartesianProductArray{N, <:LazySet{N}}) where {N<:Real, V<:AbstractVector{N}}
+function σ(d::AbstractVector{N}, cpa::CartesianProductArray{N}) where {N<:Real}
     svec = similar(d)
     jinit = 1
     for sj in cpa.array

--- a/src/ConvexHull.jl
+++ b/src/ConvexHull.jl
@@ -78,7 +78,7 @@ function dim(ch::ConvexHull)::Int
 end
 
 """
-    σ(d::V, ch::ConvexHull) where {N<:Real, V<:AbstractVector{N}}
+    σ(d::AbstractVector{N}, ch::ConvexHull{N}) where {N<:Real}
 
 Return the support vector of a convex hull of two convex sets in a given
 direction.
@@ -88,7 +88,7 @@ direction.
 - `d`  -- direction
 - `ch` -- convex hull of two convex sets
 """
-function σ(d::V, ch::ConvexHull) where {N<:Real, V<:AbstractVector{N}}
+function σ(d::AbstractVector{N}, ch::ConvexHull{N}) where {N<:Real}
     σ1 = σ(d, ch.X)
     σ2 = σ(d, ch.Y)
     ρ1 = dot(d, σ1)
@@ -193,7 +193,7 @@ function dim(cha::ConvexHullArray)::Int
 end
 
 """
-    σ(d::V, cha::ConvexHullArray) where {N<:Real, V<:AbstractVector{N}}
+    σ(d::AbstractVector{N}, cha::ConvexHullArray{N}) where {N<:Real}
 
 Return the support vector of a convex hull array in a given direction.
 
@@ -202,7 +202,7 @@ Return the support vector of a convex hull array in a given direction.
 - `d`   -- direction
 - `cha` -- convex hull array
 """
-function σ(d::V, cha::ConvexHullArray) where {N<:Real, V<:AbstractVector{N}}
+function σ(d::AbstractVector{N}, cha::ConvexHullArray{N}) where {N<:Real}
     s = σ(d, cha.array[1])
     ri = dot(d, s)
     rmax = ri

--- a/src/Ellipsoid.jl
+++ b/src/Ellipsoid.jl
@@ -97,7 +97,7 @@ function center(E::Ellipsoid{N})::Vector{N} where {N<:AbstractFloat}
 end
 
 """
-    σ(d::V, E::Ellipsoid{N})::V where{N<:AbstractFloat, V<:AbstractVector{N}}
+    σ(d::AbstractVector{N}, E::Ellipsoid{N}) where {N<:AbstractFloat}
 
 Return the support vector of an ellipsoid in a given direction.
 
@@ -122,7 +122,7 @@ vector,
 = c + \\dfrac{Qd}{\\sqrt{d^\\mathrm{T}Q d}}.
 ```
 """
-function σ(d::V, E::Ellipsoid{N})::V where{N<:AbstractFloat, V<:AbstractVector{N}}
+function σ(d::AbstractVector{N}, E::Ellipsoid{N}) where {N<:AbstractFloat}
     if norm(d, 2) == zero(N)
         return an_element(E)
     end

--- a/src/EmptySet.jl
+++ b/src/EmptySet.jl
@@ -38,7 +38,7 @@ function dim(∅::EmptySet)::Int
 end
 
 """
-    σ(d, ∅)
+    σ(d::AbstractVector{N}, ∅::EmptySet{N}) where {N<:Real}
 
 Return the support vector of an empty set.
 
@@ -50,7 +50,7 @@ Return the support vector of an empty set.
 
 An error.
 """
-function σ(d::AbstractVector, ∅::EmptySet)
+function σ(d::AbstractVector{N}, ∅::EmptySet{N}) where {N<:Real}
     error("the support vector of an empty set does not exist")
 end
 

--- a/src/ExponentialMap.jl
+++ b/src/ExponentialMap.jl
@@ -200,7 +200,7 @@ function dim(em::ExponentialMap)::Int
 end
 
 """
-    σ(d::V, em::ExponentialMap) where {N<:Real, V<:AbstractVector{N}}
+    σ(d::AbstractVector{N}, em::ExponentialMap{N}) where {N<:Real}
 
 Return the support vector of the exponential map.
 
@@ -222,7 +222,7 @@ follows that ``σ(d, E) = \\exp(M)⋅σ(\\exp(M)^T d, S)`` for any direction ``d
 We allow sparse direction vectors, but will convert them to dense vectors to be
 able to use `expmv`.
 """
-function σ(d::V, em::ExponentialMap) where {N<:Real, V<:AbstractVector{N}}
+function σ(d::AbstractVector{N}, em::ExponentialMap{N}) where {N<:Real}
     d_dense = d isa Vector ? d : Vector(d)
     v = expmv(one(N), transpose(em.spmexp.M), d_dense) # v   <- exp(A') * d
     return expmv(one(N), em.spmexp.M, σ(v, em.X)) # res <- exp(A) * σ(v, S)
@@ -344,7 +344,8 @@ function dim(eprojmap::ExponentialProjectionMap)::Int
 end
 
 """
-    σ(d::V, eprojmap::ExponentialProjectionMap) where {N<:Real, V<:AbstractVector{N}}
+    σ(d::AbstractVector{N},
+      eprojmap::ExponentialProjectionMap{N}) where {N<:Real}
 
 Return the support vector of a projection of an exponential map.
 
@@ -367,7 +368,8 @@ exponential, and ``X`` is a set, it follows that
 We allow sparse direction vectors, but will convert them to dense vectors to be
 able to use `expmv`.
 """
-function σ(d::V, eprojmap::ExponentialProjectionMap) where {N<:Real, V<:AbstractVector{N}}
+function σ(d::AbstractVector{N},
+           eprojmap::ExponentialProjectionMap{N}) where {N<:Real}
     d_dense = d isa Vector ? d : Vector(d)
     daux = transpose(eprojmap.projspmexp.L) * d_dense
     aux1 = expmv(one(N), transpose(eprojmap.projspmexp.spmexp.M), daux)

--- a/src/HPolygon.jl
+++ b/src/HPolygon.jl
@@ -41,7 +41,7 @@ HPolygon(S::LazySet) = convert(HPolygon, S)
 
 
 """
-    σ(d::AbstractVector{N}, P::HPolygon)::Vector{N} where {N<:Real}
+    σ(d::AbstractVector{N}, P::HPolygon{N}) where {N<:Real}
 
 Return the support vector of a polygon in a given direction.
 
@@ -61,7 +61,7 @@ norm zero, any vertex is returned.
 Comparison of directions is performed using polar angles; see the overload of
 `<=` for two-dimensional vectors.
 """
-function σ(d::AbstractVector{N}, P::HPolygon)::Vector{N} where {N<:Real}
+function σ(d::AbstractVector{N}, P::HPolygon{N}) where {N<:Real}
     n = length(P.constraints)
     @assert n > 0 "the polygon has no constraints"
     k = 1

--- a/src/HPolygonOpt.jl
+++ b/src/HPolygonOpt.jl
@@ -59,7 +59,7 @@ HPolygonOpt(S::LazySet) = convert(HPolygonOpt, S)
 
 
 """
-    σ(d::AbstractVector{N}, P::HPolygonOpt)::Vector{N} where {N<:Real}
+    σ(d::AbstractVector{N}, P::HPolygonOpt{N}) where {N<:Real}
 
 Return the support vector of an optimized polygon in a given direction.
 
@@ -79,7 +79,7 @@ norm zero, any vertex is returned.
 Comparison of directions is performed using polar angles; see the overload of
 `<=` for two-dimensional vectors.
 """
-function σ(d::AbstractVector{N}, P::HPolygonOpt)::Vector{N} where {N<:Real}
+function σ(d::AbstractVector{N}, P::HPolygonOpt{N}) where {N<:Real}
     n = length(P.constraints)
     @assert n > 0 "the polygon has no constraints"
     if (d <= P.constraints[P.ind].a)

--- a/src/HPolytope.jl
+++ b/src/HPolytope.jl
@@ -65,7 +65,7 @@ function dim(P::HPolytope)::Int
 end
 
 """
-    σ(d::AbstractVector{<:Real}, P::HPolytope)::Vector{<:Real}
+    σ(d::AbstractVector{N}, P::HPolytope{N}) where {N<:Real}
 
 Return the support vector of a polyhedron (in H-representation) in a given
 direction.
@@ -83,7 +83,7 @@ The support vector in the given direction.
 
 This implementation uses `GLPKSolverLP` as linear programming backend.
 """
-function σ(d::AbstractVector{<:Real}, P::HPolytope)::Vector{<:Real}
+function σ(d::AbstractVector{N}, P::HPolytope{N}) where {N<:Real}
     c = -d
     n = length(constraints_list(P))
     @assert n > 0 "the polytope has no constraints"

--- a/src/HalfSpace.jl
+++ b/src/HalfSpace.jl
@@ -57,7 +57,7 @@ function dim(hs::HalfSpace)::Int
 end
 
 """
-    σ(d::V, hs::HalfSpace) where {N<:Real, V<:AbstractVector{N}}
+    σ(d::AbstractVector{N}, hs::HalfSpace{N}) where {N<:Real}
 
 Return the support vector of a half-space.
 
@@ -75,7 +75,7 @@ following two cases:
 In both cases the result is any point on the boundary (the defining hyperplane).
 Otherwise this function throws an error.
 """
-function σ(d::V, hs::HalfSpace) where {N<:Real, V<:AbstractVector{N}}
+function σ(d::AbstractVector{N}, hs::HalfSpace{N}) where {N<:Real}
     return σ_helper(d, Hyperplane(hs.a, hs.b), "half-space")
 end
 

--- a/src/Hyperplane.jl
+++ b/src/Hyperplane.jl
@@ -49,7 +49,7 @@ function dim(hp::Hyperplane)::Int
 end
 
 """
-    σ(d::V, hp::Hyperplane) where {N<:Real, V<:AbstractVector{N}}
+    σ(d::AbstractVector{N}, hp::Hyperplane{N}) where {N<:Real}
 
 Return the support vector of a hyperplane.
 
@@ -67,7 +67,7 @@ following two cases:
 In both cases the result is any point on the hyperplane.
 Otherwise this function throws an error.
 """
-function σ(d::V, hp::Hyperplane) where {N<:Real, V<:AbstractVector{N}}
+function σ(d::AbstractVector{N}, hp::Hyperplane{N}) where {N<:Real}
     return σ_helper(d, hp)
 end
 
@@ -116,9 +116,9 @@ end
 
 """
 ```
-    σ_helper(d::V,
-             hp::Hyperplane,
-             [name]::String="hyperplane") where {N<:Real, V<:AbstractVector{N}}
+    σ_helper(d::AbstractVector{N},
+             hp::Hyperplane{N},
+             [name]::String="hyperplane") where {N<:Real}
 ```
 
 Return the support vector of a hyperplane.
@@ -138,10 +138,9 @@ following two cases:
 In both cases the result is any point on the hyperplane.
 Otherwise this function throws an error.
 """
-@inline function σ_helper(d::V,
-                  hp::Hyperplane,
-                  name::String="hyperplane"
-                 ) where {N<:Real, V<:AbstractVector{N}}
+@inline function σ_helper(d::AbstractVector{N},
+                          hp::Hyperplane{N},
+                          name::String="hyperplane") where {N<:Real}
     @assert (length(d) == dim(hp)) "cannot compute the support vector of a " *
         "$(dim(hp))-dimensional $name along a vector of length $(length(d))"
 

--- a/src/Intersection.jl
+++ b/src/Intersection.jl
@@ -62,7 +62,7 @@ function dim(cap::Intersection)::Int
 end
 
 """
-    σ(d::V, cap::Intersection) where {N<:Real, V<:AbstractVector{N}}
+    σ(d::AbstractVector{N}, cap::Intersection{N}) where {N<:Real}
 
 Return the support vector of an intersection of two convex sets in a given
 direction.
@@ -76,7 +76,7 @@ direction.
 
 The support vector in the given direction.
 """
-function σ(d::V, cap::Intersection) where {N<:Real, V<:AbstractVector{N}}
+function σ(d::AbstractVector{N}, cap::Intersection{N}) where {N<:Real}
     # TODO document behavior if the direction has norm zero
     # TODO error message if the intersection is empty!
     # TODO implement

--- a/src/Interval.jl
+++ b/src/Interval.jl
@@ -105,7 +105,7 @@ The integer 1.
 dim(x::Interval)::Int = 1
 
 """
-    σ(d::V, x::Interval{N})::V where {N, V<:AbstractVector{N}}
+    σ(d::AbstractVector{N}, x::Interval{N}) where {N<:Real}
 
 Return the support vector of an ellipsoid in a given direction.
 
@@ -118,7 +118,7 @@ Return the support vector of an ellipsoid in a given direction.
 
 Support vector in the given direction.
 """
-function σ(d::V, x::Interval{N})::V where {N, V<:AbstractVector{N}}
+function σ(d::AbstractVector{N}, x::Interval{N}) where {N<:Real}
     @assert length(d) == dim(x)
     return d[1] > 0 ? [x.dat.hi] : [x.dat.lo]
 end

--- a/src/LazySet.jl
+++ b/src/LazySet.jl
@@ -14,16 +14,18 @@ export LazySet,
 
 Abstract type for convex sets, i.e., sets characterized by a (possibly infinite)
 intersection of halfspaces, or equivalently, sets ``S`` such that for any two
-elements ``x, y ∈ S`` and ``0 ≤ λ ≤ 1`` it holds that ``λ x + (1-λ) y ∈ S``.
+elements ``x, y ∈ S`` and ``0 ≤ λ ≤ 1`` it holds that ``λ·x + (1-λ)·y ∈ S``.
 
 ### Notes
 
-`LazySet` types should be parameterized with a type `N`, typically
-`N<:Real`, for using different numeric types.
+`LazySet` types should be parameterized with a type `N`, typically `N<:Real`,
+for using different numeric types.
 
 Every concrete `LazySet` must define the following functions:
-- `σ(d::AbstractVector{N}, S::LazySet)` -- the
-    support vector of `S` in a given direction `d`
+- `σ(d::AbstractVector{N}, S::LazySet{N}) where {N<:Real}` -- the support vector
+    of `S` in a given direction `d`; note that the numeric type `N` of `d` and
+    `S` must be identical; for some set types `N` may be more restrictive than
+    `Real`
 - `dim(S::LazySet)::Int` -- the ambient dimension of `S`
 
 ```jldoctest
@@ -68,6 +70,10 @@ Evaluate the support function of a set in a given direction.
 ### Output
 
 The support function of the set `S` for the direction `d`.
+
+### Notes
+
+The numeric type of the direction and the set must be identical.
 """
 function ρ(d::AbstractVector{N}, S::LazySet{N})::N where {N<:Real}
     return dot(d, σ(d, S))

--- a/src/Line.jl
+++ b/src/Line.jl
@@ -63,7 +63,7 @@ function dim(L::Line)::Int
 end
 
 """
-    σ(d::V, L::Line) where {N<:Real, V<:AbstractVector{N}}
+    σ(d::AbstractVector{N}, L::Line{N}) where {N<:Real}
 
 Return the support vector of a line in a given direction.
 
@@ -77,7 +77,7 @@ Return the support vector of a line in a given direction.
 The support vector in the given direction, which is defined the same way as for
 the more general `Hyperplane`.
 """
-function σ(d::V, L::Line) where {N<:Real, V<:AbstractVector{N}}
+function σ(d::AbstractVector{N}, L::Line{N}) where {N<:Real}
     return σ(d, Hyperplane(L.a, L.b))
 end
 

--- a/src/LineSegment.jl
+++ b/src/LineSegment.jl
@@ -84,7 +84,7 @@ function dim(L::LineSegment)::Int
 end
 
 """
-    σ(d::V, L::LineSegment) where {N<:Real, V<:AbstractVector{N}}
+    σ(d::AbstractVector{N}, L::LineSegment{N}) where {N<:Real}
 
 Return the support vector of a line segment in a given direction.
 
@@ -105,7 +105,7 @@ it is ``q``.
 If the angle is exactly 90° or 270°, or if the direction has norm zero, this
 implementation returns ``q``.
 """
-function σ(d::V, L::LineSegment) where {N<:Real, V<:AbstractVector{N}}
+function σ(d::AbstractVector{N}, L::LineSegment{N}) where {N<:Real}
     return sign(dot(L.q - L.p, d)) >= 0 ? L.q : L.p
 end
 

--- a/src/LinearMap.jl
+++ b/src/LinearMap.jl
@@ -147,7 +147,7 @@ function dim(lm::LinearMap)::Int
 end
 
 """
-    σ(d::V, lm::LinearMap) where {N<:Real, V<:AbstractVector{N}}
+    σ(d::AbstractVector{N}, lm::LinearMap{N}) where {N<:Real}
 
 Return the support vector of the linear map.
 
@@ -166,7 +166,7 @@ If the direction has norm zero, the result depends on the wrapped set.
 If ``L = M⋅S``, where ``M`` is a matrix and ``S`` is a convex set, it follows
 that ``σ(d, L) = M⋅σ(M^T d, S)`` for any direction ``d``.
 """
-function σ(d::V, lm::LinearMap) where {N<:Real, V<:AbstractVector{N}}
+function σ(d::AbstractVector{N}, lm::LinearMap{N}) where {N<:Real}
     return lm.M * σ(_At_mul_B(lm.M, d), lm.X)
 end
 

--- a/src/MinkowskiSum.jl
+++ b/src/MinkowskiSum.jl
@@ -85,7 +85,7 @@ function dim(ms::MinkowskiSum)::Int
 end
 
 """
-    σ(d::V, ms::MinkowskiSum) where {N<:Real, V<:AbstractVector{N}}
+    σ(d::AbstractVector{N}, ms::MinkowskiSum{N}) where {N<:Real}
 
 Return the support vector of a Minkowski sum.
 
@@ -99,7 +99,7 @@ Return the support vector of a Minkowski sum.
 The support vector in the given direction.
 If the direction has norm zero, the result depends on the summand sets.
 """
-function σ(d::V, ms::MinkowskiSum) where {N<:Real, V<:AbstractVector{N}}
+function σ(d::AbstractVector{N}, ms::MinkowskiSum{N}) where {N<:Real}
     return σ(d, ms.X) + σ(d, ms.Y)
 end
 
@@ -189,7 +189,7 @@ function dim(msa::MinkowskiSumArray)::Int
 end
 
 """
-    σ(d::AbstractVector{<:Real}, msa::MinkowskiSumArray)::Vector{<:Real}
+    σ(d::AbstractVector{N}, msa::MinkowskiSumArray{N}) where {N<:Real}
 
 Return the support vector of a Minkowski sum of a finite number of sets in a
 given direction.
@@ -204,7 +204,7 @@ given direction.
 The support vector in the given direction.
 If the direction has norm zero, the result depends on the summand sets.
 """
-function σ(d::AbstractVector{<:Real}, msa::MinkowskiSumArray)::Vector{<:Real}
+function σ(d::AbstractVector{N}, msa::MinkowskiSumArray{N}) where {N<:Real}
     return _σ_helper(d, msa.array)
 end
 
@@ -330,7 +330,7 @@ function dim(cms::CacheMinkowskiSum)::Int
 end
 
 """
-    σ(d::AbstractVector{<:Real}, cms::CacheMinkowskiSum)::Vector{<:Real}
+    σ(d::AbstractVector{N}, cms::CacheMinkowskiSum{N}) where {N<:Real}
 
 Return the support vector of a caching Minkowski sum in a given direction.
 
@@ -351,7 +351,7 @@ constant time.
 When sets are added to the caching Minkowski sum, the query is only performed
 for the new sets.
 """
-function σ(d::AbstractVector{<:Real}, cms::CacheMinkowskiSum)::Vector{<:Real}
+function σ(d::AbstractVector{N}, cms::CacheMinkowskiSum{N}) where {N<:Real}
     arr = array(cms)
     l = length(arr)
     cache = cms.cache

--- a/src/SymmetricIntervalHull.jl
+++ b/src/SymmetricIntervalHull.jl
@@ -151,7 +151,7 @@ function dim(sih::SymmetricIntervalHull)::Int
 end
 
 """
-    σ(d::V, sih::SymmetricIntervalHull{N}) where {N<:Real, V<:AbstractVector{N}}
+    σ(d::AbstractVector{N}, sih::SymmetricIntervalHull{N}) where {N<:Real}
 
 Return the support vector of a symmetric interval hull of a convex set in a
 given direction.
@@ -175,8 +175,7 @@ queries.
 One such computation just asks for the support vector of the underlying set for
 both the positive and negative unit vector in the respective dimension.
 """
-function σ(d::V,
-           sih::SymmetricIntervalHull{N}) where {N<:Real, V<:AbstractVector{N}}
+function σ(d::AbstractVector{N}, sih::SymmetricIntervalHull{N}) where {N<:Real}
     n = length(d)
     @assert n == dim(sih) "cannot compute the support vector of a " *
         "$(dim(sih))-dimensional set along a vector of length $n"

--- a/src/VPolygon.jl
+++ b/src/VPolygon.jl
@@ -143,7 +143,7 @@ end
 
 
 """
-    σ(d::AbstractVector{N}, P::VPolygon)::Vector{N} where {N<:Real}
+    σ(d::AbstractVector{N}, P::VPolygon{N}) where {N<:Real}
 
 Return the support vector of a polygon in a given direction.
 
@@ -171,7 +171,7 @@ have been sorted in counter-clockwise fashion.
 In that case a binary search algorithm can be used that runs in ``O(\\log n)``.
 See issue [#40](https://github.com/JuliaReach/LazySets.jl/issues/40).
 """
-function σ(d::AbstractVector{N}, P::VPolygon)::Vector{N} where {N<:Real}
+function σ(d::AbstractVector{N}, P::VPolygon{N}) where {N<:Real}
     @assert !isempty(P.vertices) "the polygon has no vertices"
     i_max = 1
     @inbounds for i in 2:length(P.vertices)

--- a/src/VPolytope.jl
+++ b/src/VPolytope.jl
@@ -69,7 +69,7 @@ function dim(P::VPolytope)::Int
 end
 
 """
-    σ(d::AbstractVector{<:Real}, P::VPolytope; algorithm="hrep")::Vector{<:Real}
+    σ(d::AbstractVector{N}, P::VPolytope{N}; algorithm="hrep") where {N<:Real}
 
 Return the support vector of a polyhedron (in V-representation) in a given
 direction.
@@ -84,7 +84,9 @@ direction.
 
 The support vector in the given direction.
 """
-function σ(d::AbstractVector{<:Real}, P::VPolytope; algorithm="hrep")::Vector{<:Real}
+function σ(d::AbstractVector{N},
+           P::VPolytope{N};
+           algorithm="hrep") where {N<:Real}
     if algorithm == "hrep"
         @assert isdefined(@__MODULE__, :Polyhedra) "this algorithm needs the " *
             "package 'Polyhedra' loaded"

--- a/src/ZeroSet.jl
+++ b/src/ZeroSet.jl
@@ -79,7 +79,7 @@ function dim(Z::ZeroSet)::Int
 end
 
 """
-    σ(d::AbstractVector{N}, Z::ZeroSet)::Vector{N} where {N<:Real}
+    σ(d::AbstractVector{N}, Z::ZeroSet{N}) where {N<:Real}
 
 Return the support vector of a zero set.
 
@@ -92,7 +92,7 @@ Return the support vector of a zero set.
 The returned value is the origin since it is the only point that belongs to this
 set.
 """
-function σ(d::AbstractVector{N}, Z::ZeroSet)::Vector{N} where {N<:Real}
+function σ(d::AbstractVector{N}, Z::ZeroSet{N}) where {N<:Real}
     return zeros(d)
 end
 

--- a/src/Zonotope.jl
+++ b/src/Zonotope.jl
@@ -152,7 +152,7 @@ end
 
 
 """
-    σ(d::V, Z::Zonotope) where {N<:Real, V<:AbstractVector{N}}
+    σ(d::AbstractVector{N}, Z::Zonotope{N}) where {N<:Real}
 
 Return the support vector of a zonotope in a given direction.
 
@@ -167,7 +167,7 @@ Support vector in the given direction.
 If the direction has norm zero, the vertex with ``ξ_i = 1 \\ \\ ∀ i = 1,…, p``
 is returned.
 """
-function σ(d::V, Z::Zonotope) where {N<:Real, V<:AbstractVector{N}}
+function σ(d::AbstractVector{N}, Z::Zonotope{N}) where {N<:Real}
     return Z.center .+ Z.generators * sign_cadlag.(_At_mul_B(Z.generators, d))
 end
 

--- a/test/unit_interfaces.jl
+++ b/test/unit_interfaces.jl
@@ -4,7 +4,7 @@
 
 # support vector
 @test check_method_implementation(LazySet, σ,
-                                  Function[S -> (Vector{Float64}, S)])
+                                  Function[S -> (Vector{Float64}, S{Float64})])
 # dimension
 @test check_method_implementation(LazySet, dim, Function[S -> (S,)])
 


### PR DESCRIPTION
Closes #478.

* [x] all types, including `LinearMap`
* [x] update `@docs` in `docs/src/lib/*` and add a note in `LazySet.jl` about the numeric types