### PR TITLE
Remove symmetric case (not needed)

### DIFF
--- a/src/Approximations/overapproximate.jl
+++ b/src/Approximations/overapproximate.jl
@@ -234,13 +234,18 @@ intersection is empty.
 """
 function overapproximate(cap::Intersection{N,
                                            <:LazySet,
-                                           Union{AbstractPolytope{N}, HPolyhedron{N}}},
+                                           <:Union{AbstractPolytope{N}, HPolyhedron{N}}},
                          dir::AbstractDirections{N};
                          kwargs...
                         ) where {N<:Real}
 
-    X = cap.X    # compact set
-    P = cap.Y    # polytope
+    if cap.X isa HPolyhedron # possibly unbounded
+        X = cap.Y  # compact set
+        P = cap.X  # polyhedron
+    else
+        X = cap.X    # compact set
+        P = cap.Y    # polytope
+    end
 
     Hi = constraints_list(P)
     m = length(Hi)
@@ -257,16 +262,6 @@ function overapproximate(cap::Intersection{N,
         addconstraint!(Q, HalfSpace(di, ρ_X_Hi_min))
     end
     return Q
-end
-
-# symmetric method
-function overapproximate(cap::Intersection{N,
-                                           <:Union{AbstractPolytope{N}, HPolyhedron{N}},
-                                           <:LazySet},
-                         dir::AbstractDirections{N};
-                         kwargs...
-                        ) where N<:Real
-    return overapproximate(cap.Y ∩ cap.X, dir; kwargs...)
 end
 
 """


### PR DESCRIPTION
This PR fixes a stackoverflow issue. Let

```julia
julia> V = LazySets.VPolygon{Float64}(Array{Float64,1}[[0.0378714, 0.758031], [0.286479, 0.143648], [0.842049, 0.545808], [0.7407, 0.656199], [0.416824, 0.855032]])

julia> P = LazySets.HPolyhedron{Float64}(LazySets.HalfSpace{Float64}[LazySets.HalfSpace{Float64}([3.0, 1.0], 1.4), LazySets.HalfSpace{Float64}([1.0, 0.0], 0.2)])
```

In `master`:

```julia
julia> overapproximate(V ∩ P, LazySets.Approximations.BoxDirections(2))
Segmentation fault: 11

julia> overapproximate(P ∩ V, LazySets.Approximations.BoxDirections(2))
Segmentation fault: 11
```

This branch:

```julia
julia> overapproximate(V ∩ P, LazySets.Approximations.BoxDirections(2))
LazySets.HPolytope{Float64}(LazySets.HalfSpace{Float64}[LazySets.HalfSpace{Float64}([1.0, 0.0], 0.2), LazySets.HalfSpace{Float64}([0.0, 1.0], 0.799531), LazySets.HalfSpace{Float64}([0.0, -1.0], -0.357363), LazySets.HalfSpace{Float64}([-1.0, 0.0], -0.0378714)])

julia> overapproximate(P ∩ V, LazySets.Approximations.BoxDirections(2))
LazySets.HPolytope{Float64}(LazySets.HalfSpace{Float64}[LazySets.HalfSpace{Float64}([1.0, 0.0], 0.2), LazySets.HalfSpace{Float64}([0.0, 1.0], 0.799531), LazySets.HalfSpace{Float64}([0.0, -1.0], -0.357363), LazySets.HalfSpace{Float64}([-1.0, 0.0], -0.0378714)])
```

