### PR TITLE
#121 - Replace 'IterTools.product' -> 'Iterators.product'

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,4 @@
 julia 0.6
-IterTools 0.2.1
 RecipesBase 0.3.1
 Plots 0.17.4
 GR 0.31.0

--- a/src/AbstractHyperrectangle.jl
+++ b/src/AbstractHyperrectangle.jl
@@ -52,7 +52,7 @@ For high dimensions, it is preferable to develop a `vertex_iterator` approach.
 function vertices_list(H::AbstractHyperrectangle{N}
                       )::Vector{Vector{N}} where {N<:Real}
     return [center(H) .+ si .* radius_hyperrectangle(H)
-        for si in IterTools.product([[1, -1] for i = 1:dim(H)]...)]
+        for si in Iterators.product([[1, -1] for i = 1:dim(H)]...)][:]
 end
 
 

--- a/src/LazySets.jl
+++ b/src/LazySets.jl
@@ -5,7 +5,7 @@ module LazySets
 
 include("compat.jl")
 
-using RecipesBase, IterTools, Requires
+using RecipesBase, Requires
 
 export Approximations
 

--- a/src/Zonotope.jl
+++ b/src/Zonotope.jl
@@ -141,7 +141,7 @@ function vertices_list(Z::Zonotope{N})::Vector{Vector{N}} where {N<:Real}
     vlist = Vector{Vector{N}}()
     sizehint!(vlist, 2^p)
 
-    for ξi in IterTools.product([[1, -1] for i = 1:p]...)
+    for ξi in Iterators.product([[1, -1] for i = 1:p]...)
         push!(vlist, Z.center .+ Z.generators * collect(ξi))
     end
 


### PR DESCRIPTION
See #121.

In v0.7 we could drop the dependency on `IterTools.jl`, but for now we still have it for v0.6.