### PR TITLE
#529 - Use @static for Julia version switches

### DIFF
--- a/src/Approximations/template_directions.jl
+++ b/src/Approximations/template_directions.jl
@@ -74,7 +74,7 @@ BoxDirections(n::Int) = BoxDirections{Float64}(n)
 Base.eltype(::Type{BoxDirections{N}}) where N = AbstractVector{N}
 Base.length(bd::BoxDirections) = 2 * bd.n
 
-if VERSION < v"0.7-"
+@static if VERSION < v"0.7-"
 @eval begin
 
 Base.start(bd::BoxDirections) = 1
@@ -125,7 +125,7 @@ OctDirections(n::Int) = OctDirections{Float64}(n)
 Base.eltype(::Type{OctDirections{N}}) where N = AbstractVector{N}
 Base.length(od::OctDirections) = 2 * od.n^2
 
-if VERSION < v"0.7-"
+@static if VERSION < v"0.7-"
 @eval begin
 
 function Base.start(od::OctDirections{N}) where N
@@ -267,7 +267,7 @@ BoxDiagDirections(n::Int) = BoxDiagDirections{Float64}(n)
 Base.eltype(::Type{BoxDiagDirections{N}}) where N = AbstractVector{N}
 Base.length(bdd::BoxDiagDirections) = bdd.n == 1 ? 2 : 2^bdd.n + 2 * bdd.n
 
-if VERSION < v"0.7-"
+@static if VERSION < v"0.7-"
 @eval begin
 
 Base.start(bdd::BoxDiagDirections{N}) where N = ones(N, bdd.n)

--- a/src/CartesianProduct.jl
+++ b/src/CartesianProduct.jl
@@ -36,7 +36,7 @@ struct CartesianProduct{N<:Real, S1<:LazySet{N}, S2<:LazySet{N}} <: LazySet{N}
     Y::S2
 end
 
-if VERSION < v"0.7-"
+@static if VERSION < v"0.7-"
     # convenience constructor without type parameter
     CartesianProduct(X::S1, Y::S2) where {N<:Real, S1<:LazySet{N}, S2<:LazySet{N}} =
         CartesianProduct{N, S1, S2}(X, Y)
@@ -160,7 +160,7 @@ struct CartesianProductArray{N<:Real, S<:LazySet{N}} <: LazySet{N}
     array::Vector{S}
 end
 
-if VERSION < v"0.7-"
+@static if VERSION < v"0.7-"
     # convenience constructor without type parameter
     CartesianProductArray(arr::Vector{S}) where {S<:LazySet{N}} where {N<:Real} =
         CartesianProductArray{N, S}(arr)

--- a/src/ConvexHull.jl
+++ b/src/ConvexHull.jl
@@ -134,7 +134,7 @@ struct ConvexHullArray{N<:Real, S<:LazySet{N}} <: LazySet{N}
     array::Vector{S}
 end
 
-if VERSION < v"0.7-"
+@static if VERSION < v"0.7-"
     # convenience constructor without type parameter
     ConvexHullArray(a::Vector{S}) where {S<:LazySet{N}} where {N<:Real} =
         ConvexHullArray{N, S}(a)

--- a/src/ExponentialMap.jl
+++ b/src/ExponentialMap.jl
@@ -317,7 +317,7 @@ struct ExponentialProjectionMap{N<:Real, S<:LazySet{N}} <: LazySet{N}
     X::S
 end
 
-if VERSION < v"0.7-"
+@static if VERSION < v"0.7-"
     # convenience constructor without type parameter
     ExponentialProjectionMap(projspmexp::ProjectionSparseMatrixExp, X::S
                             ) where {S<:LazySet{N}} where {N<:Real} =

--- a/src/Hyperrectangle.jl
+++ b/src/Hyperrectangle.jl
@@ -56,7 +56,7 @@ Hyperrectangle(center::Vector{N}, radius::Vector{N}) where {N<:Real} =
     Hyperrectangle{N}(center, radius)
 
 # constructor from keyword arguments (lower and upper bounds)
-if VERSION < v"0.7-"
+@static if VERSION < v"0.7-"
 @eval begin
 
 function Hyperrectangle(;kwargs...)

--- a/src/Intersection.jl
+++ b/src/Intersection.jl
@@ -154,7 +154,7 @@ struct IntersectionArray{N<:Real, S<:LazySet{N}} <: LazySet{N}
     array::Vector{S}
 end
 
-if VERSION < v"0.7-"
+@static if VERSION < v"0.7-"
     # convenience constructor without type parameter
     IntersectionArray(arr::Vector{S}) where {S<:LazySet{N}} where {N<:Real} =
         IntersectionArray{N, S}(arr)

--- a/src/Interval.jl
+++ b/src/Interval.jl
@@ -77,7 +77,7 @@ struct Interval{N<:Real, IN <: AbstractInterval{N}} <: AbstractPointSymmetricPol
    dat::IN
 end
 
-if VERSION < v"0.7-"
+@static if VERSION < v"0.7-"
     # convenience constructor without type parameter
     Interval(interval::IN) where {N<:Real, IN <: AbstractInterval{N}} =
         Interval{N, IN}(interval)

--- a/src/MinkowskiSum.jl
+++ b/src/MinkowskiSum.jl
@@ -135,7 +135,7 @@ struct MinkowskiSumArray{N<:Real, S<:LazySet{N}} <: LazySet{N}
     array::Vector{S}
 end
 
-if VERSION < v"0.7-"
+@static if VERSION < v"0.7-"
     # convenience constructor without type parameter
     MinkowskiSumArray(arr::Vector{S}) where {S<:LazySet{N}} where {N<:Real} =
         MinkowskiSumArray{N, S}(arr)

--- a/src/compat.jl
+++ b/src/compat.jl
@@ -12,7 +12,7 @@ import Compat.LinearAlgebra: norm, checksquare, LAPACKException,
 import Compat.InteractiveUtils.subtypes
 export _At_mul_B
 
-if VERSION < v"0.7-"
+@static if VERSION < v"0.7-"
     @inline function _At_mul_B(A, B)
         return At_mul_B(A, B)
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -99,7 +99,7 @@ if test_suite_doctests
     if isdefined(@__MODULE__, :Polyhedra)
         println("skipping doctests due to a clash with Polyhedra")
     else
-        if VERSION < v"0.7-"
+        @static if VERSION < v"0.7-"
             Pkg.add("Documenter")
             Pkg.pin("Documenter", v"0.18.0")
         end

--- a/test/unit_Hyperrectangle.jl
+++ b/test/unit_Hyperrectangle.jl
@@ -77,7 +77,7 @@ for N in [Float64, Rational{Int}, Float32]
     H2 = Hyperrectangle(low=l, high=h)
     @test H1.center ≈ H2.center
     @test H1.radius ≈ H2.radius
-    if VERSION < v"0.7-"
+    @static if VERSION < v"0.7-"
         @test_throws ArgumentError Hyperrectangle(xyz="zyx")
     end
 


### PR DESCRIPTION
Closes #529.

#562 also adds one more `VERSION` check without `@static`, so after merging that PR we should rebase here and fix that one place, too.
EDIT: done