### PR TITLE
Fix Travis build of documentation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ git:
 after_success:
   # documentation (restrict Documenter to release version 0.19.7 (breaking release) for now)
   - julia -e 'VERSION >= v"0.7-" && using Pkg;
+              Pkg.add("Compat");
               Pkg.add("Documenter");
               Pkg.add("Plots");
               Pkg.add("GR");

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,9 @@ git:
 after_success:
   # documentation (restrict Documenter to release version 0.19.7 (breaking release) for now)
   - julia -e 'VERSION >= v"0.7-" && using Pkg;
-              Pkg.add("Compat");
+              VERSION >= v"0.7-" && Pkg.add("Compat");
+              VERSION >= v"0.7-" && Pkg.add("IntervalArithmetic");
+              VERSION >= v"0.7-" && Pkg.add("RecipesBase");
               Pkg.add("Documenter");
               Pkg.add("Plots");
               Pkg.add("GR");


### PR DESCRIPTION
1. commit should fix
```julia
 > running doctests.
ERROR: LoadError: ArgumentError: Package Compat not found in current path:
- Run `Pkg.add("Compat")` to install the Compat package.
```
2. commit should fix the same problem for `IntervalArithmetic` and `RecipesBase`