### PR TITLE
#121 - Add type parameters to 'zeros' function

### DIFF
--- a/src/HPolytope.jl
+++ b/src/HPolytope.jl
@@ -88,8 +88,8 @@ function σ(d::AbstractVector{N}, P::HPolytope{N}) where {N<:Real}
     c = -d
     n = length(constraints_list(P))
     @assert n > 0 "the polytope has no constraints"
-    A = zeros(n, dim(P))
-    b = zeros(n)
+    A = zeros(N, n, dim(P))
+    b = zeros(N, n)
     for (i, Pi) in enumerate(constraints_list(P))
         A[i, :] = Pi.a
         b[i] = Pi.b

--- a/src/ZeroSet.jl
+++ b/src/ZeroSet.jl
@@ -94,7 +94,8 @@ The returned value is the origin since it is the only point that belongs to this
 set.
 """
 function σ(d::AbstractVector{N}, Z::ZeroSet{N}) where {N<:Real}
-    return zeros(d)
+    @assert length(d) == dim(Z) "the direction has the wrong dimension"
+    return element(Z)
 end
 
 """


### PR DESCRIPTION
See #121.

The first commit fixes a deprecation warning.
The second commit adds type parameters where they were missing.