### PR TITLE
#737 - ρ_upper_bound

### DIFF
--- a/src/Approximations/upper_bounds.jl
+++ b/src/Approximations/upper_bounds.jl
@@ -28,6 +28,28 @@ end
 
 """
     ρ_upper_bound(d::AbstractVector{N},
+                  lm::LinearMap{N};
+                  kwargs...) where {N<:Real}
+
+Return an upper bound of the support function of a given linear map.
+
+### Input
+
+- `d`  -- direction
+- `lm` -- linear map
+
+### Output
+
+An upper bound of the support function of the given linear map.
+"""
+function ρ_upper_bound(d::AbstractVector{N},
+                       lm::LinearMap{N};
+                       kwargs...) where {N<:Real}
+    return ρ_upper_bound(_At_mul_B(lm.M, d), lm.X)
+end
+
+"""
+    ρ_upper_bound(d::AbstractVector{N},
                   cap::Intersection{N}; kwargs...) where {N<:Real}
 
 Return an upper bound of the support function of the intersection of two sets.

--- a/src/is_intersection_empty.jl
+++ b/src/is_intersection_empty.jl
@@ -722,10 +722,12 @@ Optional keyword arguments can be passed to the `ρ` function. In particular, if
 function is_intersection_empty(X::LazySet{N},
                                hs::HalfSpace{N},
                                witness::Bool=false;
+                               upper_bound::Bool=false,
                                kwargs...
                                )::Union{Bool, Tuple{Bool,Vector{N}}} where N<:Real
     if !witness
-        return -ρ(-hs.a, X; kwargs...) > hs.b
+        ρ_rec = upper_bound ? Approximations.ρ_upper_bound : ρ
+        return -ρ_rec(-hs.a, X; kwargs...) > hs.b
     end
 
     # for witness production, we compute the support vector instead


### PR DESCRIPTION
See #737.

This is an example. As can be seen, we get a lot of code duplicates if we implement ρ_upper_bound for every version of ρ. I suggest that we do not follow this trail.
Instead we can do something like this:

1. Generate the functions in a loop. Downside: We lose the docstrings.
```julia
for ρ_rec in [ρ, ρ_upper_bound]
    function $ρ_rec(...)
        ...
    end
end
```
2. Write a helper function that takes the function symbol as additional argument.
```julia
function ρ(...)
    return _ρ(ρ, ...)
end
function ρ_upper_bound(...)
    return _ρ(ρ_upper_bound, ...)
end
function _ρ(ρ_rec, ...)
    ...
end
```