### PR TITLE
Add v0.6.0 build for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: julia
 os:
   - linux
 julia:
+  - 0.6.0
   - 0.6
   - 0.7
   - nightly


### PR DESCRIPTION
I realized that if our `REQUIRE` file says `julia 0.6`, we should actually test if the package runs in `v0.6.0` :face_with_head_bandage: