### PR TITLE
Fix docs

### DIFF
--- a/docs/src/lib/methods_fix.md
+++ b/docs/src/lib/methods_fix.md
@@ -26,6 +26,7 @@ low
 norm
 is_intersection_empty
 linear_map
+polyhedron
 radius
 radius_hyperrectangle
 tohrep

--- a/docs/src/lib/representations.md
+++ b/docs/src/lib/representations.md
@@ -391,11 +391,12 @@ constraints_list(::HPoly{Real})
 tosimplehrep(::HPoly{Real})
 tohrep(::HPoly{Real})
 isempty(::HPoly{N}) where {N<:Real}
-convex_hull(P1::HPoly{Real}, P2::HPoly{Real})
-cartesian_product(P1::HPoly{Real}, P2::HPoly{Real})
+convex_hull(::HPoly{Real}, ::HPoly{Real})
+cartesian_product(::HPoly{N}, ::HPoly{N}) where {N<:Real}
 tovrep(::HPoly{Real})
 vertices_list(::HPolyhedron{Real})
 singleton_list(::HPolyhedron{N}) where {N<:Real}
+polyhedron(::HPoly)
 ```
 
 Inherited from [`LazySet`](@ref):
@@ -414,6 +415,8 @@ VPolytope
 dim(::VPolytope)
 σ(::AbstractVector{Real}, ::VPolytope{Real})
 vertices_list(::VPolytope)
+cartesian_product(::VPolytope{N}, ::VPolytope{N}) where N
+polyhedron(::VPolytope)
 ```
 Inherited from [`LazySet`](@ref):
 * [`norm`](@ref norm(::LazySet, ::Real))

--- a/docs/src/lib/representations.md
+++ b/docs/src/lib/representations.md
@@ -394,7 +394,7 @@ isempty(::HPoly{N}) where {N<:Real}
 convex_hull(P1::HPoly{Real}, P2::HPoly{Real})
 cartesian_product(P1::HPoly{Real}, P2::HPoly{Real})
 tovrep(::HPoly{Real})
-vertices_list(::HPoly{Real})
+vertices_list(::HPolyhedron{Real})
 singleton_list(::HPolyhedron{N}) where {N<:Real}
 ```
 

--- a/docs/src/man/concrete_polyhedra.md
+++ b/docs/src/man/concrete_polyhedra.md
@@ -96,6 +96,19 @@ product.
 The dual representation as a list of vertices can be obtained with the
 `vertices_list` function.
 
+```@example concrete_polyhedra
+p = HPolytope([LinearConstraint([1.0, 0.0], 1.0),
+               LinearConstraint([0.0, 1.0], 1.0),
+               LinearConstraint([-1.0, 0.0], 1.0),
+               LinearConstraint([0.0, -1.0], 1.0)])
+
+constraints_list(p)
+```
+
+```@example concrete_polyhedra
+vertices_list(p)
+```
+
 For example, the concrete intersection of two polytopes is performed with the
 `intersection` method.
 

--- a/src/HPolyhedron.jl
+++ b/src/HPolyhedron.jl
@@ -334,9 +334,8 @@ function convex_hull(P1::HPoly{N},
 end
 
 """
-    cartesian_product(P1::HPOLY, P2::HPOLY;
-                      [backend]=default_polyhedra_backend(P1, N)
-                     ) where {N, HPOLY<:HPolytope{N}}
+    cartesian_product(P1::HPoly{N}, P2::HPoly{N};
+                      [backend]=default_polyhedra_backend(P1, N)) where N<:Real
 
 Compute the Cartesian product of two polyhedra in H-representaion.
 
@@ -356,8 +355,10 @@ The polyhedron obtained by the concrete cartesian product of `P1` and `P2`.
 For further information on the supported backends see
 [Polyhedra's documentation](https://juliapolyhedra.github.io/Polyhedra.jl/).
 """
-function cartesian_product(P1::HPoly{N}, P2::HPoly{N};
-                          backend=default_polyhedra_backend(P1, N)) where {N}
+function cartesian_product(P1::HPoly{N},
+                           P2::HPoly{N};
+                           backend=default_polyhedra_backend(P1, N)
+                          ) where N<:Real
     @assert isdefined(Main, :Polyhedra) "the function `cartesian_product` " *
         "needs the package 'Polyhedra' to be loaded"
     Pcp = hcartesianproduct(polyhedron(P1, backend), polyhedron(P2, backend))

--- a/src/HPolyhedron.jl
+++ b/src/HPolyhedron.jl
@@ -416,15 +416,6 @@ julia> P = HPolyhedron([HalfSpace([1.0, 0.0], 1.0),
                         HalfSpace([0.0, -1.0], 1.0)]);
 
 julia> P_as_polytope = convert(HPolytope, P);
-
-julia> using Polyhedra # needed to compute the dual representation
-
-julia> vertices_list(P_as_polytope)
-4-element Array{Array{Float64,1},1}:
- [1.0, 1.0]
- [-1.0, 1.0]
- [1.0, -1.0]
- [-1.0, -1.0]
 ```
 """
 function vertices_list(P::HPolyhedron{N}) where {N<:Real}

--- a/src/HPolyhedron.jl
+++ b/src/HPolyhedron.jl
@@ -413,7 +413,7 @@ If `P` is known to be bounded, try converting to `HPolytope` first:
 julia> P = HPolyhedron([HalfSpace([1.0, 0.0], 1.0),
                         HalfSpace([0.0, 1.0], 1.0),
                         HalfSpace([-1.0, 0.0], 1.0),
-                        HalfSpace([0.0, -1.0], 1.0)])
+                        HalfSpace([0.0, -1.0], 1.0)]);
 
 julia> P_as_polytope = convert(HPolytope, P);
 

--- a/src/HPolytope.jl
+++ b/src/HPolytope.jl
@@ -126,28 +126,6 @@ List of vertices.
 
 For further information on the supported backends see
 [Polyhedra's documentation](https://juliapolyhedra.github.io/Polyhedra.jl/).
-
-### Examples
-
-```jldoctest
-julia> using Polyhedra
-
-julia> P = HPolytope([1.0 0.0; 0.0 1.0; -1.0 0.0; 0.0 -1.0], fill(1., 4));
-
-julia> constraints_list(P)
-4-element Array{HalfSpace{Float64},1}:
- HalfSpace{Float64}([1.0, 0.0], 1.0)
- HalfSpace{Float64}([0.0, 1.0], 1.0)
- HalfSpace{Float64}([-1.0, 0.0], 1.0)
- HalfSpace{Float64}([0.0, -1.0], 1.0)
-
-julia> vertices_list(P)
-4-element Array{Array{Float64,1},1}:
- [1.0, 1.0]
- [-1.0, 1.0]
- [1.0, -1.0]
- [-1.0, -1.0]
-```
 """
 function vertices_list(P::HPolytope{N};
                        backend=default_polyhedra_backend(P, N),

--- a/src/Interval.jl
+++ b/src/Interval.jl
@@ -71,7 +71,7 @@ Interval of other numeric types can be created as well, eg. a rational interval:
 
 ```jldoctest interval_constructor
 julia> Interval(0//1, 2//1)
-Interval{Rational{Int64},IntervalArithmetic.AbstractInterval{Rational{Int64}}}([0//1, 2//1])
+Interval{Rational{Int64},AbstractInterval{Rational{Int64}}}([0//1, 2//1])
 ```
 """
 struct Interval{N<:Real, IN <: AbstractInterval{N}} <: AbstractHyperrectangle{N}

--- a/src/LazySet.jl
+++ b/src/LazySet.jl
@@ -44,10 +44,10 @@ julia> subtypes(LazySet)
  ExponentialMap
  ExponentialProjectionMap
  HPolyhedron
- HalfSpace
  Hyperplane
  Intersection
  IntersectionArray
+ HalfSpace
  Line
  LinearMap
  MinkowskiSum


### PR DESCRIPTION
There is one problem remaining: We load `Polyhedra` while we build the doctests for the library (for `vertices_list` in `HPolytope.jl` and `HPolyhedron.jl`). This creates a namespace conflict with `HalfSpace` and thus influences some other doctests. Options:
1. We modify these doctests.
2. We remove the doctests for `vertices_list`.