### PR TITLE
#188 - Add constraints_list to AbstractPolytope interface

### DIFF
--- a/src/AbstractPolytope.jl
+++ b/src/AbstractPolytope.jl
@@ -16,6 +16,8 @@ or equivalently, sets with finitely many vertices.
 ### Notes
 
 Every concrete `AbstractPolytope` must define the following functions:
+- `constraints_list(::AbstractPolytope{N})::Vector{LinearConstraint{N}}` --
+    return a list of all facet constraints
 - `vertices_list(::AbstractPolytope{N})::Vector{Vector{N}}` -- return a list of
     all vertices
 

--- a/test/unit_interfaces.jl
+++ b/test/unit_interfaces.jl
@@ -20,7 +20,7 @@ end
 @test check_method_implementation(AbstractPolytope, vertices_list,
                                   Function[S -> (S{Float64},)],
                                   ignore_types=exclusions)
-@test check_method_implementation(AbstractCentrallySymmetricPolytope, vertices_list,
+@test check_method_implementation(AbstractPolytope, constraints_list,
                                   Function[S -> (S{Float64},)])
 
 # --- AbstractCentrallySymmetric ---


### PR DESCRIPTION
Closes #188.

We have to rebase with `master` after all methods have been added.