### PR TITLE
#187 - Remove RNG from unit tests

### DIFF
--- a/test/unit_ExponentialMap.jl
+++ b/test/unit_ExponentialMap.jl
@@ -7,20 +7,20 @@ for N in [Float64, Float32]
 
     # sparse matrix
     m = spzeros(N, n, n)
-    m[1, 1] = N(0.0439726)
-    m[1, 2] = N(0.206197)
-    m[3, 2] = N(-1.64948)
-    m[4, 2] = N(-1.5343)
-    m[5, 2] = N(-1.22162)
-    m[6, 3] = N(-0.281368)
-    m[2, 4] = N(0.535221)
-    m[5, 4] = N(-0.768595)
-    m[6, 4] = N(-0.499827)
-    m[3, 5] = N(-0.76484)
-    m[2, 6] = N(0.821664)
-    m[3, 6] = N(0.715326)
-    m[4, 6] = N(-0.545632)
-    m[5, 6] = N(0.312998)
+    m[1, 1] = to_N(N, 0.0439726)
+    m[1, 2] = to_N(N, 0.206197)
+    m[3, 2] = to_N(N, -1.64948)
+    m[4, 2] = to_N(N, -1.5343)
+    m[5, 2] = to_N(N, -1.22162)
+    m[6, 3] = to_N(N, -0.281368)
+    m[2, 4] = to_N(N, 0.535221)
+    m[5, 4] = to_N(N, -0.768595)
+    m[6, 4] = to_N(N, -0.499827)
+    m[3, 5] = to_N(N, -0.76484)
+    m[2, 6] = to_N(N, 0.821664)
+    m[3, 6] = to_N(N, 0.715326)
+    m[4, 6] = to_N(N, -0.545632)
+    m[5, 6] = to_N(N, 0.312998)
 
     # a set
     b = BallInf(ones(N, n), N(0.1))
@@ -61,7 +61,8 @@ for N in [Float64, Float32]
     @test dim(emap) == n
 
     # the support vector of an exponential map
-    d = randn(N, n)
+#     d = randn(N, n)
+    d = to_N(N, [2.29681, -0.982841, -0.642168, 0.0167593, 1.32862, -0.855418])
     svec = σ(d, emap)
     # check that it works with sparse vectors
     σ(sparsevec(d), emap)
@@ -106,7 +107,8 @@ for N in [Float64, Float32]
     @test dim(projmap) == nb
 
     #compute the support vector of the projection of an exponential map
-    d = randn(N, nb)
+#     d = randn(N, nb)
+    d = to_N(N, [0.152811, 0.22498])
     svec = σ(d, projmap)
     # check that it works with sparse vectors
     σ(sparsevec(d), projmap)

--- a/test/unit_ZeroSet.jl
+++ b/test/unit_ZeroSet.jl
@@ -30,11 +30,13 @@ for N in [Float64, Rational{Int}, Float32]
     @test ⊆(z, z) && !⊆(z, ZeroSet{N}(2))
 
     # linear map (concrete)
-    M = randn(1, 1)
+#     M = randn(1, 1)
+    M = reshape(to_N(N, [0.217692]), 1, 1)
     Mz = linear_map(M, z)
     @test Mz isa ZeroSet && dim(Mz) == 1
 
-    M = randn(1, 2)
+#     M = randn(1, 2)
+    M = to_N(N, [-1.82273 -1.17261;])
     MZ = linear_map(M, Z)
     @test MZ isa ZeroSet && dim(MZ) == 1
 end


### PR DESCRIPTION
Closes #187.

The only RNG still present is in `unit_Polygon.jl`, but it should be harmless.