### PR TITLE
Fix "contains" deprecation

### DIFF
--- a/test/check_method_ambiguity_binary.jl
+++ b/test/check_method_ambiguity_binary.jl
@@ -99,7 +99,7 @@ function check_method_ambiguity_binary(op;
                                      "'$ops(::$(typeof(i1)), " *
                                      "::$(typeof(i2)))' exists")
                             end
-                        elseif contains(msg, "is ambiguous")
+                        elseif occursin("is ambiguous", msg)
                             # ambiguity error, remember
                             has_ambiguities = true
                             if print_warnings


### PR DESCRIPTION
```julia
LazySets.Approximations.decompose |   79     79
 13.837921 seconds (22.25 M allocations: 1.059 GiB, 5.83% gc time)
┌ Warning: `contains(haystack, needle)` is deprecated, use `occursin(needle, haystack)` instead.
│   caller = #check_method_ambiguity_binary#20(::Bool, ::Bool, ::Function, ::typeof(is_intersection_empty)) at check_method_ambiguity_binary.jl:102
└ @ Main ~/build/JuliaReach/LazySets.jl/test/check_method_ambiguity_binary.jl:102
```