### PR TITLE
#121 - Use keyword argument form of 'sum'

### DIFF
--- a/src/Zonotope.jl
+++ b/src/Zonotope.jl
@@ -374,7 +374,7 @@ function reduce_order(Z::Zonotope{N}, r)::Zonotope{N} where {N<:Real}
     rg = G[:, ind[1:m]] # reduced generators
 
     # interval hull computation of reduced generators
-    Gbox = diagm(sum(abs.(rg), 2)[:])
+    Gbox = diagm(Compat.sum(abs.(rg), dims=2)[:])
     if m < p
         Gnotred = G[:, ind[m+1:end]]
         Gred = [Gnotred Gbox]


### PR DESCRIPTION
See #121.

Unfortunately, `using Compat: sum` leads to errors. There are several methods of `sum`, and we use at least two of them. It seems that `Compat` fixes one of them but does not support the other.