### PR TITLE
Revise set type constructors

### DIFF
--- a/src/Ball1.jl
+++ b/src/Ball1.jl
@@ -45,12 +45,13 @@ struct Ball1{N<:Real} <: AbstractPointSymmetricPolytope{N}
     radius::N
 
     # default constructor with domain constraint for radius
-    function Ball1{N}(center, radius) where N
+    function Ball1{N}(center::Vector{N}, radius::N) where {N<:Real}
         @assert radius >= zero(N) "radius must not be negative"
-        return new(center, radius)
+        return new{N}(center, radius)
     end
 end
-# type-less convenience constructor
+
+# convenience constructor without type parameter
 Ball1(center::Vector{N}, radius::N) where {N<:Real} = Ball1{N}(center, radius)
 
 

--- a/src/Ball2.jl
+++ b/src/Ball2.jl
@@ -53,15 +53,15 @@ struct Ball2{N<:AbstractFloat} <: AbstractPointSymmetric{N}
     radius::N
 
     # default constructor with domain constraint for radius
-    function Ball2{N}(center, radius) where N
+    function Ball2{N}(center::Vector{N}, radius::N) where {N<:AbstractFloat}
         @assert radius >= zero(N) "radius must not be negative"
-        return new(center, radius)
+        return new{N}(center, radius)
     end
 end
-# type-less convenience constructor
+
+# convenience constructor without type parameter
 Ball2(center::Vector{N}, radius::N) where {N<:AbstractFloat} =
     Ball2{N}(center, radius)
-
 
 # --- AbstractPointSymmetric interface functions ---
 

--- a/src/BallInf.jl
+++ b/src/BallInf.jl
@@ -41,15 +41,15 @@ struct BallInf{N<:Real} <: AbstractHyperrectangle{N}
     radius::N
 
     # default constructor with domain constraint for radius
-    function BallInf{N}(center, radius) where N
+    function BallInf{N}(center::Vector{N}, radius::N) where {N<:Real}
         @assert radius >= zero(N) "radius must not be negative"
-        return new(center, radius)
+        return new{N}(center, radius)
     end
 end
-# type-less convenience constructor
+
+# convenience constructor without type parameter
 BallInf(center::Vector{N}, radius::N) where {N<:Real} =
     BallInf{N}(center, radius)
-
 
 # --- AbstractHyperrectangle interface functions ---
 

--- a/src/Ballp.jl
+++ b/src/Ballp.jl
@@ -58,7 +58,8 @@ struct Ballp{N<:AbstractFloat} <: AbstractPointSymmetric{N}
     radius::N
 
     # default constructor with domain constraint for radius and p
-    function Ballp{N}(p, center, radius) where N
+    function Ballp{N}(p::N, center::Vector{N}, radius::N
+                     ) where {N<:AbstractFloat}
         @assert radius >= zero(N) "radius must not be negative"
         @assert p >= 1 "p must not be less than 1"
         if p == Inf
@@ -68,14 +69,14 @@ struct Ballp{N<:AbstractFloat} <: AbstractPointSymmetric{N}
         elseif p == 1
             return Ball1(center, radius)
         else
-            return new(p, center, radius)
+            return new{N}(p, center, radius)
         end
     end
 end
-# type-less convenience constructor
+
+# convenience constructor without type parameter
 Ballp(p::N, center::Vector{N}, radius::N) where {N<:AbstractFloat} =
     Ballp{N}(p, center, radius)
-
 
 # --- AbstractPointSymmetric interface functions ---
 

--- a/src/CartesianProduct.jl
+++ b/src/CartesianProduct.jl
@@ -35,12 +35,13 @@ struct CartesianProduct{N<:Real, S1<:LazySet{N}, S2<:LazySet{N}} <: LazySet{N}
     X::S1
     Y::S2
 end
-# type-less convenience constructor
-CartesianProduct(X1::S1, X2::S2
-                ) where {S1<:LazySet{N}, S2<:LazySet{N}} where {N<:Real} =
-    CartesianProduct{N, S1, S2}(X1, X2)
+
+# convenience constructor without type parameter
+CartesianProduct(X::S1, Y::S2) where {N<:Real, S1<:LazySet{N}, S2<:LazySet{N}} =
+    CartesianProduct{N, S1, S2}(X, Y)
+
 # constructor from an array
-CartesianProduct(Xarr::Vector{S}) where {S<:LazySet{N}} where {N<:Real} =
+CartesianProduct(Xarr::Vector{S}) where {N<:Real, S<:LazySet{N}} =
     (length(Xarr) == 0
         ? EmptySet{N}()
         : length(Xarr) == 1
@@ -157,7 +158,7 @@ struct CartesianProductArray{N<:Real, S<:LazySet{N}} <: LazySet{N}
     array::Vector{S}
 end
 
-# type-less convenience constructor
+# convenience constructor without type parameter
 CartesianProductArray(arr::Vector{S}) where {S<:LazySet{N}} where {N<:Real} =
     CartesianProductArray{N, S}(arr)
 

--- a/src/CartesianProduct.jl
+++ b/src/CartesianProduct.jl
@@ -36,9 +36,11 @@ struct CartesianProduct{N<:Real, S1<:LazySet{N}, S2<:LazySet{N}} <: LazySet{N}
     Y::S2
 end
 
-# convenience constructor without type parameter
-CartesianProduct(X::S1, Y::S2) where {N<:Real, S1<:LazySet{N}, S2<:LazySet{N}} =
-    CartesianProduct{N, S1, S2}(X, Y)
+if VERSION < v"0.7-"
+    # convenience constructor without type parameter
+    CartesianProduct(X::S1, Y::S2) where {N<:Real, S1<:LazySet{N}, S2<:LazySet{N}} =
+        CartesianProduct{N, S1, S2}(X, Y)
+end
 
 # constructor from an array
 CartesianProduct(Xarr::Vector{S}) where {N<:Real, S<:LazySet{N}} =
@@ -158,9 +160,11 @@ struct CartesianProductArray{N<:Real, S<:LazySet{N}} <: LazySet{N}
     array::Vector{S}
 end
 
-# convenience constructor without type parameter
-CartesianProductArray(arr::Vector{S}) where {S<:LazySet{N}} where {N<:Real} =
-    CartesianProductArray{N, S}(arr)
+if VERSION < v"0.7-"
+    # convenience constructor without type parameter
+    CartesianProductArray(arr::Vector{S}) where {S<:LazySet{N}} where {N<:Real} =
+        CartesianProductArray{N, S}(arr)
+end
 
 # constructor for an empty product with optional size hint and numeric type
 function CartesianProductArray(n::Int=0, N::Type=Float64)::CartesianProductArray

--- a/src/ConvexHull.jl
+++ b/src/ConvexHull.jl
@@ -134,9 +134,11 @@ struct ConvexHullArray{N<:Real, S<:LazySet{N}} <: LazySet{N}
     array::Vector{S}
 end
 
-# convenience constructor without type parameter
-ConvexHullArray(a::Vector{S}) where {S<:LazySet{N}} where {N<:Real} =
-    ConvexHullArray{N, S}(a)
+if VERSION < v"0.7-"
+    # convenience constructor without type parameter
+    ConvexHullArray(a::Vector{S}) where {S<:LazySet{N}} where {N<:Real} =
+        ConvexHullArray{N, S}(a)
+end
 
 # constructor for an empty hull with optional size hint and numeric type
 function ConvexHullArray(n::Int=0, N::Type=Float64)::ConvexHullArray

--- a/src/ConvexHull.jl
+++ b/src/ConvexHull.jl
@@ -43,11 +43,12 @@ struct ConvexHull{N<:Real, S1<:LazySet{N}, S2<:LazySet{N}} <: LazySet{N}
             {N<:Real, S1<:LazySet{N}, S2<:LazySet{N}}
         @assert dim(X) == dim(Y) "sets in a convex hull must have the same " *
             "dimension"
-        return new(X, Y)
+        return new{N, S1, S2}(X, Y)
     end
 end
-# type-less convenience constructor
-ConvexHull(X::S1, Y::S2) where {S1<:LazySet{N}, S2<:LazySet{N}} where {N<:Real} =
+
+# convenience constructor without type parameter
+ConvexHull(X::S1, Y::S2) where {N<:Real, S1<:LazySet{N}, S2<:LazySet{N}} =
     ConvexHull{N, S1, S2}(X, Y)
 
 # EmptySet is the neutral element for ConvexHull
@@ -133,7 +134,7 @@ struct ConvexHullArray{N<:Real, S<:LazySet{N}} <: LazySet{N}
     array::Vector{S}
 end
 
-# type-less convenience constructor
+# convenience constructor without type parameter
 ConvexHullArray(a::Vector{S}) where {S<:LazySet{N}} where {N<:Real} =
     ConvexHullArray{N, S}(a)
 

--- a/src/Ellipsoid.jl
+++ b/src/Ellipsoid.jl
@@ -65,13 +65,14 @@ struct Ellipsoid{N<:AbstractFloat} <: AbstractPointSymmetric{N}
     shape_matrix::AbstractMatrix{N}
 
     # default constructor with dimension check
-    function Ellipsoid{N}(c::AbstractVector{N}, Q::AbstractMatrix{N}) where {N<:AbstractFloat}
+    function Ellipsoid{N}(c::AbstractVector{N},
+                          Q::AbstractMatrix{N}) where {N<:AbstractFloat}
         @assert length(c) == checksquare(Q)
-        return new(c, Q)
+        return new{N}(c, Q)
     end
 end
 
-# type-less convenience constructor
+# convenience constructor without type parameter
 Ellipsoid(c::AbstractVector{N}, Q::AbstractMatrix{N}) where {N<:AbstractFloat} =
     Ellipsoid{N}(c, Q)
 

--- a/src/EmptySet.jl
+++ b/src/EmptySet.jl
@@ -10,7 +10,7 @@ Type that represents the empty set, i.e., the set with no elements.
 """
 struct EmptySet{N<:Real} <: LazySet{N} end
 
-# type-less convenience constructor
+# default constructor of type Float64
 EmptySet() = EmptySet{Float64}()
 
 """

--- a/src/ExponentialMap.jl
+++ b/src/ExponentialMap.jl
@@ -295,10 +295,12 @@ struct ExponentialProjectionMap{N<:Real, S<:LazySet{N}} <: LazySet{N}
     X::S
 end
 
-# convenience constructor without type parameter
-ExponentialProjectionMap(projspmexp::ProjectionSparseMatrixExp, X::S
-                        ) where {S<:LazySet{N}} where {N<:Real} =
-    ExponentialProjectionMap{N, S}(projspmexp, X)
+if VERSION < v"0.7-"
+    # convenience constructor without type parameter
+    ExponentialProjectionMap(projspmexp::ProjectionSparseMatrixExp, X::S
+                            ) where {S<:LazySet{N}} where {N<:Real} =
+        ExponentialProjectionMap{N, S}(projspmexp, X)
+end
 
 """
 ```

--- a/src/ExponentialMap.jl
+++ b/src/ExponentialMap.jl
@@ -158,9 +158,6 @@ struct ExponentialMap{N, S<:LazySet{N}} <: LazySet{N}
     spmexp::SparseMatrixExp{N}
     X::S
 end
-# type-less convenience constructor
-ExponentialMap(spmexp::SparseMatrixExp, X::S) where {S<:LazySet{N}} where {N} =
-    ExponentialMap{N, S}(spmexp, X)
 
 """
 ```
@@ -297,7 +294,8 @@ struct ExponentialProjectionMap{N<:Real, S<:LazySet{N}} <: LazySet{N}
     projspmexp::ProjectionSparseMatrixExp
     X::S
 end
-# type-less convenience constructor
+
+# convenience constructor without type parameter
 ExponentialProjectionMap(projspmexp::ProjectionSparseMatrixExp, X::S
                         ) where {S<:LazySet{N}} where {N<:Real} =
     ExponentialProjectionMap{N, S}(projspmexp, X)

--- a/src/HPolygon.jl
+++ b/src/HPolygon.jl
@@ -27,6 +27,7 @@ Use `addconstraint!` to iteratively add the edges in a sorted way.
 struct HPolygon{N<:Real} <: AbstractHPolygon{N}
     constraints::Vector{LinearConstraint{N}}
 end
+
 # constructor for an HPolygon with no constraints
 HPolygon{N}() where {N<:Real} = HPolygon{N}(Vector{LinearConstraint{N}}(0))
 

--- a/src/HPolygonOpt.jl
+++ b/src/HPolygonOpt.jl
@@ -39,13 +39,15 @@ mutable struct HPolygonOpt{N<:Real} <: AbstractHPolygon{N}
                    ind::Int=1) where {N<:Real} =
         new{N}(constraints, ind)
 end
-# type-less convenience constructor with optional index
+
+# convenience constructor without type parameter
 HPolygonOpt(constraints::Vector{LinearConstraint{N}},
             ind::Int=1) where {N<:Real} =
     HPolygonOpt{N}(constraints, ind)
 
 # constructor for an HPolygon with no constraints
-HPolygonOpt{N}() where {N<:Real} = HPolygonOpt{N}(Vector{LinearConstraint{N}}(0), 1)
+HPolygonOpt{N}() where {N<:Real} =
+    HPolygonOpt{N}(Vector{LinearConstraint{N}}(0))
 
 # constructor for an HPolygon with no constraints of type Float64
 HPolygonOpt() = HPolygonOpt{Float64}()

--- a/src/HPolytope.jl
+++ b/src/HPolytope.jl
@@ -24,16 +24,17 @@ This is a running assumption in this type.
 struct HPolytope{N<:Real} <: AbstractPolytope{N}
     constraints::Vector{LinearConstraint{N}}
 end
-# constructor for a HPolytope with no constraints
+
+# constructor for an HPolytope with no constraints
 HPolytope{N}() where {N<:Real} = HPolytope{N}(Vector{LinearConstraint{N}}(0))
 
-# constructor for a HPolytope with no constraints of type Float64
+# constructor for an HPolytope with no constraints of type Float64
 HPolytope() = HPolytope{Float64}()
 
 # conversion constructor
 HPolytope(S::LazySet) = convert(HPolytope, S)
 
-# constructor for a HPolytope from a simple H-representation
+# constructor for an HPolytope from a simple H-representation
 function HPolytope(A::Matrix{N}, b::Vector{N}) where {N<:Real}
     m = size(A, 1)
     constraints = LinearConstraint{N}[]

--- a/src/Hyperrectangle.jl
+++ b/src/Hyperrectangle.jl
@@ -26,10 +26,11 @@ struct Hyperrectangle{N<:Real} <: AbstractHyperrectangle{N}
         @assert length(center) == length(radius) "length of center and " *
             "radius must be equal"
         @assert all(v -> v >= zero(N), radius) "radius must not be negative"
-        return new(center, radius)
+        return new{N}(center, radius)
     end
 end
-# type-less convenience constructor
+
+# convenience constructor without type parameter
 Hyperrectangle(center::Vector{N}, radius::Vector{N}) where {N<:Real} =
     Hyperrectangle{N}(center, radius)
 

--- a/src/Intersection.jl
+++ b/src/Intersection.jl
@@ -154,9 +154,11 @@ struct IntersectionArray{N<:Real, S<:LazySet{N}} <: LazySet{N}
     array::Vector{S}
 end
 
-# convenience constructor without type parameter
-IntersectionArray(arr::Vector{S}) where {S<:LazySet{N}} where {N<:Real} =
-    IntersectionArray{N, S}(arr)
+if VERSION < v"0.7-"
+    # convenience constructor without type parameter
+    IntersectionArray(arr::Vector{S}) where {S<:LazySet{N}} where {N<:Real} =
+        IntersectionArray{N, S}(arr)
+end
 
 # constructor for an empty sum with optional size hint and numeric type
 function IntersectionArray(n::Int=0, N::Type=Float64)::IntersectionArray

--- a/src/Intersection.jl
+++ b/src/Intersection.jl
@@ -23,11 +23,12 @@ struct Intersection{N<:Real, S1<:LazySet{N}, S2<:LazySet{N}} <: LazySet{N}
             {N<:Real, S1<:LazySet{N}, S2<:LazySet{N}}
         @assert dim(X) == dim(Y) "sets in an intersection must have the same " *
             "dimension"
-        return new(X, Y)
+        return new{N, S1, S2}(X, Y)
     end
 end
-# type-less convenience constructor
-Intersection(X::S1, Y::S2) where {S1<:LazySet{N}, S2<:LazySet{N}} where {N<:Real} =
+
+# convenience constructor without type parameter
+Intersection(X::S1, Y::S2) where {N<:Real, S1<:LazySet{N}, S2<:LazySet{N}} =
     Intersection{N, S1, S2}(X, Y)
 
 # EmptySet is the absorbing element for Intersection
@@ -153,7 +154,7 @@ struct IntersectionArray{N<:Real, S<:LazySet{N}} <: LazySet{N}
     array::Vector{S}
 end
 
-# type-less convenience constructor
+# convenience constructor without type parameter
 IntersectionArray(arr::Vector{S}) where {S<:LazySet{N}} where {N<:Real} =
     IntersectionArray{N, S}(arr)
 

--- a/src/Interval.jl
+++ b/src/Interval.jl
@@ -78,16 +78,32 @@ LazySets.Interval{Rational{Int64},IntervalArithmetic.AbstractInterval{Rational{I
 struct Interval{N<:Real, IN <: AbstractInterval{N}} <: AbstractPointSymmetricPolytope{N}
    dat::IN
 end
-# type-less convenience constructor
-Interval(interval::IN) where {N, IN <: AbstractInterval{N}} = Interval{N, IN}(interval)
 
-# constructor that takes two numbers
-Interval(lo::N, hi::N) where {N} = Interval(IntervalArithmetic.Interval(lo, hi))
+# convenience constructor without type parameter
+Interval(interval::IN) where {N<:Real, IN <: AbstractInterval{N}} =
+    Interval{N, IN}(interval)
 
-Interval(lo::Rational{N}, hi::Rational{N}) where {N} = Interval{Rational{N}, IntervalArithmetic.AbstractInterval{Rational{N}}}(IntervalArithmetic.Interval(lo, hi))
+# constructor from two numbers
+Interval(lo::N, hi::N) where {N<:Real} =
+    Interval(IntervalArithmetic.Interval(lo, hi))
+
+# constructor from two rational numbers
+Interval(lo::N, hi::N) where {N<:Rational} =
+    Interval{N, IntervalArithmetic.AbstractInterval{N}}(
+        IntervalArithmetic.Interval(lo, hi))
 
 # constructor from a vector
-Interval(x::AbstractVector{N}) where {N} = Interval(IntervalArithmetic.Interval(x[1], x[2]))
+function Interval(x::AbstractVector{N}) where {N<:Real}
+    @assert length(x) == 2 "vector for Interval constructor has to be 2D"
+    Interval(IntervalArithmetic.Interval(x[1], x[2]))
+end
+
+# constructor from a rational vector
+function Interval(x::AbstractVector{N}) where {N<:Rational}
+    @assert length(x) == 2 "vector for Interval constructor has to be 2D"
+    Interval{N, IntervalArithmetic.AbstractInterval{N}}(
+        IntervalArithmetic.Interval(x[1], x[2]))
+end
 
 """
     dim(x::Interval)::Int

--- a/src/Interval.jl
+++ b/src/Interval.jl
@@ -79,9 +79,11 @@ struct Interval{N<:Real, IN <: AbstractInterval{N}} <: AbstractPointSymmetricPol
    dat::IN
 end
 
-# convenience constructor without type parameter
-Interval(interval::IN) where {N<:Real, IN <: AbstractInterval{N}} =
-    Interval{N, IN}(interval)
+if VERSION < v"0.7-"
+    # convenience constructor without type parameter
+    Interval(interval::IN) where {N<:Real, IN <: AbstractInterval{N}} =
+        Interval{N, IN}(interval)
+end
 
 # constructor from two numbers
 Interval(lo::N, hi::N) where {N<:Real} =

--- a/src/Line.jl
+++ b/src/Line.jl
@@ -35,7 +35,7 @@ struct Line{N<:Real, V<:AbstractVector{N}} <: LazySet{N}
     end
 end
 
-# type-less convenience constructor
+# convenience constructor without type parameter
 Line(a::V, b::N) where {N<:Real, V<:AbstractVector{N}} = Line{N, V}(a, b)
 
 # constructor from a LinearConstraint

--- a/src/LineSegment.jl
+++ b/src/LineSegment.jl
@@ -58,7 +58,7 @@ struct LineSegment{N<:Real} <: AbstractPointSymmetricPolytope{N}
     end
 end
 
-# type-less convenience constructor
+# convenience constructor without type parameter
 LineSegment(p::AbstractVector{N}, q::AbstractVector{N}) where {N<:Real} =
     LineSegment{N}(p, q)
 

--- a/src/LinearMap.jl
+++ b/src/LinearMap.jl
@@ -31,11 +31,11 @@ struct LinearMap{N<:Real, S<:LazySet{N},
             S<:LazySet{N}, NM, MAT<:AbstractMatrix{NM}}
         @assert dim(X) == size(M, 2) "a linear map of size $(size(M)) cannot " *
             "be applied to a set of dimension $(dim(X))"
-        return new(M, X)
+        return new{N, S, NM, MAT}(M, X)
     end
 end
 
-# type-less convenience constructor
+# convenience constructor without type parameter
 LinearMap(M::MAT,
           X::S) where {N<:Real, S<:LazySet{N}, NM, MAT<:AbstractMatrix{NM}} =
     LinearMap{N, S, NM, MAT}(M, X)

--- a/src/MinkowskiSum.jl
+++ b/src/MinkowskiSum.jl
@@ -135,9 +135,11 @@ struct MinkowskiSumArray{N<:Real, S<:LazySet{N}} <: LazySet{N}
     array::Vector{S}
 end
 
-# convenience constructor without type parameter
-MinkowskiSumArray(arr::Vector{S}) where {S<:LazySet{N}} where {N<:Real} =
-    MinkowskiSumArray{N, S}(arr)
+if VERSION < v"0.7-"
+    # convenience constructor without type parameter
+    MinkowskiSumArray(arr::Vector{S}) where {S<:LazySet{N}} where {N<:Real} =
+        MinkowskiSumArray{N, S}(arr)
+end
 
 # constructor for an empty sum with optional size hint and numeric type
 function MinkowskiSumArray(n::Int=0, N::Type=Float64)::MinkowskiSumArray

--- a/src/MinkowskiSum.jl
+++ b/src/MinkowskiSum.jl
@@ -31,11 +31,12 @@ struct MinkowskiSum{N<:Real, S1<:LazySet{N}, S2<:LazySet{N}} <: LazySet{N}
             {N<:Real, S1<:LazySet{N}, S2<:LazySet{N}}
         @assert dim(X) == dim(Y) "sets in a Minkowski sum must have the " *
             "same dimension"
-        return new(X, Y)
+        return new{N, S1, S2}(X, Y)
     end
 end
-# type-less convenience constructor
-MinkowskiSum(X::S1, Y::S2) where {S1<:LazySet{N}, S2<:LazySet{N}} where {N<:Real} =
+
+# convenience constructor without type parameter
+MinkowskiSum(X::S1, Y::S2) where {N<:Real, S1<:LazySet{N}, S2<:LazySet{N}} =
     MinkowskiSum{N, S1, S2}(X, Y)
 
 # ZeroSet is the neutral element for MinkowskiSum
@@ -134,7 +135,7 @@ struct MinkowskiSumArray{N<:Real, S<:LazySet{N}} <: LazySet{N}
     array::Vector{S}
 end
 
-# type-less convenience constructor
+# convenience constructor without type parameter
 MinkowskiSumArray(arr::Vector{S}) where {S<:LazySet{N}} where {N<:Real} =
     MinkowskiSumArray{N, S}(arr)
 
@@ -277,7 +278,7 @@ struct CacheMinkowskiSum{N<:Real, S<:LazySet{N}} <: LazySet{N}
         new{N, S}(arr, Dict{AbstractVector{N}, CachedPair{N}}())
 end
 
-# type-less convenience constructor
+# convenience constructor without type parameter
 CacheMinkowskiSum(arr::Vector{S}) where {N<:Real, S<:LazySet{N}} =
     CacheMinkowskiSum{N, S}(arr)
 

--- a/src/SymmetricIntervalHull.jl
+++ b/src/SymmetricIntervalHull.jl
@@ -30,13 +30,15 @@ struct SymmetricIntervalHull{N<:Real, S<:LazySet{N}} <: AbstractHyperrectangle{N
     X::S
     cache::Vector{N}
 
-    function SymmetricIntervalHull{N, S}(X::S) where {S<:LazySet{N}} where {N<:Real}
+    # default constructor that initializes cache
+    function SymmetricIntervalHull{N, S}(X::S) where {N<:Real, S<:LazySet{N}}
         cache = fill(-one(N), dim(X))
         return new{N, S}(X, cache)
     end
 end
-# type-less convenience constructor
-SymmetricIntervalHull(X::S) where {S<:LazySet{N}} where {N<:Real} =
+
+# convenience constructor without type parameter
+SymmetricIntervalHull(X::S) where {N<:Real, S<:LazySet{N}} =
     SymmetricIntervalHull{N, S}(X)
 
 """

--- a/src/VPolygon.jl
+++ b/src/VPolygon.jl
@@ -26,9 +26,9 @@ struct VPolygon{N<:Real} <: AbstractPolygon{N}
     vertices::Vector{Vector{N}}
 
     # default constructor that applies a convex hull algorithm
-    function VPolygon(vertices::Vector{Vector{N}};
-                      apply_convex_hull::Bool=true,
-                      algorithm::String="monotone_chain") where {N<:Real}
+    function VPolygon{N}(vertices::Vector{Vector{N}};
+                         apply_convex_hull::Bool=true,
+                         algorithm::String="monotone_chain") where {N<:Real}
         if apply_convex_hull
             return new{N}(convex_hull(vertices, algorithm=algorithm))
         else
@@ -36,6 +36,13 @@ struct VPolygon{N<:Real} <: AbstractPolygon{N}
         end
     end
 end
+
+# convenience constructor without type parameter
+VPolygon(vertices::Vector{Vector{N}};
+         apply_convex_hull::Bool=true,
+         algorithm::String="monotone_chain") where {N<:Real} =
+    VPolygon{N}(vertices; apply_convex_hull=apply_convex_hull,
+                algorithm=algorithm)
 
 
 # --- AbstractPolygon interface functions ---

--- a/src/VPolytope.jl
+++ b/src/VPolytope.jl
@@ -15,6 +15,7 @@ Type that represents a convex polytope in V-representation.
 struct VPolytope{N<:Real} <: AbstractPolytope{N}
     vertices::Vector{Vector{N}}
 end
+
 # constructor for a VPolytope with empty vertices list
 VPolytope{N}() where {N<:Real} = VPolytope{N}(Vector{N}(0))
 

--- a/src/ZeroSet.jl
+++ b/src/ZeroSet.jl
@@ -15,7 +15,8 @@ Type that represents the zero set, i.e., the set that only contains the origin.
 struct ZeroSet{N<:Real} <: AbstractSingleton{N}
     dim::Int
 end
-# type-less convenience constructor
+
+# default constructor of type Float64
 ZeroSet(dim::Int) = ZeroSet{Float64}(dim)
 
 

--- a/src/Zonotope.jl
+++ b/src/Zonotope.jl
@@ -85,9 +85,10 @@ struct Zonotope{N<:Real} <: AbstractPointSymmetricPolytope{N}
     center::AbstractVector{N}
     generators::AbstractMatrix{N}
 end
+
 # constructor from center and list of generators
-Zonotope(center::AbstractVector{N},
-         generators_list::AbstractVector{T}) where {N<:Real, T<:AbstractVector{N}} =
+Zonotope(center::AbstractVector{N}, generators_list::AbstractVector{T}
+        ) where {N<:Real, T<:AbstractVector{N}} =
     Zonotope(center, hcat(generators_list...))
 
 

--- a/src/convex_hull_algorithms.jl
+++ b/src/convex_hull_algorithms.jl
@@ -1,6 +1,6 @@
 """
     convex_hull(points::Vector{S}; [algorithm]::String="monotone_chain"
-               )::Vector{S} where {S<:AbstractVector{N}} where {N<:Real}
+               )::Vector{S} where {N<:Real, S<:AbstractVector{N}}
 
 Compute the convex hull of points in the plane.
 
@@ -41,13 +41,13 @@ julia> plot!(VPolygon(hull), alpha=0.2);
 ```
 """
 function convex_hull(points::Vector{S}; algorithm::String="monotone_chain"
-                    )::Vector{S} where {S<:AbstractVector{N}} where {N<:Real}
+                    )::Vector{S} where {N<:Real, S<:AbstractVector{N}}
     return convex_hull!(copy(points), algorithm=algorithm)
 end
 
 """
     convex_hull!(points::Vector{S}; [algorithm]::String="monotone_chain"
-                )::Vector{S} where {S<:AbstractVector{N}} where {N<:Real}
+                )::Vector{S} where {N<:Real, S<:AbstractVector{N}}
 
 Compute the convex hull of points in the plane, in-place.
 
@@ -70,7 +70,7 @@ See the non-modifying version `convex_hull` for more details.
 """
 function convex_hull!(points::Vector{S};
                       algorithm::String="monotone_chain"
-                     )::Vector{S} where {S<:AbstractVector{N}} where {N<:Real}
+                     )::Vector{S} where {N<:Real, S<:AbstractVector{N}}
     (length(points) == 1 || length(points) == 2) && return points
 
     if algorithm == "monotone_chain"
@@ -114,7 +114,7 @@ end
 
 """
     monotone_chain!(points::Vector{S}; sort::Bool=true
-                   )::Vector{S} where {S<:AbstractVector{N}} where {N<:Real}
+                   )::Vector{S} where {N<:Real, S<:AbstractVector{N}}
 
 Compute the convex hull of points in the plane using Andrew's monotone chain
 method.
@@ -147,7 +147,7 @@ For further details see
 [Monotone chain](https://en.wikibooks.org/wiki/Algorithm_Implementation/Geometry/Convex_hull/Monotone_chain)
 """
 function monotone_chain!(points::Vector{S}; sort::Bool=true
-                        )::Vector{S} where {S<:AbstractVector{N}} where {N<:Real}
+                        )::Vector{S} where {N<:Real, S<:AbstractVector{N}}
 
     @inline function build_hull!(semihull, iterator, points, zero_N)
         @inbounds for i in iterator


### PR DESCRIPTION
Our convenience constructors are sometimes redundant, and in Julia v0.7 they even override the default constructors (see #121). Further reading [here](https://docs.julialang.org/en/latest/manual/constructors/#Parametric-Constructors-1).