### PR TITLE
Add Optim for building docs

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,5 +1,5 @@
 ENV["GKSwstype"] = "100"  # set 'GR environment' to 'no output' (for Travis CI)
-using Documenter, LazySets, Polyhedra
+using Documenter, LazySets, Polyhedra, Optim
 
 makedocs(
     doctest = false,


### PR DESCRIPTION
This fixes the following problem when building the docs locally:
```julia
 !! Undefined binding 'LazySets._line_search'. [src/lib/operations.md]
```