### PR TITLE
More efficient alternative Hyperrectangle constructor for v0.7

### DIFF
--- a/docs/src/lib/representations.md
+++ b/docs/src/lib/representations.md
@@ -168,7 +168,6 @@ Inherited from [`LazySet`](@ref):
 
 ```@docs
 Hyperrectangle
-Hyperrectangle(;kwargs...)
 center(::Hyperrectangle)
 radius_hyperrectangle(::Hyperrectangle)
 radius_hyperrectangle(::Hyperrectangle, ::Int)

--- a/test/unit_Hyperrectangle.jl
+++ b/test/unit_Hyperrectangle.jl
@@ -68,22 +68,18 @@ for N in [Float64, Rational{Int}, Float32]
     # diameter
     @test diameter(h) == norm(N[5., 3.] - N[1., 1.], Inf)
 
-    # alternative constructors
+    # alternative constructor
     c = ones(N, 2)
     r = to_N(N, [0.1, 0.2])
     l = to_N(N, [0.9, 0.8])
     h = to_N(N, [1.1, 1.2])
     H1 = Hyperrectangle(c, r)
-    H2 = Hyperrectangle(center=c, radius=r)
-    H3 = Hyperrectangle(low=l, high=h)
-    @test H1.center == H2.center
-    @test H2.center ≈ H3.center
-    @test H1.radius == H2.radius
-    @test H2.radius ≈ H3.radius
-    @test_throws ArgumentError Hyperrectangle(xyz="zyx")
+    H2 = Hyperrectangle(low=l, high=h)
+    @test H1.center ≈ H2.center
+    @test H1.radius ≈ H2.radius
 
     # Test low and high methods for a hyperrectangle
-    H = Hyperrectangle(center=to_N(N, [-2.1, 5.6, 0.9]), radius=fill(to_N(N, 0.5), 3))
+    H = Hyperrectangle(to_N(N, [-2.1, 5.6, 0.9]), fill(to_N(N, 0.5), 3))
     @test low(H) ≈ to_N(N, [-2.6, 5.1, 0.4])
     @test high(H) ≈ to_N(N, [-1.6, 6.1, 1.4])
 


### PR DESCRIPTION
This is a proposal to remove one of the keyword argument constructors for `Hyperrectangle` to make the other one more efficient in Julia v0.7. We do not need the removed constructor because it just imitates the default constructor in an inefficient way.

Old version in v0.6:
```julia
julia> @time Hyperrectangle(high=[1.], low=[1.])
  0.000283 seconds (72 allocations: 3.703 KiB)
LazySets.Hyperrectangle{Float64}([1.0], [0.0])
```
New version in v0.7:
```julia
julia> @time Hyperrectangle(high=[1.], low=[1.])
  0.000022 seconds (15 allocations: 848 bytes)
Hyperrectangle{Float64}([1.0], [0.0])
```