### PR TITLE
WIP #202 - Optional algorithms for <=

### DIFF
--- a/src/AbstractHPolygon.jl
+++ b/src/AbstractHPolygon.jl
@@ -217,7 +217,8 @@ function addconstraint!(P::AbstractHPolygon{N},
         else
             if linear_search
                 # linear search
-                while d <= P.constraints[k].a
+                quadrant_d = quadrant(d)
+                while le_quadrant(d, quadrant_d, P.constraints[k].a)
                     k -= 1
                 end
             else
@@ -267,8 +268,9 @@ function binary_search_constraints(d::AbstractVector{N},
                                   )::Int where {N}
     lower = 1
     upper = n+1
+    quadrant_d = quadrant(d)
     while lower + 1 < upper
-        if constraints[k].a <= d
+        if le_quadrant(constraints[k].a, d, quadrant_d)
             lower = k
         else
             upper = k
@@ -278,7 +280,7 @@ function binary_search_constraints(d::AbstractVector{N},
     if choose_lower
         return lower
     else
-        if lower == 1 && !(constraints[1].a <= d)
+        if lower == 1 && !le_quadrant(constraints[1].a, d, quadrant_d)
             # special case for index 1
             return 1
         end

--- a/src/AbstractPolygon.jl
+++ b/src/AbstractPolygon.jl
@@ -48,7 +48,7 @@ The ambient dimension of the polygon, which is 2.
 end
 
 """
-    jump2pi(x::N)::N where {N<:AbstractFloat}
+    jump2pi(x::N)::N where N<:AbstractFloat
 
 Return ``x + 2π`` if ``x`` is negative, otherwise return ``x``.
 
@@ -75,18 +75,18 @@ julia> jump2pi(0.5)
 0.5
 ```
 """
-@inline function jump2pi(x::N)::N where {N<:AbstractFloat}
+@inline function jump2pi(x::N)::N where N<:AbstractFloat
     x < zero(N) ? 2 * pi + x : x
 end
 
 """
-    quadrant(w::AbstractVector{N})::Int where {N<:Real}
+    quadrant(w::AbstractVector{N})::Int where N<:Real
 
 Compute the quadrant where the direction `w` belongs.
 
 ### Input
 
-- `w` --  direction
+- `w` -- direction
 
 ### Output
 
@@ -107,21 +107,21 @@ The idea is to encode the following logic function:
 This function is inspired from AGPX's answer in:
 [Sort points in clockwise order?](https://stackoverflow.com/a/46635372)
 """
-@inline function quadrant(w::AbstractVector{N})::Int where {N<:Real}
+@inline function quadrant(w::AbstractVector{N})::Int where N<:Real
     dwx = w[1] >= zero(N) ? 1 : 0
     dwy = w[2] >= zero(N) ? 1 : 0
     return (1 - dwx) + (1 - dwy) + ((dwx & (1 - dwy)) << 1)
 end
 
 """
-    <=(u::AbstractVector{N}, v::AbstractVector{N})::Bool where {N<:Real}
+    le_quadrant(u::AbstractVector{N}, v::AbstractVector{N})::Bool where N<:Real
 
 Compares two 2D vectors by their direction.
 
 ### Input
 
-- `u` --  first 2D direction
-- `v` --  second 2D direction
+- `u` -- first 2D direction
+- `v` -- second 2D direction
 
 ### Output
 
@@ -134,30 +134,33 @@ direction (1, 0).
 
 ### Algorithm
 
-The implementation checks the quadrant of each direction, and compares directions
-using the right-hand rule. In particular, it doesn't use the arctangent.
+The implementation checks the quadrant of each direction, and compares
+directions using the right-hand rule.
+In particular, it doesn't use the arctangent.
 """
-function <=(u::AbstractVector{N}, v::AbstractVector{N})::Bool where {N<:Real}
+function le_quadrant(u::AbstractVector{N},
+                     v::AbstractVector{N})::Bool where N<:Real
     qu, qv = quadrant(u), quadrant(v)
     if qu == qv
         # same quadrant, check right-turn with center 0
-        ans = u[1] * v[2] - v[1] * u[2] >= zero(N)
+        le = u[1] * v[2] - v[1] * u[2] >= zero(N)
     else
         # different quadrant
-        ans = qu < qv
+        le = qu < qv
     end
-    return ans
+    return le
 end
 
 """
-    <=(u::AbstractVector{N}, v::AbstractVector{N})::Bool where {N<:AbstractFloat}
+    le_jump2pi(u::AbstractVector{N},
+               v::AbstractVector{N})::Bool where N<:AbstractFloat
 
 Compares two 2D vectors by their direction.
 
 ### Input
 
-- `u` --  first 2D direction
-- `v` --  second 2D direction
+- `u` -- first 2D direction
+- `v` -- second 2D direction
 
 ### Output
 
@@ -174,9 +177,50 @@ The implementation uses the arctangent function with sign, `atan`, which for two
 arguments implements the
 [`atan2` function](https://en.wikipedia.org/wiki/Atan2).
 """
-function <=(u::AbstractVector{N},
-            v::AbstractVector{N})::Bool where {N<:AbstractFloat}
+function le_jump2pi(u::AbstractVector{N},
+                    v::AbstractVector{N})::Bool where N<:AbstractFloat
     return jump2pi(atan(u[2], u[1])) <= jump2pi(atan(v[2], v[1]))
+end
+
+"""
+    <=(u::AbstractVector{N},
+       v::AbstractVector{N};
+       [algorithm]="quadrant")::Bool where N<:Real
+
+Compares two 2D vectors by their direction.
+
+### Input
+
+- `u`         -- first 2D direction
+- `v`         -- second 2D direction
+- `algorithm` -- (optional; default: "quadrant") algorithm backend
+
+### Output
+
+True iff ``\\arg(u) [2π] ≤ \\arg(v) [2π]``
+
+### Notes
+
+The argument is measured in counter-clockwise fashion, with the 0 being the
+direction (1, 0).
+"""
+function <=(u::AbstractVector{N},
+            v::AbstractVector{N},
+            algorithm::String)::Bool where N<:Real
+    if algorithm == "quadrant"
+        res = le_quadrant(u, v)
+    elseif algorithm == "jump2pi"
+        res = le_jump2pi(u, v)
+    else
+        error("unknown algorithm $algorithm")
+    end
+    return res
+end
+
+# faster default implementation
+function <=(u::AbstractVector{N},
+            v::AbstractVector{N})::Bool where N<:Real
+    return le_quadrant(u, v)
 end
 
 """

--- a/src/AbstractPolygon.jl
+++ b/src/AbstractPolygon.jl
@@ -185,7 +185,7 @@ end
 """
     <=(u::AbstractVector{N},
        v::AbstractVector{N};
-       [algorithm]="quadrant")::Bool where N<:Real
+       [algorithm]::String="quadrant")::Bool where N<:Real
 
 Compares two 2D vectors by their direction.
 
@@ -204,23 +204,38 @@ True iff ``\\arg(u) [2π] ≤ \\arg(v) [2π]``
 The argument is measured in counter-clockwise fashion, with the 0 being the
 direction (1, 0).
 """
-function <=(u::AbstractVector{N},
-            v::AbstractVector{N},
-            algorithm::String)::Bool where N<:Real
-    if algorithm == "quadrant"
-        res = le_quadrant(u, v)
-    elseif algorithm == "jump2pi"
-        res = le_jump2pi(u, v)
-    else
-        error("unknown algorithm $algorithm")
+@static if VERSION < v"0.7-"
+    function <=(u::AbstractVector{N},
+                v::AbstractVector{N},
+                algorithm::String)::Bool where N<:Real
+        if algorithm == "quadrant"
+            res = le_quadrant(u, v)
+        elseif algorithm == "jump2pi"
+            res = le_jump2pi(u, v)
+        else
+            error("unknown algorithm $algorithm")
+        end
+        return res
     end
-    return res
-end
 
-# faster default implementation
-function <=(u::AbstractVector{N},
-            v::AbstractVector{N})::Bool where N<:Real
-    return le_quadrant(u, v)
+    # faster default implementation
+    function <=(u::AbstractVector{N},
+                v::AbstractVector{N})::Bool where N<:Real
+        return le_quadrant(u, v)
+    end
+else
+    function <=(u::AbstractVector{N},
+                v::AbstractVector{N};
+                algorithm::String="quadrant")::Bool where N<:Real
+        if algorithm == "quadrant"
+            res = le_quadrant(u, v)
+        elseif algorithm == "jump2pi"
+            res = le_jump2pi(u, v)
+        else
+            error("unknown algorithm $algorithm")
+        end
+        return res
+    end
 end
 
 """

--- a/src/AbstractPolygon.jl
+++ b/src/AbstractPolygon.jl
@@ -114,14 +114,19 @@ This function is inspired from AGPX's answer in:
 end
 
 """
-    le_quadrant(u::AbstractVector{N}, v::AbstractVector{N})::Bool where N<:Real
+    le_quadrant(u::AbstractVector{N},
+                [quadrant_u]::Int=quadrant(u),
+                v::AbstractVector{N},
+                [quadrant_v]::Int=quadrant(v))::Bool where N<:Real
 
 Compares two 2D vectors by their direction.
 
 ### Input
 
-- `u` -- first 2D direction
-- `v` -- second 2D direction
+- `u`          -- first 2D direction
+- `quadrant_u` -- (optional, default: `quadrant(u)`) quadrant of `u`
+- `v`          -- second 2D direction
+- `quadrant_v` -- (optional, default: `quadrant(v)`) quadrant of `v`
 
 ### Output
 
@@ -136,19 +141,40 @@ direction (1, 0).
 
 The implementation checks the quadrant of each direction, and compares
 directions using the right-hand rule.
-In particular, it doesn't use the arctangent.
+In particular, it does not use the arctangent.
 """
 function le_quadrant(u::AbstractVector{N},
-                     v::AbstractVector{N})::Bool where N<:Real
-    qu, qv = quadrant(u), quadrant(v)
-    if qu == qv
+                     quadrant_u::Int,
+                     v::AbstractVector{N},
+                     quadrant_v::Int)::Bool where N<:Real
+    if quadrant_u == quadrant_v
         # same quadrant, check right-turn with center 0
         le = u[1] * v[2] - v[1] * u[2] >= zero(N)
     else
         # different quadrant
-        le = qu < qv
+        le = quadrant_u < quadrant_v
     end
     return le
+end
+
+# quadrant of u known
+@inline function le_quadrant(u::AbstractVector{N},
+                             quadrant_u::Int,
+                             v::AbstractVector{N})::Bool where N<:Real
+    return le_quadrant(u, quadrant_u, v, quadrant(v))
+end
+
+# quadrant of v known
+@inline function le_quadrant(u::AbstractVector{N},
+                             v::AbstractVector{N},
+                             quadrant_v::Int)::Bool where N<:Real
+    return le_quadrant(u, quadrant(u), v, quadrant_v)
+end
+
+# no quadrant known
+@inline function le_quadrant(u::AbstractVector{N},
+                             v::AbstractVector{N})::Bool where N<:Real
+    return le_quadrant(u, quadrant(u), v, quadrant(v))
 end
 
 """

--- a/src/HPolygon.jl
+++ b/src/HPolygon.jl
@@ -1,5 +1,3 @@
-import Base.<=
-
 export HPolygon
 
 """

--- a/src/HPolygon.jl
+++ b/src/HPolygon.jl
@@ -76,7 +76,8 @@ function σ(d::AbstractVector{N}, P::HPolygon{N};
     if linear_search
         # linear search
         k = 1
-        while k <= n && P.constraints[k].a <= d
+        quadrant_d = quadrant(d)
+        while k <= n && le_quadrant(P.constraints[k].a, d, quadrant_d)
             k += 1
         end
     else

--- a/src/HPolygonOpt.jl
+++ b/src/HPolygonOpt.jl
@@ -93,10 +93,11 @@ function σ(d::AbstractVector{N}, P::HPolygonOpt{N};
     @assert n > 0 "the polygon has no constraints"
     if linear_search
         # linear search
-        if (d <= P.constraints[P.ind].a)
+        quadrant_d = quadrant(d)
+        if le_quadrant(d, quadrant_d, P.constraints[P.ind].a)
             # search backward
             k = P.ind-1
-            while (k >= 1 && d <= P.constraints[k].a)
+            while (k >= 1 && le_quadrant(d, quadrant_d, P.constraints[k].a))
                 k -= 1
             end
             if (k == 0)
@@ -110,7 +111,7 @@ function σ(d::AbstractVector{N}, P::HPolygonOpt{N};
         else
             # search forward
             k = P.ind+1
-            while (k <= n && P.constraints[k].a <= d)
+            while (k <= n && le_quadrant(P.constraints[k].a, d, quadrant_d))
                 k += 1
             end
             if (k == n+1)

--- a/src/HPolygonOpt.jl
+++ b/src/HPolygonOpt.jl
@@ -1,5 +1,3 @@
-import Base.<=
-
 export HPolygonOpt
 
 """


### PR DESCRIPTION
Closes #202.

I had to find out that Julia is not very efficient for optional arguments, even if the default argument is chosen (I had assumed that this case can be statically optimized).
Hence I defined `<=` without additional arguments (the default implementation), and added a method with an additional `algorithm` argument. If you instead use
`<=(u::AbstractVector{N}, v::AbstractVector{N}; algorithm::String="quadrant")`,
you will get the following timings:
```julia
julia> using LazySets, BenchmarkTools

julia> x = rand(2); y = rand(2);

julia> @btime LazySets.le_quadrant($x, $y);
  5.173 ns (0 allocations: 0 bytes)

julia> @btime <=($x, $y); # should be equivalent to the above, but it is slower
  10.923 ns (0 allocations: 0 bytes)

julia> @btime <=($x, $y, algorithm="quadrant");
  46.827 ns (1 allocation: 96 bytes)
```