### PR TITLE
Use strict doctests again

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -2,7 +2,7 @@ ENV["GKSwstype"] = "100"  # set 'GR environment' to 'no output' (for Travis CI)
 using Documenter, LazySets, Polyhedra
 
 makedocs(
-    doctest = true,  # use this flag to skip doctests (saves time!)
+    doctest = false,
     modules = [LazySets, Approximations],
     format = :html,
     assets = ["assets/juliareach.css"],

--- a/docs/make_doctests_only.jl
+++ b/docs/make_doctests_only.jl
@@ -4,5 +4,5 @@ makedocs(
     doctest = true,
     modules = Module[LazySets, Approximations],
     source = "src/lib",
-    strict = false
+    strict = true
 )

--- a/docs/src/lib/operations.md
+++ b/docs/src/lib/operations.md
@@ -115,6 +115,7 @@ isempty_known(::Intersection)
 set_isempty!(::Intersection, ::Bool)
 swap(::Intersection)
 use_precise_ρ
+_line_search
 _projection
 ```
 

--- a/src/LazySet.jl
+++ b/src/LazySet.jl
@@ -44,10 +44,10 @@ julia> subtypes(LazySet)
  ExponentialMap
  ExponentialProjectionMap
  HPolyhedron
+ HalfSpace
  Hyperplane
  Intersection
  IntersectionArray
- HalfSpace
  Line
  LinearMap
  MinkowskiSum


### PR DESCRIPTION
See #71.

Proposal:
* reactivate strict doctests during testing
* deactivate doctests for actual docs building

Somehow it would be good to also build the manual. Currently there are errors and they are not detected (in both `master` and this branch).