### PR TITLE
#121 - Replace 'start/next/done' iterators -> 'iterate'

### DIFF
--- a/src/Approximations/template_directions.jl
+++ b/src/Approximations/template_directions.jl
@@ -72,12 +72,32 @@ end
 BoxDirections(n::Int) = BoxDirections{Float64}(n)
 
 Base.eltype(::Type{BoxDirections{N}}) where N = AbstractVector{N}
+Base.length(bd::BoxDirections) = 2 * bd.n
+
+if VERSION < v"0.7-"
+@eval begin
+
 Base.start(bd::BoxDirections) = 1
 Base.next(bd::BoxDirections{N}, state) where N = (
     UnitVector{N}(abs(state), bd.n, convert(N, sign(state))), # value
     state == bd.n ? -bd.n : state + 1) # next state
 Base.done(bd::BoxDirections, state) = state == 0
-Base.length(bd::BoxDirections) = 2 * bd.n
+
+end # @eval
+else
+@eval begin
+
+function Base.iterate(bd::BoxDirections{N}, state::Int=1) where N
+    if state == 0
+        return nothing
+    end
+    vec = UnitVector{N}(abs(state), bd.n, convert(N, sign(state)))
+    state = (state == bd.n) ? -bd.n : state + 1
+    return (vec, state)
+end
+
+end # @eval
+end # if
 
 # octagon directions
 
@@ -103,6 +123,11 @@ end
 OctDirections(n::Int) = OctDirections{Float64}(n)
 
 Base.eltype(::Type{OctDirections{N}}) where N = AbstractVector{N}
+Base.length(od::OctDirections) = 2 * od.n^2
+
+if VERSION < v"0.7-"
+@eval begin
+
 function Base.start(od::OctDirections{N}) where N
     if od.n == 1
         return 1 # fall back to box directions in 1D case
@@ -112,6 +137,7 @@ function Base.start(od::OctDirections{N}) where N
     vec[2] = vec[1]
     return (vec, 1, 2)
 end
+
 function Base.next(od::OctDirections{N}, state::Tuple) where N
     vec = state[1]
     i = state[2]
@@ -145,10 +171,73 @@ function Base.next(od::OctDirections{N}, state::Tuple) where N
     end
     return (copy(vec), (vec, i, j))
 end
+
 Base.next(od::OctDirections{N}, state::Int) where N =
     next(BoxDirections{N}(od.n), state)
+
 Base.done(od::OctDirections, state) = state == 0
-Base.length(od::OctDirections) = 2 * od.n^2
+
+end # @eval
+else
+@eval begin
+
+function Base.iterate(od::OctDirections{N}) where N
+    if od.n == 1
+        # fall back to box directions in 1D case
+        return iterate(od, 1)
+    end
+    vec = spzeros(N, od.n)
+    vec[1] = one(N)
+    vec[2] = one(N)
+    return (copy(vec), (vec, 1, 2))
+end
+
+# basic idea: modify the vector from the previous iteration
+# have two indices i = 1, j = i + 1
+# - run j through all indices > i
+# - i = i + 1, j = i + 1
+# - for any pair (i, j) create four vectors [..., i: ±1, ..., j: ±1, ...]
+# in the end continue with box directions
+function Base.iterate(od::OctDirections{N}, state::Tuple) where N
+    # continue with octagon directions
+    vec = state[1]
+    i = state[2]
+    j = state[3]
+    if vec[j] > 0
+        # change sign at j
+        vec[j] = -one(N)
+    elseif vec[i] > 0
+        # change sign at i and j
+        vec[i] = -one(N)
+        vec[j] = one(N)
+    elseif j < od.n
+        # advance j, reset i
+        vec[i] = one(N)
+        vec[j] = zero(N)
+        j = j + 1
+        vec[j] = one(N)
+    elseif i < od.n - 1
+        # advance i
+        vec[i] = zero(N)
+        vec[j] = zero(N)
+        i = i + 1
+        j = i + 1
+        vec[i] = one(N)
+        vec[j] = one(N)
+    else
+        # continue with box directions
+        return iterate(od, 1)
+    end
+    return (copy(vec), (vec, i, j))
+end
+
+function Base.iterate(od::OctDirections{N}, state::Int) where N
+    # continue with box directions
+    return iterate(BoxDirections{N}(od.n), state)
+end
+
+end # @eval
+end # if
 
 # box-diagonal directions
 
@@ -176,7 +265,13 @@ end
 BoxDiagDirections(n::Int) = BoxDiagDirections{Float64}(n)
 
 Base.eltype(::Type{BoxDiagDirections{N}}) where N = AbstractVector{N}
+Base.length(bdd::BoxDiagDirections) = bdd.n == 1 ? 2 : 2^bdd.n + 2 * bdd.n
+
+if VERSION < v"0.7-"
+@eval begin
+
 Base.start(bdd::BoxDiagDirections{N}) where N = ones(N, bdd.n)
+
 function Base.next(bdd::BoxDiagDirections{N}, state::AbstractVector) where N
     i = 1
     while i <= bdd.n && state[i] < 0
@@ -194,7 +289,43 @@ function Base.next(bdd::BoxDiagDirections{N}, state::AbstractVector) where N
         return (copy(state), state)
     end
 end
+
 Base.next(bdd::BoxDiagDirections{N}, state::Int) where N =
     next(BoxDirections{N}(bdd.n), state)
 Base.done(bdd::BoxDiagDirections, state) = state == 0
-Base.length(bdd::BoxDiagDirections) = bdd.n == 1 ? 2 : 2^bdd.n + 2 * bdd.n
+
+end # @eval
+else
+@eval begin
+
+Base.iterate(bdd::BoxDiagDirections{N}) where N =
+    (ones(N, bdd.n), ones(N, bdd.n))
+
+function Base.iterate(bdd::BoxDiagDirections{N}, state::AbstractVector) where N
+    # continue with diagonal directions
+    i = 1
+    while i <= bdd.n && state[i] < 0
+        state[i] = -state[i]
+        i = i+1
+    end
+    if i > bdd.n
+        if bdd.n == 1
+            # finish here to avoid duplicates
+            return nothing
+        else
+            # continue with box directions
+            return iterate(bdd, 1)
+        end
+    else
+        state[i] = -state[i]
+        return (copy(state), state)
+    end
+end
+
+function Base.iterate(bdd::BoxDiagDirections{N}, state::Int) where N
+    # continue with box directions
+    return iterate(BoxDirections{N}(bdd.n), state)
+end
+
+end # @eval
+end # if


### PR DESCRIPTION
See #121.

Unfortunately, v0.7 deprecates the 'start/next/done' iterators, so now we have to support both versions.