### PR TITLE
Fix some problems with docs for v0.7

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -2,7 +2,14 @@
 
 ```@meta
 DocTestFilters = [r"[0-9\.]+ seconds \(.*\)"]
+CurrentModule = LazySets
+DocTestSetup = quote
+    using LazySets
+    using Compat.SparseArrays, Compat.LinearAlgebra
+end
 ```
+
+
 
 `LazySets` is a [Julia](http://julialang.org) package for calculus with convex
 sets.
@@ -68,8 +75,6 @@ Finally, let δ = 0.1.
 Using `LazySets`, we can define this problem as follows:
 
 ```jldoctest index_label
-julia> using LazySets;
-
 julia> A = sprandn(1000, 1000, 0.01);
 
 julia> δ = 0.1;

--- a/docs/src/lib/interfaces.md
+++ b/docs/src/lib/interfaces.md
@@ -27,6 +27,7 @@ Depth = 4
 CurrentModule = LazySets
 DocTestSetup = quote
     using LazySets
+    using Compat.InteractiveUtils: subtypes
 end
 ```
 

--- a/docs/src/lib/operations.md
+++ b/docs/src/lib/operations.md
@@ -212,6 +212,7 @@ Inherited from [`LazySet`](@ref):
 ```@docs
 SparseMatrixExp
 *(::SparseMatrixExp, ::LazySet)
+get_row(::SparseMatrixExp, ::Int)
 ```
 
 ```@docs

--- a/docs/src/lib/operations.md
+++ b/docs/src/lib/operations.md
@@ -12,6 +12,7 @@ Depth = 3
 CurrentModule = LazySets
 DocTestSetup = quote
     using LazySets
+    using Compat.SparseArrays, Compat.LinearAlgebra
 end
 ```
 

--- a/docs/src/lib/representations.md
+++ b/docs/src/lib/representations.md
@@ -11,6 +11,7 @@ Depth = 3
 CurrentModule = LazySets
 DocTestSetup = quote
     using LazySets
+    using Compat.SparseArrays, Compat.LinearAlgebra
 end
 ```
 

--- a/docs/src/lib/utils.md
+++ b/docs/src/lib/utils.md
@@ -22,7 +22,6 @@ sign_cadlag
 @neutral_absorbing
 @array_neutral
 @array_absorbing
-
 get_radius!
 an_element_helper
 σ_helper

--- a/docs/src/man/reach_zonotopes.md
+++ b/docs/src/man/reach_zonotopes.md
@@ -38,21 +38,21 @@ function Algorithm1(A, X0, δ, μ, T)
 
     # bloating factors
     Anorm = norm(A, Inf)
-    α = (expm(δ*Anorm) - 1 - δ*Anorm)/norm(X0, Inf)
-    β = (expm(δ*Anorm) - 1)*μ/Anorm
+    α = (expm(δ * Anorm) - 1 - δ * Anorm) / norm(X0, Inf)
+    β = (expm(δ * Anorm) - 1) * μ / Anorm
 
     # discretized system
     n = size(A, 1)
-    ϕ = expm(δ*A)
-    N = floor(Int, T/δ)
+    ϕ = expm(δ * A)
+    N = floor(Int, T / δ)
 
     # preallocate arrays
     Q = Vector{LazySet}(N)
     R = Vector{LazySet}(N)
 
     # initial reach set in the time interval [0, δ]
-    ϕp = (I+ϕ)/2
-    ϕm = (I-ϕ)/2
+    ϕp = (I+ϕ) / 2
+    ϕm = (I-ϕ) / 2
     c = X0.center
     Q1_generators = hcat(ϕp * X0.generators, ϕm * c, ϕm * X0.generators)
     Q[1] = Zonotope(ϕp * c, Q1_generators) ⊕ BallInf(zeros(n), α + β)
@@ -82,12 +82,12 @@ end
 
 ```@example example_reach_zonotopes
 A = [-1 -4; 4 -1]
-X0 = Zonotope([1.0, 0.0], 0.1*eye(2))
+X0 = Zonotope([1.0, 0.0], 0.1 * eye(2))
 μ = 0.05
 δ = 0.02
 T = 2.
 
-R = Algorithm1(A, X0, δ, μ, 2.*δ); # warm-up
+R = Algorithm1(A, X0, δ, μ, 2 * δ); # warm-up
 
 R = Algorithm1(A, X0, δ, μ, T)
 
@@ -103,12 +103,12 @@ A = Matrix{Float64}([-1 -4 0 0 0;
                       0 0 -3 1 0;
                       0 0 -1 -3 0;
                       0 0 0 0 -2])
-X0 = Zonotope([1.0, 0.0, 0.0, 0.0, 0.0], 0.1*eye(5))
+X0 = Zonotope([1.0, 0.0, 0.0, 0.0, 0.0], 0.1 * eye(5))
 μ = 0.01
 δ = 0.005
 T = 1.
 
-R = Algorithm1(A, X0, δ, μ, 2*δ); # warm-up
+R = Algorithm1(A, X0, δ, μ, 2 * δ); # warm-up
 
 R = Algorithm1(A, X0, δ, μ, T)
 Rproj = project(R, [1, 3], 5)

--- a/src/Ellipsoid.jl
+++ b/src/Ellipsoid.jl
@@ -29,7 +29,7 @@ For instance, a 3D ellipsoid with center at the origin and the shape matrix bein
 the identity can be created with:
 
 ```jldoctest ellipsoid_constructor
-julia> E = Ellipsoid(eye(3))
+julia> E = Ellipsoid(Matrix{Float64}(I, 3, 3))
 LazySets.Ellipsoid{Float64}([0.0, 0.0, 0.0], [1.0 0.0 0.0; 0.0 1.0 0.0; 0.0 0.0 1.0])
 
 julia> dim(E)

--- a/src/ExponentialMap.jl
+++ b/src/ExponentialMap.jl
@@ -267,6 +267,8 @@ This follows from ``\\exp(-M)⋅\\exp(M) = I`` for any ``M``.
 ### Examples
 
 ```jldoctest
+julia> using Compat.SparseArrays: SparseMatrixCSC;
+
 julia> em = ExponentialMap(SparseMatrixExp(SparseMatrixCSC([2.0 0.0; 0.0 1.0])),
                            BallInf([1., 1.], 1.));
 

--- a/src/ExponentialMap.jl
+++ b/src/ExponentialMap.jl
@@ -158,7 +158,7 @@ Type that represents the action of an exponential map on a convex set.
 The `ExponentialMap` type is overloaded to the usual times `*` operator when the
 linear map is a lazy matrix exponential. For instance,
 
-```jldoctest ExponentialMap_constructor
+```jldoctest
 julia> A = sprandn(100, 100, 0.1);
 
 julia> E = SparseMatrixExp(A);

--- a/src/HPolytope.jl
+++ b/src/HPolytope.jl
@@ -346,7 +346,7 @@ List of vertices.
 ```jldoctest
 julia> using Polyhedra
 
-julia> P = HPolytope(vcat(eye(2), -eye(2)), fill(1., 4));
+julia> P = HPolytope([1.0 0.0; 0.0 1.0; 1.0 0.0; 0.0 1.0], fill(1., 4));
 
 julia> constraints_list(P)
 4-element Array{LazySets.HalfSpace{Float64},1}:

--- a/src/Zonotope.jl
+++ b/src/Zonotope.jl
@@ -44,7 +44,7 @@ ball in ``\\mathbb{R}^n`` by an affine transformation.
 A two-dimensional zonotope with given center and set of generators:
 
 ```jldoctest zonotope_label
-julia> Z = Zonotope([1.0, 0.0], 0.1*eye(2))
+julia> Z = Zonotope([1.0, 0.0], [0.1 0.0; 0.0 0.1])
 LazySets.Zonotope{Float64}([1.0, 0.0], [0.1 0.0; 0.0 0.1])
 julia> dim(Z)
 2
@@ -192,7 +192,7 @@ Check whether a given point is contained in a zonotope.
 ### Examples
 
 ```jldoctest
-julia> Z = Zonotope([1.0, 0.0], 0.1*eye(2));
+julia> Z = Zonotope([1.0, 0.0], [0.1 0.0; 0.0 0.1]);
 
 julia> ∈([1.0, 0.2], Z)
 false


### PR DESCRIPTION
Fix some `Documenter` warnings for v0.7.
The remaining fails are due to #544 and #547.