### PR TITLE
#121 - Fix dot notation by adding a space

### DIFF
--- a/test/unit_overapproximate.jl
+++ b/test/unit_overapproximate.jl
@@ -16,7 +16,7 @@ for N in [Float64, Float32] # TODO Rational{Int}
     p = tovrep(overapproximate(b, ε))
     for v in vertices_list(p)
     @test norm(v) >= N(1.)
-    @test norm(v) <= N(1.+ε)
+    @test norm(v) <= N(1. + ε)
     end
 
     # Check that there are no redundant constraints for a ballinf

--- a/test/unit_template_directions.jl
+++ b/test/unit_template_directions.jl
@@ -19,7 +19,7 @@ for N in [Float64, Float32, Rational{Int}]
     # template direction approximation
     for n in 1:3
         B = BallInf(zeros(N, n), N(2.))
-        A = 2.*eye(N, n) + ones(N, n, n)
+        A = N(2.) * eye(N, n) + ones(N, n, n)
         X = A * B
 
         # box directions


### PR DESCRIPTION
See #121.

This fixes the same problem as in #499, only for other operators.