### PR TITLE
Remove unused code in manual

### DIFF
--- a/docs/src/man/reach_zonotopes_hybrid.md
+++ b/docs/src/man/reach_zonotopes_hybrid.md
@@ -100,9 +100,8 @@ function reach_continuous(A, X0, δ, μ, T, max_order)
     ϕp = (I+ϕ)/2
     ϕm = (I-ϕ)/2
     c = X0.center
-    Q1_generators = hcat(ϕp * X0.generators, ϕm * c, ϕm * X0.generators)
-    P1 = Phi1(A, δ)
-    R[1] = minkowski_sum(Zonotope(ϕp * c, Q1_generators),
+    gens = hcat(ϕp * X0.generators, ϕm * c, ϕm * X0.generators)
+    R[1] = minkowski_sum(Zonotope(ϕp * c, gens),
                          Zonotope(zeros(n), Matrix((α + β)*I, n, n)))
     if order(R[1]) > max_order
         R[1] = reduce_order(R[1], max_order)
@@ -117,20 +116,6 @@ function reach_continuous(A, X0, δ, μ, T, max_order)
         end
     end
     return R
-end
-nothing # hide
-```
-
-The function `Phi1` represents the approximation model.
-We use the following implementation here.
-
-```@example example_reach_zonotopes_hybrid
-function Phi1(A, δ)
-    n = size(A, 1)
-    P = expm(full([A * δ sparse(δ*I, n, n) spzeros(n, n);
-                   spzeros(n, 2*n) sparse(δ*I, n, n);
-                   spzeros(n, 3*n)]))
-    return P[1:n, (n+1):2*n]
 end
 nothing # hide
 ```


### PR DESCRIPTION
I am a bit confused why we had this. But it works locally without that part.