### PR TITLE
#534 - Remove redundant 'to_N(N, ...)' from unit tests

### DIFF
--- a/test/unit_Ball1.jl
+++ b/test/unit_Ball1.jl
@@ -1,71 +1,71 @@
 for N in [Float64, Rational{Int}, Float32]
     # 1D Ball1
-    b = Ball1(N[0.], N(1.))
+    b = Ball1(N[0], N(1))
     # dimension
     @test dim(b) == 1
     # support vector
-    d = N[1.]
-    @test σ(d, b) == N[1.]
-    d = N[-1.]
-    @test σ(d, b) == N[-1.]
+    d = N[1]
+    @test σ(d, b) == N[1]
+    d = N[-1]
+    @test σ(d, b) == N[-1]
 
     # 2D Ball1
-    b = Ball1(N[0., 0.], N(1.))
+    b = Ball1(N[0, 0], N(1))
     # dimension
     @test dim(b) == 2
     # support vector
-    d = N[1., 0.]
-    @test σ(d, b) == N[1., 0.]
-    d = N[-1., 0.]
-    @test σ(d, b) == N[-1., 0.]
-    d = N[0., 1.]
-    @test σ(d, b) == N[0., 1.]
-    d = N[0., -1.]
-    @test σ(d, b) == N[0., -1.]
-    d = N[0., 0.]
-    @test σ(d, b) == N[0., 0.]
+    d = N[1, 0]
+    @test σ(d, b) == N[1, 0]
+    d = N[-1, 0]
+    @test σ(d, b) == N[-1, 0]
+    d = N[0, 1]
+    @test σ(d, b) == N[0, 1]
+    d = N[0, -1]
+    @test σ(d, b) == N[0, -1]
+    d = N[0, 0]
+    @test σ(d, b) == N[0, 0]
 
     # 2D Ball1 not 0-centered
-    b = Ball1(N[1., 2.], N(1.))
+    b = Ball1(N[1, 2], N(1))
     # dimension
     @test dim(b) == 2
     # support vector
-    d = N[1., 0.]
-    @test σ(d, b) == N[2., 2.]
-    d = N[-1., 0.]
-    @test σ(d, b) == N[0., 2.]
-    d = N[0., 1.]
-    @test σ(d, b) == N[1., 3.]
-    d = N[0., -1.]
-    @test σ(d, b) == N[1., 1.]
+    d = N[1, 0]
+    @test σ(d, b) == N[2, 2]
+    d = N[-1, 0]
+    @test σ(d, b) == N[0, 2]
+    d = N[0, 1]
+    @test σ(d, b) == N[1, 3]
+    d = N[0, -1]
+    @test σ(d, b) == N[1, 1]
 
     # 2D Ball1 radius != 1
-    b = Ball1(N[0., 0.], N(2.))
+    b = Ball1(N[0, 0], N(2))
     # dimension
     @test dim(b) == 2
     # support vector
-    d = N[1., 0.]
-    @test σ(d, b) == N[2., 0.]
-    d = N[-1., 0.]
-    @test σ(d, b) == N[-2., 0.]
-    d = N[0., 1.]
-    @test σ(d, b) == N[0., 2.]
-    d = N[0., -1.]
-    @test σ(d, b) == N[0., -2.]
+    d = N[1, 0]
+    @test σ(d, b) == N[2, 0]
+    d = N[-1, 0]
+    @test σ(d, b) == N[-2, 0]
+    d = N[0, 1]
+    @test σ(d, b) == N[0, 2]
+    d = N[0, -1]
+    @test σ(d, b) == N[0, -2]
 
     # center
-    @test center(b) == N[0., 0.]
+    @test center(b) == N[0, 0]
 
     # an_element & membership function
     @test an_element(b) ∈ b
 
     # vertices_list
     vl = vertices_list(b)
-    @test length(vl) == 4 && N[2., 0.] ∈ vl && N[0., 2.] ∈ vl &&
-          N[-2., 0.] ∈ vl && N[0., -2.] ∈ vl
+    @test length(vl) == 4 && N[2, 0] ∈ vl && N[0, 2] ∈ vl &&
+          N[-2, 0] ∈ vl && N[0, -2] ∈ vl
 
     # check that vertices_list for zero radius doesn't repeat vertices
-    b = Ball1(N[1., 2.], N(0.0))
+    b = Ball1(N[1, 2], N(0))
     vl = vertices_list(b)
     @test length(vl) == 1 && vl[1] == b.center
 end

--- a/test/unit_Ball2.jl
+++ b/test/unit_Ball2.jl
@@ -1,84 +1,84 @@
 for N in [Float64, Float32]
     # 1D Ball2
-    b = Ball2(N[0.], N(1.))
+    b = Ball2(N[0], N(1))
     # Test Dimension
     @test dim(b) == 1
     # Test Support Vector
-    d = N[1.]
-    @test σ(d, b) == N[1.]
-    d = N[-1.]
-    @test σ(d, b) == N[-1.]
+    d = N[1]
+    @test σ(d, b) == N[1]
+    d = N[-1]
+    @test σ(d, b) == N[-1]
 
     # 2D Ball2
-    b = Ball2(N[0., 0.], N(1.))
+    b = Ball2(N[0, 0], N(1))
     # Test Dimension
     @test dim(b) == 2
     # Test Support Vector
-    d = N[1., 0.]
-    @test σ(d, b) == N[1., 0.]
-    d = N[-1., 0.]
-    @test σ(d, b) == N[-1., 0.]
-    d = N[0., 1.]
-    @test σ(d, b) == N[0., 1.]
-    d = N[0., -1.]
-    @test σ(d, b) == N[0., -1.]
-    d = N[0., 0.]
-    @test σ(d, b) == N[0., 0.]
+    d = N[1, 0]
+    @test σ(d, b) == N[1, 0]
+    d = N[-1, 0]
+    @test σ(d, b) == N[-1, 0]
+    d = N[0, 1]
+    @test σ(d, b) == N[0, 1]
+    d = N[0, -1]
+    @test σ(d, b) == N[0, -1]
+    d = N[0, 0]
+    @test σ(d, b) == N[0, 0]
 
     # 2D Ball2 not 0-centered
-    b = Ball2(N[1., 2.], N(1.))
+    b = Ball2(N[1, 2], N(1))
     # Test Dimension
     @test dim(b) == 2
     # Test Support Vector
-    d = N[1., 0.]
-    @test σ(d, b) == N[2., 2.]
-    d = N[-1., 0.]
-    @test σ(d, b) == N[0., 2.]
-    d = N[0., 1.]
-    @test σ(d, b) == N[1., 3.]
-    d = N[0., -1.]
-    @test σ(d, b) == N[1., 1.]
+    d = N[1, 0]
+    @test σ(d, b) == N[2, 2]
+    d = N[-1, 0]
+    @test σ(d, b) == N[0, 2]
+    d = N[0, 1]
+    @test σ(d, b) == N[1, 3]
+    d = N[0, -1]
+    @test σ(d, b) == N[1, 1]
 
     # 2D Ball2 radius =/= 1
-    b = Ball2(N[0., 0.], N(2.))
+    b = Ball2(N[0, 0], N(2))
     # Test Dimension
     @test dim(b) == 2
     # Test Support Vector
-    d = N[1., 0.]
-    @test σ(d, b) == N[2., 0.]
-    d = N[-1., 0.]
-    @test σ(d, b) == N[-2., 0.]
-    d = N[0., 1.]
-    @test σ(d, b) == N[0., 2.]
-    d = N[0., -1.]
-    @test σ(d, b) == N[0., -2.]
+    d = N[1, 0]
+    @test σ(d, b) == N[2, 0]
+    d = N[-1, 0]
+    @test σ(d, b) == N[-2, 0]
+    d = N[0, 1]
+    @test σ(d, b) == N[0, 2]
+    d = N[0, -1]
+    @test σ(d, b) == N[0, -2]
 
     # an_element function
-    b = Ball2(N[1., 2.], N(2.))
+    b = Ball2(N[1, 2], N(2))
     @test an_element(b) ∈ b
 
     # subset
-    b1 = Ball2(N[1., 2.], N(2.))
-    b2 = Ball2(N[1., 2.], N(0.))
-    b3 = Ball2(N[1.7, 2.7], N(1.))
-    s1 = Singleton(N[1., 2.])
-    s2 = Singleton(N[2., 2.])
+    b1 = Ball2(N[1, 2], N(2))
+    b2 = Ball2(N[1, 2], N(0))
+    b3 = Ball2(N[1.7, 2.7], N(1))
+    s1 = Singleton(N[1, 2])
+    s2 = Singleton(N[2, 2])
     subset, point = ⊆(b1, s1, true)
     @test !⊆(b1, s1) && !subset && point ∈ b1 && point ∉ s1
     @test ⊆(b2, s1) && ⊆(b2, s1, true)[1]
     subset, point = ⊆(b1, s2, true)
     @test !⊆(b1, s2) && !subset && point ∈ b1 && point ∉ s2
-    @test !⊆(b1, BallInf(N[1., 2.], N(1.)))
-    @test ⊆(b2, BallInf(N[1., 2.], N(2.)))
+    @test !⊆(b1, BallInf(N[1, 2], N(1)))
+    @test ⊆(b2, BallInf(N[1, 2], N(2)))
     subset, point = ⊆(b1, b3, true)
     @test !⊆(b1, b3) && !subset && point ∈ b1 && point ∉ b3
     @test ⊆(b3, b1) && ⊆(b3, b1, true)[1]
 
     # intersection
-    b1 = Ball2(N[0., 0.], N(2.))
-    b2 = Ball2(N[2., 2.], N(2.))
-    b3 = Ball2(N[4., 4.], N(2.))
-    b4 = Ball2(N[1., 1.], N(1.))
+    b1 = Ball2(N[0, 0], N(2))
+    b2 = Ball2(N[2, 2], N(2))
+    b3 = Ball2(N[4, 4], N(2))
+    b4 = Ball2(N[1, 1], N(1))
     intersection_empty, point = is_intersection_empty(b1, b2, true)
     @test !is_intersection_empty(b1, b2) && !intersection_empty && point ∈ b1 && point ∈ b2
     @test is_intersection_empty(b1, b3) && is_intersection_empty(b1, b3, true)[1]

--- a/test/unit_BallInf.jl
+++ b/test/unit_BallInf.jl
@@ -1,63 +1,63 @@
 for N in [Float64, Rational{Int}, Float32]
     # 1D BallInf
-    b = BallInf(N[0.], N(1.))
+    b = BallInf(N[0], N(1))
     # Test Dimension
     @test dim(b) == 1
     # Test Support Vector
-    d = N[1.]
-    @test σ(d, b) == N[1.]
-    d = N[-1.]
-    @test σ(d, b) == N[-1.]
+    d = N[1]
+    @test σ(d, b) == N[1]
+    d = N[-1]
+    @test σ(d, b) == N[-1]
 
     # 2D BallInf
-    b = BallInf(N[0., 0.], N(1.))
+    b = BallInf(N[0, 0], N(1))
     # Test Dimension
     @test dim(b) == 2
     # Test Support Vector
-    d = N[1., 1.]
-    @test σ(d, b) == N[1., 1.]
-    d = N[-1., 1.]
-    @test σ(d, b) == N[-1., 1.]
-    d = N[-1., -1.]
-    @test σ(d, b) == N[-1., -1.]
-    d = N[1., -1.]
-    @test σ(d, b) == N[1., -1.]
+    d = N[1, 1]
+    @test σ(d, b) == N[1, 1]
+    d = N[-1, 1]
+    @test σ(d, b) == N[-1, 1]
+    d = N[-1, -1]
+    @test σ(d, b) == N[-1, -1]
+    d = N[1, -1]
+    @test σ(d, b) == N[1, -1]
 
     # 2D BallInf not 0-centered
-    b = BallInf(N[1., 2.], N(1.))
+    b = BallInf(N[1, 2], N(1))
     # Test Dimension
     @test dim(b) == 2
     # Test Support Vector
-    d = N[1., 1.]
-    @test σ(d, b) == N[2., 3.]
-    d = N[-1., 1.]
-    @test σ(d, b) == N[0., 3.]
-    d = N[-1., -1.]
-    @test σ(d, b) == N[0., 1.]
-    d = N[0., -1.]
-    @test σ(d, b) == N[2., 1.]
+    d = N[1, 1]
+    @test σ(d, b) == N[2, 3]
+    d = N[-1, 1]
+    @test σ(d, b) == N[0, 3]
+    d = N[-1, -1]
+    @test σ(d, b) == N[0, 1]
+    d = N[0, -1]
+    @test σ(d, b) == N[2, 1]
 
     # 2D BallInf radius =/= 1
-    b = BallInf(N[0., 0.], N(2.))
+    b = BallInf(N[0, 0], N(2))
     # Test Dimension
     @test dim(b) == 2
     # Test Support Vector
-    d = N[1., 1.]
-    @test σ(d, b) == N[2., 2.]
-    d = N[-1., 1.]
-    @test σ(d, b) == N[-2., 2.]
-    d = N[-1., -1.]
-    @test σ(d, b) == N[-2., -2.]
-    d = N[1., -1.]
-    @test σ(d, b) == N[2., -2.]
+    d = N[1, 1]
+    @test σ(d, b) == N[2, 2]
+    d = N[-1, 1]
+    @test σ(d, b) == N[-2, 2]
+    d = N[-1, -1]
+    @test σ(d, b) == N[-2, -2]
+    d = N[1, -1]
+    @test σ(d, b) == N[2, -2]
 
     # membership
-    b = BallInf(N[1., 1.], N(1.))
-    @test !∈(N[.5, -.5], b)
-    @test ∈(N[.5, 1.5], b)
+    b = BallInf(N[1, 1], N(1))
+    @test !∈(N[0.5, -0.5], b)
+    @test ∈(N[0.5, 1.5], b)
 
     # an_element function
-    b = BallInf(N[1., 2.], N(3.))
+    b = BallInf(N[1, 2], N(3))
     @test an_element(b) ∈ b
 
     # check that vertices_list for zero radius doesn't repeat vertices

--- a/test/unit_Ballp.jl
+++ b/test/unit_Ballp.jl
@@ -1,34 +1,34 @@
 for N in [Float64, Float32]
     # 1D Ball3
-    b = Ballp(N(3.), N[0.], N(1.))
+    b = Ballp(N(3), N[0], N(1))
     # dimension
     @test dim(b) == 1
     # support vector
-    d = N[1.]
-    @test σ(d, b) == N[1.]
-    d = N[-1.]
-    @test σ(d, b) == N[-1.]
+    d = N[1]
+    @test σ(d, b) == N[1]
+    d = N[-1]
+    @test σ(d, b) == N[-1]
 
     # 2D Ball3
-    b = Ballp(N(3.), N[0., 0.], N(2.))
+    b = Ballp(N(3), N[0, 0], N(2))
     # dimension
     @test dim(b) == 2
     # support vector
-    d = N[1., 0.]
-    @test σ(d, b) == N[2., 0.]
-    d = N[-1., 0.]
-    @test σ(d, b) == N[-2., 0.]
-    d = N[0., 1.]
-    @test σ(d, b) == N[0., 2.]
-    d = N[0., -1.]
-    @test σ(d, b) == N[0., -2.]
-    d = N[0., 0.]
-    @test σ(d, b) == N[0., 0.]
+    d = N[1, 0]
+    @test σ(d, b) == N[2, 0]
+    d = N[-1, 0]
+    @test σ(d, b) == N[-2, 0]
+    d = N[0, 1]
+    @test σ(d, b) == N[0, 2]
+    d = N[0, -1]
+    @test σ(d, b) == N[0, -2]
+    d = N[0, 0]
+    @test σ(d, b) == N[0, 0]
 
     # constructors that fall back to specialized set types
-    @test Ballp(N(1.), N[3.], N(4.)) isa Ball1
-    @test Ballp(N(2.), N[3.], N(4.)) isa Ball2
-    @test Ballp(N(Inf), N[3.], N(4.)) isa BallInf
+    @test Ballp(N(1), N[3], N(4)) isa Ball1
+    @test Ballp(N(2), N[3], N(4)) isa Ball2
+    @test Ballp(N(Inf), N[3], N(4)) isa BallInf
 
     # center
     @test center(b) == b.center

--- a/test/unit_CartesianProduct.jl
+++ b/test/unit_CartesianProduct.jl
@@ -1,8 +1,8 @@
 for N in [Float64, Float32, Rational{Int}]
     # Cartesian Product of a centered 1D BallInf and a centered 2D BallInf
     # Here a 3D BallInf
-    b1 = BallInf(N[0.], N(1.))
-    b2 = BallInf(N[0., 0.], N(1.))
+    b1 = BallInf(N[0], N(1))
+    b2 = BallInf(N[0, 0], N(1))
     # Test Construction
     c1 = CartesianProduct(b1, b2)
     @test c1.X == b1
@@ -10,51 +10,51 @@ for N in [Float64, Float32, Rational{Int}]
     # Test Dimension
     @test dim(c1) == 3
     # Test Support Vector
-    d = N[1., 1., 1.]
-    @test σ(d, c1) == N[1., 1., 1.]
-    d = N[1., 1., -1.]
-    @test σ(d, c1) == N[1., 1., -1.]
-    d = N[1., -1., 1.]
-    @test σ(d, c1) == N[1., -1., 1.]
-    d = N[1., -1., -1.]
-    @test σ(d, c1) == N[1., -1., -1.]
-    d = N[-1., 1., 1.]
-    @test σ(d, c1) == N[-1., 1., 1.]
-    d = N[-1., 1., -1.]
-    @test σ(d, c1) == N[-1., 1., -1.]
-    d = N[-1., -1., 1.]
-    @test σ(d, c1) == N[-1., -1., 1.]
-    d = N[-1., -1., -1.]
-    @test σ(d, c1) == N[-1., -1., -1.]
+    d = N[1, 1, 1]
+    @test σ(d, c1) == N[1, 1, 1]
+    d = N[1, 1, -1]
+    @test σ(d, c1) == N[1, 1, -1]
+    d = N[1, -1, 1]
+    @test σ(d, c1) == N[1, -1, 1]
+    d = N[1, -1, -1]
+    @test σ(d, c1) == N[1, -1, -1]
+    d = N[-1, 1, 1]
+    @test σ(d, c1) == N[-1, 1, 1]
+    d = N[-1, 1, -1]
+    @test σ(d, c1) == N[-1, 1, -1]
+    d = N[-1, -1, 1]
+    @test σ(d, c1) == N[-1, -1, 1]
+    d = N[-1, -1, -1]
+    @test σ(d, c1) == N[-1, -1, -1]
 
     # Cartesian Product of a not-centered 1D BallInf and a not-centered 2D BallInf
-    # Here a Hyperrectangle where c = [1., -3., 4.] and r = [3., 2., 2.]
-    b1 = BallInf(N[1.], N(3.))
-    b2 = BallInf(N[-3., 4.], N(2.))
+    # Here a Hyperrectangle where c = [1, -3, 4] and r = [3, 2, 2]
+    b1 = BallInf(N[1], N(3))
+    b2 = BallInf(N[-3, 4], N(2))
     # Test Construction
     c = CartesianProduct(b1, b2)
     # Test Dimension
     @test dim(c) == 3
     # Test Support Vector
-    d = N[1., 1., 1.]
-    @test σ(d, c) == N[4., -1., 6.]
-    d = N[1., 1., -1.]
-    @test σ(d, c) == N[4., -1., 2.]
-    d = N[1., -1., 1.]
-    @test σ(d, c) == N[4., -5., 6.]
-    d = N[1., -1., -1.]
-    @test σ(d, c) == N[4., -5., 2.]
-    d = N[-1., 1., 1.]
-    @test σ(d, c) == N[-2., -1., 6.]
-    d = N[-1., 1., -1.]
-    @test σ(d, c) == N[-2., -1., 2.]
-    d = N[-1., -1., 1.]
-    @test σ(d, c) == N[-2., -5., 6.]
-    d = N[-1., -1., -1.]
-    @test σ(d, c) == N[-2., -5., 2.]
+    d = N[1, 1, 1]
+    @test σ(d, c) == N[4, -1, 6]
+    d = N[1, 1, -1]
+    @test σ(d, c) == N[4, -1, 2]
+    d = N[1, -1, 1]
+    @test σ(d, c) == N[4, -5, 6]
+    d = N[1, -1, -1]
+    @test σ(d, c) == N[4, -5, 2]
+    d = N[-1, 1, 1]
+    @test σ(d, c) == N[-2, -1, 6]
+    d = N[-1, 1, -1]
+    @test σ(d, c) == N[-2, -1, 2]
+    d = N[-1, -1, 1]
+    @test σ(d, c) == N[-2, -5, 6]
+    d = N[-1, -1, -1]
+    @test σ(d, c) == N[-2, -5, 2]
 
     # Test Cartesian Product with EmptySet
-    s = Singleton(N[1.])
+    s = Singleton(N[1])
     E = EmptySet{N}()
     cs1 = E * s
     cs2 = s * E
@@ -67,45 +67,45 @@ for N in [Float64, Float32, Rational{Int}]
     cs = CartesianProduct(as)
     @test cs isa EmptySet
     # 1-element
-    as = [Singleton(N[1.])]
+    as = [Singleton(N[1])]
     cs = CartesianProduct(as)
-    @test cs.element == N[1.]
+    @test cs.element == N[1]
     # 3-elements
-    as = [Singleton(N[1.]), Singleton(N[2.]), Singleton(N[3.])]
+    as = [Singleton(N[1]), Singleton(N[2]), Singleton(N[3])]
     cs = CartesianProduct(as)
-    @test cs.X.element == N[1.]
-    @test cs.Y.X.element == N[2.]
-    @test cs.Y.Y.element == N[3.]
+    @test cs.X.element == N[1]
+    @test cs.Y.X.element == N[2]
+    @test cs.Y.Y.element == N[3]
 
     # Test containment with respect to CartesianProduct
     p1 = HPolygon{N}()
-    addconstraint!(p1, LinearConstraint(N[2., 2.], N(12.)))
-    addconstraint!(p1, LinearConstraint(N[-3., 3.], N(6.)))
-    addconstraint!(p1, LinearConstraint(N[-1., -1.], N(0.)))
-    addconstraint!(p1, LinearConstraint(N[2., -4.], N(0.)))
+    addconstraint!(p1, LinearConstraint(N[2, 2], N(12)))
+    addconstraint!(p1, LinearConstraint(N[-3, 3], N(6)))
+    addconstraint!(p1, LinearConstraint(N[-1, -1], N(0)))
+    addconstraint!(p1, LinearConstraint(N[2, -4], N(0)))
     p2 = HPolygon{N}()
-    addconstraint!(p2, LinearConstraint(N[1., 0.], N(1.)))
-    addconstraint!(p2, LinearConstraint(N[-1., 0.], N(1.)))
-    addconstraint!(p2, LinearConstraint(N[0., 1.], N(1.)))
-    addconstraint!(p2, LinearConstraint(N[0., -1.], N(1.)))
+    addconstraint!(p2, LinearConstraint(N[1, 0], N(1)))
+    addconstraint!(p2, LinearConstraint(N[-1, 0], N(1)))
+    addconstraint!(p2, LinearConstraint(N[0, 1], N(1)))
+    addconstraint!(p2, LinearConstraint(N[0, -1], N(1)))
     cp = CartesianProduct(p1, p2)
 
-    @test ∈(N[0., 0., 0., 0.], cp)
-    @test ∈(N[4., 2., 1., 0.], cp)
-    @test ∈(N[2., 4., -1., 0.], cp)
-    @test ∈(N[-1., 1., .5, .7], cp)
-    @test ∈(N[2., 3., -.8, .9], cp)
-    @test ∈(N[1., 1., -1., 0.], cp)
-    @test ∈(N[3., 2., 0., 1.], cp)
-    @test ∈(N[5. / 4., 7. / 4., 1., 1.], cp)
-    @test !∈(N[4., 1., 0., 0.], cp)
-    @test !∈(N[5., 2., 0., 0.], cp)
-    @test !∈(N[3., 4., 0., 0.], cp)
-    @test !∈(N[-1., 5., 0., 0.], cp)
-    @test !∈(N[4., 2., 3., 1.], cp)
-    @test !∈(N[2., 3., 3., 1.], cp)
-    @test !∈(N[0., 0., 3., 1.], cp)
-    @test !∈(N[1., 1., 3., 1.], cp)
+    @test ∈(N[0, 0, 0, 0], cp)
+    @test ∈(N[4, 2, 1, 0], cp)
+    @test ∈(N[2, 4, -1, 0], cp)
+    @test ∈(N[-1, 1, 0.5, 0.7], cp)
+    @test ∈(N[2, 3, -0.8, 0.9], cp)
+    @test ∈(N[1, 1, -1, 0], cp)
+    @test ∈(N[3, 2, 0, 1], cp)
+    @test ∈(N[5 / 4, 7 / 4, 1, 1], cp)
+    @test !∈(N[4, 1, 0, 0], cp)
+    @test !∈(N[5, 2, 0, 0], cp)
+    @test !∈(N[3, 4, 0, 0], cp)
+    @test !∈(N[-1, 5, 0, 0], cp)
+    @test !∈(N[4, 2, 3, 1], cp)
+    @test !∈(N[2, 3, 3, 1], cp)
+    @test !∈(N[0, 0, 3, 1], cp)
+    @test !∈(N[1, 1, 3, 1], cp)
 
     # =====================
     # CartesianProductArray
@@ -117,8 +117,8 @@ for N in [Float64, Float32, Rational{Int}]
 
     # standard constructor
     v = Vector{LazySet{N}}()
-    push!(v, Singleton(N[1., 2.]))
-    push!(v, Singleton(N[3., 4.]))
+    push!(v, Singleton(N[1, 2]))
+    push!(v, Singleton(N[3, 4]))
     cpa = CartesianProductArray(v)
 
     # constructor with size hint and type
@@ -128,11 +128,11 @@ for N in [Float64, Float32, Rational{Int}]
     @test array(cpa) ≡ v
 
     # membership
-    @test ∈(N[1., 2., 3., 4.], cpa)
-    @test !∈(N[3., 4., 1., 2.], cpa)
+    @test ∈(N[1, 2, 3, 4], cpa)
+    @test !∈(N[3, 4, 1, 2], cpa)
 
     # in-place modification
-    b = BallInf(N[0., 0.], N(2.))
+    b = BallInf(N[0, 0], N(2))
     cpa = CartesianProductArray(LazySet{N}[])
     @test CartesianProduct!(b, b) isa CartesianProduct &&
           length(array(cpa)) == 0
@@ -149,7 +149,7 @@ for N in [Float64, Float32, Rational{Int}]
 
     # absorbing element
     e = EmptySet{N}()
-    b = BallInf(N[0., 0.], N(2.))
+    b = BallInf(N[0, 0], N(2))
     @test absorbing(CartesianProduct) == absorbing(CartesianProductArray) ==
           EmptySet
     @test b × e == e × b == cpa × e == e × cpa == e × e == e

--- a/test/unit_ConvexHull.jl
+++ b/test/unit_ConvexHull.jl
@@ -1,7 +1,7 @@
 for N in [Float64, Rational{Int}, Float32]
     # ConvexHull of two 2D Ball1
-    b1 = Ball1(to_N(N, [0., 0.]), to_N(N, 1.))
-    b2 = Ball1(to_N(N, [1., 2.]), to_N(N, 1.))
+    b1 = Ball1(N[0., 0.], N(1.))
+    b2 = Ball1(N[1., 2.], N(1.))
     # Test Construction
     ch1 = ConvexHull(b1, b2)
     ch2 = CH(b1, b2)
@@ -9,14 +9,14 @@ for N in [Float64, Rational{Int}, Float32]
     # Test Dimension
     @test dim(ch1) == 2
     # Test Support Vector
-    d = to_N(N, [1., 0.])
-    @test σ(d, ch1) == to_N(N, [2., 2.])
-    d = to_N(N, [-1., 0.])
-    @test σ(d, ch1) == to_N(N, [-1., 0.])
-    d = to_N(N, [0., 1.])
-    @test σ(d, ch1) == to_N(N, [1., 3.])
-    d = to_N(N, [0., -1.])
-    @test σ(d, ch1) == to_N(N, [0., -1.])
+    d = N[1., 0.]
+    @test σ(d, ch1) == N[2., 2.]
+    d = N[-1., 0.]
+    @test σ(d, ch1) == N[-1., 0.]
+    d = N[0., 1.]
+    @test σ(d, ch1) == N[1., 3.]
+    d = N[0., -1.]
+    @test σ(d, ch1) == N[0., -1.]
 
     # test convex hull of a set of points using the default algorithm
     points = to_N(N, [[0.9,0.2], [0.4,0.6], [0.2,0.1], [0.1,0.3], [0.3,0.28]])
@@ -39,14 +39,14 @@ for N in [Float64, Rational{Int}, Float32]
     # test dimension
     @test dim(C) == 2
     # test support vector
-    d = to_N(N, [1., 0.])
-    @test σ(d, C) == to_N(N, [2., 2.])
-    d = to_N(N, [-1., 0.])
-    @test σ(d, C) == to_N(N, [-1., 0.])
-    d = to_N(N, [0., 1.])
-    @test σ(d, C) == to_N(N, [1., 3.])
-    d = to_N(N, [0., -1.])
-    @test σ(d, C) == to_N(N, [0., -1.])
+    d = N[1., 0.]
+    @test σ(d, C) == N[2., 2.]
+    d = N[-1., 0.]
+    @test σ(d, C) == N[-1., 0.]
+    d = N[0., 1.]
+    @test σ(d, C) == N[1., 3.]
+    d = N[0., -1.]
+    @test σ(d, C) == N[0., -1.]
     # test convex hull array of singleton
     C = ConvexHullArray([Singleton(to_N(N, [1.0, 0.5])), Singleton(to_N(N, [1.1, 0.2])), Singleton(to_N(N, [1.4, 0.3])), Singleton(to_N(N, [1.7, 0.5])), Singleton(to_N(N, [1.4, 0.8]))])
 

--- a/test/unit_ConvexHull.jl
+++ b/test/unit_ConvexHull.jl
@@ -1,7 +1,7 @@
 for N in [Float64, Rational{Int}, Float32]
     # ConvexHull of two 2D Ball1
-    b1 = Ball1(N[0., 0.], N(1.))
-    b2 = Ball1(N[1., 2.], N(1.))
+    b1 = Ball1(N[0, 0], N(1))
+    b2 = Ball1(N[1, 2], N(1))
     # Test Construction
     ch1 = ConvexHull(b1, b2)
     ch2 = CH(b1, b2)
@@ -9,18 +9,18 @@ for N in [Float64, Rational{Int}, Float32]
     # Test Dimension
     @test dim(ch1) == 2
     # Test Support Vector
-    d = N[1., 0.]
-    @test σ(d, ch1) == N[2., 2.]
-    d = N[-1., 0.]
-    @test σ(d, ch1) == N[-1., 0.]
-    d = N[0., 1.]
-    @test σ(d, ch1) == N[1., 3.]
-    d = N[0., -1.]
-    @test σ(d, ch1) == N[0., -1.]
+    d = N[1, 0]
+    @test σ(d, ch1) == N[2, 2]
+    d = N[-1, 0]
+    @test σ(d, ch1) == N[-1, 0]
+    d = N[0, 1]
+    @test σ(d, ch1) == N[1, 3]
+    d = N[0, -1]
+    @test σ(d, ch1) == N[0, -1]
 
     # test convex hull of a set of points using the default algorithm
-    points = to_N(N, [[0.9,0.2], [0.4,0.6], [0.2,0.1], [0.1,0.3], [0.3,0.28]])
-    @test convex_hull(points) == to_N(N, [[0.1,0.3],[0.2,0.1], [0.9,0.2],[0.4,0.6]])
+    points = to_N(N, [[0.9, 0.2], [0.4, 0.6], [0.2, 0.1], [0.1, 0.3], [0.3, 0.28]])
+    @test convex_hull(points) == to_N(N, [[0.1, 0.3], [0.2, 0.1], [0.9, 0.2], [0.4, 0.6]])
 
     # ===============
     # ConvexHullArray
@@ -39,16 +39,19 @@ for N in [Float64, Rational{Int}, Float32]
     # test dimension
     @test dim(C) == 2
     # test support vector
-    d = N[1., 0.]
-    @test σ(d, C) == N[2., 2.]
-    d = N[-1., 0.]
-    @test σ(d, C) == N[-1., 0.]
-    d = N[0., 1.]
-    @test σ(d, C) == N[1., 3.]
-    d = N[0., -1.]
-    @test σ(d, C) == N[0., -1.]
+    d = N[1, 0]
+    @test σ(d, C) == N[2, 2]
+    d = N[-1, 0]
+    @test σ(d, C) == N[-1, 0]
+    d = N[0, 1]
+    @test σ(d, C) == N[1, 3]
+    d = N[0, -1]
+    @test σ(d, C) == N[0, -1]
     # test convex hull array of singleton
-    C = ConvexHullArray([Singleton(to_N(N, [1.0, 0.5])), Singleton(to_N(N, [1.1, 0.2])), Singleton(to_N(N, [1.4, 0.3])), Singleton(to_N(N, [1.7, 0.5])), Singleton(to_N(N, [1.4, 0.8]))])
+    C = ConvexHullArray(
+        [Singleton(to_N(N, [10, 0.5])), Singleton(to_N(N, [1.1, 0.2])),
+         Singleton(to_N(N, [1.4, 0.3])), Singleton(to_N(N, [1.7, 0.5])),
+         Singleton(to_N(N, [1.4, 0.8]))])
 
     # array getter
     v = Vector{LazySet{N}}()
@@ -81,8 +84,8 @@ for N in [Float64, Rational{Int}, Float32]
     # concrete convex hull operation
     # ==============================
 
-    points = to_N(N, [[0.9,0.2], [0.4,0.6], [0.2,0.1], [0.1,0.3], [0.3,0.28]])
-    sorted = to_N(N, [[0.1,0.3],[0.2,0.1], [0.9,0.2],[0.4,0.6]])
+    points = to_N(N, [[0.9, 0.2], [0.4, 0.6], [0.2, 0.1], [0.1, 0.3], [0.3, 0.28]])
+    sorted = to_N(N, [[0.1, 0.3], [0.2, 0.1], [0.9, 0.2], [0.4, 0.6]])
     @test convex_hull!(points, algorithm="monotone_chain") == sorted
     @test convex_hull!(points, algorithm="monotone_chain_sorted") == sorted
     @test_throws ErrorException convex_hull!(points, algorithm="")

--- a/test/unit_Ellipsoid.jl
+++ b/test/unit_Ellipsoid.jl
@@ -1,60 +1,60 @@
 for N in [Float64, Float32]
     # 1D ellipsoid
-    E = Ellipsoid(N[0.], Diagonal(N[1.]))
+    E = Ellipsoid(N[0], Diagonal(N[1]))
     # Test Dimension
     @test dim(E) == 1
     # Test Support Vector
-    d = N[1.]
-    @test σ(d, E) == N[1.]
-    d = N[-1.]
-    @test σ(d, E) == N[-1.]
+    d = N[1]
+    @test σ(d, E) == N[1]
+    d = N[-1]
+    @test σ(d, E) == N[-1]
     # test constructor
-    E = Ellipsoid(Diagonal(N[1.]))
-    @test E.center == N[0.]
+    E = Ellipsoid(Diagonal(N[1]))
+    @test E.center == N[0]
 
     # 2D Ellipsoid
-    E = Ellipsoid(N[0., 0.], Diagonal(N[1., 1.]))
+    E = Ellipsoid(N[0, 0], Diagonal(N[1, 1]))
     # Test Dimension
     @test dim(E) == 2
     # Test Support Vector
-    d = N[1., 0.]
-    @test σ(d, E) == N[1., 0.]
-    d = N[-1., 0.]
-    @test σ(d, E) == N[-1., 0.]
-    d = N[0., 1.]
-    @test σ(d, E) == N[0., 1.]
-    d = N[0., -1.]
-    @test σ(d, E) == N[0., -1.]
-    d = N[0., 0.]
+    d = N[1, 0]
+    @test σ(d, E) == N[1, 0]
+    d = N[-1, 0]
+    @test σ(d, E) == N[-1, 0]
+    d = N[0, 1]
+    @test σ(d, E) == N[0, 1]
+    d = N[0, -1]
+    @test σ(d, E) == N[0, -1]
+    d = N[0, 0]
     @test σ(d, E) ∈ E
 
     # 2D Ellipsoid not 0-centered
-    E = Ellipsoid(N[1., 2.], Diagonal(N[1., 1.]))
+    E = Ellipsoid(N[1, 2], Diagonal(N[1, 1]))
     # Test Dimension
     @test dim(E) == 2
     # Test Support Vector
-    d = N[1., 0.]
-    @test σ(d, E) == N[2., 2.]
-    d = N[-1., 0.]
-    @test σ(d, E) == N[0., 2.]
-    d = N[0., 1.]
-    @test σ(d, E) == N[1., 3.]
-    d = N[0., -1.]
-    @test σ(d, E) == N[1., 1.]
+    d = N[1, 0]
+    @test σ(d, E) == N[2, 2]
+    d = N[-1, 0]
+    @test σ(d, E) == N[0, 2]
+    d = N[0, 1]
+    @test σ(d, E) == N[1, 3]
+    d = N[0, -1]
+    @test σ(d, E) == N[1, 1]
 
     # another shape matrix
-    E = Ellipsoid(N[1., 2.], Diagonal(N[.5, 2.]))
+    E = Ellipsoid(N[1, 2], Diagonal(N[0.5, 2]))
     # Test Support Vector
-    d = N[1., 0.]
-    @test σ(d, E) ≈ N[1+sqrt(.5), 2.]
-    d = N[-1., 0.]
-    @test σ(d, E) ≈ N[1-sqrt(.5), 2.]
-    d = N[0., 1.]
-    @test σ(d, E) ≈ N[1., 2. + sqrt(2)]
-    d = N[0., -1.]
-    @test σ(d, E) ≈ N[1., 2. - sqrt(2)]
+    d = N[1, 0]
+    @test σ(d, E) ≈ N[1+sqrt(0.5), 2]
+    d = N[-1, 0]
+    @test σ(d, E) ≈ N[1-sqrt(0.5), 2]
+    d = N[0, 1]
+    @test σ(d, E) ≈ N[1, 2 + sqrt(2)]
+    d = N[0, -1]
+    @test σ(d, E) ≈ N[1, 2 - sqrt(2)]
 
     # an_element and set membership functions
-    E = Ellipsoid(N[1., 2.], Matrix{N}(2I, 2, 2))
+    E = Ellipsoid(N[1, 2], Matrix{N}(2I, 2, 2))
     @test an_element(E) ∈ E
 end

--- a/test/unit_EmptySet.jl
+++ b/test/unit_EmptySet.jl
@@ -1,13 +1,13 @@
 for N in [Float64, Rational{Int}, Float32]
     E = EmptySet{N}()
-    B = BallInf(ones(N, 2), N(1.))
+    B = BallInf(ones(N, 2), N(1))
 
     # testing that the empty set is an absorbing element for the cartesian product
     @test B * E isa EmptySet && E * B isa EmptySet
     # testing the mathematical alias ×
     @test B × E isa EmptySet && E × B isa EmptySet
 
-    cpa = CartesianProductArray([B, N(2.) * B, N(3.) * B])
+    cpa = CartesianProductArray([B, N(2) * B, N(3) * B])
     @test cpa * E isa EmptySet && E * cpa isa EmptySet
     @test cpa × E isa EmptySet && E × cpa isa EmptySet
 
@@ -19,7 +19,7 @@ for N in [Float64, Rational{Int}, Float32]
     # testing the mathematical alias ⊕
     @test B ⊕ E isa EmptySet && E ⊕ B isa EmptySet
 
-    msa = MinkowskiSumArray([B, N(2.) * B, N(3.) * B])
+    msa = MinkowskiSumArray([B, N(2) * B, N(3) * B])
     @test msa + E isa EmptySet && E + msa isa EmptySet
     @test msa ⊕ E isa EmptySet && E ⊕ msa isa EmptySet
 
@@ -37,11 +37,11 @@ for N in [Float64, Rational{Int}, Float32]
     @test dim(E) == -1
 
     # support vector
-    @test_throws ErrorException σ(N[0.], E)
+    @test_throws ErrorException σ(N[0], E)
 
     # membership
-    @test !∈(N[0.], E)
-    @test !∈(N[0., 0.], E)
+    @test !∈(N[0], E)
+    @test !∈(N[0, 0], E)
 
     # an_element/norm/radius/diameter functions
     @test_throws ErrorException an_element(E)

--- a/test/unit_HalfSpace.jl
+++ b/test/unit_HalfSpace.jl
@@ -1,7 +1,7 @@
 for N in [Float64, Rational{Int}, Float32]
     # normal constructor
     normal = ones(N, 3)
-    hs = HalfSpace(normal, N(5.))
+    hs = HalfSpace(normal, N(5))
 
     # dimension
     @test dim(hs) == 3
@@ -9,8 +9,8 @@ for N in [Float64, Rational{Int}, Float32]
     # support vector and membership function
     function test_svec(hs, d)
         @test σ(d, hs) ∈ hs
-        @test σ(N(2.) * d, hs) ∈ hs
-        d2 = N[1., 0., 0.]
+        @test σ(N(2) * d, hs) ∈ hs
+        d2 = N[1, 0, 0]
         @test_throws ErrorException σ(d2, hs)
         d2 = zeros(N, 3)
         @test σ(d2, hs) ∈ hs
@@ -18,16 +18,16 @@ for N in [Float64, Rational{Int}, Float32]
     # tests 1
     normal = ones(N, 3)
     d = ones(N, 3)
-    test_svec(HalfSpace(normal, N(5.)), d)
+    test_svec(HalfSpace(normal, N(5)), d)
     # tests 2
-    normal = zeros(N, 3); normal[3] = N(1.)
-    d = zeros(N, 3); d[3] = 1.
-    test_svec(HalfSpace(normal, N(5.)), d)
+    normal = zeros(N, 3); normal[3] = N(1)
+    d = zeros(N, 3); d[3] = 1
+    test_svec(HalfSpace(normal, N(5)), d)
 
     # an_element function and membership function
     @test an_element(hs) ∈ hs
 
     # halfspace_left & halfspace_right
-    @test N[1., 2.] ∈ halfspace_left(N[1., 1.], N[2., 2.])
-    @test N[2., 1.] ∈ halfspace_right(N[1., 1.], N[2., 2.])
+    @test N[1, 2] ∈ halfspace_left(N[1, 1], N[2, 2])
+    @test N[2, 1] ∈ halfspace_right(N[1, 1], N[2, 2])
 end

--- a/test/unit_Hyperplane.jl
+++ b/test/unit_Hyperplane.jl
@@ -1,7 +1,7 @@
 for N in [Float64, Rational{Int}, Float32]
     # normal constructor
     a = ones(N, 3)
-    hp = Hyperplane(a, N(5.))
+    hp = Hyperplane(a, N(5))
 
     # dimension
     @test dim(hp) == 3
@@ -10,20 +10,20 @@ for N in [Float64, Rational{Int}, Float32]
     function test_svec(hp)
         d1 = copy(hp.a)
         @test σ(d1, hp) ∈ hp
-        @test σ(N(2.) * d1, hp) ∈ hp
-        d2 = N[1., 0., 0.]
+        @test σ(N(2) * d1, hp) ∈ hp
+        d2 = N[1, 0, 0]
         @test_throws ErrorException σ(d2, hp)
-        d3 = N[1., 1., 2.]
+        d3 = N[1, 1, 2]
         @test_throws ErrorException σ(d3, hp)
         d4 = zeros(N, 3)
         @test σ(d4, hp) ∈ hp
     end
     # tests 1
     a = ones(N, 3)
-    test_svec(Hyperplane(a, N(5.)))
+    test_svec(Hyperplane(a, N(5)))
     # tests 2
-    a = zeros(N, 3); a[3] = N(1.)
-    test_svec(Hyperplane(a, N(5.)))
+    a = zeros(N, 3); a[3] = N(1)
+    test_svec(Hyperplane(a, N(5)))
 
     # an_element function and membership function
     @test an_element(hp) ∈ hp

--- a/test/unit_Hyperrectangle.jl
+++ b/test/unit_Hyperrectangle.jl
@@ -1,72 +1,72 @@
 for N in [Float64, Rational{Int}, Float32]
     # 1D Hyperrectangle
-    h = Hyperrectangle(N[0.], N[1.])
+    h = Hyperrectangle(N[0], N[1])
     # Test Dimension
     @test dim(h) == 1
     # Test Support Vector
-    d = N[1.]
-    @test σ(d, h) == N[1.]
-    d = N[-1.]
-    @test σ(d, h) == N[-1.]
+    d = N[1]
+    @test σ(d, h) == N[1]
+    d = N[-1]
+    @test σ(d, h) == N[-1]
 
     # 2D Hyperrectangle
-    h = Hyperrectangle(N[0., 0.], N[1., 1.])
+    h = Hyperrectangle(N[0, 0], N[1, 1])
     # Test Dimension
     @test dim(h) == 2
     # Test Support Vector
-    d = N[1., 1.]
-    @test σ(d, h) == N[1., 1.]
-    d = N[-1., 1.]
-    @test σ(d, h) == N[-1., 1.]
-    d = N[-1., -1.]
-    @test σ(d, h) == N[-1., -1.]
-    d = N[1., -1.]
-    @test σ(d, h) == N[1., -1.]
+    d = N[1, 1]
+    @test σ(d, h) == N[1, 1]
+    d = N[-1, 1]
+    @test σ(d, h) == N[-1, 1]
+    d = N[-1, -1]
+    @test σ(d, h) == N[-1, -1]
+    d = N[1, -1]
+    @test σ(d, h) == N[1, -1]
 
     # 2D Hyperrectangle not 0-centered
-    h = Hyperrectangle(N[1., 2.], N[1., 1.])
+    h = Hyperrectangle(N[1, 2], N[1, 1])
     # Test Dimension
     @test dim(h) == 2
     # Test Support Vector
-    d = N[1., 1.]
-    @test σ(d, h) == N[2., 3.]
-    d = N[-1., 1.]
-    @test σ(d, h) == N[0., 3.]
-    d = N[-1., -1.]
-    @test σ(d, h) == N[0., 1.]
-    d = N[0., -1.]
-    @test σ(d, h) == N[2., 1.]
+    d = N[1, 1]
+    @test σ(d, h) == N[2, 3]
+    d = N[-1, 1]
+    @test σ(d, h) == N[0, 3]
+    d = N[-1, -1]
+    @test σ(d, h) == N[0, 1]
+    d = N[0, -1]
+    @test σ(d, h) == N[2, 1]
 
     # 2D Hyperrectangle not same radius in each direction
-    h = Hyperrectangle(N[0., 0.], N[1., 2.])
+    h = Hyperrectangle(N[0, 0], N[1, 2])
     # Test Dimension
     @test dim(h) == 2
     # Test Support Vector
-    d = N[1., 1.]
-    @test σ(d, h) == N[1., 2.]
-    d = N[-1., 1.]
-    @test σ(d, h) == N[-1., 2.]
-    d = N[-1., -1.]
-    @test σ(d, h) == N[-1., -2.]
-    d = N[1., -1.]
-    @test σ(d, h) == N[1., -2.]
+    d = N[1, 1]
+    @test σ(d, h) == N[1, 2]
+    d = N[-1, 1]
+    @test σ(d, h) == N[-1, 2]
+    d = N[-1, -1]
+    @test σ(d, h) == N[-1, -2]
+    d = N[1, -1]
+    @test σ(d, h) == N[1, -2]
 
     # 2D Hyperrectangle not centered, not same radius, for vertex representation,
     # radius, and diameter
-    h = Hyperrectangle(N[3., 2.], N[2., 1.])
+    h = Hyperrectangle(N[3, 2], N[2, 1])
     vl = vertices_list(h)
     # Test Vertices
     @test length(vl) == 4
-    @test N[1., 1.] ∈ vl
-    @test N[1., 3.] ∈ vl
-    @test N[5., 1.] ∈ vl
-    @test N[5., 3.] ∈ vl
+    @test N[1, 1] ∈ vl
+    @test N[1, 3] ∈ vl
+    @test N[5, 1] ∈ vl
+    @test N[5, 3] ∈ vl
     # norm
-    @test norm(h) == norm(N[5., 3.], Inf)
+    @test norm(h) == norm(N[5, 3], Inf)
     # radius
-    @test radius(h) == norm(N[2., 1.], Inf)
+    @test radius(h) == norm(N[2, 1], Inf)
     # diameter
-    @test diameter(h) == norm(N[5., 3.] - N[1., 1.], Inf)
+    @test diameter(h) == norm(N[5, 3] - N[1, 1], Inf)
 
     # alternative constructor
     c = ones(N, 2)
@@ -87,20 +87,20 @@ for N in [Float64, Rational{Int}, Float32]
     @test high(H) ≈ to_N(N, [-1.6, 6.1, 1.4])
 
     # membership
-    H = Hyperrectangle(N[1.0, 1.0], N[2.0, 3.0])
+    H = Hyperrectangle(N[1, 1], N[2, 3])
     @test !∈(N[-1.1, 4.1], H)
-    @test ∈(N[-1.0, 4.0], H)
+    @test ∈(N[-1, 4], H)
 
     # an_element function
-    H = Hyperrectangle(N[1.0, 2.0], N[3.0, 4.0])
+    H = Hyperrectangle(N[1, 2], N[3, 4])
     @test an_element(H) ∈ H
 
     # subset
-    H1 = Hyperrectangle(N[1.0, 3.0], N[0.5, 0.5])
-    H2 = Hyperrectangle(N[2.0, 2.5], N[0.5, 0.5])
-    H3 = Hyperrectangle(N[2.0, 2.0], N[2.0, 3.0])
-    B1 = BallInf(N[2.0, 2.5], N(0.5))
-    B2 = BallInf(N[2.0, 2.0], N(1.0))
+    H1 = Hyperrectangle(N[1, 3], N[0.5, 0.5])
+    H2 = Hyperrectangle(N[2, 2.5], N[0.5, 0.5])
+    H3 = Hyperrectangle(N[2, 2], N[2, 3])
+    B1 = BallInf(N[2, 2.5], N(0.5))
+    B2 = BallInf(N[2, 2], N(1))
     @test !⊆(H1, H2) && ⊆(H1, H3) && ⊆(H2, H3)
     subset, point = ⊆(H1, H2, true)
     @test !subset && point ∈ H1 && point ∉ H2
@@ -112,14 +112,14 @@ for N in [Float64, Rational{Int}, Float32]
     @test ⊆(B1, B2) && !⊆(B2, B1)
 
     # intersection & intersection emptiness
-    H1 = Hyperrectangle(N[1.0, 1.0], N[2.0, 2.0])
-    H2 = Hyperrectangle(N[3.0, 3.0], N[2.0, 2.0])
-    B1 = BallInf(N[2.0, 4.0], N(0.5))
+    H1 = Hyperrectangle(N[1, 1], N[2, 2])
+    H2 = Hyperrectangle(N[3, 3], N[2, 2])
+    B1 = BallInf(N[2, 4], N(0.5))
     for (X1, X2) in [(H1, H2), (H2, H1)]
         intersection_empty, point = is_intersection_empty(X1, X2, true)
         cap = intersection(X1, X2)
-        @test cap isa Hyperrectangle{N} && center(cap) == N[2., 2.] &&
-              radius_hyperrectangle(cap) == N[1., 1.]
+        @test cap isa Hyperrectangle{N} && center(cap) == N[2, 2] &&
+              radius_hyperrectangle(cap) == N[1, 1]
         @test !is_intersection_empty(X1, X2) &&
               !intersection_empty && point ∈ X1 && point ∈ X2
     end
@@ -128,9 +128,9 @@ for N in [Float64, Rational{Int}, Float32]
     @test is_intersection_empty(H1, B1) && is_intersection_empty(H1, B1, true)[1]
 
     # linear map (concrete)
-    P = linear_map(N[1. 0.; 0. 2.], H1)
+    P = linear_map(N[1 0; 0 2], H1)
     @test P isa VPolygon # in 2D we get a polygon
-    P = linear_map(Diagonal(N[1., 2., 3., 4.]),
+    P = linear_map(Diagonal(N[1, 2, 3, 4]),
                    Approximations.overapproximate(H1 * H1))
     @test P isa VPolytope # in 4D we get a VPolytope
 

--- a/test/unit_Intersection.jl
+++ b/test/unit_Intersection.jl
@@ -1,5 +1,5 @@
 for N in [Float64, Rational{Int}, Float32]
-    B = BallInf(ones(N, 2), N(3.))
+    B = BallInf(ones(N, 2), N(3))
     H = Hyperrectangle(ones(N, 2), ones(N, 2))
     E = EmptySet{N}()
 
@@ -13,7 +13,7 @@ for N in [Float64, Rational{Int}, Float32]
     @test_throws ErrorException σ(ones(N, 2), I)
 
     # membership
-    @test ∈(ones(N, 2), I) && !∈(N[5., 5.], I)
+    @test ∈(ones(N, 2), I) && !∈(N[5, 5], I)
 
     # emptiness of intersection
     @test !isempty(I)
@@ -36,7 +36,7 @@ for N in [Float64, Rational{Int}, Float32]
     @test_throws ErrorException σ(ones(N, 2), IA)
 
     # membership
-    @test ∈(ones(N, 2), IA) && !∈(N[5., 5.], IA)
+    @test ∈(ones(N, 2), IA) && !∈(N[5, 5], IA)
 
     # array getter
     v = Vector{LazySet{N}}()

--- a/test/unit_Interval.jl
+++ b/test/unit_Interval.jl
@@ -2,63 +2,63 @@ import IntervalArithmetic
 
 for N in [Float64, Float32, Rational{Int}]
     # constructor from IntervalArithmetic.Interval
-    x = Interval(IntervalArithmetic.Interval(N(0.0), N(1.0)))
+    x = Interval(IntervalArithmetic.Interval(N(0), N(1)))
 
     # constructor from a vector
-    x = Interval(N[0.0, 1.0])
+    x = Interval(N[0, 1])
 
     # type-less constructor
-    x = Interval(N(0.0), N(1.0))
+    x = Interval(N(0), N(1))
 
     @test dim(x) == 1
     @test center(x) == N[0.5]
-    @test low(x) == N(0.0) && high(x) == N(1.0)
+    @test low(x) == N(0) && high(x) == N(1)
     v = vertices_list(x)
-    @test N[0.0] in v && N[1.0] in v
+    @test N[0] in v && N[1] in v
     # test interface method an_element and membership
     @test an_element(x) ∈ x
     # test containment
-    @test (x ⊆ x) && !(x ⊆ N(0.2) * x) && (x ⊆ N(2.0) * x)
-    @test ⊆(x, Interval(N(0.0), N(2.0)))
-    @test !⊆(x, Interval(N(-1.0), N(0.5)))
+    @test (x ⊆ x) && !(x ⊆ N(0.2) * x) && (x ⊆ N(2) * x)
+    @test ⊆(x, Interval(N(0), N(2)))
+    @test !⊆(x, Interval(N(-1), N(0.5)))
 
     # + operator (= concrete Minkowski sum of intervals)
-    y = Interval(N(-2.0), N(0.5))
+    y = Interval(N(-2), N(0.5))
     m = x + y
     @test dim(m) == 1
-    @test σ(N[1.0], m) == N[1.5]
-    @test σ(N[-1.0], m) == N[-2.0]
-    @test low(m) == N(-2.0) && high(m) == N(1.5)
+    @test σ(N[1], m) == N[1.5]
+    @test σ(N[-1], m) == N[-2]
+    @test low(m) == N(-2) && high(m) == N(1.5)
     v = vertices_list(m)
-    @test N[1.5] in v && N[-2.0] in v
+    @test N[1.5] in v && N[-2] in v
 
     # difference
     d = x - y
     @test dim(d) == 1
-    @test σ(N[1.0], d) == N[3.0]
-    @test σ(N[-1.0], d) == N[-0.5]
-    @test low(d) == N(-0.5) && high(d) == N(3.0)
+    @test σ(N[1], d) == N[3]
+    @test σ(N[-1], d) == N[-0.5]
+    @test low(d) == N(-0.5) && high(d) == N(3)
     v = vertices_list(d)
-    @test N[-0.5] in v && N[3.0] in v
+    @test N[-0.5] in v && N[3] in v
 
     # product of intervals: use the * operator
     p = x * y
     @test dim(p) == 1
-    @test σ(N[1.0], p) == N[0.5]
-    @test σ(N[-1.0], p) == N[-2.0]
+    @test σ(N[1], p) == N[0.5]
+    @test σ(N[-1], p) == N[-2]
     v = vertices_list(p)
-    @test N[0.5] in v && N[-2.0] in v
+    @test N[0.5] in v && N[-2] in v
 
     # test different arithmetic operations
     r = (x + y) - (d + p)
-    @test low(r) == N(-5.5) && high(r) == N(4.0)
+    @test low(r) == N(-5.5) && high(r) == N(4)
 
     # Minkowski sum (test that we get the same results as the concrete operation)
     m = x ⊕ y
     @test m isa MinkowskiSum
     @test dim(m) == 1
-    @test σ(N[1.0], m) == N[1.5]
-    @test σ(N[-1.0], m) == N[-2.0]
+    @test σ(N[1], m) == N[1.5]
+    @test σ(N[-1], m) == N[-2]
 
     # cartesian product
     cp = x × y

--- a/test/unit_Line.jl
+++ b/test/unit_Line.jl
@@ -1,18 +1,18 @@
 for N in [Float64, Rational{Int}, Float32]
     # construction
-    l1 = Line(N[0., 1.], N(1.))
-    l2 = Line(N[1., 0.], N(1.))
-    l3 = Line(N[0., 1.], N(2.))
-    l4 = Line(N[1., 1.], N(0.))
-    l1_copy = Line(N[0., 1.], N(1.))
+    l1 = Line(N[0, 1], N(1))
+    l2 = Line(N[1, 0], N(1))
+    l3 = Line(N[0, 1], N(2))
+    l4 = Line(N[1, 1], N(0))
+    l1_copy = Line(N[0, 1], N(1))
 
     # dimension
     @test dim(l1) == 2
 
     # support vector & membership
-    σ(N[0., 1.], l1)
-    σ(N[1., 0.], l2)
-    σ(N[0., 1.], l3)
+    σ(N[0, 1], l1)
+    σ(N[1, 0], l2)
+    σ(N[0, 1], l3)
 
     # an_element and membership
     an_element(l1) ∈ l1
@@ -25,6 +25,6 @@ for N in [Float64, Rational{Int}, Float32]
     cap12 = intersection(l1, l2)
     cap13 = intersection(l1, l3)
     @test cap11 isa Line && cap11.a == l1.a && cap11.b == l1.b
-    @test cap12 isa Singleton && element(cap12) == N[1., 1.]
+    @test cap12 isa Singleton && element(cap12) == N[1, 1]
     @test cap13 isa EmptySet{N}
 end

--- a/test/unit_LineSegment.jl
+++ b/test/unit_LineSegment.jl
@@ -1,27 +1,27 @@
 for N in [Float64, Rational{Int}, Float32]
     # construction
-    p, q = N[1., 1.], N[2., 2.]
+    p, q = N[1, 1], N[2, 2]
     l = LineSegment(p, q)
 
     # dimension
     @test dim(l) == 2
 
     # support vector
-    @test σ(N[1., 1.], l) == q
-    @test σ(N[0., 1.], l) == q
-    @test σ(N[-1., 1.], l) == q
-    @test σ(N[-1., 0.], l) == p
-    @test σ(N[-1., -1.], l) == p
-    @test σ(N[0., -1.], l) == p
-    @test σ(N[1., -1.], l) == q
-    @test σ(N[1., 0.], l) == q
+    @test σ(N[1, 1], l) == q
+    @test σ(N[0, 1], l) == q
+    @test σ(N[-1, 1], l) == q
+    @test σ(N[-1, 0], l) == p
+    @test σ(N[-1, -1], l) == p
+    @test σ(N[0, -1], l) == p
+    @test σ(N[1, -1], l) == q
+    @test σ(N[1, 0], l) == q
 
     # membership
-    @test !∈(N[0., 0.], l)
-    @test ∈(N[1., 1.], l)
+    @test !∈(N[0, 0], l)
+    @test ∈(N[1, 1], l)
     @test ∈(N[1.5, 1.5], l)
-    @test !∈(N[3., 4.], l)
-    @test !∈(N[7., 4.], l)
+    @test !∈(N[3, 4], l)
+    @test !∈(N[7, 4], l)
     @test !∈(N[1.5, 1.6], l)
 
     # center function
@@ -35,14 +35,14 @@ for N in [Float64, Rational{Int}, Float32]
     @test length(vl) == 2 && l.p ∈ vl && l.q ∈ vl
 
     # intersection emptiness
-    l1 = LineSegment(N[1., 1.], N[2., 2.])
-    l2 = LineSegment(N[2., 1.], N[1., 2.])
-    l3 = LineSegment(N[0., 1.], N[0., 2.])
-    l4 = LineSegment(N[1., 1.], N[1., 1.])
-    l5 = LineSegment(N[0., 0.], N[0., 0.])
+    l1 = LineSegment(N[1, 1], N[2, 2])
+    l2 = LineSegment(N[2, 1], N[1, 2])
+    l3 = LineSegment(N[0, 1], N[0, 2])
+    l4 = LineSegment(N[1, 1], N[1, 1])
+    l5 = LineSegment(N[0, 0], N[0, 0])
     l6 = LineSegment(to_N(N, [1.3, 1.3]), to_N(N, [2.3, 2.3]))
-    l7 = LineSegment(N[3., 3.], N[4., 4.])
-    l8 = LineSegment(N[1., 2.], N[2., 3.])
+    l7 = LineSegment(N[3, 3], N[4, 4])
+    l8 = LineSegment(N[1, 2], N[2, 3])
     l1_copy = LineSegment(copy(l1.p), copy(l1.q))
     intersection_empty, point = is_intersection_empty(l1, l1, true)
     @test !is_intersection_empty(l1, l1) && !intersection_empty && point ∈ l1
@@ -81,21 +81,21 @@ for N in [Float64, Rational{Int}, Float32]
     @test !is_intersection_empty(l1, l1_copy) && !intersection_empty && point ∈ l1
 
     # subset
-    l = LineSegment(N[1., 1.], N[2., 2.])
+    l = LineSegment(N[1, 1], N[2, 2])
     b1 = Ball1(N[1.5, 1.5], N(1.1))
-    b2 = Ball1(N[1.5, 1.5], N(.4))
+    b2 = Ball1(N[1.5, 1.5], N(0.4))
     subset, point = ⊆(l, b1, true)
     @test ⊆(l, b1) && subset && point == N[]
     subset, point = ⊆(l, b2, true)
     @test !⊆(l, b2) && !subset && point ∈ l && point ∉ b2
-    h1 = Hyperrectangle(N[1.5, 1.5], N[.6, .8])
-    h2 = Hyperrectangle(N[1.5, 1.5], N[.4, .8])
+    h1 = Hyperrectangle(N[1.5, 1.5], N[0.6, 0.8])
+    h2 = Hyperrectangle(N[1.5, 1.5], N[0.4, 0.8])
     subset, point = ⊆(l, h1, true)
     @test ⊆(l, h1) && subset && point == N[]
     subset, point = ⊆(l, h2, true)
     @test !⊆(l, h2) && !subset && point ∈ l && point ∉ h2
 
     # halfspace_left & halfspace_right
-    @test N[1., 2.] ∈ halfspace_left(l)
-    @test N[2., 1.] ∈ halfspace_right(l)
+    @test N[1, 2] ∈ halfspace_left(l)
+    @test N[2, 1] ∈ halfspace_right(l)
 end

--- a/test/unit_LinearMap.jl
+++ b/test/unit_LinearMap.jl
@@ -1,7 +1,7 @@
 for N in [Float64, Rational{Int}, Float32]
     # π/2 trigonometric rotation
-    b = BallInf(N[1., 2.], N(1.))
-    M = N[0. -1. ; 1. 0.]
+    b = BallInf(N[1, 2], N(1))
+    M = N[0 -1 ; 1 0]
     # Test Construction
     lm1 = LinearMap(M, b)
     @test lm1.M == M
@@ -9,43 +9,43 @@ for N in [Float64, Rational{Int}, Float32]
     # Test Dimension
     @test dim(lm1) == 2
     # Test Support Vector
-    d = N[1., 1.]
-    @test σ(d, lm1) == N[-1., 2.]
-    d = N[-1., 1.]
-    @test σ(d, lm1) == N[-3., 2.]
-    d = N[-1., -1.]
-    @test σ(d, lm1) == N[-3., 0.]
-    d = N[1., -1.]
-    @test σ(d, lm1) == N[-1., 0.]
+    d = N[1, 1]
+    @test σ(d, lm1) == N[-1, 2]
+    d = N[-1, 1]
+    @test σ(d, lm1) == N[-3, 2]
+    d = N[-1, -1]
+    @test σ(d, lm1) == N[-3, 0]
+    d = N[1, -1]
+    @test σ(d, lm1) == N[-1, 0]
 
     # 2D -> 1D Projection
-    b = BallInf(N[1., 2.], N(1.))
-    M = N[1. 0.]
+    b = BallInf(N[1, 2], N(1))
+    M = N[1 0]
     lm = M*b
     # Test Dimension
     @test dim(lm) == 1
     # Test Support Vector
-    d = N[1.]
-    @test σ(d, lm) == N[2.]
-    d = N[-1.]
-    @test σ(d, lm) == N[0.]
+    d = N[1]
+    @test σ(d, lm) == N[2]
+    d = N[-1]
+    @test σ(d, lm) == N[0]
 
     # scalar multiplication
-    b = BallInf(N[0., 0.], N(1.))
-    lm = N(2.) * b
+    b = BallInf(N[0, 0], N(1))
+    lm = N(2) * b
     # repeated scalar multiplication
-    lm2 = N(2.) * lm
+    lm2 = N(2) * lm
     # Test Dimension
     @test dim(lm) == 2
     # Test Support Vector
-    d = N[1., 1.]
-    @test σ(d, lm) == N[2., 2.]
-    d = N[-1., 1.]
-    @test σ(d, lm) == N[-2., 2.]
-    d = N[-1., -1.]
-    @test σ(d, lm) == N[-2., -2.]
-    d = N[1., -1.]
-    @test σ(d, lm) == N[2., -2.]
+    d = N[1, 1]
+    @test σ(d, lm) == N[2, 2]
+    d = N[-1, 1]
+    @test σ(d, lm) == N[-2, 2]
+    d = N[-1, -1]
+    @test σ(d, lm) == N[-2, -2]
+    d = N[1, -1]
+    @test σ(d, lm) == N[2, -2]
 
     # Nested construction
     lm1_copy = LinearMap(Matrix{N}(I, 2, 2), lm1)
@@ -53,16 +53,16 @@ for N in [Float64, Rational{Int}, Float32]
     @test lm1_copy.X == lm1.X
 
     # an_element function
-    lm = N(2.) * BallInf(N[0., 0.], N(1.))
+    lm = N(2) * BallInf(N[0, 0], N(1))
     an_element(lm)
     @test an_element(lm) ∈ lm
 
     # check linear map between vector and set
-    X = BallInf(N[1.0], N(1.10445))
-    a = N[-1., 2.]
+    X = BallInf(N[1], N(1.10445))
+    a = N[-1, 2]
     @test a * X isa LinearMap{N, BallInf{N}, N, Matrix{N}}
 
     # linear map with a ZeroSet
-    X = N[0. -1. ; 1. 0.] * ZeroSet{N}(2)
+    X = N[0 -1 ; 1 0] * ZeroSet{N}(2)
     @test X isa ZeroSet{N} && dim(X) == 2
 end

--- a/test/unit_MinkowskiSum.jl
+++ b/test/unit_MinkowskiSum.jl
@@ -1,7 +1,7 @@
 for N in [Float64, Rational{Int}, Float32]
     # Sum of 2D centered balls in norm 1 and infinity
-    b1 = BallInf(N[0., 0.], N(2.))
-    b2 = Ball1(N[0., 0.], N(1.))
+    b1 = BallInf(N[0, 0], N(2))
+    b2 = Ball1(N[0, 0], N(1))
     # Test Construction
     X = MinkowskiSum(b1, b2)
     @test X.X == b1
@@ -9,52 +9,52 @@ for N in [Float64, Rational{Int}, Float32]
     # Test Dimension
     @test dim(X) == 2
     # Test Support Vector
-    d = N[1., 0.]
+    d = N[1, 0]
     v = σ(d, X)
-    @test v[1] == N(3.)
-    d = N[-1., 0.]
+    @test v[1] == N(3)
+    d = N[-1, 0]
     v = σ(d, X)
-    @test v[1] == N(-3.)
-    d = N[0., 1.]
+    @test v[1] == N(-3)
+    d = N[0, 1]
     v = σ(d, X)
-    @test v[2] == N(3.)
-    d = N[0., -1.]
+    @test v[2] == N(3)
+    d = N[0, -1]
     v = σ(d, X)
-    @test v[2] == N(-3.)
+    @test v[2] == N(-3)
 
     # Sum of not-centered 2D balls in norm 1 and infinity
-    b1 = BallInf(N[-1., 3.], N(2.))
-    b2 = Ball1(N[1., 2.], N(1.))
+    b1 = BallInf(N[-1, 3], N(2))
+    b2 = Ball1(N[1, 2], N(1))
     s = b1 + b2
     # Test Support Vector
-    d = N[1., 0.]
+    d = N[1, 0]
     v = σ(d, s)
-    @test v[1] == N(3.)
-    d = N[-1., 0.]
+    @test v[1] == N(3)
+    d = N[-1, 0]
     v = σ(d, s)
-    @test v[1] == N(-3.)
-    d = N[0., 1.]
+    @test v[1] == N(-3)
+    d = N[0, 1]
     v = σ(d, s)
-    @test v[2] == N(8.)
-    d = N[0., -1.]
+    @test v[2] == N(8)
+    d = N[0, -1]
     v = σ(d, s)
-    @test v[2] == N(2.)
+    @test v[2] == N(2)
 
     # Sum of array of LazySet
     # 2-elements
-    ms = MinkowskiSum(Singleton(N[1.]), Singleton(N[2.]))
-    @test ρ(N[1.], ms) == 3.
-    @test ρ(N[-1.], ms) == -3.
+    ms = MinkowskiSum(Singleton(N[1]), Singleton(N[2]))
+    @test ρ(N[1], ms) == 3
+    @test ρ(N[-1], ms) == -3
     # 3-elements
-    ms = MinkowskiSum(Singleton(N[1.]), MinkowskiSum(Singleton(N[2.]), Singleton(N[3.])))
-    @test ρ(N[1.], ms) == N(6.)
-    @test ρ(N[-1.], ms) == N(-6.)
+    ms = MinkowskiSum(Singleton(N[1]), MinkowskiSum(Singleton(N[2]), Singleton(N[3])))
+    @test ρ(N[1], ms) == N(6)
+    @test ρ(N[-1], ms) == N(-6)
 
     # an_element function (falls back to the default implementation
-    X = MinkowskiSum(LineSegment(N[0., 0.], N[1., 1.]),
-                     LineSegment(N[1., 0.], N[0., 1.]))
+    X = MinkowskiSum(LineSegment(N[0, 0], N[1, 1]),
+                     LineSegment(N[1, 0], N[0, 1]))
     v = an_element(X)
-    @test v ∈ Ball1(N[1., 1.], N(1.))
+    @test v ∈ Ball1(N[1, 1], N(1))
 
     # =================
     # MinkowskiSumArray
@@ -88,9 +88,9 @@ for N in [Float64, Rational{Int}, Float32]
     @test dim(msa) == 2
 
     # support vector
-    d = N[1., 1.]
+    d = N[1, 1]
     @test σ(d, ms) == σ(d, msa)
-    d = N[-1., 1.]
+    d = N[-1, 1]
     @test σ(d, ms) == σ(d, msa)
 
     # =================
@@ -99,8 +99,8 @@ for N in [Float64, Rational{Int}, Float32]
 
     # caching Minkowski sum
     cms = CacheMinkowskiSum(2, N)
-    x1 = BallInf(ones(N, 3), N(3.))
-    x2 = Ball1(ones(N, 3), N(5.))
+    x1 = BallInf(ones(N, 3), N(3))
+    x2 = Ball1(ones(N, 3), N(5))
     d = ones(N, 3)
     a = array(cms)
     push!(a, x1)
@@ -120,8 +120,8 @@ for N in [Float64, Rational{Int}, Float32]
     d[1] = zero(N)
     @test haskey(cms.cache, ones(N, 3))
     # getindex
-    cp = LazySets.CachedPair(1, N[2.])
-    @test cp[1] == 1 && cp[2] == N[2.]
+    cp = LazySets.CachedPair(1, N[2])
+    @test cp[1] == 1 && cp[2] == N[2]
     @test_throws ErrorException cp[3]
 
     # ================

--- a/test/unit_Polygon.jl
+++ b/test/unit_Polygon.jl
@@ -134,14 +134,14 @@ for N in [Float64, Float32, Rational{Int}]
     @test σ(d, vp) == points[2]
 
     # test that #83 is fixed
-    v = VPolygon(to_N(N, [[2.0, 3.0]]))
+    v = VPolygon([N[2.0, 3.0]])
     @test N[2.0, 3.0] ∈ v
     @test !(N[3.0, 2.0] ∈ v)
-    v = VPolygon(to_N(N, [[2.0, 3.0], [-1.0, -3.4]]))
+    v = VPolygon([N[2.0, 3.0], to_N(N, [-1.0, -3.4])])
     @test to_N(N, [-1.0, -3.4]) ∈ v
 
     # an_element function
-    v = VPolygon(to_N(N, [[2., 3.]]))
+    v = VPolygon([N[2., 3.]])
     @test an_element(v) ∈ v
 
     # membership
@@ -152,8 +152,8 @@ for N in [Float64, Float32, Rational{Int}]
     @test point ∉ VPolygon([N[1., 0.], N[1., 2.]])
 
     # subset
-    p1 = VPolygon(to_N(N, [[0., 0.], [2., 0.]]))
-    p2 = VPolygon(to_N(N, [[1., 0.]]))
+    p1 = VPolygon([N[0., 0.], N[2., 0.]])
+    p2 = VPolygon([N[1., 0.]])
     b = BallInf(N[2., 0.], N(1.))
     @test ⊆(p2, p1) && ⊆(p2, p1, true)[1]
     @test ⊆(HPolygon{N}(), p1)

--- a/test/unit_Polygon.jl
+++ b/test/unit_Polygon.jl
@@ -3,10 +3,10 @@ for N in [Float64, Float32, Rational{Int}]
     p = HPolygon{N}()
 
     # Test that constraints are automatically sorted
-    c1 = LinearConstraint(N[2., 2.], N(12.))
-    c2 = LinearConstraint(N[-3., 3.], N(6.))
-    c3 = LinearConstraint(N[-1., -1.], N(0.))
-    c4 = LinearConstraint(N[2., -4.], N(0.))
+    c1 = LinearConstraint(N[2, 2], N(12))
+    c2 = LinearConstraint(N[-3, 3], N(6))
+    c3 = LinearConstraint(N[-1, -1], N(0))
+    c4 = LinearConstraint(N[2, -4], N(0))
     addconstraint!(p, c3)
     addconstraint!(p, c1)
     addconstraint!(p, c4)
@@ -33,15 +33,15 @@ for N in [Float64, Float32, Rational{Int}]
     HPolytope(po)
 
     # support vector of empty polygon
-    @test_throws AssertionError σ(N[0.], HPolygon{N}())
-    @test_throws AssertionError σ(N[0.], HPolygonOpt(HPolygon{N}()))
-    @test_throws AssertionError σ(N[0.], HPolytope{N}())
+    @test_throws AssertionError σ(N[0], HPolygon{N}())
+    @test_throws AssertionError σ(N[0], HPolygonOpt(HPolygon{N}()))
+    @test_throws AssertionError σ(N[0], HPolytope{N}())
 
     # subset
-    b1 = Ball1(N[0., 0.], N(1.))
-    b2 = Ball1(N[1., 1.], N(4.))
-    l1 = LinearMap(N[1. 0.; 0. 1.], b1)
-    l2 = LinearMap(N[1. 0.; 0. 1.], b2)
+    b1 = Ball1(N[0, 0], N(1))
+    b2 = Ball1(N[1, 1], N(4))
+    l1 = LinearMap(N[1 0; 0 1], b1)
+    l2 = LinearMap(N[1 0; 0 1], b2)
     subset, point = ⊆(p, b1, true)
     @test !subset && point ∈ p && !(point ∈ b1)
     subset, point = ⊆(p, l1, true)
@@ -58,35 +58,35 @@ for N in [Float64, Float32, Rational{Int}]
         @test dim(hp) == 2
 
         # test support vector, with linear and binary search
-        d = N[1., 0.]
-        @test σ(d, hp) == N[4., 2.]
+        d = N[1, 0]
+        @test σ(d, hp) == N[4, 2]
         @test σ(d, hp, linear_search=true) == σ(d, hp, linear_search=false)
-        d = N[0., 1.]
-        @test σ(d, hp) == N[2., 4.]
+        d = N[0, 1]
+        @test σ(d, hp) == N[2, 4]
         @test σ(d, hp, linear_search=true) == σ(d, hp, linear_search=false)
-        d = N[0., -1.]
-        @test σ(d, hp) == N[0., 0.]
+        d = N[0, -1]
+        @test σ(d, hp) == N[0, 0]
         @test σ(d, hp, linear_search=true) == σ(d, hp, linear_search=false)
-        d = N[-1., 0.]
-        @test σ(d, hp) == N[-1., 1.]
+        d = N[-1, 0]
+        @test σ(d, hp) == N[-1, 1]
         @test σ(d, hp, linear_search=true) == σ(d, hp, linear_search=false)
-        d = N[1., -1.]
-        @test σ(d, hp) == N[4., 2.]
+        d = N[1, -1]
+        @test σ(d, hp) == N[4, 2]
         @test σ(d, hp, linear_search=true) == σ(d, hp, linear_search=false)
 
         # membership
-        @test ∈(N[0., 0.], hp)
-        @test ∈(N[4., 2.], hp)
-        @test ∈(N[2., 4.], hp)
-        @test ∈(N[-1., 1.], hp)
-        @test ∈(N[2., 3.], hp)
-        @test ∈(N[1., 1.], hp)
-        @test ∈(N[3., 2.], hp)
-        @test ∈(N[5. / 4., 7. / 4.], hp)
-        @test !∈(N[4., 1.], hp)
-        @test !∈(N[5., 2.], hp)
-        @test !∈(N[3., 4.], hp)
-        @test !∈(N[-1., 5.], hp)
+        @test ∈(N[0, 0], hp)
+        @test ∈(N[4, 2], hp)
+        @test ∈(N[2, 4], hp)
+        @test ∈(N[-1, 1], hp)
+        @test ∈(N[2, 3], hp)
+        @test ∈(N[1, 1], hp)
+        @test ∈(N[3, 2], hp)
+        @test ∈(N[5 / 4, 7 / 4], hp)
+        @test !∈(N[4, 1], hp)
+        @test !∈(N[5, 2], hp)
+        @test !∈(N[3, 4], hp)
+        @test !∈(N[-1, 5], hp)
 
         # an_element function
         @test an_element(hp) ∈ hp
@@ -104,10 +104,10 @@ for N in [Float64, Float32, Rational{Int}]
 
     # Test VRepresentation
     vp = tovrep(p)
-    @test N[2., 4.] ∈ vertices_list(vp)
-    @test N[-1., 1.] ∈ vertices_list(vp)
-    @test N[0., 0.] ∈ vertices_list(vp)
-    @test N[4., 2.] ∈ vertices_list(vp)
+    @test N[2, 4] ∈ vertices_list(vp)
+    @test N[-1, 1] ∈ vertices_list(vp)
+    @test N[0, 0] ∈ vertices_list(vp)
+    @test N[4, 2] ∈ vertices_list(vp)
     @test tovrep(vp) == vp
 
     # test convex hull of a set of points using the default algorithm
@@ -124,37 +124,37 @@ for N in [Float64, Float32, Rational{Int}]
     @test vertices_list(vp) == to_N(N, [[0.1, 0.3], [0.2, 0.1], [0.9, 0.2], [0.4, 0.6]])
 
     # test support vector of a VPolygon
-    d = N[1., 0.]
+    d = N[1, 0]
     @test σ(d, vp) == points[5]
-    d = N[0., 1.]
+    d = N[0, 1]
     @test σ(d, vp) == points[4]
-    d = N[-1., 0.]
+    d = N[-1, 0]
     @test σ(d, vp) == points[1]
-    d = N[0., -1.]
+    d = N[0, -1]
     @test σ(d, vp) == points[2]
 
     # test that #83 is fixed
-    v = VPolygon([N[2.0, 3.0]])
-    @test N[2.0, 3.0] ∈ v
-    @test !(N[3.0, 2.0] ∈ v)
-    v = VPolygon([N[2.0, 3.0], to_N(N, [-1.0, -3.4])])
-    @test to_N(N, [-1.0, -3.4]) ∈ v
+    v = VPolygon([N[2, 3]])
+    @test N[2, 3] ∈ v
+    @test !(N[3, 2] ∈ v)
+    v = VPolygon([N[2, 3], to_N(N, [-1, -3.4])])
+    @test to_N(N, [-1, -3.4]) ∈ v
 
     # an_element function
-    v = VPolygon([N[2., 3.]])
+    v = VPolygon([N[2, 3]])
     @test an_element(v) ∈ v
 
     # membership
-    point = N[0., 1.]
+    point = N[0, 1]
     @test point ∉ VPolygon(Vector{Vector{N}}(), apply_convex_hull=false)
-    @test point ∉ VPolygon([N[0., 2.]])
-    @test point ∈ VPolygon([N[0., 0.], N[0., 2.]])
-    @test point ∉ VPolygon([N[1., 0.], N[1., 2.]])
+    @test point ∉ VPolygon([N[0, 2]])
+    @test point ∈ VPolygon([N[0, 0], N[0, 2]])
+    @test point ∉ VPolygon([N[1, 0], N[1, 2]])
 
     # subset
-    p1 = VPolygon([N[0., 0.], N[2., 0.]])
-    p2 = VPolygon([N[1., 0.]])
-    b = BallInf(N[2., 0.], N(1.))
+    p1 = VPolygon([N[0, 0], N[2, 0]])
+    p2 = VPolygon([N[1, 0]])
+    b = BallInf(N[2, 0], N(1))
     @test ⊆(p2, p1) && ⊆(p2, p1, true)[1]
     @test ⊆(HPolygon{N}(), p1)
     subset, witness = ⊆(p1, b, true)
@@ -162,14 +162,14 @@ for N in [Float64, Float32, Rational{Int}]
     subset, witness = ⊆(p2, b, true)
     @test ⊆(p2, b) && subset
 
-    v1 = N[1.0, 0.0]
-    v2 = N[1.0, 1.0]
-    v3 = N[0.0, 1.0]
-    v4 = N[-1.0, 1.0]
-    v5 = N[-1.0, 0.0]
-    v6 = N[-1.0, -1.0]
-    v7 = N[0, -1.0]
-    v8 = N[1.0, -1.0]
+    v1 = N[1, 0]
+    v2 = N[1, 1]
+    v3 = N[0, 1]
+    v4 = N[-1, 1]
+    v5 = N[-1, 0]
+    v6 = N[-1, -1]
+    v7 = N[0, -1]
+    v8 = N[1, -1]
     v = [v1, v2, v3, v4, v5, v6, v7, v8]
 
     for (i, vi) in enumerate(v)
@@ -198,19 +198,19 @@ for N in [Float64, Float32, Rational{Int}]
             @test v1 ∈ h1
         elseif i == 2
             c = h1.constraints[1]
-            @test c.a ≈ to_N(N, [0.4, 0.5])&& c.b ≈ to_N(N, (0.46))
+            @test c.a ≈ to_N(N, [0.4, 0.5]) && c.b ≈ to_N(N, (0.46))
             c = h1.constraints[3]
-            @test c.a ≈ to_N(N, [-0.4, -0.5])&& c.b ≈ to_N(N, (-0.46))
+            @test c.a ≈ to_N(N, [-0.4, -0.5]) && c.b ≈ to_N(N, (-0.46))
         elseif i == 4
             @test length(h1.constraints) == 4
             c = h1.constraints[1]
-            @test c.a ≈ to_N(N, [0.4, 0.5])&& c.b ≈ to_N(N, (0.46))
+            @test c.a ≈ to_N(N, [0.4, 0.5]) && c.b ≈ to_N(N, (0.46))
             c = h1.constraints[2]
-            @test c.a ≈ to_N(N, [-0.3, 0.3])&& c.b ≈ to_N(N, (0.06))
+            @test c.a ≈ to_N(N, [-0.3, 0.3]) && c.b ≈ to_N(N, (0.06))
             c = h1.constraints[3]
-            @test c.a ≈ to_N(N, [-0.2, -0.1])&& c.b ≈ to_N(N, (-0.05))
+            @test c.a ≈ to_N(N, [-0.2, -0.1]) && c.b ≈ to_N(N, (-0.05))
             c = h1.constraints[4]
-            @test c.a ≈ to_N(N, [0.1, -0.7])&& c.b ≈ to_N(N, (-0.05))
+            @test c.a ≈ to_N(N, [0.1, -0.7]) && c.b ≈ to_N(N, (-0.05))
         end
 
         # check that constraints are sorted correctly

--- a/test/unit_Polytope.jl
+++ b/test/unit_Polytope.jl
@@ -6,13 +6,13 @@ for N in [Float64, Rational{Int}, Float32]
     # -----
 
     # constructor from matrix and vector
-    A = [N(1.) N(2.); N(-1.) N(1.)]
-    b = [N(1.), N(2.)]
+    A = [N(1) N(2); N(-1) N(1)]
+    b = [N(1), N(2)]
     p = HPolytope(A, b)
     c = p.constraints
     @test c isa Vector{LinearConstraint{N}}
-    @test c[1].a == N[1.0, 2.0] && c[1].b == N(1.0)
-    @test c[2].a == N[-1.0, 1.0] && c[2].b == N(2.0)
+    @test c[1].a == N[1, 2] && c[1].b == N(1)
+    @test c[2].a == N[-1, 1] && c[2].b == N(2)
 
     # convert back to matrix and vector
     A2, b2 = tosimplehrep(p)
@@ -20,28 +20,28 @@ for N in [Float64, Rational{Int}, Float32]
 
     # 2D polytope
     p = HPolytope{N}()
-    c1 = LinearConstraint(N[2., 2.], N(12.))
-    c2 = LinearConstraint(N[-3., 3.], N(6.))
-    c3 = LinearConstraint(N[-1., -1.], N(0.))
-    c4 = LinearConstraint(N[2., -4.], N(0.))
+    c1 = LinearConstraint(N[2, 2], N(12))
+    c2 = LinearConstraint(N[-3, 3], N(6))
+    c3 = LinearConstraint(N[-1, -1], N(0))
+    c4 = LinearConstraint(N[2, -4], N(0))
     addconstraint!(p, c3)
     addconstraint!(p, c1)
     addconstraint!(p, c4)
     addconstraint!(p, c2)
 
     # support vector
-    d = N[1., 0.]
-    @test σ(d, p) == N[4., 2.]
-    d = N[0., 1.]
-    @test σ(d, p) == N[2., 4.]
-    d = N[-1., 0.]
-    @test σ(d, p) == N[-1., 1.]
-    d = N[0., -1.]
-    @test σ(d, p) == N[0., 0.]
+    d = N[1, 0]
+    @test σ(d, p) == N[4, 2]
+    d = N[0, 1]
+    @test σ(d, p) == N[2, 4]
+    d = N[-1, 0]
+    @test σ(d, p) == N[-1, 1]
+    d = N[0, -1]
+    @test σ(d, p) == N[0, 0]
 
     # membership
-    @test ∈(N[5. / 4., 7. / 4.], p)
-    @test !∈(N[4., 1.], p)
+    @test ∈(N[5 / 4, 7 / 4], p)
+    @test !∈(N[4, 1], p)
 
     # singleton list (only available with Polyhedra library)
     if test_suite_polyhedra
@@ -61,7 +61,7 @@ for N in [Float64, Rational{Int}, Float32]
     # -----
 
     # constructor from a VPolygon
-    polygon = VPolygon([N[0., 0.], N[1., 0.], N[0., 1.]])
+    polygon = VPolygon([N[0, 0], N[1, 0], N[0, 1]])
     p = VPolytope(polygon)
     @test vertices_list(polygon) == vertices_list(p)
 
@@ -69,7 +69,7 @@ for N in [Float64, Rational{Int}, Float32]
     @test dim(p) == 2
 
     # support vector (only available with Polyhedra library)
-    d = N[1., 0.]
+    d = N[1, 0]
     @test_throws ErrorException σ(d, p, algorithm="xyz")
     if test_suite_polyhedra
         @test_throws MethodError σ(d, p) # not implemented yet
@@ -99,11 +99,11 @@ if test_suite_polyhedra
         # -----
 
         # intersection
-        A = [N(0.) N(1.); N(1.) N(0.); N(2.) N(2.)]
-        b = N[0., 0., 1.]
+        A = [N(0) N(1); N(1) N(0); N(2) N(2)]
+        b = N[0, 0, 1]
         p1 = HPolytope(A, b)
-        A = [N(0.) N(-1.); N(-1.) N(0.); N(1.) N(1.)]
-        b = N[-0.25, -0.25, -0.]
+        A = [N(0) N(-1); N(-1) N(0); N(1) N(1)]
+        b = N[-0.25, -0.25, -0]
         p2 = HPolytope(A, b)
         cap = intersect(p1, p2)
         # currently broken, see #565
@@ -113,8 +113,8 @@ if test_suite_polyhedra
         # currently broken, see #566
 
         # Cartesian product
-        A = [N(1.) N(-1.)]'
-        b = N[1., 0.]
+        A = [N(1) N(-1)]'
+        b = N[1, 0]
         p1 = HPolytope(A, b)
         p2 = HPolytope(A, b)
         cp = cartesian_product(p1, p2)
@@ -122,28 +122,28 @@ if test_suite_polyhedra
         @test length(cl) == 4
 
         # vertices_list
-        A = [N(1.) N(-1.)]'
-        b = N[1., 0.]
+        A = [N(1) N(-1)]'
+        b = N[1, 0]
         p = HPolytope(A, b)
         vl = vertices_list(p)
-        @test length(vl) == 2 && N[0.] ∈ vl && [1.] ∈ vl
+        @test length(vl) == 2 && N[0] ∈ vl && [1] ∈ vl
 
         # -----
         # V-rep
         # -----
 
         # intersection
-        p1 = VPolytope(vertices_list(BallInf(N[0., 0.], N(1.))))
-        p2 = VPolytope(vertices_list(BallInf(N[2., 2.], N(1.))))
+        p1 = VPolytope(vertices_list(BallInf(N[0, 0], N(1))))
+        p2 = VPolytope(vertices_list(BallInf(N[2, 2], N(1))))
         cap = intersect(p1, p2)
-        @test vertices_list(cap) == [N[1., 1.]]
+        @test vertices_list(cap) == [N[1, 1]]
 
         # convex hull
-        v1 = N[1., 0.]
-        v2 = N[0., 1.]
-        v3 = N[-1., 0.]
-        v4 = N[0., -1.]
-        v5 = N[0., 0.]
+        v1 = N[1, 0]
+        v2 = N[0, 1]
+        v3 = N[-1, 0]
+        v4 = N[0, -1]
+        v5 = N[0, 0]
         p1 = VPolytope([v1, v2, v5])
         p2 = VPolytope([v3, v4])
         ch = convex_hull(p1, p2)
@@ -155,10 +155,10 @@ if test_suite_polyhedra
         @test length(vl) == 5 && v5 ∈ vl
 
         # Cartesian product
-        p1 = VPolytope([N[0., 0.], N[1., 1.]])
-        p2 = VPolytope([N[2.]])
+        p1 = VPolytope([N[0, 0], N[1, 1]])
+        p2 = VPolytope([N[2]])
         cp = cartesian_product(p1, p2)
         vl = vertices_list(cp)
-        @test length(vl) == 2 && N[0., 0., 2.] ∈ vl && N[1., 1., 2.] ∈ vl
+        @test length(vl) == 2 && N[0, 0, 2] ∈ vl && N[1, 1, 2] ∈ vl
     end
 end

--- a/test/unit_Singleton.jl
+++ b/test/unit_Singleton.jl
@@ -1,21 +1,21 @@
 for N in [Float64, Rational{Int}, Float32]
     # 1D singleton
-    s = Singleton(N[1.])
-    d = N[1.]
-    @test σ(d, s) == N[1.]
-    d = N[-1.]
-    @test σ(d, s) == N[1.]
-    d = N[0.]
-    @test σ(d, s) == N[1.]
+    s = Singleton(N[1])
+    d = N[1]
+    @test σ(d, s) == N[1]
+    d = N[-1]
+    @test σ(d, s) == N[1]
+    d = N[0]
+    @test σ(d, s) == N[1]
 
     # 2D singleton
-    s = Singleton(N[1., 2.])
-    d = N[1., 0.]
-    @test σ(d, s) == N[1., 2.]
-    d = N[-1., .5]
-    @test σ(d, s) == N[1., 2.]
-    d = N[0., 0.]
-    @test σ(d, s) == N[1., 2.]
+    s = Singleton(N[1, 2])
+    d = N[1, 0]
+    @test σ(d, s) == N[1, 2]
+    d = N[-1, 0.5]
+    @test σ(d, s) == N[1, 2]
+    d = N[0, 0]
+    @test σ(d, s) == N[1, 2]
 
     # element function
     @test element(s) == s.element
@@ -24,9 +24,9 @@ for N in [Float64, Rational{Int}, Float32]
     end
 
     # membership
-    S = Singleton(N[1., 1.])
+    S = Singleton(N[1, 1])
     !∈(N[0.9, 1.1], S)
-    ∈(N[1.0, 1.0], S)
+    ∈(N[1, 1], S)
 
     # an_element function
     @test an_element(S) ∈ S
@@ -42,11 +42,11 @@ for N in [Float64, Rational{Int}, Float32]
     @test element(linear_map(M, S)) == an_element(M * S)
 
     # subset
-    s1 = Singleton(N[0., 1.])
-    s2 = Singleton(N[0., 3.])
-    p1 = VPolygon([N[0.,0.], N[0., 2.]])
-    p2 = VPolygon([N[0.,0.], N[0., 2.], N[2., 0.]])
-    b = BallInf(N[0., 1.], N(1.))
+    s1 = Singleton(N[0, 1])
+    s2 = Singleton(N[0, 3])
+    p1 = VPolygon([N[0,0], N[0, 2]])
+    p2 = VPolygon([N[0,0], N[0, 2], N[2, 0]])
+    b = BallInf(N[0, 1], N(1))
     @test ⊆(s1, p1) && ⊆(s1, p1, true)[1]
     subset, point = ⊆(s2, p2, true)
     @test !⊆(s2, p2) && !subset && point ∈ s2 && !(point ∈ p2)
@@ -59,11 +59,11 @@ for N in [Float64, Rational{Int}, Float32]
     @test !⊆(s2, b) && !subset && point ∈ s2 && !(point ∈ b)
 
     # intersection emptiness
-    S1 = Singleton(N[1.0, 1.0])
-    S2 = Singleton(N[0.0, 0.0])
+    S1 = Singleton(N[1, 1])
+    S2 = Singleton(N[0, 0])
     S3 = ZeroSet{N}(2)
-    H = BallInf(N[1.0, 1.0], N(0.5))
-    M = LinearMap(N[1. 0.; 0. 1.], H)
+    H = BallInf(N[1, 1], N(0.5))
+    M = LinearMap(N[1 0; 0 1], H)
     @test is_intersection_empty(S1, S2) && is_intersection_empty(S1, S2, true)[1]
     intersection_empty, point = is_intersection_empty(S2, S3, true)
     @test !is_intersection_empty(S2, S3) && !intersection_empty &&

--- a/test/unit_SymmetricIntervalHull.jl
+++ b/test/unit_SymmetricIntervalHull.jl
@@ -4,24 +4,24 @@ for N in [Float64, Rational{Int}, Float32]
     @test SymmetricIntervalHull(E) == E
 
     # normal constructor
-    h = SymmetricIntervalHull(Ball1(N[2., 3.], N(4.)))
+    h = SymmetricIntervalHull(Ball1(N[2, 3], N(4)))
 
     # dimension
     @test dim(h) == 2
 
     # support vector
-    d = N[1., 0.]
-    @test σ(d, h)[1] == N(6.) && σ(-d, h)[1] == N(-6.)
-    d = N[0., 1.]
-    @test σ(d, h)[2] == N(7.) && σ(-d, h)[2] == N(-7.)
+    d = N[1, 0]
+    @test σ(d, h)[1] == N(6) && σ(-d, h)[1] == N(-6)
+    d = N[0, 1]
+    @test σ(d, h)[2] == N(7) && σ(-d, h)[2] == N(-7)
 
     # an_element function
-    @test an_element(h) == N[0., 0.]
+    @test an_element(h) == N[0, 0]
 
     # radius_hyperrectangle function (uncached and cached)
-    h = SymmetricIntervalHull(Ball1(N[2., 3.], N(4.)))
+    h = SymmetricIntervalHull(Ball1(N[2, 3], N(4)))
     for i in 1:2
-        @test radius_hyperrectangle(h, 1) == 6.
-        @test radius_hyperrectangle(h) == N[6., 7.]
+        @test radius_hyperrectangle(h, 1) == 6
+        @test radius_hyperrectangle(h) == N[6, 7]
     end
 end

--- a/test/unit_ZeroSet.jl
+++ b/test/unit_ZeroSet.jl
@@ -1,15 +1,15 @@
 for N in [Float64, Rational{Int}, Float32]
     Z = ZeroSet{N}(2)
-    B = BallInf(ones(N, 2), N(1.))
+    B = BallInf(ones(N, 2), N(1))
 
     # support vector
-    d = N[1., 0.]
+    d = N[1, 0]
     @test σ(d, Z) == zeros(N, 2)
 
     # testing that the zero set is neutral element for the Minkowski sum
     @test B ⊕ Z == B && Z ⊕ B == B
 
-    cpa = MinkowskiSumArray([B, N(2.) * B, N(3.) * B])
+    cpa = MinkowskiSumArray([B, N(2) * B, N(3) * B])
     @test cpa ⊕ Z == cpa && Z ⊕ cpa == cpa
 
     # test M-sum of zero set with itself
@@ -22,8 +22,8 @@ for N in [Float64, Rational{Int}, Float32]
 
     # subset
     z = ZeroSet{N}(1)
-    s1 = Singleton(N[0.])
-    s2 = Singleton(N[2.])
+    s1 = Singleton(N[0])
+    s2 = Singleton(N[2])
     @test ⊆(z, s1) && ⊆(z, s1, true)[1]
     subset, point = ⊆(z, s2, true)
     @test !⊆(z, s2) && !subset && point ∈ z && !(point ∈ s2)

--- a/test/unit_Zonotope.jl
+++ b/test/unit_Zonotope.jl
@@ -1,76 +1,76 @@
 for N in [Float64, Rational{Int}, Float32]
     # 1D Zonotope
-    z = Zonotope(N[0.], Matrix{N}(I, 1, 1))
+    z = Zonotope(N[0], Matrix{N}(I, 1, 1))
     # Test Dimension
     @test dim(z) == 1
     # Test Support Vector
-    d = N[1.]
-    @test σ(d, z) == N[1.]
-    d = N[-1.]
-    @test σ(d, z) == N[-1.]
+    d = N[1]
+    @test σ(d, z) == N[1]
+    d = N[-1]
+    @test σ(d, z) == N[-1]
 
     # 2D Zonotope
-    z = Zonotope(N[0., 0.], Matrix{N}(I, 2, 2))
+    z = Zonotope(N[0, 0], Matrix{N}(I, 2, 2))
     # Test Dimension
     @test dim(z) == 2
     # Test Support Vector
-    d = N[1., 0.]
-    @test σ(d, z) == N[1., 1.] || N[1., -1]
-    d = N[-1., 0.]
-    @test σ(d, z) == N[-1., 1.] || N[-1., -1]
-    d = N[0., 1.]
-    @test σ(d, z) == N[1., 1.] || N[-1., 1]
-    d = N[0., -1.]
-    @test σ(d, z) == N[1., -1.] || N[-1., -1]
+    d = N[1, 0]
+    @test σ(d, z) == N[1, 1] || N[1, -1]
+    d = N[-1, 0]
+    @test σ(d, z) == N[-1, 1] || N[-1, -1]
+    d = N[0, 1]
+    @test σ(d, z) == N[1, 1] || N[-1, 1]
+    d = N[0, -1]
+    @test σ(d, z) == N[1, -1] || N[-1, -1]
 
     # 2D Zonotope not 0-centered
-    z = Zonotope(N[1., 2.], Matrix{N}(I, 2, 2))
+    z = Zonotope(N[1, 2], Matrix{N}(I, 2, 2))
     # Test Dimension
     @test dim(z) == 2
     # Test Support Vector
-    d = N[1., 0.]
-    @test σ(d, z) == N[2., 3]
-    d = N[-1., 0.]
-    @test σ(d, z) == N[0., 3]
-    d = N[0., 1.]
-    @test σ(d, z) == N[2., 3]
-    d = N[0., -1.]
-    @test σ(d, z) == N[2., 1.]
+    d = N[1, 0]
+    @test σ(d, z) == N[2, 3]
+    d = N[-1, 0]
+    @test σ(d, z) == N[0, 3]
+    d = N[0, 1]
+    @test σ(d, z) == N[2, 3]
+    d = N[0, -1]
+    @test σ(d, z) == N[2, 1]
 
     # an_element function
     @test an_element(z) ∈ z
 
     # concrete operations
-    Z1 = Zonotope(N[1, 1.], N[1 1; -1 1.])
-    Z2 = Zonotope(N[-1, 1.], Matrix{N}(I, 2, 2))
+    Z1 = Zonotope(N[1, 1], N[1 1; -1 1])
+    Z2 = Zonotope(N[-1, 1], Matrix{N}(I, 2, 2))
     A = N[0.5 1; 1 0.5]
 
     # concrete Minkowski sum
     Z3 = minkowski_sum(Z1, Z2)
-    @test Z3.center == N[0, 2.]
-    @test Z3.generators == N[1 1 1 0; -1 1 0 1.]
+    @test Z3.center == N[0, 2]
+    @test Z3.generators == N[1 1 1 0; -1 1 0 1]
 
     # concrete linear map and scale
     Z4 = linear_map(A, Z3)
-    @test Z4.center == N[2, 1.]
-    @test Z4.generators == N[-0.5 1.5 0.5 1.0; 0.5 1.5 1.0 0.5]
+    @test Z4.center == N[2, 1]
+    @test Z4.generators == N[-0.5 1.5 0.5 1; 0.5 1.5 1 0.5]
     Z5 = scale(0.5, Z3)
-    @test Z5.center == N[0, 1.]
-    @test Z5.generators == N[0.5 0.5 0.5 0.0; -0.5 0.5 0.0 0.5]
+    @test Z5.center == N[0, 1]
+    @test Z5.generators == N[0.5 0.5 0.5 0; -0.5 0.5 0 0.5]
 
     # intersection with a hyperplane
-    H1 = Hyperplane(N[1., 1.], N(3.))
+    H1 = Hyperplane(N[1, 1], N(3))
     #intersection_empty, point = is_intersection_empty(Z1, H1, true)
     @test !is_intersection_empty(Z1, H1) #&& !intersection_empty &&
           #point ∈ Z1 && point ∈ H1
     @test_throws ErrorException is_intersection_empty(Z1, H1, true)
-    H2 = Hyperplane(N[1., 1.], N(-11.))
+    H2 = Hyperplane(N[1, 1], N(-11))
     @test is_intersection_empty(Z1, H2) && is_intersection_empty(Z1, H2, true)[1]
     @test !is_intersection_empty(H1, Z1)
     @test is_intersection_empty(H2, Z1) && is_intersection_empty(H2, Z1, true)[1]
 
     # test number of generators
-    Z = Zonotope(N[2, 1.], N[-0.5 1.5 0.5 1.0; 0.5 1.5 1.0 0.5])
+    Z = Zonotope(N[2, 1], N[-0.5 1.5 0.5 1; 0.5 1.5 1 0.5])
     @test ngens(Z) == 4
     # test order reduction
     Zred1 = reduce_order(Z, 1)
@@ -79,13 +79,13 @@ for N in [Float64, Rational{Int}, Float32]
     Zred2 = reduce_order(Z, 2)
     @test ngens(Zred2) == 4
     @test order(Zred2) == 2
-    Z = Zonotope(N[2, 1.], N[-0.5 1.5 0.5 1.0 0.0 1.0; 0.5 1.5 1.0 0.5 1.0 0.0])
+    Z = Zonotope(N[2, 1], N[-0.5 1.5 0.5 1 0 1; 0.5 1.5 1 0.5 1 0])
     Zred3 = reduce_order(Z, 2)
     @test ngens(Zred3) == 4
     @test order(Zred3) == 2
 
     # test conversion from hyperrectangular sets
-    Z = convert(Zonotope, Hyperrectangle(N[2., 3.], N[4., 5.]))
-    @test Z.center == N[2., 3.] && diag(Z.generators) == N[4., 5.]
-    convert(Zonotope, BallInf(N[5., 3.], N(2.)))
+    Z = convert(Zonotope, Hyperrectangle(N[2, 3], N[4, 5]))
+    @test Z.center == N[2, 3] && diag(Z.generators) == N[4, 5]
+    convert(Zonotope, BallInf(N[5, 3], N(2)))
 end

--- a/test/unit_ballinf_approximation.jl
+++ b/test/unit_ballinf_approximation.jl
@@ -2,21 +2,21 @@ import LazySets.Approximations.ballinf_approximation
 
 for N in [Float64, Float32, Rational{Int}]
     # BallInf approximation of a 3D unit ball in the 1-norm centered at [1,2,0]
-    b = Ball1(N[1., 2., 0.], N(1.))
+    b = Ball1(N[1, 2, 0], N(1))
     bi = ballinf_approximation(b)
-    biexp = BallInf(N[1., 2., 0.], N(1.))
+    biexp = BallInf(N[1, 2, 0], N(1))
     @test bi.center ≈ biexp.center
     @test bi.radius ≈ biexp.radius
 
     # BallInf approximation of a 2D polygon whose vertices are
     # (0,1), (1,1), (2,-1), (-1,0)
     p = HPolygon{N}()
-    addconstraint!(p, LinearConstraint(N[0., 1.], N(1.)))
-    addconstraint!(p, LinearConstraint(N[-1., 1.], N(1.)))
-    addconstraint!(p, LinearConstraint(N[-1., -3.], N(1.)))
-    addconstraint!(p, LinearConstraint(N[2., 1.], N(3.)))
+    addconstraint!(p, LinearConstraint(N[0, 1], N(1)))
+    addconstraint!(p, LinearConstraint(N[-1, 1], N(1)))
+    addconstraint!(p, LinearConstraint(N[-1, -3], N(1)))
+    addconstraint!(p, LinearConstraint(N[2, 1], N(3)))
     bi = ballinf_approximation(p)
-    biexp = BallInf(N[.5, 0.], N(1.5))
+    biexp = BallInf(N[0.5, 0], N(1.5))
     @test bi.center ≈ biexp.center
     @test bi.radius ≈ biexp.radius
 end

--- a/test/unit_box_approximation.jl
+++ b/test/unit_box_approximation.jl
@@ -7,28 +7,28 @@ for N in [Float64, Rational{Int}, Float32]
     # Testing box approximation
     # ==============================
     # Box approximation of a 2D square
-    b = BallInf(N[1., 1.], N(0.1))
+    b = BallInf(N[1, 1], N(0.1))
     h = box_approximation(b)
-    hexp = Hyperrectangle(N[1., 1.], N[0.1, 0.1])
+    hexp = Hyperrectangle(N[1, 1], N[0.1, 0.1])
     @test h.center ≈ hexp.center
     @test h.radius ≈ hexp.radius
 
     # Box approximation of a 2D unit ball in the 1-norm
-    b = Ball1(N[1., -2.], N(0.2))
+    b = Ball1(N[1, -2], N(0.2))
     h = box_approximation(b)
-    hexp = Hyperrectangle(N[1., -2.], N[0.2, 0.2])
+    hexp = Hyperrectangle(N[1, -2], N[0.2, 0.2])
     @test h.center ≈ hexp.center
     @test h.radius ≈ hexp.radius
 
     # Box approximation of a 3D unit ball in the 1-norm
-    b = Ball1(N[1., 2., 0.], N(1.))
+    b = Ball1(N[1, 2, 0], N(1))
     h = box_approximation(b)
-    hexp = Hyperrectangle(N[1., 2., 0.], N[1., 1., 1.])
+    hexp = Hyperrectangle(N[1, 2, 0], N[1, 1, 1])
     @test h.center ≈ hexp.center
     @test h.radius ≈ hexp.radius
 
     # Box approximation of a Hyperrectangle
-    hexp = Hyperrectangle(N[0., 0.], N[1., 1.])
+    hexp = Hyperrectangle(N[0, 0], N[1, 1])
     h = box_approximation(hexp)
     @test h.center ≈ hexp.center
     @test h.radius ≈ hexp.radius
@@ -37,23 +37,23 @@ for N in [Float64, Rational{Int}, Float32]
     # Testing box_approximation_symmetric (= symmetric interval hull)
     # ===================================================================
     # Box approximation of a 2D square
-    b = BallInf(N[1., 1.], to_N(N, 0.1))
+    b = BallInf(N[1, 1], to_N(N, 0.1))
     h = box_approximation_symmetric(b)
-    hexp = Hyperrectangle(N[0.0, 0.0], to_N(N, [1.1, 1.1]))
+    hexp = Hyperrectangle(N[0, 0], to_N(N, [1.1, 1.1]))
     @test h.center ≈ hexp.center
     @test h.radius ≈ hexp.radius
 
     # Box approximation of a 2D unit ball in the 1-norm
-    b = Ball1(N[1., -2.], to_N(N, 0.2))
+    b = Ball1(N[1, -2], to_N(N, 0.2))
     h = box_approximation_symmetric(b)
-    hexp = Hyperrectangle(N[0., 0.], to_N(N, [1.2, 2.2]))
+    hexp = Hyperrectangle(N[0, 0], to_N(N, [1.2, 2.2]))
     @test h.center ≈ hexp.center
     @test h.radius ≈ hexp.radius
 
     # Box approximation of a 3D unit ball in the 1-norm
-    b = Ball1(N[1., 2., 0.], to_N(N, 0.1))
+    b = Ball1(N[1, 2, 0], to_N(N, 0.1))
     h = box_approximation_symmetric(b)
-    hexp = Hyperrectangle(N[0., 0., 0.], to_N(N, [1.1, 2.1, 0.1]))
+    hexp = Hyperrectangle(N[0, 0, 0], to_N(N, [1.1, 2.1, 0.1]))
     @test h.center ≈ hexp.center
     @test h.radius ≈ hexp.radius
 

--- a/test/unit_box_approximation.jl
+++ b/test/unit_box_approximation.jl
@@ -7,23 +7,23 @@ for N in [Float64, Rational{Int}, Float32]
     # Testing box approximation
     # ==============================
     # Box approximation of a 2D square
-    b = BallInf(to_N(N, [1., 1.]), to_N(N, 0.1))
+    b = BallInf(N[1., 1.], N(0.1))
     h = box_approximation(b)
-    hexp = Hyperrectangle(to_N(N, [1., 1.]), to_N(N, [0.1, 0.1]))
+    hexp = Hyperrectangle(N[1., 1.], N[0.1, 0.1])
     @test h.center ≈ hexp.center
     @test h.radius ≈ hexp.radius
 
     # Box approximation of a 2D unit ball in the 1-norm
-    b = Ball1(to_N(N, [1., -2.]), to_N(N, 0.2))
+    b = Ball1(N[1., -2.], N(0.2))
     h = box_approximation(b)
-    hexp = Hyperrectangle(to_N(N, [1., -2.]), to_N(N, [0.2, 0.2]))
+    hexp = Hyperrectangle(N[1., -2.], N[0.2, 0.2])
     @test h.center ≈ hexp.center
     @test h.radius ≈ hexp.radius
 
     # Box approximation of a 3D unit ball in the 1-norm
-    b = Ball1(to_N(N, [1., 2., 0.]), to_N(N, 1.))
+    b = Ball1(N[1., 2., 0.], N(1.))
     h = box_approximation(b)
-    hexp = Hyperrectangle(to_N(N, [1., 2., 0.]), to_N(N, [1., 1., 1.]))
+    hexp = Hyperrectangle(N[1., 2., 0.], N[1., 1., 1.])
     @test h.center ≈ hexp.center
     @test h.radius ≈ hexp.radius
 
@@ -37,28 +37,29 @@ for N in [Float64, Rational{Int}, Float32]
     # Testing box_approximation_symmetric (= symmetric interval hull)
     # ===================================================================
     # Box approximation of a 2D square
-    b = BallInf(to_N(N, [1., 1.]), to_N(N, 0.1))
+    b = BallInf(N[1., 1.], to_N(N, 0.1))
     h = box_approximation_symmetric(b)
-    hexp = Hyperrectangle(to_N(N, [0.0, 0.0]), to_N(N, [1.1, 1.1]))
+    hexp = Hyperrectangle(N[0.0, 0.0], to_N(N, [1.1, 1.1]))
     @test h.center ≈ hexp.center
     @test h.radius ≈ hexp.radius
 
     # Box approximation of a 2D unit ball in the 1-norm
-    b = Ball1(to_N(N, [1., -2.]), to_N(N, 0.2))
+    b = Ball1(N[1., -2.], to_N(N, 0.2))
     h = box_approximation_symmetric(b)
-    hexp = Hyperrectangle(to_N(N, [0., 0.]), to_N(N, [1.2, 2.2]))
+    hexp = Hyperrectangle(N[0., 0.], to_N(N, [1.2, 2.2]))
     @test h.center ≈ hexp.center
     @test h.radius ≈ hexp.radius
 
     # Box approximation of a 3D unit ball in the 1-norm
-    b = Ball1(to_N(N, [1., 2., 0.]), to_N(N, 0.1))
+    b = Ball1(N[1., 2., 0.], to_N(N, 0.1))
     h = box_approximation_symmetric(b)
-    hexp = Hyperrectangle(to_N(N, [0., 0., 0.]), to_N(N, [1.1, 2.1, 0.1]))
+    hexp = Hyperrectangle(N[0., 0., 0.], to_N(N, [1.1, 2.1, 0.1]))
     @test h.center ≈ hexp.center
     @test h.radius ≈ hexp.radius
 
     # Box approximation of a 4D hyperrectangle
-    b = Hyperrectangle(to_N(N, [-1.5, -2.5, 2.4, -0.4]), to_N(N, [0.1, 0.2, 0.3, 0.4]))
+    b = Hyperrectangle(to_N(N, [-1.5, -2.5, 2.4, -0.4]),
+                       to_N(N, [0.1, 0.2, 0.3, 0.4]))
     h = box_approximation_symmetric(b)
     hexp = Hyperrectangle(zeros(N, 4), to_N(N, [1.6, 2.7, 2.7, 0.8]))
     @test h.center ≈ hexp.center

--- a/test/unit_overapproximate.jl
+++ b/test/unit_overapproximate.jl
@@ -11,10 +11,10 @@ for N in [Float64, Rational{Int}, Float32]
     c = N[0., 0.]
     b = Ball1(c, N(1.))
     p = overapproximate(b, HPolygon)
-    for d in to_N(N, [[1., 0.], [-1., 0.]])
+    for d in [N[1., 0.], N[-1., 0.]]
         @test σ(d, p)[1] ≈ σ(d, b)[1]
     end
-    for d in to_N(N, [[0., 1.], [0., -1.]])
+    for d in [N[0., 1.], N[0., -1.]]
         @test σ(d, p)[2] ≈ σ(d, b)[2]
     end
 
@@ -22,10 +22,10 @@ for N in [Float64, Rational{Int}, Float32]
     c = N[0., 0.]
     b = Ball1(c, N(1.))
     p = overapproximate(b, Hyperrectangle)
-    for d in to_N(N, [[1., 0.], [-1., 0.]])
+    for d in [N[1., 0.], N[-1., 0.]]
         @test σ(d, p)[1] ≈ σ(d, b)[1]
     end
-    for d in to_N(N, [[0., 1.], [0., -1.]])
+    for d in [N[0., 1.], N[0., -1.]]
         @test σ(d, p)[2] ≈ σ(d, b)[2]
     end
     @test p.center ≈ c
@@ -34,7 +34,7 @@ for N in [Float64, Rational{Int}, Float32]
     # Interval approximation
     b = Ball1(N[0.], N(1.))
     p = overapproximate(b, LazySets.Interval)
-    for d in to_N(N, [[1.], [-1.]])
+    for d in [N[1.], N[-1.]]
         @test σ(d, p)[1] ≈ σ(d, b)[1]
     end
 end

--- a/test/unit_overapproximate.jl
+++ b/test/unit_overapproximate.jl
@@ -39,18 +39,18 @@ for N in [Float64, Rational{Int}, Float32]
     end
 end
 
-# useful for benchmarking overapproximate and LinearMap's support vector
-# (see #290)
-function overapproximate_lmap(n)
-    B = BallInf(ones(n), 2)
-    π = sparse([1, 2], [1, 2], ones(2), 2, n)
-    return Approximations.overapproximate(π*B)
-end
-o = overapproximate_lmap(50)
-@test o.center == [1, 1] && o.radius == [2, 2]
-
 # tests that do not work with Rational{Int}
 for N in [Float64, Float32]
+    # useful for benchmarking overapproximate and LinearMap's support vector
+    # (see #290)
+    function overapproximate_lmap(n)
+        B = BallInf(ones(N, n), N(2))
+        π = sparse(N[1, 2], N[1, 2], ones(N, 2), 2, n)
+        return Approximations.overapproximate(π*B)
+    end
+    o = overapproximate_lmap(50)
+    @test o.center == N[1, 1] && o.radius == N[2, 2]
+
     # Approximation of a 2D centered unit ball in norm 1
     # All vertices v should be like this:
     # ‖v‖ >= 1 and ‖v‖ <= 1+ε

--- a/test/unit_overapproximate.jl
+++ b/test/unit_overapproximate.jl
@@ -8,33 +8,33 @@ for N in [Float64, Rational{Int}, Float32]
     @test overapproximate(e, EmptySet) == e
 
     # HPolygon approximation with box directions
-    c = N[0., 0.]
-    b = Ball1(c, N(1.))
+    c = N[0, 0]
+    b = Ball1(c, N(1))
     p = overapproximate(b, HPolygon)
-    for d in [N[1., 0.], N[-1., 0.]]
+    for d in [N[1, 0], N[-1, 0]]
         @test σ(d, p)[1] ≈ σ(d, b)[1]
     end
-    for d in [N[0., 1.], N[0., -1.]]
+    for d in [N[0, 1], N[0, -1]]
         @test σ(d, p)[2] ≈ σ(d, b)[2]
     end
 
     # Hyperrectangle approximation
-    c = N[0., 0.]
-    b = Ball1(c, N(1.))
+    c = N[0, 0]
+    b = Ball1(c, N(1))
     p = overapproximate(b, Hyperrectangle)
-    for d in [N[1., 0.], N[-1., 0.]]
+    for d in [N[1, 0], N[-1, 0]]
         @test σ(d, p)[1] ≈ σ(d, b)[1]
     end
-    for d in [N[0., 1.], N[0., -1.]]
+    for d in [N[0, 1], N[0, -1]]
         @test σ(d, p)[2] ≈ σ(d, b)[2]
     end
     @test p.center ≈ c
-    @test p.radius ≈ N[1., 1.]
+    @test p.radius ≈ N[1, 1]
 
     # Interval approximation
-    b = Ball1(N[0.], N(1.))
+    b = Ball1(N[0], N(1))
     p = overapproximate(b, LazySets.Interval)
-    for d in [N[1.], N[-1.]]
+    for d in [N[1], N[-1]]
         @test σ(d, p)[1] ≈ σ(d, b)[1]
     end
 end
@@ -42,12 +42,12 @@ end
 # useful for benchmarking overapproximate and LinearMap's support vector
 # (see #290)
 function overapproximate_lmap(n)
-    B = BallInf(ones(n), 2.)
+    B = BallInf(ones(n), 2)
     π = sparse([1, 2], [1, 2], ones(2), 2, n)
     return Approximations.overapproximate(π*B)
 end
 o = overapproximate_lmap(50)
-@test o.center == [1., 1] && o.radius == [2., 2]
+@test o.center == [1, 1] && o.radius == [2, 2]
 
 # tests that do not work with Rational{Int}
 for N in [Float64, Float32]
@@ -55,59 +55,59 @@ for N in [Float64, Float32]
     # All vertices v should be like this:
     # ‖v‖ >= 1 and ‖v‖ <= 1+ε
     # Where ε is the given error bound
-    b = Ball1(N[0., 0.], N(1.))
-    ε = N(.01)
+    b = Ball1(N[0, 0], N(1))
+    ε = N(0.01)
     p = tovrep(overapproximate(b, ε))
     for v in vertices_list(p)
-    @test norm(v) >= N(1.)
-    @test norm(v) <= N(1. + ε)
+    @test norm(v) >= N(1)
+    @test norm(v) <= N(1 + ε)
     end
 
     # Check that there are no redundant constraints for a ballinf
     b = BallInf(N[0.5, 0.5], N(0.1))
-    lcl = overapproximate(b, N(.001)).constraints
+    lcl = overapproximate(b, N(0.001)).constraints
     @test length(lcl) == 4
-    @test lcl[1].a == N[1.0, 0.0]
+    @test lcl[1].a == N[1, 0]
     @test lcl[1].b == N(0.6)
-    @test lcl[2].a == N[0.0, 1.0]
+    @test lcl[2].a == N[0, 1]
     @test lcl[2].b == N(0.6)
-    @test lcl[3].a == N[-1.0, 0.0]
+    @test lcl[3].a == N[-1, 0]
     @test lcl[3].b == N(-0.4)
-    @test lcl[4].a == N[0.0, -1.0]
+    @test lcl[4].a == N[0, -1]
     @test lcl[4].b == N(-0.4)
 
     # Check that there are no redundant constraints for a HPolygon (octagon)
     p = HPolygon{N}()
-    addconstraint!(p, LinearConstraint(N[1.0, 0.0], N(1.0)))
-    addconstraint!(p, LinearConstraint(N[0.0, 1.0], N(1.0)))
-    addconstraint!(p, LinearConstraint(N[-1.0, 0.0], N(1.0)))
-    addconstraint!(p, LinearConstraint(N[0.0, -1.0], N(1.0)))
-    addconstraint!(p, LinearConstraint(N[sqrt(2.0)/2.0, sqrt(2.0)/2.0], N(1.0)))
-    addconstraint!(p, LinearConstraint(N[-sqrt(2.0)/2.0, sqrt(2.0)/2.0], N(1.0)))
-    addconstraint!(p, LinearConstraint(N[sqrt(2.0)/2.0, -sqrt(2.0)/2.0], N(1.0)))
-    addconstraint!(p, LinearConstraint(N[-sqrt(2.0)/2.0, -sqrt(2.0)/2.0], N(1.0)))
+    addconstraint!(p, LinearConstraint(N[1, 0], N(1)))
+    addconstraint!(p, LinearConstraint(N[0, 1], N(1)))
+    addconstraint!(p, LinearConstraint(N[-1, 0], N(1)))
+    addconstraint!(p, LinearConstraint(N[0, -1], N(1)))
+    addconstraint!(p, LinearConstraint(N[sqrt(2)/2, sqrt(2)/2], N(1)))
+    addconstraint!(p, LinearConstraint(N[-sqrt(2)/2, sqrt(2)/2], N(1)))
+    addconstraint!(p, LinearConstraint(N[sqrt(2)/2, -sqrt(2)/2], N(1)))
+    addconstraint!(p, LinearConstraint(N[-sqrt(2)/2, -sqrt(2)/2], N(1)))
     lcl = overapproximate(p, N(.001)).constraints
     @test length(lcl) == 8
-    @test lcl[1].a ≈ N[1.0, 0.0]
-    @test lcl[1].b ≈ N(1.0)
-    @test lcl[2].a ≈ N[sqrt(2.0)/2.0, sqrt(2.0)/2.0]
-    @test lcl[2].b ≈ N(1.0)
-    @test lcl[3].a ≈ N[0.0, 1.0]
-    @test lcl[3].b ≈ N(1.0)
-    @test lcl[4].a ≈ N[-sqrt(2.0)/2.0, sqrt(2.0)/2.0]
-    @test lcl[4].b ≈ N(1.0)
-    @test lcl[5].a ≈ N[-1.0, 0.0]
-    @test lcl[5].b ≈ N(1.0)
-    @test lcl[6].a ≈ N[-sqrt(2.0)/2.0, -sqrt(2.0)/2.0]
-    @test lcl[6].b ≈ N(1.0)
-    @test lcl[7].a ≈ N[0.0, -1.0]
-    @test lcl[7].b ≈ N(1.0)
-    @test lcl[8].a ≈ N[sqrt(2.0)/2.0, -sqrt(2.0)/2.0]
-    @test lcl[8].b ≈ N(1.0)
+    @test lcl[1].a ≈ N[1, 0]
+    @test lcl[1].b ≈ N(1)
+    @test lcl[2].a ≈ N[sqrt(2)/2, sqrt(2)/2]
+    @test lcl[2].b ≈ N(1)
+    @test lcl[3].a ≈ N[0, 1]
+    @test lcl[3].b ≈ N(1)
+    @test lcl[4].a ≈ N[-sqrt(2)/2, sqrt(2)/2]
+    @test lcl[4].b ≈ N(1)
+    @test lcl[5].a ≈ N[-1, 0]
+    @test lcl[5].b ≈ N(1)
+    @test lcl[6].a ≈ N[-sqrt(2)/2, -sqrt(2)/2]
+    @test lcl[6].b ≈ N(1)
+    @test lcl[7].a ≈ N[0, -1]
+    @test lcl[7].b ≈ N(1)
+    @test lcl[8].a ≈ N[sqrt(2)/2, -sqrt(2)/2]
+    @test lcl[8].b ≈ N(1)
 
     # Zonotope approximation
-    Z1 = Zonotope(ones(N, 2), [N[1., 0.], N[0., 1.], N[1., 1.]])
-    Z2 = Zonotope(-ones(N, 2), [N[.5, 1.], N[-.1, .9], N[1., 4.]])
+    Z1 = Zonotope(ones(N, 2), [N[1, 0], N[0, 1], N[1, 1]])
+    Z2 = Zonotope(-ones(N, 2), [N[0.5, 1], N[-0.1, 0.9], N[1, 4]])
     Y = ConvexHull(Z1, Z2)
     Y_polygon = overapproximate(Y, N(1e-3)) # overapproximate with a polygon
     Y_zonotope = overapproximate(Y, Zonotope) # overapproximate with a zonotope

--- a/test/unit_plot.jl
+++ b/test/unit_plot.jl
@@ -42,7 +42,7 @@ for N in [Float64, Rational{Int}, Float32]
 
     # unary set operations
     sih = SymmetricIntervalHull(b1)
-    lm = LinearMap(N[2. 1.; 1. 2.], bi)
+    lm = LinearMap(N[2 1; 1 2], bi)
 
     # binary set operations
     ch = ConvexHull(b1, bi)

--- a/test/unit_radiusdiameter.jl
+++ b/test/unit_radiusdiameter.jl
@@ -4,16 +4,16 @@ for N in [Float64, Rational{Int}, Float32]
     # =======
 
     # approximation of a centered unit Ball1
-    b = Ball1(N[0., 0., 0.], N(1.))
-    @test norm(b) ≈ N(1.)  # in the infinity norm (default)
-    @test radius(b) ≈ N(1.)  # in the infinity norm (default)
-    @test diameter(b) ≈ N(2.)  # in the infinity norm (default)
+    b = Ball1(N[0, 0, 0], N(1))
+    @test norm(b) ≈ N(1)  # in the infinity norm (default)
+    @test radius(b) ≈ N(1)  # in the infinity norm (default)
+    @test diameter(b) ≈ N(2)  # in the infinity norm (default)
 
     # approximations of a non-centered unit Ball1
-    b = Ball1(N[1., 2., 0.], N(1.))
-    @test norm(b) ≈ N(3.)  # in the infinity norm (default)
-    @test radius(b) ≈ N(1.)  # in the infinity norm (default)
-    @test diameter(b) ≈ N(2.)  # in the infinity norm (default)
+    b = Ball1(N[1, 2, 0], N(1))
+    @test norm(b) ≈ N(3)  # in the infinity norm (default)
+    @test radius(b) ≈ N(1)  # in the infinity norm (default)
+    @test diameter(b) ≈ N(2)  # in the infinity norm (default)
 
 
     # ================
@@ -21,22 +21,22 @@ for N in [Float64, Rational{Int}, Float32]
     # ================
 
     # metrics in the infinity norm (default)
-    h = Hyperrectangle(N[-1., 2.], N[0.2, 0.5])
+    h = Hyperrectangle(N[-1, 2], N[0.2, 0.5])
     @test norm(h, Inf) ≈ N(2.5)
     @test radius(h, Inf) ≈ N(0.5)
-    @test diameter(h, Inf) ≈ N(1.)
+    @test diameter(h, Inf) ≈ N(1)
 
     # metrics in the 2-norm
     @test norm(h, 2) ≈ N(sqrt(2.5^2 + 1.2^2))
-    @test radius(h, 2) ≈ N(sqrt(.5^2 + .2^2))
-    @test diameter(h, 2) ≈ N(2*sqrt(.5^2 + .2^2))
+    @test radius(h, 2) ≈ N(sqrt(0.5^2 + 0.2^2))
+    @test diameter(h, 2) ≈ N(2*sqrt(0.5^2 + 0.2^2))
 
     # =========
     #  BallInf
     # =========
 
     # metrics in the infinity norm (default)
-    b = BallInf(N[-1., -2., -4], N(0.2))
+    b = BallInf(N[-1, -2, -4], N(0.2))
     @test norm(b, Inf) ≈ N(4.2)
     @test radius(b, Inf) ≈ N(0.2)
     @test diameter(b, Inf) ≈ N(0.4)

--- a/test/unit_template_directions.jl
+++ b/test/unit_template_directions.jl
@@ -17,7 +17,7 @@ for N in [Float64, Float32, Rational{Int}]
 
     # template direction approximation
     for n in 1:3
-        B = BallInf(zeros(N, n), N(2.))
+        B = BallInf(zeros(N, n), N(2))
         A = Matrix{N}(2I, n, n) + ones(N, n, n)
         X = A * B
 


### PR DESCRIPTION
Closes #534.