### PR TITLE
#605 - Function for checking boundedness

### DIFF
--- a/docs/src/lib/interfaces.md
+++ b/docs/src/lib/interfaces.md
@@ -56,6 +56,8 @@ support_function
 norm(::LazySet, ::Real=Inf)
 radius(::LazySet, ::Real=Inf)
 diameter(::LazySet, ::Real=Inf)
+isbounded(::LazySet)
+isbounded_unit_dims(::LazySet{N}) where {N<:Real}
 an_element(::LazySet{N}) where {N<:Real}
 ==(::LazySet, ::LazySet)
 RecipesBase.apply_recipe(::Dict{Symbol,Any}, ::LazySet)
@@ -86,6 +88,7 @@ This interface defines the following functions:
 
 ```@docs
 dim(::AbstractCentrallySymmetric)
+isbounded(::AbstractCentrallySymmetric)
 an_element(::AbstractCentrallySymmetric{N}) where {N<:Real}
 isempty(::AbstractCentrallySymmetric)
 ```
@@ -104,6 +107,7 @@ AbstractPolytope
 This interface defines the following functions:
 
 ```@docs
+isbounded(::AbstractPolytope)
 singleton_list(::AbstractPolytope{N}) where {N<:Real}
 linear_map(::AbstractMatrix{N}, ::AbstractPolytope{N}) where {N<:Real}
 isempty(::AbstractPolytope)

--- a/docs/src/lib/interfaces.md
+++ b/docs/src/lib/interfaces.md
@@ -57,7 +57,7 @@ norm(::LazySet, ::Real=Inf)
 radius(::LazySet, ::Real=Inf)
 diameter(::LazySet, ::Real=Inf)
 isbounded(::LazySet)
-isbounded_unit_dims(::LazySet{N}) where {N<:Real}
+isbounded_unit_dimensions(::LazySet{N}) where {N<:Real}
 an_element(::LazySet{N}) where {N<:Real}
 ==(::LazySet, ::LazySet)
 RecipesBase.apply_recipe(::Dict{Symbol,Any}, ::LazySet)

--- a/docs/src/lib/operations.md
+++ b/docs/src/lib/operations.md
@@ -27,6 +27,7 @@ CartesianProduct
 dim(::CartesianProduct)
 ρ(::AbstractVector{N}, ::CartesianProduct{N}) where {N<:Real}
 σ(::AbstractVector{N}, ::CartesianProduct{N}) where {N<:Real}
+isbounded(::CartesianProduct)
 ∈(::AbstractVector{N}, ::CartesianProduct{N}) where {N<:Real}
 isempty(::CartesianProduct)
 constraints_list(::CartesianProduct{N}) where {N<:Real}
@@ -45,6 +46,7 @@ CartesianProductArray
 dim(::CartesianProductArray)
 ρ(::AbstractVector{N}, ::CartesianProductArray{N}) where {N<:Real}
 σ(::AbstractVector{N}, ::CartesianProductArray{N}) where {N<:Real}
+isbounded(::CartesianProductArray)
 ∈(::AbstractVector{N}, ::CartesianProductArray{N}) where {N<:Real}
 isempty(::CartesianProductArray)
 constraints_list(::CartesianProductArray{N}) where {N<:Real}
@@ -67,6 +69,7 @@ CH
 dim(::ConvexHull)
 ρ(::AbstractVector{N}, ::ConvexHull{N}) where {N<:Real}
 σ(::AbstractVector{N}, ::ConvexHull{N}) where {N<:Real}
+isbounded(::ConvexHull)
 isempty(::ConvexHull)
 ```
 Inherited from [`LazySet`](@ref):
@@ -83,6 +86,7 @@ CHArray
 dim(::ConvexHullArray)
 ρ(::AbstractVector{N}, ::ConvexHullArray{N}) where {N<:Real}
 σ(::AbstractVector{N}, ::ConvexHullArray{N}) where {N<:Real}
+isbounded(::ConvexHullArray)
 array(::ConvexHullArray{N, S}) where {N<:Real, S<:LazySet{N}}
 isempty(::ConvexHullArray)
 ```
@@ -112,8 +116,9 @@ dim(::Intersection)
 ρ(::AbstractVector{N}, ::Intersection{N}) where {N<:Real}
 ρ(::AbstractVector{N}, ::Intersection{N, S1, S2}) where {N<:Real, S1<:LazySet{N}, S2<:Union{HalfSpace{N}, Hyperplane{N}, Line{N}}}
 ρ(::AbstractVector{N}, ::Intersection{N, S1, S2}) where {N<:Real, S1<:LazySet{N}, S2<:AbstractPolytope{N}}
-isempty(::Intersection)
 σ(::AbstractVector{N}, ::Intersection{N}) where {N<:Real}
+isbounded(::Intersection)
+isempty(::Intersection)
 ∈(::AbstractVector{N}, ::Intersection{N}) where {N<:Real}
 isempty_known(::Intersection)
 set_isempty!(::Intersection, ::Bool)
@@ -141,6 +146,7 @@ IntersectionCache
 IntersectionArray
 dim(::IntersectionArray)
 σ(::AbstractVector{N}, ::IntersectionArray{N}) where {N<:Real}
+isbounded(::IntersectionArray)
 ∈(::AbstractVector{N}, ::IntersectionArray{N}) where {N<:Real}
 array(::IntersectionArray{N, S}) where {N<:Real, S<:LazySet{N}}
 ```
@@ -161,6 +167,7 @@ MinkowskiSum
 dim(::MinkowskiSum)
 ρ(::AbstractVector{N}, ::MinkowskiSum{N}) where {N<:Real}
 σ(::AbstractVector{N}, ::MinkowskiSum{N}) where {N<:Real}
+isbounded(::MinkowskiSum)
 isempty(::MinkowskiSum)
 ```
 Inherited from [`LazySet`](@ref):
@@ -176,6 +183,7 @@ MinkowskiSumArray
 dim(::MinkowskiSumArray)
 ρ(::AbstractVector{N}, ::MinkowskiSumArray{N}) where {N<:Real}
 σ(::AbstractVector{N}, ::MinkowskiSumArray{N}) where {N<:Real}
+isbounded(::MinkowskiSumArray)
 isempty(::MinkowskiSumArray)
 array(::MinkowskiSumArray{N, S}) where {N<:Real, S<:LazySet{N}}
 ```
@@ -191,6 +199,7 @@ Inherited from [`LazySet`](@ref):
 CacheMinkowskiSum
 dim(::CacheMinkowskiSum)
 σ(::AbstractVector{N}, ::CacheMinkowskiSum{N}) where {N<:Real}
+isbounded(::CacheMinkowskiSum)
 isempty(::CacheMinkowskiSum)
 array(::CacheMinkowskiSum{N, S}) where {N<:Real, S<:LazySet{N}}
 forget_sets!(::CacheMinkowskiSum)
@@ -216,6 +225,7 @@ dim(::LinearMap)
 σ(::AbstractVector{N}, ::LinearMap{N}) where {N<:Real}
 ∈(::AbstractVector{N}, ::LinearMap{N}) where {N<:Real}
 an_element(::LinearMap{N}) where {N<:Real}
+isbounded(::LinearMap)
 isempty(::LinearMap)
 vertices_list(::LinearMap{N}) where {N<:Real}
 ```
@@ -232,6 +242,7 @@ dim(::ExponentialMap)
 ρ(::AbstractVector{N}, ::ExponentialMap{N}) where {N<:Real}
 σ(::AbstractVector{N}, ::ExponentialMap{N}) where {N<:Real}
 ∈(::AbstractVector{N}, ::ExponentialMap{N}) where {N<:Real}
+isbounded(::ExponentialMap)
 isempty(::ExponentialMap)
 vertices_list(::ExponentialMap{N}) where {N<:Real}
 ```
@@ -245,6 +256,7 @@ Inherited from [`LazySet`](@ref):
 ExponentialProjectionMap
 dim(::ExponentialProjectionMap)
 σ(::AbstractVector{N}, ::ExponentialProjectionMap{N}) where {N<:Real}
+isbounded(::ExponentialProjectionMap)
 isempty(::ExponentialProjectionMap)
 ```
 Inherited from [`LazySet`](@ref):
@@ -278,6 +290,7 @@ Inherited from [`LazySet`](@ref):
 * [`diameter`](@ref diameter(::LazySet, ::Real))
 
 Inherited from [`AbstractPolytope`](@ref):
+* [`isbounded`](@ref isbounded(::AbstractPolytope))
 * [`singleton_list`](@ref singleton_list(::AbstractPolytope{N}) where {N<:Real})
 * [`linear_map`](@ref linear_map(::AbstractMatrix{N}, ::AbstractPolytope{N}) where {N<:Real})
 

--- a/docs/src/lib/representations.md
+++ b/docs/src/lib/representations.md
@@ -33,6 +33,7 @@ Inherited from [`LazySet`](@ref):
 
 Inherited from [`AbstractCentrallySymmetric`](@ref):
 * [`dim`](@ref dim(::AbstractCentrallySymmetric))
+* [`isbounded`](@ref isbounded(::AbstractCentrallySymmetric))
 * [`isempty`](@ref isempty(::AbstractCentrallySymmetric))
 * [`an_element`](@ref an_element(::AbstractCentrallySymmetric{N}) where {N<:Real})
 
@@ -50,6 +51,7 @@ Inherited from [`LazySet`](@ref):
 * [`diameter`](@ref diameter(::LazySet, ::Real))
 
 Inherited from [`AbstractPolytope`](@ref):
+* [`isbounded`](@ref isbounded(::AbstractPolytope))
 * [`singleton_list`](@ref singleton_list(::AbstractPolytope{N}) where {N<:Real})
 * [`linear_map`](@ref linear_map(::AbstractMatrix{N}, ::AbstractPolytope{N}) where {N<:Real})
 
@@ -83,6 +85,7 @@ Inherited from [`LazySet`](@ref):
 * [`diameter`](@ref diameter(::LazySet, ::Real))
 
 Inherited from [`AbstractPolytope`](@ref):
+* [`isbounded`](@ref isbounded(::AbstractPolytope))
 * [`singleton_list`](@ref singleton_list(::AbstractPolytope{N}) where {N<:Real})
 * [`linear_map`](@ref linear_map(::AbstractMatrix{N}, ::AbstractPolytope{N}) where {N<:Real})
 
@@ -107,6 +110,7 @@ Inherited from [`LazySet`](@ref):
 
 Inherited from [`AbstractCentrallySymmetric`](@ref):
 * [`dim`](@ref dim(::AbstractCentrallySymmetric))
+* [`isbounded`](@ref isbounded(::AbstractCentrallySymmetric))
 * [`isempty`](@ref isempty(::AbstractCentrallySymmetric))
 * [`an_element`](@ref an_element(::AbstractCentrallySymmetric{N}) where {N<:Real})
 
@@ -126,6 +130,7 @@ Inherited from [`LazySet`](@ref):
 
 Inherited from [`AbstractCentrallySymmetric`](@ref):
 * [`dim`](@ref dim(::AbstractCentrallySymmetric))
+* [`isbounded`](@ref isbounded(::AbstractCentrallySymmetric))
 * [`isempty`](@ref isempty(::AbstractCentrallySymmetric))
 * [`an_element`](@ref an_element(::AbstractCentrallySymmetric{N}) where {N<:Real})
 
@@ -139,6 +144,7 @@ dim(::EmptySet)
 ∈(::AbstractVector{N}, ::EmptySet{N}) where {N<:Real}
 an_element(::EmptySet)
 rand(::Type{EmptySet})
+isbounded(::EmptySet)
 isempty(::EmptySet)
 norm(::EmptySet, ::Real=Inf)
 radius(::EmptySet, ::Real=Inf)
@@ -160,6 +166,7 @@ dim(::HalfSpace)
 ∈(::AbstractVector{N}, ::HalfSpace{N}) where {N<:Real}
 an_element(::HalfSpace{N}) where {N<:Real}
 rand(::Type{HalfSpace})
+isbounded(::HalfSpace)
 isempty(::HalfSpace)
 constraints_list(::HalfSpace{N}) where {N<:Real}
 constrained_dimensions(::HalfSpace{N}) where {N<:Real}
@@ -181,6 +188,7 @@ dim(::Hyperplane)
 ∈(::AbstractVector{N}, ::Hyperplane{N}) where {N<:Real}
 an_element(::Hyperplane{N}) where {N<:Real}
 rand(::Type{Hyperplane})
+isbounded(::Hyperplane)
 isempty(::Hyperplane)
 constrained_dimensions(::Hyperplane{N}) where {N<:Real}
 ```
@@ -202,6 +210,7 @@ Inherited from [`LazySet`](@ref):
 * [`diameter`](@ref diameter(::LazySet, ::Real))
 
 Inherited from [`AbstractPolytope`](@ref):
+* [`isbounded`](@ref isbounded(::AbstractPolytope))
 * [`singleton_list`](@ref singleton_list(::AbstractPolytope{N}) where {N<:Real})
 * [`linear_map`](@ref linear_map(::AbstractMatrix{N}, ::AbstractPolytope{N}) where {N<:Real})
 
@@ -245,6 +254,7 @@ Inherited from [`LazySet`](@ref):
 * [`diameter`](@ref diameter(::LazySet, ::Real))
 
 Inherited from [`AbstractPolytope`](@ref):
+* [`isbounded`](@ref isbounded(::AbstractPolytope))
 * [`singleton_list`](@ref singleton_list(::AbstractPolytope{N}) where {N<:Real})
 * [`linear_map`](@ref linear_map(::AbstractMatrix{N}, ::AbstractPolytope{N}) where {N<:Real})
 
@@ -264,6 +274,7 @@ dim(::Line)
 ∈(::AbstractVector{N}, ::Line{N}) where {N<:Real}
 an_element(::Line{N}) where {N<:Real}
 rand(::Type{Line})
+isbounded(::Line)
 isempty(::Line)
 constrained_dimensions(::Line{N}) where {N<:Real}
 ```
@@ -294,6 +305,9 @@ Inherited from [`LazySet`](@ref):
 * [`radius`](@ref radius(::LazySet, ::Real))
 * [`diameter`](@ref diameter(::LazySet, ::Real))
 
+Inherited from [`AbstractPolytope`](@ref):
+* [`isbounded`](@ref isbounded(::AbstractPolytope))
+
 Inherited from [`AbstractCentrallySymmetricPolytope`](@ref):
 * [`isempty`](@ref isempty(::AbstractCentrallySymmetricPolytope))
 
@@ -311,6 +325,7 @@ Inherited from [`LazySet`](@ref):
 * [`diameter`](@ref diameter(::LazySet, ::Real))
 
 Inherited from [`AbstractPolytope`](@ref):
+* [`isbounded`](@ref isbounded(::AbstractPolytope))
 * [`isempty`](@ref isempty(::AbstractPolytope))
 * [`singleton_list`](@ref singleton_list(::AbstractPolytope{N}) where {N<:Real})
 * [`linear_map`](@ref linear_map(::AbstractMatrix{N}, ::AbstractPolytope{N}) where {N<:Real})
@@ -339,6 +354,7 @@ Inherited from [`LazySet`](@ref):
 * [`diameter`](@ref diameter(::LazySet, ::Real))
 
 Inherited from [`AbstractPolytope`](@ref):
+* [`isbounded`](@ref isbounded(::AbstractPolytope))
 * [`isempty`](@ref isempty(::AbstractPolytope))
 * [`singleton_list`](@ref singleton_list(::AbstractPolytope{N}) where {N<:Real})
 * [`linear_map`](@ref linear_map(::AbstractMatrix{N}, ::AbstractPolytope{N}) where {N<:Real})
@@ -374,6 +390,7 @@ Inherited from [`LazySet`](@ref):
 * [`diameter`](@ref diameter(::LazySet, ::Real))
 
 Inherited from [`AbstractPolytope`](@ref):
+* [`isbounded`](@ref isbounded(::AbstractPolytope))
 * [`isempty`](@ref isempty(::AbstractPolytope))
 * [`singleton_list`](@ref singleton_list(::AbstractPolytope{N}) where {N<:Real})
 * [`linear_map`](@ref linear_map(::AbstractMatrix{N}, ::AbstractPolytope{N}) where {N<:Real})
@@ -443,6 +460,7 @@ vertices_list(::HPolytope{N}) where {N<:Real}
 ```
 
 Inherited from [`AbstractPolytope`](@ref):
+* [`isbounded`](@ref isbounded(::AbstractPolytope))
 * [`singleton_list`](@ref singleton_list(::AbstractPolytope{N}) where {N<:Real})
 
 #### Polyhedra
@@ -451,6 +469,7 @@ The following methods are specific for `HPolyhedron`.
 
 ```@docs
 rand(::Type{HPolyhedron})
+isbounded(::HPolyhedron)
 vertices_list(::HPolyhedron{N}) where {N<:Real}
 singleton_list(::HPolyhedron{N}) where {N<:Real}
 constrained_dimensions(::HPolyhedron{N}) where {N<:Real}
@@ -476,6 +495,7 @@ Inherited from [`LazySet`](@ref):
 * [`diameter`](@ref diameter(::LazySet, ::Real))
 
 Inherited from [`AbstractPolytope`](@ref):
+* [`isbounded`](@ref isbounded(::AbstractPolytope))
 * [`isempty`](@ref isempty(::AbstractPolytope))
 * [`singleton_list`](@ref singleton_list(::AbstractPolytope{N}) where {N<:Real})
 * [`linear_map`](@ref linear_map(::AbstractMatrix{N}, ::AbstractPolytope{N}) where {N<:Real})
@@ -492,6 +512,7 @@ Inherited from [`LazySet`](@ref):
 * [`diameter`](@ref diameter(::LazySet, ::Real))
 
 Inherited from [`AbstractPolytope`](@ref):
+* [`isbounded`](@ref isbounded(::AbstractPolytope))
 * [`singleton_list`](@ref singleton_list(::AbstractPolytope{N}) where {N<:Real})
 
 Inherited from [`AbstractCentrallySymmetricPolytope`](@ref):
@@ -530,6 +551,7 @@ Inherited from [`LazySet`](@ref):
 * [`diameter`](@ref diameter(::LazySet, ::Real))
 
 Inherited from [`AbstractPolytope`](@ref):
+* [`isbounded`](@ref isbounded(::AbstractPolytope))
 * [`singleton_list`](@ref singleton_list(::AbstractPolytope{N}) where {N<:Real})
 
 Inherited from [`AbstractCentrallySymmetricPolytope`](@ref):
@@ -571,6 +593,7 @@ Inherited from [`LazySet`](@ref):
 * [`diameter`](@ref diameter(::LazySet, ::Real))
 
 Inherited from [`AbstractPolytope`](@ref):
+* [`isbounded`](@ref isbounded(::AbstractPolytope))
 * [`singleton_list`](@ref singleton_list(::AbstractPolytope{N}) where {N<:Real})
 
 Inherited from [`AbstractCentrallySymmetricPolytope`](@ref):

--- a/docs/src/man/set_operations.md
+++ b/docs/src/man/set_operations.md
@@ -61,54 +61,54 @@ The table entries have the following meaning.
 - "i" indicates that the operation is inherited from a supertype.
 
 
-| type ↓ \ operation →         | dim | ρ | σ | an_element | ∈ | isempty | linear_map | norm | radius | diameter |
-|------------------------------|-----|---|---|------------|---|---------|------------|------|--------|----------|
-| **Interfaces**               |     |   |   |            |   |         |            |      |        |          |
-| `LazySet`                    |     | x |   | x          |   |         |            |      |        | x        |
-| `APolytope`                  |     | i |   | i          |   | x       | x          |      |        | i        |
-| `ACentrallySymmetric`        | x   | i |   | x          |   | x       |            |      |        | i        |
-| `ACentrallySymmetricPolytope`| i   | i |   | i          |   | x       | i          |      |        | i        |
-| `APolygon`                   | x   | i |   | i          |   | i       | i          |      |        | i        |
-| `AHyperrectangle`            | i   | i | x | i          | x | i       | i          | x    | x      | i        |
-| `AHPolygon`                  | i   | i |   | x          | x | i       | i          |      |        | i        |
-| `ASingleton`                 | i   | i | x | i          | x | i       | x          | i    | i      | i        |
-|                              |     |   |   |            |   |         |            |      |        |          |
-| **Basic set types**          |     |   |   |            |   |         |            |      |        |          |
-| `Ball1`                      | i   | i | x | i          | x | i       | i          |      |        | i        |
-| `Ball2`                      | i   | i | x | i          | x | i       |            |      |        | i        |
-| `BallInf`                    | i   | i | i | i          | i | i       | i          | i    | x      | i        |
-| `Ballp`                      | i   | i | x | i          | x | i       |            |      |        | i        |
-| `Ellipsoid`                  | i   | i | x | i          | x | i       |            |      |        | i        |
-| `EmptySet`                   | x   | i | x | x          | x | x       |            | x    | x      | x        |
-| `HalfSpace`                  | x   | x | x | x          | x | x       |            |      |        | i        |
-| `HPolygon`/`HPolygonOpt`     | i   | i | x | i          | i | i       | i          |      |        | i        |
-| `HPolyhedron`                | x   | x | x | i          | x | x       |            |      |        | i        |
-| `HPolytope`                  | x   | x | x | i          | x | x       | i          |      |        | i        |
-| `Hyperplane`                 | x   | x | x | x          | x | x       |            |      |        | i        |
-| `Hyperrectangle`             | i   | i | i | i          | i | i       | i          | i    | i      | i        |
-| `Interval`                   | x   | i | x | x          | x | i       | i          | i    | i      | i        |
-| `Line`                       | x   | i | x | x          | x | x       |            |      |        | i        |
-| `LineSegment`                | x   | i | x | x          | x | i       | i          |      |        | i        |
-| `Singleton`                  | i   | i | i | i          | i | i       | i          | i    | i      | i        |
-| `VPolygon`                   | i   | i | x | x          | x | i       | x          |      |        | i        |
-| `VPolytope`                  | x   | i | x | i          |   | i       | x          |      |        | i        |
-| `ZeroSet`                    | x   | i | x | i          | x | i       | x          | i    | i      | i        |
-| `Zonotope`                   | i   | i | x | i          | x | i       | x          |      |        | i        |
-|                              |     |   |   |            |   |         |            |      |        |          |
-| **Lazy set operation types** |     |   |   |            |   |         |            |      |        |          |
-| `CartesianProduct`           | x   | x | x | i          | x | x       |            |      |        | i        |
-| `CartesianProductArray`      | x   | x | x | i          | x | x       |            |      |        | i        |
-| `ConvexHull`                 | x   | x | x | i          |   | x       |            |      |        | i        |
-| `ConvexHullArray`            | x   | x | x | i          |   | x       |            |      |        | i        |
-| `ExponentialMap`             | x   | x | x | i          | x | x       |            |      |        | i        |
-| `ExponentialProjectionMap`   | x   | i | x | i          |   | x       |            |      |        | i        |
-| `Intersection`               | x   | x |   | i          | x | x       |            |      |        | i        |
-| `IntersectionArray`          | x   | i |   | i          | x |         |            |      |        | i        |
-| `LinearMap`                  | x   | x | x | x          | x | x       |            |      |        | i        |
-| `MinkowskiSum`               | x   | x | x | i          |   | x       |            |      |        | i        |
-| `MinkowskiSumArray`          | x   | x | x | i          |   | x       |            |      |        | i        |
-| `CacheMinkowskiSum`          | x   | i | x | i          |   | x       |            |      |        | i        |
-| `SymmetricIntervalHull`      | x   | i | x | i          | i | i       | i          | i    | i      | i        |
+| type ↓ \ operation →         | dim | ρ | σ | an_element | ∈ | isempty | isbounded | linear_map | norm | radius | diameter |
+|------------------------------|-----|---|---|------------|---|---------|-----------|------------|------|--------|----------|
+| **Interfaces**               |     |   |   |            |   |         |           |            |      |        |          |
+| `LazySet`                    |     | x |   | x          |   |         | x         |            |      |        | x        |
+| `APolytope`                  |     | i |   | i          |   | x       | x         | x          |      |        | i        |
+| `ACentrallySymmetric`        | x   | i |   | x          |   | x       | x         |            |      |        | i        |
+| `ACentrallySymmetricPolytope`| i   | i |   | i          |   | x       | i         | i          |      |        | i        |
+| `APolygon`                   | x   | i |   | i          |   | i       | i         | i          |      |        | i        |
+| `AHyperrectangle`            | i   | i | x | i          | x | i       | i         | i          | x    | x      | i        |
+| `AHPolygon`                  | i   | i |   | x          | x | i       | i         | i          |      |        | i        |
+| `ASingleton`                 | i   | i | x | i          | x | i       | i         | x          | i    | i      | i        |
+|                              |     |   |   |            |   |         |           |            |      |        |          |
+| **Basic set types**          |     |   |   |            |   |         |           |            |      |        |          |
+| `Ball1`                      | i   | i | x | i          | x | i       | i         | i          |      |        | i        |
+| `Ball2`                      | i   | i | x | i          | x | i       | i         |            |      |        | i        |
+| `BallInf`                    | i   | i | i | i          | i | i       | i         | i          | i    | x      | i        |
+| `Ballp`                      | i   | i | x | i          | x | i       | i         |            |      |        | i        |
+| `Ellipsoid`                  | i   | i | x | i          | x | i       | i         |            |      |        | i        |
+| `EmptySet`                   | x   | i | x | x          | x | x       | x         |            | x    | x      | x        |
+| `HalfSpace`                  | x   | x | x | x          | x | x       | x         |            |      |        | i        |
+| `HPolygon`/`HPolygonOpt`     | i   | i | x | i          | i | i       | i         | i          |      |        | i        |
+| `HPolyhedron`                | x   | x | x | i          | x | x       | x         |            |      |        | i        |
+| `HPolytope`                  | x   | x | x | i          | x | x       | i         | i          |      |        | i        |
+| `Hyperplane`                 | x   | x | x | x          | x | x       | x         |            |      |        | i        |
+| `Hyperrectangle`             | i   | i | i | i          | i | i       | i         | i          | i    | i      | i        |
+| `Interval`                   | x   | i | x | x          | x | i       | i         | i          | i    | i      | i        |
+| `Line`                       | x   | i | x | x          | x | x       | x         |            |      |        | i        |
+| `LineSegment`                | x   | i | x | x          | x | i       | i         | i          |      |        | i        |
+| `Singleton`                  | i   | i | i | i          | i | i       | i         | i          | i    | i      | i        |
+| `VPolygon`                   | i   | i | x | x          | x | i       | i         | x          |      |        | i        |
+| `VPolytope`                  | x   | i | x | i          |   | i       | i         | x          |      |        | i        |
+| `ZeroSet`                    | x   | i | x | i          | x | i       | i         | x          | i    | i      | i        |
+| `Zonotope`                   | i   | i | x | i          | x | i       | i         | x          |      |        | i        |
+|                              |     |   |   |            |   |         |           |            |      |        |          |
+| **Lazy set operation types** |     |   |   |            |   |         |           |            |      |        |          |
+| `CartesianProduct`           | x   | x | x | i          | x | x       | x         |            |      |        | i        |
+| `CartesianProductArray`      | x   | x | x | i          | x | x       | x         |            |      |        | i        |
+| `ConvexHull`                 | x   | x | x | i          |   | x       | x         |            |      |        | i        |
+| `ConvexHullArray`            | x   | x | x | i          |   | x       | x         |            |      |        | i        |
+| `ExponentialMap`             | x   | x | x | i          | x | x       | x         |            |      |        | i        |
+| `ExponentialProjectionMap`   | x   | i | x | i          |   | x       | x         |            |      |        | i        |
+| `Intersection`               | x   | x |   | i          | x | x       | x         |            |      |        | i        |
+| `IntersectionArray`          | x   | i |   | i          | x |         | x         |            |      |        | i        |
+| `LinearMap`                  | x   | x | x | x          | x | x       | x         |            |      |        | i        |
+| `MinkowskiSum`               | x   | x | x | i          |   | x       | x         |            |      |        | i        |
+| `MinkowskiSumArray`          | x   | x | x | i          |   | x       | x         |            |      |        | i        |
+| `CacheMinkowskiSum`          | x   | i | x | i          |   | x       | x         |            |      |        | i        |
+| `SymmetricIntervalHull`      | x   | i | x | i          | i | i       | i         | i          | i    | i      | i        |
 
 ### `dim`
 

--- a/src/AbstractCentrallySymmetric.jl
+++ b/src/AbstractCentrallySymmetric.jl
@@ -45,6 +45,23 @@ The ambient dimension of the set.
 end
 
 """
+    isbounded(S::AbstractCentrallySymmetric)::Bool
+
+Determine whether a centrally symmetric set is bounded.
+
+### Input
+
+- `S` -- centrally symmetric set
+
+### Output
+
+`true` (since a set with a unique center must be bounded).
+"""
+function isbounded(::AbstractCentrallySymmetric)::Bool
+    return true
+end
+
+"""
     an_element(S::AbstractCentrallySymmetric{N})::Vector{N} where {N<:Real}
 
 Return some element of a centrally symmetric set.
@@ -74,6 +91,6 @@ Return if a centrally symmetric set is empty or not.
 
 `false`.
 """
-function isempty(S::AbstractCentrallySymmetric)::Bool
+function isempty(::AbstractCentrallySymmetric)::Bool
     return false
 end

--- a/src/AbstractPolytope.jl
+++ b/src/AbstractPolytope.jl
@@ -37,13 +37,30 @@ abstract type AbstractPolytope{N<:Real} <: LazySet{N} end
 
 
 """
+    isbounded(P::AbstractPolytope)::Bool
+
+Determine whether a polytopic set is bounded.
+
+### Input
+
+- `P` -- polytopic set
+
+### Output
+
+`true` (since a polytope must be bounded).
+"""
+function isbounded(::AbstractPolytope)::Bool
+    return true
+end
+
+"""
     singleton_list(P::AbstractPolytope{N})::Vector{Singleton{N}} where {N<:Real}
 
 Return the vertices of a polytopic set as a list of singletons.
 
 ### Input
 
-- `P` -- a polytopic set
+- `P` -- polytopic set
 
 ### Output
 

--- a/src/CartesianProduct.jl
+++ b/src/CartesianProduct.jl
@@ -130,6 +130,23 @@ function ρ(d::AbstractVector{N}, cp::CartesianProduct{N}) where {N<:Real}
 end
 
 """
+    isbounded(cp::CartesianProduct)::Bool
+
+Determine whether a Cartesian product is bounded.
+
+### Input
+
+- `cp` -- Cartesian product
+
+### Output
+
+`true` iff both wrapped sets are bounded.
+"""
+function isbounded(cp::CartesianProduct)::Bool
+    return isbounded(cp.X) && isbounded(cp.Y)
+end
+
+"""
     ∈(x::AbstractVector{N}, cp::CartesianProduct{N})::Bool where {N<:Real}
 
 Check whether a given point is contained in a Cartesian product.
@@ -356,6 +373,24 @@ function ρ(d::AbstractVector{N}, cpa::CartesianProductArray{N}) where {N<:Real}
         i0 = i1 + 1
     end
     return sfun
+end
+
+"""
+    isbounded(cpa::CartesianProductArray)::Bool
+
+Determine whether a Cartesian product of a finite number of convex sets is
+bounded.
+
+### Input
+
+- `cpa` -- Cartesian product of a finite number of convex sets
+
+### Output
+
+`true` iff all wrapped sets are bounded.
+"""
+function isbounded(cpa::CartesianProductArray)::Bool
+    return all(x -> isbounded(x), cpa.array)
 end
 
 """

--- a/src/ConvexHull.jl
+++ b/src/ConvexHull.jl
@@ -123,6 +123,23 @@ function ρ(d::AbstractVector{N}, ch::ConvexHull{N}) where {N<:Real}
 end
 
 """
+    isbounded(ch::ConvexHull)::Bool
+
+Determine whether a convex hull of two convex sets is bounded.
+
+### Input
+
+- `ch` -- convex hull of two convex sets
+
+### Output
+
+`true` iff both wrapped sets are bounded.
+"""
+function isbounded(ch::ConvexHull)::Bool
+    return isbounded(ch.X) && isbounded(ch.Y)
+end
+
+"""
     isempty(ch::ConvexHull)::Bool
 
 Return if a convex hull of two convex sets is empty or not.
@@ -283,6 +300,24 @@ This algorihm calculates the maximum over all ``ρ(d, X_i)`` where the
 """
 function ρ(d::AbstractVector{N}, cha::ConvexHullArray{N}) where {N<:Real}
     return maximum([ρ(d, Xi) for Xi in array(cha)])
+end
+
+"""
+    isbounded(cha::ConvexHullArray)::Bool
+
+Determine whether a convex hull of a finite number of convex sets is
+bounded.
+
+### Input
+
+- `cha` -- convex hull of a finite number of convex sets
+
+### Output
+
+`true` iff all wrapped sets are bounded.
+"""
+function isbounded(cha::ConvexHullArray)::Bool
+    return all(x -> isbounded(x), cha.array)
 end
 
 """

--- a/src/EmptySet.jl
+++ b/src/EmptySet.jl
@@ -61,6 +61,23 @@ function σ(d::AbstractVector{N}, ∅::EmptySet{N}) where {N<:Real}
 end
 
 """
+    isbounded(∅::EmptySet)::Bool
+
+Determine whether an empty set is bounded.
+
+### Input
+
+- `∅` -- empty set
+
+### Output
+
+`true`.
+"""
+function isbounded(::EmptySet)::Bool
+    return true
+end
+
+"""
     ∈(x::AbstractVector{N}, ∅::EmptySet{N})::Bool where {N<:Real}
 
 Check whether a given point is contained in an empty set.

--- a/src/ExponentialMap.jl
+++ b/src/ExponentialMap.jl
@@ -518,7 +518,7 @@ Determine whether an exponential projection map is bounded.
 
 We first check if the wrapped set is bounded or if the left or right projection
 matrix is zero.
-Otherwise, we check boundedness via `isbounded_unit_dims`.
+Otherwise, we check boundedness via [`isbounded_unit_dimensions`](@ref).
 """
 function isbounded(eprojmap::ExponentialProjectionMap)::Bool
     if isbounded(eprojmap.X)
@@ -527,7 +527,7 @@ function isbounded(eprojmap::ExponentialProjectionMap)::Bool
     if iszero(eprojmap.projspmexp.L) || iszero(eprojmap.projspmexp.R)
         return true
     end
-    return isbounded_unit_dims(eprojmap)
+    return isbounded_unit_dimensions(eprojmap)
 end
 
 """

--- a/src/ExponentialMap.jl
+++ b/src/ExponentialMap.jl
@@ -516,8 +516,8 @@ Determine whether an exponential projection map is bounded.
 
 ### Algorithm
 
-We first check if the wrapped set is bounded or if the left or right projection
-matrix is zero.
+We first check if the left or right projection matrix is zero or the wrapped set
+is bounded.
 Otherwise, we check boundedness via [`isbounded_unit_dimensions`](@ref).
 """
 function isbounded(eprojmap::ExponentialProjectionMap)::Bool

--- a/src/ExponentialMap.jl
+++ b/src/ExponentialMap.jl
@@ -276,6 +276,23 @@ function ρ(d::AbstractVector{N}, em::ExponentialMap{N}) where {N<:Real}
 end
 
 """
+    isbounded(em::ExponentialMap)::Bool
+
+Determine whether an exponential map is bounded.
+
+### Input
+
+- `em` -- exponential map
+
+### Output
+
+`true` iff the exponential map is bounded.
+"""
+function isbounded(em::ExponentialMap)::Bool
+    return isbounded(em.X)
+end
+
+"""
     ∈(x::AbstractVector{N}, em::ExponentialMap{N})::Bool where {N<:Real}
 
 Check whether a given point is contained in an exponential map of a convex set.
@@ -482,6 +499,35 @@ function σ(d::AbstractVector{N},
     aux2 = eprojmap.projspmexp.R * svec
     daux = expmv(one(N), eprojmap.projspmexp.spmexp.M, aux2)
     return eprojmap.projspmexp.L * daux
+end
+
+"""
+    isbounded(eprojmap::ExponentialProjectionMap)::Bool
+
+Determine whether an exponential projection map is bounded.
+
+### Input
+
+- `eprojmap` -- exponential projection map
+
+### Output
+
+`true` iff the exponential projection map is bounded.
+
+### Algorithm
+
+We first check if the wrapped set is bounded or if the left or right projection
+matrix is zero.
+Otherwise, we check boundedness via `isbounded_unit_dims`.
+"""
+function isbounded(eprojmap::ExponentialProjectionMap)::Bool
+    if isbounded(eprojmap.X)
+        return true
+    end
+    if iszero(eprojmap.projspmexp.L) || iszero(eprojmap.projspmexp.R)
+        return true
+    end
+    return isbounded_unit_dims(eprojmap)
 end
 
 """

--- a/src/ExponentialMap.jl
+++ b/src/ExponentialMap.jl
@@ -521,10 +521,8 @@ matrix is zero.
 Otherwise, we check boundedness via [`isbounded_unit_dimensions`](@ref).
 """
 function isbounded(eprojmap::ExponentialProjectionMap)::Bool
-    if isbounded(eprojmap.X)
-        return true
-    end
-    if iszero(eprojmap.projspmexp.L) || iszero(eprojmap.projspmexp.R)
+    if iszero(eprojmap.projspmexp.L) || iszero(eprojmap.projspmexp.R) ||
+            isbounded(eprojmap.X)
         return true
     end
     return isbounded_unit_dimensions(eprojmap)

--- a/src/HPolyhedron.jl
+++ b/src/HPolyhedron.jl
@@ -192,13 +192,13 @@ Determine whether a polyhedron in constraint representation is bounded.
 
 We first check if the polyhedron has at least `max(dim(P), 1)` constraints,
 which is a necessary condition for boundedness.
-If so, we check boundedness via `isbounded_unit_dims`.
+If so, we check boundedness via [`isbounded_unit_dimensions`](@ref).
 """
 function isbounded(P::HPolyhedron)::Bool
     if length(P.constraints) <= max(dim(P), 1)
         return false
     end
-    return isbounded_unit_dims(P)
+    return isbounded_unit_dimensions(P)
 end
 
 """

--- a/src/HPolyhedron.jl
+++ b/src/HPolyhedron.jl
@@ -190,7 +190,7 @@ Determine whether a polyhedron in constraint representation is bounded.
 
 ### Algorithm
 
-We first check if the polyhedron has at least `max(dim(P), 1)` constraints,
+We first check if the polyhedron has more than `max(dim(P), 1)` constraints,
 which is a necessary condition for boundedness.
 If so, we check boundedness via [`isbounded_unit_dimensions`](@ref).
 """

--- a/src/HPolyhedron.jl
+++ b/src/HPolyhedron.jl
@@ -176,6 +176,32 @@ function σ_helper(d::AbstractVector{N}, P::HPoly{N}) where {N<:Real}
 end
 
 """
+    isbounded(P::HPolyhedron)::Bool
+
+Determine whether a polyhedron in constraint representation is bounded.
+
+### Input
+
+- `P` -- polyhedron in constraint representation
+
+### Output
+
+`true` iff the polyhedron is bounded.
+
+### Algorithm
+
+We first check if the polyhedron has at least `max(dim(P), 1)` constraints,
+which is a necessary condition for boundedness.
+If so, we check boundedness via `isbounded_unit_dims`.
+"""
+function isbounded(P::HPolyhedron)::Bool
+    if length(P.constraints) <= max(dim(P), 1)
+        return false
+    end
+    return isbounded_unit_dims(P)
+end
+
+"""
     ∈(x::AbstractVector{N}, P::HPoly{N})::Bool where {N<:Real}
 
 Check whether a given point is contained in a polyhedron in constraint

--- a/src/HalfSpace.jl
+++ b/src/HalfSpace.jl
@@ -109,6 +109,23 @@ function σ(d::AbstractVector{N}, hs::HalfSpace{N}) where {N<:Real}
 end
 
 """
+    isbounded(hs::HalfSpace)::Bool
+
+Determine whether a half-space is bounded.
+
+### Input
+
+- `hs` -- half-space
+
+### Output
+
+`false`.
+"""
+function isbounded(::HalfSpace)::Bool
+    return false
+end
+
+"""
     an_element(hs::HalfSpace{N})::Vector{N} where {N<:Real}
 
 Return some element of a half-space.

--- a/src/Hyperplane.jl
+++ b/src/Hyperplane.jl
@@ -98,6 +98,23 @@ function σ(d::AbstractVector{N}, hp::Hyperplane{N}) where {N<:Real}
 end
 
 """
+    isbounded(hp::Hyperplane)::Bool
+
+Determine whether a hyperplane is bounded.
+
+### Input
+
+- `hp` -- hyperplane
+
+### Output
+
+`false`.
+"""
+function isbounded(::Hyperplane)::Bool
+    return false
+end
+
+"""
     an_element(hp::Hyperplane{N})::Vector{N} where {N<:Real}
 
 Return some element of a hyperplane.

--- a/src/Intersection.jl
+++ b/src/Intersection.jl
@@ -483,13 +483,13 @@ Determine whether an intersection of two convex sets is bounded.
 ### Algorithm
 
 We first check if any of the wrapped sets is bounded.
-Otherwise, we check boundedness via `isbounded_unit_dims`.
+Otherwise, we check boundedness via [`isbounded_unit_dimensions`](@ref).
 """
 function isbounded(cap::Intersection)::Bool
     if isbounded(cap.X) || isbounded(cap.Y)
         return true
     end
-    return isbounded_unit_dims(cap)
+    return isbounded_unit_dimensions(cap)
 end
 
 """
@@ -671,13 +671,13 @@ Determine whether an intersection of a finite number of convex sets is bounded.
 ### Algorithm
 
 We first check if any of the wrapped sets is bounded.
-Otherwise, we check boundedness via `isbounded_unit_dims`.
+Otherwise, we check boundedness via [`isbounded_unit_dimensions`](@ref).
 """
 function isbounded(ia::IntersectionArray)::Bool
     if any(x -> isbounded(x), ia.array)
         return true
     end
-    return isbounded_unit_dims(ia)
+    return isbounded_unit_dimensions(ia)
 end
 
 """

--- a/src/Intersection.jl
+++ b/src/Intersection.jl
@@ -468,6 +468,31 @@ function ρ(d::AbstractVector{N},
 end
 
 """
+    isbounded(cap::Intersection)::Bool
+
+Determine whether an intersection of two convex sets is bounded.
+
+### Input
+
+- `cap` -- intersection of two convex sets
+
+### Output
+
+`true` iff the intersection is bounded.
+
+### Algorithm
+
+We first check if any of the wrapped sets is bounded.
+Otherwise, we check boundedness via `isbounded_unit_dims`.
+"""
+function isbounded(cap::Intersection)::Bool
+    if isbounded(cap.X) || isbounded(cap.Y)
+        return true
+    end
+    return isbounded_unit_dims(cap)
+end
+
+"""
     ∈(x::AbstractVector{N}, cap::Intersection{N})::Bool where {N<:Real}
 
 Check whether a given point is contained in an intersection of two convex sets.
@@ -628,6 +653,31 @@ function σ(d::AbstractVector{N},
            ia::IntersectionArray{N})::Vector{N} where {N<:Real}
     # TODO implement
     error("not implemented yet")
+end
+
+"""
+    isbounded(ia::IntersectionArray)::Bool
+
+Determine whether an intersection of a finite number of convex sets is bounded.
+
+### Input
+
+- `ia` -- intersection of a finite number of convex sets
+
+### Output
+
+`true` iff the intersection is bounded.
+
+### Algorithm
+
+We first check if any of the wrapped sets is bounded.
+Otherwise, we check boundedness via `isbounded_unit_dims`.
+"""
+function isbounded(ia::IntersectionArray)::Bool
+    if any(x -> isbounded(x), ia.array)
+        return true
+    end
+    return isbounded_unit_dims(ia)
 end
 
 """

--- a/src/LazySet.jl
+++ b/src/LazySet.jl
@@ -8,7 +8,7 @@ export LazySet,
        radius,
        diameter,
        an_element,
-       isbounded, isbounded_unit_dims,
+       isbounded, isbounded_unit_dimensions,
        neutral,
        absorbing
 
@@ -119,14 +119,14 @@ Determine whether a set is bounded.
 
 ### Algorithm
 
-We check boundedness via `isbounded_unit_dims`.
+We check boundedness via [`isbounded_unit_dimensions`](@ref).
 """
 function isbounded(S::LazySet)::Bool
-    return isbounded_unit_dims(S)
+    return isbounded_unit_dimensions(S)
 end
 
 """
-    isbounded_unit_dims(S::LazySet{N})::Bool where {N<:Real}
+    isbounded_unit_dimensions(S::LazySet{N})::Bool where {N<:Real}
 
 Determine whether a set is bounded in each unit dimension.
 
@@ -143,7 +143,7 @@ Determine whether a set is bounded in each unit dimension.
 This function performs ``2n`` support function checks, where ``n`` is the
 ambient dimension of `S`.
 """
-function isbounded_unit_dims(S::LazySet{N})::Bool where {N<:Real}
+function isbounded_unit_dimensions(S::LazySet{N})::Bool where {N<:Real}
     n = dim(S)
     for i in 1:n
         for o in [one(N), -one(N)]

--- a/src/LazySet.jl
+++ b/src/LazySet.jl
@@ -145,7 +145,7 @@ ambient dimension of `S`.
 """
 function isbounded_unit_dimensions(S::LazySet{N})::Bool where {N<:Real}
     n = dim(S)
-    for i in 1:n
+    @inbounds for i in 1:n
         for o in [one(N), -one(N)]
             d = LazySets.Approximations.UnitVector(i, n, o)
             if ρ(d, S) == N(Inf)

--- a/src/LazySet.jl
+++ b/src/LazySet.jl
@@ -8,6 +8,7 @@ export LazySet,
        radius,
        diameter,
        an_element,
+       isbounded, isbounded_unit_dims,
        neutral,
        absorbing
 
@@ -103,6 +104,57 @@ Alias for the support vector σ.
 """
 const support_vector = σ
 
+"""
+    isbounded(S::LazySet)::Bool
+
+Determine whether a set is bounded.
+
+### Input
+
+- `S` -- set
+
+### Output
+
+`true` iff the set is bounded.
+
+### Algorithm
+
+We check boundedness via `isbounded_unit_dims`.
+"""
+function isbounded(S::LazySet)::Bool
+    return isbounded_unit_dims(S)
+end
+
+"""
+    isbounded_unit_dims(S::LazySet{N})::Bool where {N<:Real}
+
+Determine whether a set is bounded in each unit dimension.
+
+### Input
+
+- `S` -- set
+
+### Output
+
+`true` iff the set is bounded in each unit dimension.
+
+### Algorithm
+
+This function performs ``2n`` support function checks, where ``n`` is the
+ambient dimension of `S`.
+"""
+function isbounded_unit_dims(S::LazySet{N})::Bool where {N<:Real}
+    n = dim(S)
+    for i in 1:n
+        for o in [one(N), -one(N)]
+            d = LazySets.Approximations.UnitVector(i, n, o)
+            if ρ(d, S) == N(Inf)
+                return false
+            end
+        end
+    end
+    return true
+end
 
 """
     norm(S::LazySet, [p]::Real=Inf)

--- a/src/Line.jl
+++ b/src/Line.jl
@@ -124,6 +124,23 @@ function σ(d::AbstractVector{N}, L::Line{N}) where {N<:Real}
 end
 
 """
+    isbounded(L::Line)::Bool
+
+Determine whether a line is bounded.
+
+### Input
+
+- `L` -- line
+
+### Output
+
+`false`.
+"""
+function isbounded(::Line)::Bool
+    return false
+end
+
+"""
     an_element(L::Line{N})::Vector{N} where N<:Real
 
 Return some element of a line.

--- a/src/LinearMap.jl
+++ b/src/LinearMap.jl
@@ -216,7 +216,7 @@ Determine whether a linear map is bounded.
 ### Algorithm
 
 We first check if the wrapped set is bounded or the matrix is zero.
-Otherwise, we check boundedness via `isbounded_unit_dims`.
+Otherwise, we check boundedness via [`isbounded_unit_dimensions`](@ref).
 """
 function isbounded(lm::LinearMap)::Bool
     if isbounded(lm.X)
@@ -225,7 +225,7 @@ function isbounded(lm::LinearMap)::Bool
     if iszero(lm.M)
         return true
     end
-    return isbounded_unit_dims(lm)
+    return isbounded_unit_dimensions(lm)
 end
 
 """

--- a/src/LinearMap.jl
+++ b/src/LinearMap.jl
@@ -215,14 +215,11 @@ Determine whether a linear map is bounded.
 
 ### Algorithm
 
-We first check if the wrapped set is bounded or the matrix is zero.
+We first check if the matrix is zero or the wrapped set is bounded.
 Otherwise, we check boundedness via [`isbounded_unit_dimensions`](@ref).
 """
 function isbounded(lm::LinearMap)::Bool
-    if isbounded(lm.X)
-        return true
-    end
-    if iszero(lm.M)
+    if iszero(lm.M) || isbounded(lm.X)
         return true
     end
     return isbounded_unit_dimensions(lm)

--- a/src/LinearMap.jl
+++ b/src/LinearMap.jl
@@ -201,6 +201,34 @@ function ρ(d::AbstractVector{N}, lm::LinearMap{N}; kwargs...) where {N<:Real}
 end
 
 """
+    isbounded(lm::LinearMap)::Bool
+
+Determine whether a linear map is bounded.
+
+### Input
+
+- `lm` -- linear map
+
+### Output
+
+`true` iff the linear map is bounded.
+
+### Algorithm
+
+We first check if the wrapped set is bounded or the matrix is zero.
+Otherwise, we check boundedness via `isbounded_unit_dims`.
+"""
+function isbounded(lm::LinearMap)::Bool
+    if isbounded(lm.X)
+        return true
+    end
+    if iszero(lm.M)
+        return true
+    end
+    return isbounded_unit_dims(lm)
+end
+
+"""
     ∈(x::AbstractVector{N}, lm::LinearMap{N})::Bool where {N<:Real}
 
 Check whether a given point is contained in a linear map of a convex set.

--- a/src/MinkowskiSum.jl
+++ b/src/MinkowskiSum.jl
@@ -135,6 +135,23 @@ function ρ(d::AbstractVector{N}, ms::MinkowskiSum{N}) where {N<:Real}
 end
 
 """
+    isbounded(ms::MinkowskiSum)::Bool
+
+Determine whether a Minkowski sum is bounded.
+
+### Input
+
+- `ms` -- Minkowski sum
+
+### Output
+
+`true` iff both wrapped sets are bounded.
+"""
+function isbounded(ms::MinkowskiSum)::Bool
+    return isbounded(ms.X) && isbounded(ms.Y)
+end
+
+"""
     isempty(ms::MinkowskiSum)::Bool
 
 Return if a Minkowski sum is empty or not.
@@ -283,13 +300,30 @@ function ρ(d::AbstractVector{N}, msa::MinkowskiSumArray{N}) where {N<:Real}
 end
 
 """
+	isbounded(msa::MinkowskiSumArray)::Bool
+
+Determine whether a Minkowski sum of a finite number of convex sets is bounded.
+
+### Input
+
+- `msa` -- Minkowski sum of a finite number of convex sets
+
+### Output
+
+`true` iff all wrapped sets are bounded.
+"""
+function isbounded(msa::MinkowskiSumArray)::Bool
+    return all(x -> isbounded(x), msa.array)
+end
+
+"""
     isempty(msa::MinkowskiSumArray)::Bool
 
 Return if a Minkowski sum array is empty or not.
 
 ### Input
 
-- `cp` -- Minkowski sum array
+- `msa` -- Minkowski sum array
 
 ### Output
 
@@ -469,13 +503,30 @@ function σ(d::AbstractVector{N}, cms::CacheMinkowskiSum{N}) where {N<:Real}
 end
 
 """
+	isbounded(cms::CacheMinkowskiSum)::Bool
+
+Determine whether a caching Minkowski sum is bounded.
+
+### Input
+
+- `cms` -- caching Minkowski sum
+
+### Output
+
+`true` iff all wrapped sets are bounded.
+"""
+function isbounded(cms::CacheMinkowskiSum)::Bool
+    return all(x -> isbounded(x), cms.array)
+end
+
+"""
     isempty(cms::CacheMinkowskiSum)::Bool
 
 Return if a caching Minkowski sum array is empty or not.
 
 ### Input
 
-- `cp` -- caching Minkowski sum
+- `cms` -- caching Minkowski sum
 
 ### Output
 

--- a/test/unit_Ball1.jl
+++ b/test/unit_Ball1.jl
@@ -59,6 +59,9 @@ for N in [Float64, Rational{Int}, Float32]
     # center
     @test center(b) == N[0, 0]
 
+    # boundedness
+    @test isbounded(b)
+
     # isempty
     @test !isempty(b)
 

--- a/test/unit_Ball2.jl
+++ b/test/unit_Ball2.jl
@@ -56,6 +56,9 @@ for N in [Float64, Float32]
     d = N[0, -1]
     @test σ(d, b) == N[0, -2]
 
+    # boundedness
+    @test isbounded(b)
+
     # isempty
     @test !isempty(b)
 

--- a/test/unit_BallInf.jl
+++ b/test/unit_BallInf.jl
@@ -54,6 +54,9 @@ for N in [Float64, Rational{Int}, Float32]
     d = N[1, -1]
     @test σ(d, b) == N[2, -2]
 
+    # boundedness
+    @test isbounded(b)
+
     # isempty
     @test !isempty(b)
 

--- a/test/unit_Ballp.jl
+++ b/test/unit_Ballp.jl
@@ -37,6 +37,9 @@ for N in [Float64, Float32]
     @test center(b) == b.center
     @test an_element(b) isa AbstractVector{N}
 
+    # boundedness
+    @test isbounded(b)
+
     # isempty
     @test !isempty(b)
 

--- a/test/unit_CartesianProduct.jl
+++ b/test/unit_CartesianProduct.jl
@@ -4,31 +4,35 @@ for N in [Float64, Float32, Rational{Int}]
     b1 = BallInf(N[0], N(1))
     b2 = BallInf(N[0, 0], N(1))
     # Test Construction
-    c1 = CartesianProduct(b1, b2)
-    @test c1.X == b1
-    @test c1.Y == b2
+    cp = CartesianProduct(b1, b2)
+    @test cp.X == b1
+    @test cp.Y == b2
     # Test Dimension
-    @test dim(c1) == 3
+    @test dim(cp) == 3
     # Test Support Vector
     d = N[1, 1, 1]
-    @test σ(d, c1) == N[1, 1, 1]
+    @test σ(d, cp) == N[1, 1, 1]
     d = N[1, 1, -1]
-    @test σ(d, c1) == N[1, 1, -1]
+    @test σ(d, cp) == N[1, 1, -1]
     d = N[1, -1, 1]
-    @test σ(d, c1) == N[1, -1, 1]
+    @test σ(d, cp) == N[1, -1, 1]
     d = N[1, -1, -1]
-    @test σ(d, c1) == N[1, -1, -1]
+    @test σ(d, cp) == N[1, -1, -1]
     d = N[-1, 1, 1]
-    @test σ(d, c1) == N[-1, 1, 1]
+    @test σ(d, cp) == N[-1, 1, 1]
     d = N[-1, 1, -1]
-    @test σ(d, c1) == N[-1, 1, -1]
+    @test σ(d, cp) == N[-1, 1, -1]
     d = N[-1, -1, 1]
-    @test σ(d, c1) == N[-1, -1, 1]
+    @test σ(d, cp) == N[-1, -1, 1]
     d = N[-1, -1, -1]
-    @test σ(d, c1) == N[-1, -1, -1]
+    @test σ(d, cp) == N[-1, -1, -1]
+
+    # boundedness
+    @test isbounded(cp)
+    @test !isbounded(Singleton(N[1]) * HalfSpace(N[1], N(1)))
 
     # isempty
-    @test !isempty(c1)
+    @test !isempty(cp)
 
     # Cartesian Product of a not-centered 1D BallInf and a not-centered 2D BallInf
     # Here a Hyperrectangle where c = [1, -3, 4] and r = [3, 2, 2]
@@ -143,6 +147,10 @@ for N in [Float64, Float32, Rational{Int}]
 
     # array getter
     @test array(cpa) ≡ v
+
+    # boundedness
+    @test isbounded(cpa)
+    @test !isbounded(CartesianProductArray([Singleton(N[1]), HalfSpace(N[1], N(1))]))
 
     # membership
     @test ∈(N[1, 2, 3, 4], cpa)

--- a/test/unit_ConvexHull.jl
+++ b/test/unit_ConvexHull.jl
@@ -3,23 +3,26 @@ for N in [Float64, Rational{Int}, Float32]
     b1 = Ball1(N[0, 0], N(1))
     b2 = Ball1(N[1, 2], N(1))
     # Test Construction
-    ch1 = ConvexHull(b1, b2)
-    ch2 = CH(b1, b2)
-    @test ch1 == ch2
+    ch = ConvexHull(b1, b2)
+    @test ch == CH(b1, b2)
     # Test Dimension
-    @test dim(ch1) == 2
+    @test dim(ch) == 2
     # Test Support Vector
     d = N[1, 0]
-    @test σ(d, ch1) == N[2, 2]
+    @test σ(d, ch) == N[2, 2]
     d = N[-1, 0]
-    @test σ(d, ch1) == N[-1, 0]
+    @test σ(d, ch) == N[-1, 0]
     d = N[0, 1]
-    @test σ(d, ch1) == N[1, 3]
+    @test σ(d, ch) == N[1, 3]
     d = N[0, -1]
-    @test σ(d, ch1) == N[0, -1]
+    @test σ(d, ch) == N[0, -1]
+
+    # boundedness
+    @test isbounded(ch)
+    @test !isbounded(CH(Singleton(N[1]), HalfSpace(N[1], N(1))))
 
     # isempty
-    @test !isempty(ch1)
+    @test !isempty(ch)
 
     # test convex hull of a set of points using the default algorithm
     points = to_N(N, [[0.9, 0.2], [0.4, 0.6], [0.2, 0.1], [0.1, 0.3], [0.3, 0.28]])
@@ -34,28 +37,32 @@ for N in [Float64, Rational{Int}, Float32]
     @test LazySets.is_array_constructor(ConvexHullArray)
 
     # convex hull array of 2 sets
-    C = ConvexHullArray([b1, b2])
+    cha = ConvexHullArray([b1, b2])
     # constructor with size hint and type
     ConvexHullArray(10, N)
     # test alias
     @test CHArray([b1, b2]) isa ConvexHullArray
     # test dimension
-    @test dim(C) == 2
+    @test dim(cha) == 2
     # test support vector
     d = N[1, 0]
-    @test σ(d, C) == N[2, 2]
+    @test σ(d, cha) == N[2, 2]
     d = N[-1, 0]
-    @test σ(d, C) == N[-1, 0]
+    @test σ(d, cha) == N[-1, 0]
     d = N[0, 1]
-    @test σ(d, C) == N[1, 3]
+    @test σ(d, cha) == N[1, 3]
     d = N[0, -1]
-    @test σ(d, C) == N[0, -1]
+    @test σ(d, cha) == N[0, -1]
+
+    # boundedness
+    @test isbounded(cha)
+    @test !isbounded(ConvexHullArray([Singleton(N[1]), HalfSpace(N[1], N(1))]))
 
     # isempty
-    @test !isempty(C)
+    @test !isempty(cha)
 
     # test convex hull array of singleton
-    C = ConvexHullArray(
+    ConvexHullArray(
         [Singleton(to_N(N, [10, 0.5])), Singleton(to_N(N, [1.1, 0.2])),
          Singleton(to_N(N, [1.4, 0.3])), Singleton(to_N(N, [1.7, 0.5])),
          Singleton(to_N(N, [1.4, 0.8]))])

--- a/test/unit_Ellipsoid.jl
+++ b/test/unit_Ellipsoid.jl
@@ -57,6 +57,9 @@ for N in [Float64, Float32]
     d = N[0, -1]
     @test σ(d, E) ≈ N[1, 2 - sqrt(2)]
 
+    # boundedness
+    @test isbounded(E)
+
     # isempty
     @test !isempty(E)
 

--- a/test/unit_EmptySet.jl
+++ b/test/unit_EmptySet.jl
@@ -42,6 +42,9 @@ for N in [Float64, Rational{Int}, Float32]
     # support vector
     @test_throws ErrorException σ(N[0], E)
 
+    # boundedness
+    @test isbounded(E)
+
     # membership
     @test !∈(N[0], E)
     @test !∈(N[0, 0], E)

--- a/test/unit_ExponentialMap.jl
+++ b/test/unit_ExponentialMap.jl
@@ -69,6 +69,10 @@ for N in [Float64, Float32]
         @test svec ≈ svec_explicit
     end
 
+    # boundedness
+    @test isbounded(emap)
+    @test !isbounded(me * HalfSpace(ones(N, n), N(1)))
+
     # isempty
     @test !isempty(emap)
 
@@ -103,6 +107,13 @@ for N in [Float64, Float32]
 
     # query the ambient dimension of projmap (hint: it is the output dimension)
     @test dim(projmap) == nb
+
+    # boundedness
+    @test isbounded(projmap)
+    @test isbounded(ProjectionSparseMatrixExp(spzeros(N, nb, nb), me, R) * HalfSpace(ones(N, nb), N(1)))
+    @test isbounded(ProjectionSparseMatrixExp(L, me, spzeros(N, nb, nb)) * HalfSpace(ones(N, nb), N(1)))
+    # the following test crashes because ρ(::ExponentialProjectionMap) is not implemented yet
+    @test_throws ErrorException !isbounded(proj * HalfSpace(ones(N, nb), N(1)))
 
     # isempty
     @test !isempty(projmap)

--- a/test/unit_HalfSpace.jl
+++ b/test/unit_HalfSpace.jl
@@ -39,6 +39,9 @@ for N in [Float64, Rational{Int}, Float32]
     # any other direction
     @test_throws ErrorException σ(N[1, 1], HalfSpace(N[1, 0], N(1)))
 
+    # boundedness
+    @test !isbounded(hs)
+
     # isempty
     @test !isempty(hs)
 

--- a/test/unit_Hyperplane.jl
+++ b/test/unit_Hyperplane.jl
@@ -40,6 +40,9 @@ for N in [Float64, Rational{Int}, Float32]
     # support vector in other directions throws an error (but see #750)
     @test_throws ErrorException σ(N[1, 1], Hyperplane(N[1, 0], N(1)))
 
+    # boundedness
+    @test !isbounded(hp)
+
     # isempty
     @test !isempty(hp)
 

--- a/test/unit_Hyperrectangle.jl
+++ b/test/unit_Hyperrectangle.jl
@@ -85,6 +85,9 @@ for N in [Float64, Rational{Int}, Float32]
     @test low(H) ≈ to_N(N, [-2.6, 5.1, 0.4])
     @test high(H) ≈ to_N(N, [-1.6, 6.1, 1.4])
 
+    # boundedness
+    @test isbounded(H)
+
     # isempty
     @test !isempty(H)
 

--- a/test/unit_Intersection.jl
+++ b/test/unit_Intersection.jl
@@ -17,6 +17,10 @@ for N in [Float64, Rational{Int}, Float32]
     # membership
     @test ∈(ones(N, 2), I) && !∈(N[5, 5], I)
 
+    # boundedness (more tests in Float64-only section)
+    @test isbounded(I)
+    @test isbounded(Singleton(N[1]) ∩ HalfSpace(N[1], N(1)))
+
     # emptiness of intersection
     @test !isempty_known(I)
     @test !isempty(I)
@@ -39,6 +43,13 @@ for N in [Float64, Rational{Int}, Float32]
 
     # support vector (currently throws an error)
     @test_throws ErrorException σ(ones(N, 2), IA)
+
+    # boundedness
+    @test isbounded(IA)
+    @test isbounded(IntersectionArray([Singleton(N[1]), HalfSpace(N[1], N(1))]))
+    # the following tests crash because ρ(::IntersectionArray) is not implemented yet
+    @test_throws ErrorException isbounded(IntersectionArray([HalfSpace(N[1], N(1)), HalfSpace(N[1], N(-1))]))
+    @test_throws ErrorException !isbounded(IntersectionArray([HalfSpace(ones(N, 2), N(1)), HalfSpace(ones(N, 2), N(-1))]))
 
     # isempty
     @test_throws MethodError isempty(IA)
@@ -85,6 +96,10 @@ for N in [Float64]
     # specify  line search algorithm
     @test ρ(d, X ∩ H, algorithm="line_search") < 1e-6 &&
         ρ(d, H ∩ X, algorithm="line_search") < 1e-6
+
+    # boundedness
+    @test isbounded(HalfSpace(N[1], N(1)) ∩ HalfSpace(N[-1], N(1)))
+    @test !isbounded(HalfSpace(ones(N, 2), N(1)) ∩ HalfSpace(-ones(N, 2), N(1)))
 
     # HalfSpace vs. Ball2 intersection
     B2 = Ball2(zeros(2), N(1));

--- a/test/unit_Interval.jl
+++ b/test/unit_Interval.jl
@@ -70,6 +70,9 @@ for N in [Float64, Float32, Rational{Int}]
     @test σ(N[1], m) == N[1.5]
     @test σ(N[-1], m) == N[-2]
 
+    # boundedness
+    @test isbounded(x)
+
     # cartesian product
     cp = x × y
     @test cp isa CartesianProduct

--- a/test/unit_Line.jl
+++ b/test/unit_Line.jl
@@ -31,6 +31,9 @@ for N in [Float64, Rational{Int}, Float32]
     σ(N[1, 0], l2)
     σ(N[0, 1], l3)
 
+    # boundedness
+    @test !isbounded(l1)
+
     # isempty
     @test !isempty(l1)
 

--- a/test/unit_LineSegment.jl
+++ b/test/unit_LineSegment.jl
@@ -19,6 +19,9 @@ for N in [Float64, Rational{Int}, Float32]
     @test σ(N[1, -1], l) == q
     @test σ(N[1, 0], l) == q
 
+    # boundedness
+    @test isbounded(l)
+
     # membership
     @test !∈(N[0, 0], l)
     @test ∈(N[1, 1], l)

--- a/test/unit_LinearMap.jl
+++ b/test/unit_LinearMap.jl
@@ -52,6 +52,11 @@ for N in [Float64, Rational{Int}, Float32]
     @test lm1_copy.M == lm1.M
     @test lm1_copy.X == lm1.X
 
+    # boundedness
+    @test isbounded(lm)
+    @test isbounded(zeros(N, 2, 2) * HalfSpace(N[1, 1], N(1)))
+    @test !isbounded(ones(N, 2, 2) * HalfSpace(N[1, 1], N(1)))
+
     # isempty
     @test !isempty(lm)
 

--- a/test/unit_MinkowskiSum.jl
+++ b/test/unit_MinkowskiSum.jl
@@ -50,6 +50,10 @@ for N in [Float64, Rational{Int}, Float32]
     @test ρ(N[1], ms) == N(6)
     @test ρ(N[-1], ms) == N(-6)
 
+    # boundedness
+    @test isbounded(ms)
+    @test !isbounded(Singleton(N[1]) + HalfSpace(N[1], N(1)))
+
     # isempty
     @test !isempty(ms)
 
@@ -96,6 +100,10 @@ for N in [Float64, Rational{Int}, Float32]
     d = N[-1, 1]
     @test σ(d, ms) == σ(d, msa)
 
+    # boundedness
+    @test isbounded(msa)
+    @test !isbounded(MinkowskiSumArray([Singleton(N[1]), HalfSpace(N[1], N(1))]))
+
     # isempty
     @test !isempty(msa)
 
@@ -129,6 +137,10 @@ for N in [Float64, Rational{Int}, Float32]
     cp = LazySets.CachedPair(1, N[2])
     @test cp[1] == 1 && cp[2] == N[2]
     @test_throws ErrorException cp[3]
+
+    # boundedness
+    @test isbounded(cms)
+    @test !isbounded(CacheMinkowskiSum([Singleton(N[1]), HalfSpace(N[1], N(1))]))
 
     # isempty
     @test !isempty(cms)

--- a/test/unit_Polygon.jl
+++ b/test/unit_Polygon.jl
@@ -41,6 +41,10 @@ for N in [Float64, Float32, Rational{Int}]
     @test_throws AssertionError σ(N[0], HPolygon{N}())
     @test_throws AssertionError σ(N[0], HPolygonOpt(HPolygon{N}()))
 
+    # boundedness
+    @test isbounded(p)
+    @test isbounded(po)
+
     # isempty
     @test !isempty(p)
     @test !isempty(po)

--- a/test/unit_Polyhedron.jl
+++ b/test/unit_Polyhedron.jl
@@ -41,6 +41,10 @@ for N in [Float64, Rational{Int}, Float32]
     # support vector of polyhedron with no constraints
     @test σ(N[1], HPolyhedron{N}()) == N[Inf]
 
+    # boundedness
+    @test isbounded(p)
+    @test !isbounded(HPolyhedron{N}())
+
     # membership
     @test ∈(N[5 / 4, 7 / 4], p)
     @test !∈(N[4, 1], p)

--- a/test/unit_Polytope.jl
+++ b/test/unit_Polytope.jl
@@ -50,6 +50,9 @@ for N in [Float64, Rational{Int}, Float32]
     # support vector of polytope with no constraints
     @test_throws ErrorException σ(N[0], HPolytope{N}())
 
+    # boundedness
+    @test isbounded(p)
+
     # membership
     @test ∈(N[5 / 4, 7 / 4], p)
     @test !∈(N[4, 1], p)
@@ -105,6 +108,9 @@ for N in [Float64, Rational{Int}, Float32]
 
     # dim
     @test dim(p) == 2
+
+    # boundedness
+    @test isbounded(p)
 
     # isempty
     @test !isempty(p)

--- a/test/unit_Singleton.jl
+++ b/test/unit_Singleton.jl
@@ -20,6 +20,9 @@ for N in [Float64, Rational{Int}, Float32]
     d = N[0, 0]
     @test σ(d, s) == N[1, 2]
 
+    # boundedness
+    @test isbounded(s)
+
     # element function
     @test element(s) == s.element
     for i in 1:2

--- a/test/unit_SymmetricIntervalHull.jl
+++ b/test/unit_SymmetricIntervalHull.jl
@@ -15,6 +15,9 @@ for N in [Float64, Rational{Int}, Float32]
     d = N[0, 1]
     @test σ(d, h)[2] == N(7) && σ(-d, h)[2] == N(-7)
 
+    # boundedness
+    @test isbounded(h)
+
     # isempty
     @test !isempty(h)
 

--- a/test/unit_ZeroSet.jl
+++ b/test/unit_ZeroSet.jl
@@ -18,6 +18,9 @@ for N in [Float64, Rational{Int}, Float32]
     # test M-sum of zero set with itself
     @test ZeroSet{N}(2) ⊕ ZeroSet{N}(2) == ZeroSet{N}(2)
 
+    # boundedness
+    @test isbounded(Z)
+
     # element & an_element function
     @test element(Z) ∈ Z
     @test element(Z, 1) == 0

--- a/test/unit_Zonotope.jl
+++ b/test/unit_Zonotope.jl
@@ -40,6 +40,9 @@ for N in [Float64, Rational{Int}, Float32]
     d = N[0, -1]
     @test σ(d, z) == N[2, 1]
 
+    # boundedness
+    @test isbounded(z)
+
     # isempty
     @test !isempty(z)
 


### PR DESCRIPTION
Closes #605.

This PR adds `isbounded(::Set)`.
There is a default implementation (that uses `isbounded_unit_dims`), but only the implementations of `ExponentialProjectionMap`, `HPolyhedron`, `Intersection(Array)`, and `LinearMap` may fall back to that default if some sufficient/necessary checks fail. For the other set types, the check is trivial (or recursive for operations).

<strike>Some tests do not work before merging #940, so they currently throw an error. Whatever gets merged last has to update those tests.</strike>

@mforets: Can you please check the implementations for `LinearMap`, `ExponentialMap`, and `ExponentialProjectionMap` if they are correct or if they can be improved?