### PR TITLE
#973 - Use numeric / vector / matrix conventions

### DIFF
--- a/src/Approximations/box_approximations.jl
+++ b/src/Approximations/box_approximations.jl
@@ -3,7 +3,8 @@
 # ===================================
 
 """
-    box_approximation(S::LazySet)::Hyperrectangle
+    box_approximation(S::LazySet{N})::Union{Hyperrectangle{N}, EmptySet{N}}
+        where {N<:Real}
 
 Overapproximate a convex set by a tight hyperrectangle.
 
@@ -21,8 +22,8 @@ The center of the hyperrectangle is obtained by averaging the support function
 of the given set in the canonical directions, and the lengths of the sides can
 be recovered from the distance among support functions in the same directions.
 """
-function box_approximation(S::LazySet{N};
-                          )::Union{Hyperrectangle{N}, EmptySet{N}} where N<:Real
+function box_approximation(S::LazySet{N}
+                          )::Union{Hyperrectangle{N}, EmptySet{N}} where {N<:Real}
     (c, r) = box_approximation_helper(S)
     if r[1] < 0
         return EmptySet{N}()

--- a/src/Approximations/iterative_refinement.jl
+++ b/src/Approximations/iterative_refinement.jl
@@ -61,13 +61,13 @@ struct PolygonalOverapproximation{N<:Real}
     approx_stack::Vector{LocalApproximation{N}}
     constraints::Vector{LinearConstraint{N}}
 
-    PolygonalOverapproximation(S::LazySet{N}) where N<:Real = new{N}(
+    PolygonalOverapproximation(S::LazySet{N}) where {N<:Real} = new{N}(
         S, Vector{LocalApproximation{N}}(), Vector{LinearConstraint{N}}())
 end
 
 """
     new_approx(S::LazySet, p1::Vector{N}, d1::Vector{N}, p2::Vector{N},
-               d2::Vector{N}) where N<:Real
+               d2::Vector{N}) where {N<:Real}
 
 Create a `LocalApproximation` instance for the given excerpt of a polygonal
 approximation.
@@ -85,7 +85,7 @@ approximation.
 A local approximation of `S` in the given directions.
 """
 function new_approx(S::LazySet, p1::Vector{N}, d1::Vector{N}, p2::Vector{N},
-                    d2::Vector{N}) where N<:Real
+                    d2::Vector{N}) where {N<:Real}
     if norm(p1-p2, 2) <= TOL(N)
         # this approximation cannot be refined and we set q = p1 by convention
         ap = LocalApproximation{N}(p1, d1, p2, d2, p1, false, zero(N))
@@ -102,7 +102,7 @@ end
 
 """
     addapproximation!(Ω::PolygonalOverapproximation, p1::Vector{N},
-        d1::Vector{N}, p2::Vector{N}, d2::Vector{N}) where N<:Real
+        d1::Vector{N}, p2::Vector{N}, d2::Vector{N}) where {N<:Real}
 
 ### Input
 
@@ -119,7 +119,7 @@ the new approximation is returned by this function.
 """
 function addapproximation!(Ω::PolygonalOverapproximation,
                            p1::Vector{N}, d1::Vector{N}, p2::Vector{N},
-                           d2::Vector{N})::LocalApproximation{N} where N<:Real
+                           d2::Vector{N})::LocalApproximation{N} where {N<:Real}
 
     approx = new_approx(Ω.S, p1, d1, p2, d2)
     push!(Ω.approx_stack, approx)
@@ -155,7 +155,8 @@ function refine(approx::LocalApproximation,
 end
 
 """
-    tohrep(Ω::PolygonalOverapproximation{N})::AbstractHPolygon{N} where N<:Real
+    tohrep(Ω::PolygonalOverapproximation{N})::AbstractHPolygon{N}
+        where {N<:Real}
 
 Convert a polygonal overapproximation into a concrete polygon.
 
@@ -173,7 +174,7 @@ Internally we keep the constraints sorted.
 Hence we do not need to use `addconstraint!` when creating the `HPolygon`.
 """
 function tohrep(Ω::PolygonalOverapproximation{N}
-               )::AbstractHPolygon{N} where N<:Real
+               )::AbstractHPolygon{N} where {N<:Real}
     # already finalized
     if isempty(Ω.approx_stack)
         return HPolygon(Ω.constraints, sort_constraints=false)
@@ -188,7 +189,7 @@ end
 
 """
     approximate(S::LazySet{N},
-                ε::N)::PolygonalOverapproximation{N} where N<:Real
+                ε::N)::PolygonalOverapproximation{N} where {N<:Real}
 
 Return an ε-close approximation of the given 2D convex set (in terms of
 Hausdorff distance) as an inner and an outer approximation composed by sorted
@@ -204,7 +205,7 @@ local `Approximation2D`.
 An ε-close approximation of the given 2D convex set.
 """
 function approximate(S::LazySet{N},
-                     ε::N)::PolygonalOverapproximation{N} where N<:Real
+                     ε::N)::PolygonalOverapproximation{N} where {N<:Real}
 
     # initialize box directions
     pe = σ(DIR_EAST(N), S)

--- a/src/Approximations/overapproximate.jl
+++ b/src/Approximations/overapproximate.jl
@@ -134,9 +134,8 @@ function overapproximate(S::ConvexHull{N, Zonotope{N}, Zonotope{N}},
 end
 
 """
-    overapproximate(X::LazySet,
-                    dir::AbstractDirections
-                   )::HPolytope
+    overapproximate(X::LazySet{N}, dir::AbstractDirections{N})::HPolytope{N}
+        where {N}
 
 Overapproximating a set with template directions.
 
@@ -150,8 +149,8 @@ Overapproximating a set with template directions.
 A `HPolytope` overapproximating the set `X` with the directions from `dir`.
 """
 function overapproximate(X::LazySet{N},
-                         dir::AbstractDirections{N};
-                        )::HPolytope{N} where N
+                         dir::AbstractDirections{N}
+                        )::HPolytope{N} where {N}
     halfspaces = Vector{LinearConstraint{N}}()
     sizehint!(halfspaces, length(dir))
     H = HPolytope(halfspaces)
@@ -162,9 +161,7 @@ function overapproximate(X::LazySet{N},
 end
 
 """
-    overapproximate(S::LazySet{N},
-                    ::Type{Interval}
-                   ) where {N<:Real}
+    overapproximate(S::LazySet{N}, ::Type{Interval}) where {N<:Real}
 
 Return the overapproximation of a real unidimensional set with an interval.
 
@@ -177,9 +174,7 @@ Return the overapproximation of a real unidimensional set with an interval.
 
 An interval.
 """
-function overapproximate(S::LazySet{N},
-                         ::Type{Interval}
-                        ) where {N<:Real}
+function overapproximate(S::LazySet{N}, ::Type{Interval}) where {N<:Real}
     @assert dim(S) == 1
     lo = σ([-one(N)], S)[1]
     hi = σ([one(N)], S)[1]
@@ -270,7 +265,7 @@ function overapproximate(cap::Intersection{N,
                                            <:LazySet},
                          dir::AbstractDirections{N};
                          kwargs...
-                        ) where N<:Real
+                        ) where {N<:Real}
     return overapproximate_cap_helper(cap.Y, cap.X, dir; kwargs...)
 end
 
@@ -280,7 +275,7 @@ function overapproximate(cap::Intersection{N,
                                            <:Union{AbstractPolytope{N}, HPolyhedron{N}}},
                          dir::AbstractDirections{N};
                          kwargs...
-                        ) where N<:Real
+                        ) where {N<:Real}
     return overapproximate_cap_helper(cap.X, cap.Y, dir; kwargs...)
 end
 
@@ -290,7 +285,7 @@ function overapproximate(cap::Intersection{N,
                                            <:AbstractPolytope{N}},
                          dir::AbstractDirections{N};
                          kwargs...
-                        ) where N<:Real
+                        ) where {N<:Real}
     return overapproximate_cap_helper(cap.Y, cap.X, dir; kwargs...)
 end
 
@@ -300,7 +295,7 @@ function overapproximate(cap::Intersection{N,
                                            <:HPolyhedron{N}},
                          dir::AbstractDirections{N};
                          kwargs...
-                        ) where N<:Real
+                        ) where {N<:Real}
     return overapproximate_cap_helper(cap.X, cap.Y, dir; kwargs...)
 end
 
@@ -310,7 +305,7 @@ function overapproximate(cap::Intersection{N,
                                            <:AbstractPolytope{N}},
                          dir::AbstractDirections{N};
                          kwargs...
-                        ) where N<:Real
+                        ) where {N<:Real}
     return overapproximate_cap_helper(cap.Y, cap.X, dir; kwargs...)
 end
 

--- a/src/Approximations/overapproximate.jl
+++ b/src/Approximations/overapproximate.jl
@@ -1,5 +1,5 @@
 """
-    overapproximate(X::S, ::Type{S}) where {S <: LazySet}
+    overapproximate(X::S, ::Type{S}) where {S<:LazySet}
 
 Overapproximating a set of type `S` with type `S` is a no-op.
 
@@ -12,7 +12,7 @@ Overapproximating a set of type `S` with type `S` is a no-op.
 
 The input set.
 """
-function overapproximate(X::S, ::Type{S}) where {S <: LazySet}
+function overapproximate(X::S, ::Type{S}) where {S<:LazySet}
     return X
 end
 

--- a/src/Approximations/template_directions.jl
+++ b/src/Approximations/template_directions.jl
@@ -71,14 +71,14 @@ end
 # constructor for type Float64
 BoxDirections(n::Int) = BoxDirections{Float64}(n)
 
-Base.eltype(::Type{BoxDirections{N}}) where N = AbstractVector{N}
+Base.eltype(::Type{BoxDirections{N}}) where {N} = AbstractVector{N}
 Base.length(bd::BoxDirections) = 2 * bd.n
 
 @static if VERSION < v"0.7-"
 @eval begin
 
 Base.start(bd::BoxDirections) = 1
-Base.next(bd::BoxDirections{N}, state) where N = (
+Base.next(bd::BoxDirections{N}, state) where {N} = (
     UnitVector{N}(abs(state), bd.n, convert(N, sign(state))), # value
     state == bd.n ? -bd.n : state + 1) # next state
 Base.done(bd::BoxDirections, state) = state == 0
@@ -87,7 +87,7 @@ end # @eval
 else
 @eval begin
 
-function Base.iterate(bd::BoxDirections{N}, state::Int=1) where N
+function Base.iterate(bd::BoxDirections{N}, state::Int=1) where {N}
     if state == 0
         return nothing
     end
@@ -122,13 +122,13 @@ end
 # constructor for type Float64
 OctDirections(n::Int) = OctDirections{Float64}(n)
 
-Base.eltype(::Type{OctDirections{N}}) where N = AbstractVector{N}
+Base.eltype(::Type{OctDirections{N}}) where {N} = AbstractVector{N}
 Base.length(od::OctDirections) = 2 * od.n^2
 
 @static if VERSION < v"0.7-"
 @eval begin
 
-function Base.start(od::OctDirections{N}) where N
+function Base.start(od::OctDirections{N}) where {N}
     if od.n == 1
         return 1 # fall back to box directions in 1D case
     end
@@ -138,7 +138,7 @@ function Base.start(od::OctDirections{N}) where N
     return (vec, 1, 2)
 end
 
-function Base.next(od::OctDirections{N}, state::Tuple) where N
+function Base.next(od::OctDirections{N}, state::Tuple) where {N}
     vec = state[1]
     i = state[2]
     j = state[3]
@@ -172,7 +172,7 @@ function Base.next(od::OctDirections{N}, state::Tuple) where N
     return (copy(vec), (vec, i, j))
 end
 
-Base.next(od::OctDirections{N}, state::Int) where N =
+Base.next(od::OctDirections{N}, state::Int) where {N} =
     next(BoxDirections{N}(od.n), state)
 
 Base.done(od::OctDirections, state) = state == 0
@@ -181,7 +181,7 @@ end # @eval
 else
 @eval begin
 
-function Base.iterate(od::OctDirections{N}) where N
+function Base.iterate(od::OctDirections{N}) where {N}
     if od.n == 1
         # fall back to box directions in 1D case
         return iterate(od, 1)
@@ -198,7 +198,7 @@ end
 # - i = i + 1, j = i + 1
 # - for any pair (i, j) create four vectors [..., i: ±1, ..., j: ±1, ...]
 # in the end continue with box directions
-function Base.iterate(od::OctDirections{N}, state::Tuple) where N
+function Base.iterate(od::OctDirections{N}, state::Tuple) where {N}
     # continue with octagon directions
     vec = state[1]
     i = state[2]
@@ -231,7 +231,7 @@ function Base.iterate(od::OctDirections{N}, state::Tuple) where N
     return (copy(vec), (vec, i, j))
 end
 
-function Base.iterate(od::OctDirections{N}, state::Int) where N
+function Base.iterate(od::OctDirections{N}, state::Int) where {N}
     # continue with box directions
     return iterate(BoxDirections{N}(od.n), state)
 end
@@ -264,15 +264,15 @@ end
 # constructor for type Float64
 BoxDiagDirections(n::Int) = BoxDiagDirections{Float64}(n)
 
-Base.eltype(::Type{BoxDiagDirections{N}}) where N = AbstractVector{N}
+Base.eltype(::Type{BoxDiagDirections{N}}) where {N} = AbstractVector{N}
 Base.length(bdd::BoxDiagDirections) = bdd.n == 1 ? 2 : 2^bdd.n + 2 * bdd.n
 
 @static if VERSION < v"0.7-"
 @eval begin
 
-Base.start(bdd::BoxDiagDirections{N}) where N = ones(N, bdd.n)
+Base.start(bdd::BoxDiagDirections{N}) where {N} = ones(N, bdd.n)
 
-function Base.next(bdd::BoxDiagDirections{N}, state::AbstractVector) where N
+function Base.next(bdd::BoxDiagDirections{N}, state::AbstractVector) where {N}
     i = 1
     while i <= bdd.n && state[i] < 0
         state[i] = -state[i]
@@ -290,7 +290,7 @@ function Base.next(bdd::BoxDiagDirections{N}, state::AbstractVector) where N
     end
 end
 
-Base.next(bdd::BoxDiagDirections{N}, state::Int) where N =
+Base.next(bdd::BoxDiagDirections{N}, state::Int) where {N} =
     next(BoxDirections{N}(bdd.n), state)
 Base.done(bdd::BoxDiagDirections, state) = state == 0
 
@@ -298,10 +298,11 @@ end # @eval
 else
 @eval begin
 
-Base.iterate(bdd::BoxDiagDirections{N}) where N =
+Base.iterate(bdd::BoxDiagDirections{N}) where {N} =
     (ones(N, bdd.n), ones(N, bdd.n))
 
-function Base.iterate(bdd::BoxDiagDirections{N}, state::AbstractVector) where N
+function Base.iterate(bdd::BoxDiagDirections{N},
+                      state::AbstractVector) where {N}
     # continue with diagonal directions
     i = 1
     while i <= bdd.n && state[i] < 0
@@ -322,7 +323,7 @@ function Base.iterate(bdd::BoxDiagDirections{N}, state::AbstractVector) where N
     end
 end
 
-function Base.iterate(bdd::BoxDiagDirections{N}, state::Int) where N
+function Base.iterate(bdd::BoxDiagDirections{N}, state::Int) where {N}
     # continue with box directions
     return iterate(BoxDirections{N}(bdd.n), state)
 end

--- a/src/CartesianProduct.jl
+++ b/src/CartesianProduct.jl
@@ -270,7 +270,7 @@ end
 
 @static if VERSION < v"0.7-"
     # convenience constructor without type parameter
-    CartesianProductArray(arr::Vector{S}) where {S<:LazySet{N}} where {N<:Real} =
+    CartesianProductArray(arr::Vector{S}) where {N<:Real, S<:LazySet{N}} =
         CartesianProductArray{N, S}(arr)
 end
 

--- a/src/CartesianProduct.jl
+++ b/src/CartesianProduct.jl
@@ -187,7 +187,7 @@ end
 
 """
     constraints_list(cp::CartesianProduct{N}
-                    )::Vector{LinearConstraint{N}} where N<:Real
+                    )::Vector{LinearConstraint{N}} where {N<:Real}
 
 Return the list of constraints of a (polytopic) Cartesian product.
 
@@ -200,12 +200,12 @@ Return the list of constraints of a (polytopic) Cartesian product.
 A list of constraints.
 """
 function constraints_list(cp::CartesianProduct{N}
-                         )::Vector{LinearConstraint{N}} where N<:Real
+                         )::Vector{LinearConstraint{N}} where {N<:Real}
     return constraints_list(CartesianProductArray([cp.X, cp.Y]))
 end
 
 """
-    vertices_list(cp::CartesianProduct{N})::Vector{Vector{N}} where N<:Real
+    vertices_list(cp::CartesianProduct{N})::Vector{Vector{N}} where {N<:Real}
 
 Return the list of vertices of a (polytopic) Cartesian product.
 
@@ -223,7 +223,8 @@ We assume that the underlying sets are polytopic.
 Then the high-dimensional set of vertices is just the Cartesian product of the
 low-dimensional sets of vertices.
 """
-function vertices_list(cp::CartesianProduct{N})::Vector{Vector{N}} where N<:Real
+function vertices_list(cp::CartesianProduct{N}
+                      )::Vector{Vector{N}} where {N<:Real}
     # collect low-dimensional vertices lists
     vlist_low = (vertices_list(cp.X), vertices_list(cp.Y))
 
@@ -443,7 +444,7 @@ end
 
 """
     constraints_list(cpa::CartesianProductArray{N}
-                    )::Vector{LinearConstraint{N}} where N<:Real
+                    )::Vector{LinearConstraint{N}} where {N<:Real}
 
 Return the list of constraints of a (polytopic) Cartesian product of a finite
 number of sets.
@@ -457,7 +458,7 @@ number of sets.
 A list of constraints.
 """
 function constraints_list(cpa::CartesianProductArray{N}
-                         )::Vector{LinearConstraint{N}} where N<:Real
+                         )::Vector{LinearConstraint{N}} where {N<:Real}
     clist = Vector{LinearConstraint{N}}()
     n = dim(cpa)
     sizehint!(clist, n)
@@ -480,7 +481,8 @@ function constraints_list(cpa::CartesianProductArray{N}
 end
 
 """
-    vertices_list(cpa::CartesianProductArray{N})::Vector{Vector{N}} where N<:Real
+    vertices_list(cpa::CartesianProductArray{N}
+                 )::Vector{Vector{N}} where {N<:Real}
 
 Return the list of vertices of a (polytopic) Cartesian product of a finite
 number of sets.
@@ -499,7 +501,8 @@ We assume that the underlying sets are polytopic.
 Then the high-dimensional set of vertices is just the Cartesian product of the
 low-dimensional sets of vertices.
 """
-function vertices_list(cpa::CartesianProductArray{N})::Vector{Vector{N}} where N<:Real
+function vertices_list(cpa::CartesianProductArray{N}
+                      )::Vector{Vector{N}} where {N<:Real}
     # collect low-dimensional vertices lists
     vlist_low = [vertices_list(X) for X in array(cpa)]
 

--- a/src/ConvexHull.jl
+++ b/src/ConvexHull.jl
@@ -195,7 +195,7 @@ end
 
 @static if VERSION < v"0.7-"
     # convenience constructor without type parameter
-    ConvexHullArray(a::Vector{S}) where {S<:LazySet{N}} where {N<:Real} =
+    ConvexHullArray(a::Vector{S}) where {N<:Real, S<:LazySet{N}} =
         ConvexHullArray{N, S}(a)
 end
 

--- a/src/ExponentialMap.jl
+++ b/src/ExponentialMap.jl
@@ -418,7 +418,7 @@ end
 @static if VERSION < v"0.7-"
     # convenience constructor without type parameter
     ExponentialProjectionMap(projspmexp::ProjectionSparseMatrixExp, X::S
-                            ) where {S<:LazySet{N}} where {N<:Real} =
+                            ) where {N<:Real, S<:LazySet{N}} =
         ExponentialProjectionMap{N, S}(projspmexp, X)
 end
 

--- a/src/ExponentialMap.jl
+++ b/src/ExponentialMap.jl
@@ -348,7 +348,7 @@ function isempty(em::ExponentialMap)::Bool
 end
 
 """
-    vertices_list(em::ExponentialMap{N})::Vector{Vector{N}} where N<:Real
+    vertices_list(em::ExponentialMap{N})::Vector{Vector{N}} where {N<:Real}
 
 Return the list of vertices of a (polytopic) exponential map.
 
@@ -365,7 +365,7 @@ A list of vertices.
 We assume that the underlying set `X` is polytopic.
 Then the result is just the exponential map applied to the vertices of `X`.
 """
-function vertices_list(em::ExponentialMap{N})::Vector{Vector{N}} where N<:Real
+function vertices_list(em::ExponentialMap{N})::Vector{Vector{N}} where {N<:Real}
     # collect low-dimensional vertices lists
     vlist_X = vertices_list(em.X)
 

--- a/src/HPolyhedron.jl
+++ b/src/HPolyhedron.jl
@@ -543,7 +543,8 @@ end
 
 """
     cartesian_product(P1::HPoly{N}, P2::HPoly{N};
-                      [backend]=default_polyhedra_backend(P1, N)) where N<:Real
+                      [backend]=default_polyhedra_backend(P1, N)
+                     ) where {N<:Real}
 
 Compute the Cartesian product of two polyhedra in H-representaion.
 
@@ -566,7 +567,7 @@ For further information on the supported backends see
 function cartesian_product(P1::HPoly{N},
                            P2::HPoly{N};
                            backend=default_polyhedra_backend(P1, N)
-                          ) where N<:Real
+                          ) where {N<:Real}
     @assert isdefined(@__MODULE__, :Polyhedra) "the function `cartesian_product` " *
                                                "needs the package 'Polyhedra' to be loaded"
     Pcp = hcartesianproduct(polyhedron(P1; backend=backend), polyhedron(P2; backend=backend))
@@ -685,9 +686,9 @@ function isempty(P::HPoly{N};
     return Polyhedra.isempty(polyhedron(P; backend=backend), solver)
 end
 
-convert(::Type{HPolytope}, P::HPolyhedron{N}) where N =
+convert(::Type{HPolytope}, P::HPolyhedron{N}) where {N<:Real} =
     HPolytope{N}(copy(constraints_list(P)))
-convert(::Type{HPolyhedron}, P::HPolytope{N}) where N =
+convert(::Type{HPolyhedron}, P::HPolytope{N}) where {N<:Real} =
     HPolyhedron{N}(copy(constraints_list(P)))
 
 # ==========================================

--- a/src/HalfSpace.jl
+++ b/src/HalfSpace.jl
@@ -240,7 +240,7 @@ function constraints_list(hs::HalfSpace{N}
 end
 
 """
-    constrained_dimensions(hs::HalfSpace{N})::Vector{Int} where N<:Real
+    constrained_dimensions(hs::HalfSpace{N})::Vector{Int} where {N<:Real}
 
 Return the indices in which a half-space is constrained.
 
@@ -257,7 +257,7 @@ dimension `i`.
 
 A 2D half-space with constraint ``x1 ≥ 0`` is constrained in dimension 1 only.
 """
-function constrained_dimensions(hs::HalfSpace{N})::Vector{Int} where N<:Real
+function constrained_dimensions(hs::HalfSpace{N})::Vector{Int} where {N<:Real}
     return nonzero_indices(hs.a)
 end
 

--- a/src/Hyperplane.jl
+++ b/src/Hyperplane.jl
@@ -210,7 +210,7 @@ function isempty(hp::Hyperplane)::Bool
 end
 
 """
-    constrained_dimensions(hp::Hyperplane{N})::Vector{Int} where N<:Real
+    constrained_dimensions(hp::Hyperplane{N})::Vector{Int} where {N<:Real}
 
 Return the indices in which a hyperplane is constrained.
 
@@ -227,7 +227,7 @@ dimension `i`.
 
 A 2D hyperplane with constraint ``x1 = 0`` is constrained in dimension 1 only.
 """
-function constrained_dimensions(hp::Hyperplane{N})::Vector{Int} where N<:Real
+function constrained_dimensions(hp::Hyperplane{N})::Vector{Int} where {N<:Real}
     return nonzero_indices(hp.a)
 end
 

--- a/src/Intersection.jl
+++ b/src/Intersection.jl
@@ -578,7 +578,7 @@ end
 
 @static if VERSION < v"0.7-"
     # convenience constructor without type parameter
-    IntersectionArray(arr::Vector{S}) where {S<:LazySet{N}} where {N<:Real} =
+    IntersectionArray(arr::Vector{S}) where {N<:Real, S<:LazySet{N}} =
         IntersectionArray{N, S}(arr)
 end
 

--- a/src/Interval.jl
+++ b/src/Interval.jl
@@ -7,7 +7,7 @@ export Interval,
        vertices_list
 
 """
-    Interval{N<:Real, IN <: AbstractInterval{N}} <: AbstractHyperrectangle{N}
+    Interval{N<:Real, IN<:AbstractInterval{N}} <: AbstractHyperrectangle{N}
 
 Type representing an interval on the real line.
 Mathematically, it is of the form
@@ -74,18 +74,18 @@ julia> Interval(0//1, 2//1)
 Interval{Rational{Int64},AbstractInterval{Rational{Int64}}}([0//1, 2//1])
 ```
 """
-struct Interval{N<:Real, IN <: AbstractInterval{N}} <: AbstractHyperrectangle{N}
+struct Interval{N<:Real, IN<:AbstractInterval{N}} <: AbstractHyperrectangle{N}
    dat::IN
 end
 
 @static if VERSION < v"0.7-"
     # convenience constructor without type parameter
-    Interval(interval::IN) where {N<:Real, IN <: AbstractInterval{N}} =
+    Interval(interval::IN) where {N<:Real, IN<:AbstractInterval{N}} =
         Interval{N, IN}(interval)
 end
 
 # convenience constructor without type parameter for Rational
-Interval(interval::IN) where {N<:Rational, IN <: AbstractInterval{N}} =
+Interval(interval::IN) where {N<:Rational, IN<:AbstractInterval{N}} =
     Interval{N, IntervalArithmetic.AbstractInterval{N}}(interval)
 
 # constructor from two numbers

--- a/src/Line.jl
+++ b/src/Line.jl
@@ -141,7 +141,7 @@ function isbounded(::Line)::Bool
 end
 
 """
-    an_element(L::Line{N})::Vector{N} where N<:Real
+    an_element(L::Line{N})::Vector{N} where {N<:Real}
 
 Return some element of a line.
 
@@ -160,7 +160,7 @@ Otherwise the result is some ``x = [x1, x2]`` such that ``a·[x1, x2] = b``.
 We first find out in which dimension ``a`` is nonzero, say, dimension 1, and
 then choose ``x1 = 1`` and accordingly ``x2 = \\frac{b - a1}{a2}``.
 """
-function an_element(L::Line{N})::Vector{N} where N<:Real
+function an_element(L::Line{N})::Vector{N} where {N<:Real}
     if L.b == zero(N)
         return zeros(N, 2)
     end
@@ -252,7 +252,7 @@ function isempty(L::Line)::Bool
 end
 
 """
-    constrained_dimensions(L::Line{N})::Vector{Int} where N<:Real
+    constrained_dimensions(L::Line{N})::Vector{Int} where {N<:Real}
 
 Return the indices in which a line is constrained.
 
@@ -269,6 +269,6 @@ A vector of ascending indices `i` such that the line is constrained in dimension
 
 A line with constraint ``x1 = 0`` is constrained in dimension 1 only.
 """
-function constrained_dimensions(L::Line{N})::Vector{Int} where N<:Real
+function constrained_dimensions(L::Line{N})::Vector{Int} where {N<:Real}
     return nonzero_indices(L.a)
 end

--- a/src/Line.jl
+++ b/src/Line.jl
@@ -6,7 +6,7 @@ export Line,
        an_element
 
 """
-    Line{N<:Real} <: LazySet{N}
+    Line{N<:Real, VN<:AbstractVector{N}} <: LazySet{N}
 
 Type that represents a line in 2D of the form ``a⋅x = b`` (i.e., a special case
 of a `Hyperplane`).
@@ -25,20 +25,20 @@ julia> Line([1., 1.], 1.)
 Line{Float64,Array{Float64,1}}([1.0, 1.0], 1.0)
 ```
 """
-struct Line{N<:Real, V<:AbstractVector{N}} <: LazySet{N}
-    a::V
+struct Line{N<:Real, VN<:AbstractVector{N}} <: LazySet{N}
+    a::VN
     b::N
 
     # default constructor with length constraint
-    function Line{N, V}(a::V, b::N) where {N<:Real, V<:AbstractVector{N}}
+    function Line{N, VN}(a::VN, b::N) where {N<:Real, VN<:AbstractVector{N}}
         @assert length(a) == 2 "lines must be two-dimensional"
         @assert a != zeros(N, 2) "the normal vector of a line must not be zero"
-        return new{N, V}(a, b)
+        return new{N, VN}(a, b)
     end
 end
 
 # convenience constructor without type parameter
-Line(a::V, b::N) where {N<:Real, V<:AbstractVector{N}} = Line{N, V}(a, b)
+Line(a::VN, b::N) where {N<:Real, VN<:AbstractVector{N}} = Line{N, VN}(a, b)
 
 # constructor from a LinearConstraint
 Line(c::LinearConstraint{N}) where {N<:Real} = Line(c.a, c.b)

--- a/src/LinearMap.jl
+++ b/src/LinearMap.jl
@@ -306,7 +306,7 @@ function isempty(lm::LinearMap)::Bool
 end
 
 """
-    vertices_list(lm::LinearMap{N})::Vector{Vector{N}} where N<:Real
+    vertices_list(lm::LinearMap{N})::Vector{Vector{N}} where {N<:Real}
 
 Return the list of vertices of a (polytopic) linear map.
 
@@ -323,7 +323,7 @@ A list of vertices.
 We assume that the underlying set `X` is polytopic.
 Then the result is just the linear map applied to the vertices of `X`.
 """
-function vertices_list(lm::LinearMap{N})::Vector{Vector{N}} where N<:Real
+function vertices_list(lm::LinearMap{N})::Vector{Vector{N}} where {N<:Real}
     # for a zero map, the result is just the list containing the origin
     if iszero(lm.M)
         return [zeros(N, dim(lm))]

--- a/src/MinkowskiSum.jl
+++ b/src/MinkowskiSum.jl
@@ -339,7 +339,7 @@ end
 # =============================================================
 
 """
-    CachedPair{N} where N
+    CachedPair{N}
 
 A mutable pair of an index and a vector.
 

--- a/src/MinkowskiSum.jl
+++ b/src/MinkowskiSum.jl
@@ -201,7 +201,7 @@ end
 
 @static if VERSION < v"0.7-"
     # convenience constructor without type parameter
-    MinkowskiSumArray(arr::Vector{S}) where {S<:LazySet{N}} where {N<:Real} =
+    MinkowskiSumArray(arr::Vector{S}) where {N<:Real, S<:LazySet{N}} =
         MinkowskiSumArray{N, S}(arr)
 end
 

--- a/src/Zonotope.jl
+++ b/src/Zonotope.jl
@@ -38,8 +38,8 @@ ball in ``\\mathbb{R}^n`` by an affine transformation.
             generators::AbstractMatrix{N}) where {N<:Real}`
 
 - `Zonotope(center::AbstractVector{N},
-            generators_list::AbstractVector{T}
-           ) where {N<:Real, T<:AbstractVector{N}}`
+            generators_list::AbstractVector{VN}
+           ) where {N<:Real, VN<:AbstractVector{N}}`
 
 ### Examples
 
@@ -89,8 +89,8 @@ struct Zonotope{N<:Real} <: AbstractCentrallySymmetricPolytope{N}
 end
 
 # constructor from center and list of generators
-Zonotope(center::AbstractVector{N}, generators_list::AbstractVector{T}
-        ) where {N<:Real, T<:AbstractVector{N}} =
+Zonotope(center::AbstractVector{N}, generators_list::AbstractVector{VN}
+        ) where {N<:Real, VN<:AbstractVector{N}} =
     Zonotope(center, hcat(generators_list...))
 
 

--- a/src/convex_hull_algorithms.jl
+++ b/src/convex_hull_algorithms.jl
@@ -1,6 +1,6 @@
 """
-    convex_hull(points::Vector{S}; [algorithm]::String="monotone_chain"
-               )::Vector{S} where {N<:Real, S<:AbstractVector{N}}
+    convex_hull(points::Vector{VN}; [algorithm]::String="monotone_chain"
+               )::Vector{VN} where {N<:Real, VN<:AbstractVector{N}}
 
 Compute the convex hull of points in the plane.
 
@@ -40,14 +40,14 @@ julia> plot([Tuple(pi) for pi in points], seriestype=:scatter);
 julia> plot!(VPolygon(hull), alpha=0.2);
 ```
 """
-function convex_hull(points::Vector{S}; algorithm::String="monotone_chain"
-                    )::Vector{S} where {N<:Real, S<:AbstractVector{N}}
+function convex_hull(points::Vector{VN}; algorithm::String="monotone_chain"
+                    )::Vector{VN} where {N<:Real, VN<:AbstractVector{N}}
     return convex_hull!(copy(points), algorithm=algorithm)
 end
 
 """
-    convex_hull!(points::Vector{S}; [algorithm]::String="monotone_chain"
-                )::Vector{S} where {N<:Real, S<:AbstractVector{N}}
+    convex_hull!(points::Vector{VN}; [algorithm]::String="monotone_chain"
+                )::Vector{VN} where {N<:Real, VN<:AbstractVector{N}}
 
 Compute the convex hull of points in the plane, in-place.
 
@@ -68,9 +68,9 @@ The convex hull as a list of 2D vectors with the coordinates of the points.
 
 See the non-modifying version `convex_hull` for more details.
 """
-function convex_hull!(points::Vector{S};
+function convex_hull!(points::Vector{VN};
                       algorithm::String="monotone_chain"
-                     )::Vector{S} where {N<:Real, S<:AbstractVector{N}}
+                     )::Vector{VN} where {N<:Real, VN<:AbstractVector{N}}
 
     isempty(points) && return points
 
@@ -131,8 +131,8 @@ around `O` from `A` to `B`; otherwise they constitute a negative angle.
 end
 
 """
-    monotone_chain!(points::Vector{S}; sort::Bool=true
-                   )::Vector{S} where {N<:Real, S<:AbstractVector{N}}
+    monotone_chain!(points::Vector{VN}; sort::Bool=true
+                   )::Vector{VN} where {N<:Real, VN<:AbstractVector{N}}
 
 Compute the convex hull of points in the plane using Andrew's monotone chain
 method.
@@ -164,8 +164,8 @@ construct the convex hull of a set of ``n`` points in the plane in
 For further details see
 [Monotone chain](https://en.wikibooks.org/wiki/Algorithm_Implementation/Geometry/Convex_hull/Monotone_chain)
 """
-function monotone_chain!(points::Vector{S}; sort::Bool=true
-                        )::Vector{S} where {N<:Real, S<:AbstractVector{N}}
+function monotone_chain!(points::Vector{VN}; sort::Bool=true
+                        )::Vector{VN} where {N<:Real, VN<:AbstractVector{N}}
 
     @inline function build_hull!(semihull, iterator, points, zero_N)
         @inbounds for i in iterator
@@ -187,11 +187,11 @@ function monotone_chain!(points::Vector{S}; sort::Bool=true
     zero_N = zero(N)
 
     # build lower hull
-    lower = Vector{S}()
+    lower = Vector{VN}()
     build_hull!(lower, axes(points)[1], points, zero_N)
 
     # build upper hull
-    upper = Vector{S}()
+    upper = Vector{VN}()
     build_hull!(upper, reverse(axes(points)[1]), points, zero_N)
 
     # remove the last point of each segment because they are repeated

--- a/src/helper_functions.jl
+++ b/src/helper_functions.jl
@@ -110,7 +110,7 @@ end
 
 """
     samedir(u::AbstractVector{N},
-            v::AbstractVector{N})::Tuple{Bool, Real} where N<:Real
+            v::AbstractVector{N})::Tuple{Bool, Real} where {N<:Real}
 
 Check whether two vectors point in the same direction.
 
@@ -141,7 +141,7 @@ julia> LazySets.samedir([1, 2, 3], [-1, -2, -3])
 """
 function samedir(u::AbstractVector{N},
                  v::AbstractVector{N}
-                )::Tuple{Bool, Real} where N<:Real
+                )::Tuple{Bool, Real} where {N<:Real}
     @assert length(u) == length(v) "wrong dimension"
     no_factor = true
     factor = 0
@@ -172,7 +172,7 @@ function samedir(u::AbstractVector{N},
 end
 
 """
-    nonzero_indices(v::AbstractVector{N})::Vector{Int} where N<:Real
+    nonzero_indices(v::AbstractVector{N})::Vector{Int} where {N<:Real}
 
 Return the indices in which a vector is non-zero.
 
@@ -185,7 +185,7 @@ Return the indices in which a vector is non-zero.
 A vector of ascending indices `i` such that the vector is non-zero in dimension
 `i`.
 """
-function nonzero_indices(v::AbstractVector{N})::Vector{Int} where N<:Real
+function nonzero_indices(v::AbstractVector{N})::Vector{Int} where {N<:Real}
     n = length(v)
     res = Vector{Int}()
     sizehint!(res, n)
@@ -197,7 +197,7 @@ function nonzero_indices(v::AbstractVector{N})::Vector{Int} where N<:Real
     return res
 end
 
-function nonzero_indices(v::SparseVector{N})::Vector{Int} where N<:Real
+function nonzero_indices(v::SparseVector{N})::Vector{Int} where {N<:Real}
     return x.nzind
 end
 

--- a/src/is_intersection_empty.jl
+++ b/src/is_intersection_empty.jl
@@ -5,7 +5,7 @@ export is_intersection_empty,
     is_intersection_empty(X::LazySet{N},
                           Y::LazySet{N},
                           witness::Bool=false
-                          )::Union{Bool, Tuple{Bool, Vector{N}}} where N<:Real
+                          )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
 
 Check whether two sets do not intersect, and otherwise optionally compute a
 witness.
@@ -33,7 +33,7 @@ A witness is constructed using the `an_element` implementation of the result.
 function is_intersection_empty(X::LazySet{N},
                                Y::LazySet{N},
                                witness::Bool=false
-                              )::Union{Bool, Tuple{Bool, Vector{N}}} where N<:Real
+                              )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
     cap = intersection(X, Y)
     empty_intersection = isempty(cap)
     if witness
@@ -54,7 +54,7 @@ end
     is_intersection_empty(H1::AbstractHyperrectangle{N},
                           H2::AbstractHyperrectangle{N},
                           witness::Bool=false
-                         )::Union{Bool, Tuple{Bool, Vector{N}}} where N<:Real
+                         )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
 
 Check whether two hyperrectangles do not intersect, and otherwise optionally
 compute a witness.
@@ -85,7 +85,7 @@ of `H2`.
 function is_intersection_empty(H1::AbstractHyperrectangle{N},
                                H2::AbstractHyperrectangle{N},
                                witness::Bool=false
-                              )::Union{Bool, Tuple{Bool, Vector{N}}} where N<:Real
+                              )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
     empty_intersection = false
     center_diff = center(H2) - center(H1)
     for i in eachindex(center_diff)
@@ -124,7 +124,7 @@ end
 # common code for singletons
 @inline function is_intersection_empty_helper_singleton(
         S::AbstractSingleton{N}, X::LazySet{N}, witness::Bool=false
-       )::Union{Bool, Tuple{Bool, Vector{N}} } where N<:Real
+       )::Union{Bool, Tuple{Bool, Vector{N}} } where {N<:Real}
     empty_intersection = element(S) ∉ X
     if witness
         return (empty_intersection, empty_intersection ? N[] : element(S))
@@ -137,7 +137,7 @@ end
     is_intersection_empty(X::LazySet{N},
                           S::AbstractSingleton{N},
                           witness::Bool=false
-                         )::Union{Bool, Tuple{Bool, Vector{N}}} where N<:Real
+                         )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
 
 Check whether a convex set and a singleton do not intersect, and otherwise
 optionally compute a witness.
@@ -163,7 +163,7 @@ optionally compute a witness.
 function is_intersection_empty(X::LazySet{N},
                                S::AbstractSingleton{N},
                                witness::Bool=false
-                              )::Union{Bool, Tuple{Bool, Vector{N}}} where N<:Real
+                              )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
     return is_intersection_empty_helper_singleton(S, X, witness)
 end
 
@@ -171,7 +171,7 @@ end
 function is_intersection_empty(S::AbstractSingleton{N},
                                X::LazySet{N},
                                witness::Bool=false
-                              )::Union{Bool, Tuple{Bool, Vector{N}}} where N<:Real
+                              )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
     return is_intersection_empty_helper_singleton(S, X, witness)
 end
 
@@ -179,7 +179,7 @@ end
     is_intersection_empty(S1::AbstractSingleton{N},
                           S2::AbstractSingleton{N},
                           witness::Bool=false
-                         )::Union{Bool, Tuple{Bool, Vector{N}}} where N<:Real
+                         )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
 
 Check whether two singletons do not intersect, and otherwise optionally compute
 a witness.
@@ -204,7 +204,7 @@ a witness.
 function is_intersection_empty(S1::AbstractSingleton{N},
                                S2::AbstractSingleton{N},
                                witness::Bool=false
-                              )::Union{Bool, Tuple{Bool, Vector{N}}} where N<:Real
+                              )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
     empty_intersection = element(S1) != element(S2)
     if witness
         return (empty_intersection, empty_intersection ? N[] : element(S1))
@@ -217,7 +217,7 @@ end
     is_intersection_empty(H::AbstractHyperrectangle{N},
                           S::AbstractSingleton{N},
                           witness::Bool=false
-                         )::Union{Bool, Tuple{Bool, Vector{N}}} where N<:Real
+                         )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
 
 Check whether a hyperrectangle and a singleton do not intersect, and otherwise
 optionally compute a witness.
@@ -242,7 +242,7 @@ optionally compute a witness.
 function is_intersection_empty(H::AbstractHyperrectangle{N},
                                S::AbstractSingleton{N},
                                witness::Bool=false
-                              )::Union{Bool, Tuple{Bool, Vector{N}}} where N<:Real
+                              )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
     return is_intersection_empty_helper_singleton(S, H, witness)
 end
 
@@ -250,7 +250,7 @@ end
 function is_intersection_empty(S::AbstractSingleton{N},
                                H::AbstractHyperrectangle{N},
                                witness::Bool=false
-                              )::Union{Bool, Tuple{Bool, Vector{N}}} where N<:Real
+                              )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
     return is_intersection_empty_helper_singleton(S, H, witness)
 end
 
@@ -262,7 +262,7 @@ end
     is_intersection_empty(B1::Ball2{N},
                           B2::Ball2{N},
                           witness::Bool=false
-                         )::Union{Bool, Tuple{Bool, Vector{N}}} where N<:AbstractFloat
+                         )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:AbstractFloat}
 
 Check whether two balls in the 2-norm do not intersect, and otherwise optionally
 compute a witness.
@@ -295,7 +295,7 @@ choose `B1` for the smaller ball) as follows.
 function is_intersection_empty(B1::Ball2{N},
                                B2::Ball2{N},
                                witness::Bool=false
-                              )::Union{Bool, Tuple{Bool, Vector{N}}} where N<:AbstractFloat
+                              )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:AbstractFloat}
     center_diff_normed = norm(center(B2) - center(B1), 2)
     empty_intersection = center_diff_normed > B1.radius + B2.radius
 
@@ -330,7 +330,7 @@ end
 
 """
     is_intersection_empty(Z::Zonotope{N}, H::Hyperplane{N}, witness::Bool=false
-                         )::Union{Bool, Tuple{Bool, Vector{N}}} where N<:Real
+                         )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
 
 Check whether a zonotope and a hyperplane do not intersect, and otherwise
 optionally compute a witness.
@@ -360,7 +360,7 @@ general sets as the first argument.
 function is_intersection_empty(Z::Zonotope{N},
                                H::Hyperplane{N},
                                witness::Bool=false
-                              )::Union{Bool, Tuple{Bool, Vector{N}}} where N<:Real
+                              )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
     if witness
         # use less efficient implementation that supports witness production
         return invoke(is_intersection_empty,
@@ -377,7 +377,7 @@ end
 function is_intersection_empty(H::Hyperplane{N},
                                Z::Zonotope{N},
                                witness::Bool=false
-                              )::Union{Bool, Tuple{Bool, Vector{N}}} where N<:Real
+                              )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
     return is_intersection_empty(Z, H, witness)
 end
 
@@ -385,7 +385,7 @@ end
     is_intersection_empty(ls1::LineSegment{N},
                           ls2::LineSegment{N},
                           witness::Bool=false
-                         )::Union{Bool, Tuple{Bool, Vector{N}}} where N<:Real
+                         )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
 
 Check whether two line segments do not intersect, and otherwise optionally
 compute a witness.
@@ -419,8 +419,8 @@ intersection point, if it exists.
 function is_intersection_empty(ls1::LineSegment{N},
                                ls2::LineSegment{N},
                                witness::Bool=false
-                              )::Union{Bool, Tuple{Bool, Vector{N}}} where N<:Real
-    function cross(ls1::Vector{N}, ls2::Vector{N})::N where N<:Real
+                              )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+    function cross(ls1::Vector{N}, ls2::Vector{N})::N where {N<:Real}
         return ls1[1] * ls2[2] - ls1[2] * ls2[1]
     end
 
@@ -500,7 +500,7 @@ end
         hp::Union{Hyperplane{N}, Line{N}},
         X::LazySet{N},
         witness::Bool=false
-       )::Union{Bool, Tuple{Bool, Vector{N}}} where N<:Real
+       )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
     normal_hp = hp.a
     sv_left = σ(-normal_hp, X)
     if -dot(sv_left, -normal_hp) <= hp.b
@@ -531,7 +531,7 @@ end
     is_intersection_empty(X::LazySet{N},
                           hp::Union{Hyperplane{N}, Line{N}},
                           [witness]::Bool=false
-                         )::Union{Bool, Tuple{Bool, Vector{N}}} where N<:Real
+                         )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
 
 Check whether a compact set an a hyperplane do not intersect, and otherwise
 optionally compute a witness.
@@ -573,7 +573,7 @@ for the line-hyperplane intersection.
 function is_intersection_empty(X::LazySet{N},
                                hp::Union{Hyperplane{N}, Line{N}},
                                witness::Bool=false
-                              )::Union{Bool, Tuple{Bool, Vector{N}}} where N<:Real
+                              )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
     return is_intersection_empty_helper_hyperplane(hp, X, witness)
 end
 
@@ -581,7 +581,7 @@ end
 function is_intersection_empty(hp::Union{Hyperplane{N}, Line{N}},
                                X::LazySet{N},
                                witness::Bool=false
-                              )::Union{Bool, Tuple{Bool, Vector{N}}} where N<:Real
+                              )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
     return is_intersection_empty_helper_hyperplane(hp, X, witness)
 end
 
@@ -589,7 +589,7 @@ end
 function is_intersection_empty(hp1::Union{Hyperplane{N}, Line{N}},
                                hp2::Union{Hyperplane{N}, Line{N}},
                                witness::Bool=false
-                              )::Union{Bool, Tuple{Bool, Vector{N}}} where N<:Real
+                              )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
     return is_intersection_empty_helper_hyperplane(hp1, hp2, witness)
 end
 
@@ -597,7 +597,7 @@ end
 function is_intersection_empty(hp::Union{Hyperplane{N}, Line{N}},
                                S::AbstractSingleton{N},
                                witness::Bool=false
-                              )::Bool where N<:Real
+                              )::Bool where {N<:Real}
     return is_intersection_empty_helper_singleton(S, hp, witness)
 end
 
@@ -605,7 +605,7 @@ end
 function is_intersection_empty(S::AbstractSingleton{N},
                                hp::Union{Hyperplane{N}, Line{N}},
                                witness::Bool=false
-                              )::Bool where N<:Real
+                              )::Bool where {N<:Real}
     return is_intersection_empty_helper_singleton(S, hp, witness)
 end
 
@@ -617,7 +617,7 @@ end
         hs::HalfSpace{N},
         X::LazySet{N},
         witness::Bool=false
-       )::Union{Bool, Tuple{Bool, Vector{N}}} where N<:Real
+       )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
     if !witness
         return -ρ(-hs.a, X) > hs.b
     end
@@ -633,7 +633,7 @@ end
     is_intersection_empty(X::LazySet{N},
                           hs::HalfSpace{N},
                           [witness]::Bool=false
-                         )::Union{Bool, Tuple{Bool, Vector{N}}} where N<:Real
+                         )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
 
 Check whether a compact set an a half-space do not intersect, and otherwise
 optionally compute a witness.
@@ -669,7 +669,7 @@ Optional keyword arguments can be passed to the `ρ` function. In particular, if
 function is_intersection_empty(X::LazySet{N},
                                hs::HalfSpace{N},
                                witness::Bool=false
-                               )::Union{Bool, Tuple{Bool, Vector{N}}} where N<:Real
+                               )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
     return is_intersection_empty_helper_halfspace(hs, X, witness)
 end
 
@@ -677,7 +677,7 @@ end
 function is_intersection_empty(hs::HalfSpace{N},
                                X::LazySet{N},
                                witness::Bool=false
-                              )::Union{Bool, Tuple{Bool, Vector{N}}} where N<:Real
+                              )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
     return is_intersection_empty_helper_halfspace(hs, X, witness)
 end
 
@@ -685,7 +685,7 @@ end
     is_intersection_empty(hs1::HalfSpace{N},
                           hs2::HalfSpace{N},
                           [witness]::Bool=false
-                         )::Union{Bool, Tuple{Bool, Vector{N}}} where N<:Real
+                         )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
 
 Check whether two half-spaces do not intersect, and otherwise optionally compute
 a witness.
@@ -731,7 +731,7 @@ Such a dimension ``i`` always exists.
 function is_intersection_empty(hs1::HalfSpace{N},
                                hs2::HalfSpace{N},
                                witness::Bool=false
-                              )::Union{Bool, Tuple{Bool, Vector{N}}} where N<:Real
+                              )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
     a1 = hs1.a
     a2 = hs2.a
     issamedir, k = samedir(a1, -a2)
@@ -773,7 +773,7 @@ end
 function is_intersection_empty(H::HalfSpace{N},
                                S::AbstractSingleton{N},
                                witness::Bool=false
-                              )::Union{Bool, Tuple{Bool, Vector{N}}} where N<:Real
+                              )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
     return is_intersection_empty_helper_singleton(S, H, witness)
 end
 
@@ -781,7 +781,7 @@ end
 function is_intersection_empty(S::AbstractSingleton{N},
                                H::HalfSpace{N},
                                witness::Bool=false
-                              )::Union{Bool, Tuple{Bool, Vector{N}}} where N<:Real
+                              )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
     return is_intersection_empty_helper_singleton(S, H, witness)
 end
 
@@ -789,7 +789,7 @@ end
 function is_intersection_empty(hp::Union{Hyperplane{N}, Line{N}},
                                hs::HalfSpace{N},
                                witness::Bool=false
-                              )::Bool where N<:Real
+                              )::Bool where {N<:Real}
     return is_intersection_empty_helper_halfspace(hs, hp, witness)
 end
 
@@ -797,7 +797,7 @@ end
 function is_intersection_empty(hs::HalfSpace{N},
                                hp::Union{Hyperplane{N}, Line{N}},
                                witness::Bool=false
-                              )::Bool where N<:Real
+                              )::Bool where {N<:Real}
     return is_intersection_empty_helper_halfspace(hs, hp, witness)
 end
 
@@ -809,7 +809,7 @@ end
     is_intersection_empty(X::LazySet{N},
                           P::Union{HPolyhedron{N}, HPolytope{N}, AbstractHPolygon{N}},
                           witness::Bool=false
-                         )::Bool where N<:Real
+                         )::Bool where {N<:Real}
 
 Check whether a compact set and a polytope do not intersect.
 
@@ -838,7 +838,7 @@ Note that this method can be used with any set ``P`` whose constraints are known
 function is_intersection_empty(X::LazySet{N},
                                P::Union{HPolyhedron{N}, HPolytope{N}, AbstractHPolygon{N}},
                                witness::Bool=false
-                              )::Bool where N<:Real
+                              )::Bool where {N<:Real}
     for Hi in constraints_list(P)
         if is_intersection_empty(X, Hi)
             if witness
@@ -857,7 +857,7 @@ end
 function is_intersection_empty(P::Union{HPolyhedron{N}, HPolytope{N}, AbstractHPolygon{N}},
                                X::LazySet{N},
                                witness::Bool=false
-                              )::Bool where N<:Real
+                              )::Bool where {N<:Real}
     return is_intersection_empty(X, P, witness)
 end
 
@@ -865,7 +865,7 @@ end
 function is_intersection_empty(P::Union{HPolyhedron{N}, HPolytope{N}, AbstractHPolygon{N}},
                                Q::Union{HPolyhedron{N}, HPolytope{N}, AbstractHPolygon{N}},
                                witness::Bool=false
-                              )::Bool where N<:Real
+                              )::Bool where {N<:Real}
     for Hi in constraints_list(P)
         if is_intersection_empty(Q, Hi)
             if witness
@@ -884,7 +884,7 @@ end
 function is_intersection_empty(P::Union{HPolyhedron{N}, HPolytope{N}, AbstractHPolygon{N}},
                                hs::HalfSpace{N},
                                witness::Bool=false
-                              )::Bool where N<:Real
+                              )::Bool where {N<:Real}
     return is_intersection_empty_helper_halfspace(hs, P, witness)
 end
 
@@ -892,7 +892,7 @@ end
 function is_intersection_empty(hs::HalfSpace{N},
                                P::Union{HPolyhedron{N}, HPolytope{N}, AbstractHPolygon{N}},
                                witness::Bool=false
-                              )::Bool where N<:Real
+                              )::Bool where {N<:Real}
     return is_intersection_empty_helper_halfspace(hs, P, witness)
 end
 
@@ -900,7 +900,7 @@ end
 function is_intersection_empty(P::Union{HPolyhedron{N}, HPolytope{N}, AbstractHPolygon{N}},
                                S::AbstractSingleton{N},
                                witness::Bool=false
-                              )::Union{Bool, Tuple{Bool, Vector{N}}} where N<:Real
+                              )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
     return is_intersection_empty_helper_singleton(S, P, witness)
 end
 
@@ -908,7 +908,7 @@ end
 function is_intersection_empty(S::AbstractSingleton{N},
                                P::Union{HPolyhedron{N}, HPolytope{N}, AbstractHPolygon{N}},
                                witness::Bool=false
-                              )::Union{Bool, Tuple{Bool, Vector{N}}} where N<:Real
+                              )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
     return is_intersection_empty_helper_singleton(S, P, witness)
 end
 


### PR DESCRIPTION
Closes #973.

I also took the liberty to add some more `where` conventions :smiling_imp:

The only type parameter for a matrix is in `LinearMap`, but there is also the numeric type `NM` and then I found it confusing to also use `MN`.