### PR TITLE
#961 - Make low/high of Interval faster

### DIFF
--- a/docs/src/lib/representations.md
+++ b/docs/src/lib/representations.md
@@ -241,6 +241,8 @@ vertices_list(::Interval{N}) where {N<:Real}
 center(::Interval{N}) where {N<:Real}
 min(::Interval{N}) where {N<:Real}
 max(::Interval{N}) where {N<:Real}
+low(::Interval{N}) where {N<:Real}
+high(::Interval{N}) where {N<:Real}
 radius_hyperrectangle(::Interval{N}) where {N<:Real}
 radius_hyperrectangle(::Interval{N}, ::Int) where {N<:Real}
 +(::Interval{N}, ::Interval{N}) where {N<:Real}

--- a/src/Interval.jl
+++ b/src/Interval.jl
@@ -288,6 +288,40 @@ function max(x::Interval{N})::N where {N<:Real}
 end
 
 """
+    low(x::Interval{N})::Vector{N} where {N<:Real}
+
+Return the lower coordinate of an interval set.
+
+### Input
+
+- `x` -- interval
+
+### Output
+
+A vector with the lower coordinate of the interval.
+"""
+function low(x::Interval{N})::Vector{N} where {N<:Real}
+    return N[x.dat.lo]
+end
+
+"""
+    high(x::Interval{N})::Vector{N} where {N<:Real}
+
+Return the higher coordinate of an interval set.
+
+### Input
+
+- `x` -- interval
+
+### Output
+
+A vector with the higher coordinate of the interval.
+"""
+function high(x::Interval{N})::Vector{N} where {N<:Real}
+    return N[x.dat.hi]
+end
+
+"""
     an_element(x::Interval{N})::Vector{N} where {N<:Real}
 
 Return some element of an interval.


### PR DESCRIPTION
Closes #961.

Let

```julia
julia> using LazySets, BenchmarkTools

julia> x = Interval(0.9, 1.1)
Interval{Float64,IntervalArithmetic.Interval{Float64}}([0.9, 1.10001])
```

Master:

```julia
julia> @btime low($x)
  97.383 ns (3 allocations: 288 bytes)

1-element Array{Float64,1}:
 0.8999999999999999
```
 
 This branch:

 ```julia
 julia> @btime low($x)
  28.365 ns (1 allocation: 96 bytes)
1-element Array{Float64,1}:
 0.9
```
