### PR TITLE
#121 - Add 'undef's in unit tests

### DIFF
--- a/test/unit_CartesianProduct.jl
+++ b/test/unit_CartesianProduct.jl
@@ -116,7 +116,7 @@ for N in [Float64, Float32, Rational{Int}]
     @test LazySets.is_array_constructor(CartesianProductArray)
 
     # standard constructor
-    v = Vector{LazySet{N}}(0)
+    v = Vector{LazySet{N}}()
     push!(v, Singleton(N[1., 2.]))
     push!(v, Singleton(N[3., 4.]))
     cpa = CartesianProductArray(v)

--- a/test/unit_ConvexHull.jl
+++ b/test/unit_ConvexHull.jl
@@ -51,7 +51,7 @@ for N in [Float64, Rational{Int}, Float32]
     C = ConvexHullArray([Singleton(to_N(N, [1.0, 0.5])), Singleton(to_N(N, [1.1, 0.2])), Singleton(to_N(N, [1.4, 0.3])), Singleton(to_N(N, [1.7, 0.5])), Singleton(to_N(N, [1.4, 0.8]))])
 
     # array getter
-    v = Vector{LazySet{N}}(0)
+    v = Vector{LazySet{N}}()
     @test array(ConvexHullArray(v)) ≡ v
 
     # in-place modification

--- a/test/unit_Intersection.jl
+++ b/test/unit_Intersection.jl
@@ -39,7 +39,7 @@ for N in [Float64, Rational{Int}, Float32]
     @test ∈(ones(N, 2), IA) && !∈(N[5., 5.], IA)
 
     # array getter
-    v = Vector{LazySet{N}}(0)
+    v = Vector{LazySet{N}}()
     @test array(IntersectionArray(v)) ≡ v
 
     # constructor with size hint and type

--- a/test/unit_MinkowskiSum.jl
+++ b/test/unit_MinkowskiSum.jl
@@ -65,7 +65,7 @@ for N in [Float64, Rational{Int}, Float32]
     @test LazySets.is_array_constructor(MinkowskiSumArray)
 
     # array getter
-    v = Vector{LazySet{N}}(0)
+    v = Vector{LazySet{N}}()
     @test array(MinkowskiSumArray(v)) ≡ v
 
     # constructor with size hint and type


### PR DESCRIPTION
See #121.

There were still some `undef` places missing in the unit tests.