### PR TITLE
using -> import for algorithm modules

### DIFF
--- a/src/AbstractPolytope.jl
+++ b/src/AbstractPolytope.jl
@@ -109,7 +109,7 @@ function load_polyhedra_abstractpolytope() # function to be loaded by Requires
 
 return quote
 
-using CDDLib # default backend
+import CDDLib # default backend
 import Polyhedra:polyhedron, SimpleHRepresentation, SimpleHRepresentation,
                  HRep, VRep,
                  removehredundancy!, removevredundancy!,

--- a/src/Intersection.jl
+++ b/src/Intersection.jl
@@ -388,7 +388,7 @@ end
 function load_optim_intersection()
 return quote
 
-using Optim
+import Optim
 
 """
     _line_search(ℓ, X, H; kwargs...)


### PR DESCRIPTION
For this type of use we don't need to import all the names of external packages, with the module's name is enough.