### PR TITLE
#780 - Add AbstractPolyhedron interface

### DIFF
--- a/docs/src/lib/interfaces.md
+++ b/docs/src/lib/interfaces.md
@@ -100,10 +100,19 @@ an_element(::AbstractCentrallySymmetric{N}) where {N<:Real}
 isempty(::AbstractCentrallySymmetric)
 ```
 
-## Polytope
+## Polyhedron
 
-A polytope has finitely many vertices (*V-representation*) resp. facets
-(*H-representation*).
+A polyhedron has finitely many facets (*H-representation*) and is not
+necessarily bounded.
+
+```@docs
+AbstractPolyhedron
+```
+
+### Polytope
+
+A polytope is a bounded set with finitely many vertices (*V-representation*)
+resp. facets (*H-representation*).
 Note that there is a special interface combination
 [Centrally symmetric polytope](@ref).
 
@@ -122,7 +131,7 @@ RecipesBase.apply_recipe(::Dict{Symbol,Any}, ::AbstractPolytope)
 RecipesBase.apply_recipe(::Dict{Symbol,Any}, ::Vector{S}) where {S<:AbstractPolytope}
 ```
 
-### Polygon
+#### Polygon
 
 A polygon is a two-dimensional polytope.
 
@@ -137,7 +146,7 @@ dim(P::AbstractPolygon)
 linear_map(::AbstractMatrix{N}, P::AbstractPolygon{N}) where {N<:Real}
 ```
 
-#### HPolygon
+##### HPolygon
 
 An HPolygon is a polygon in H-representation (or constraint representation).
 
@@ -160,7 +169,7 @@ vertices_list(::AbstractHPolygon{N}, ::Bool=false, ::Bool=true) where {N<:Real}
 isbounded(::AbstractHPolygon, ::Bool=true)
 ```
 
-### Centrally symmetric polytope
+#### Centrally symmetric polytope
 
 A centrally symmetric polytope is a combination of two other interfaces:
 [Centrally symmetric set](@ref) and [Polytope](@ref).
@@ -177,7 +186,7 @@ an_element(::AbstractCentrallySymmetricPolytope{N}) where {N<:Real}
 isempty(::AbstractCentrallySymmetricPolytope)
 ```
 
-#### Hyperrectangle
+##### Hyperrectangle
 
 A hyperrectangle is a special centrally symmetric polytope with axis-aligned
 facets.
@@ -199,7 +208,7 @@ high(::AbstractHyperrectangle{N}) where {N<:Real}
 low(::AbstractHyperrectangle{N}) where {N<:Real}
 ```
 
-#### Singleton
+##### Singleton
 
 A singleton is a special hyperrectangle consisting of only one point.
 

--- a/docs/src/lib/interfaces.md
+++ b/docs/src/lib/interfaces.md
@@ -109,6 +109,12 @@ necessarily bounded.
 AbstractPolyhedron
 ```
 
+This interface defines the following functions:
+
+```@docs
+∈(::AbstractVector{N}, ::AbstractPolyhedron{N}) where {N<:Real}
+```
+
 ### Polytope
 
 A polytope is a bounded set with finitely many vertices (*V-representation*)

--- a/docs/src/lib/interfaces.md
+++ b/docs/src/lib/interfaces.md
@@ -113,6 +113,7 @@ This interface defines the following functions:
 
 ```@docs
 ∈(::AbstractVector{N}, ::AbstractPolyhedron{N}) where {N<:Real}
+constrained_dimensions(::AbstractPolyhedron{N}) where {N<:Real}
 ```
 
 ### Polytope

--- a/docs/src/lib/representations.md
+++ b/docs/src/lib/representations.md
@@ -174,8 +174,10 @@ constraints_list(::HalfSpace{N}) where {N<:Real}
 constrained_dimensions(::HalfSpace{N}) where {N<:Real}
 halfspace_left(::AbstractVector{N}, ::AbstractVector{N}) where {N<:Real}
 halfspace_right(::AbstractVector{N}, ::AbstractVector{N}) where {N<:Real}
-tosimplehrep(::AbstractVector{HalfSpace{N}}) where {N<:Real}
 linear_map(::AbstractMatrix{N}, ::HalfSpace{N}) where {N}
+tosimplehrep(::AbstractVector{HalfSpace{N}}) where {N<:Real}
+remove_redundant_constraints(::AbstractVector{LinearConstraint{N}}) where {N<:Real}
+remove_redundant_constraints!(::AbstractVector{LinearConstraint{N}}) where {N<:Real}
 ```
 Inherited from [`LazySet`](@ref):
 * [`norm`](@ref norm(::LazySet, ::Real))
@@ -442,11 +444,11 @@ constraints_list(::HPoly{N}) where {N<:Real}
 tohrep(::HPoly{N}) where {N<:Real}
 isempty(::HPoly{N}, ::Bool=false) where {N<:Real}
 cartesian_product(::HPoly{N}, ::HPoly{N}) where {N<:Real}
-linear_map(M::AbstractMatrix{N}, P::PT) where {N<:Real, PT<:HPoly{N}}
+linear_map(::AbstractMatrix{N}, ::PT) where {N<:Real, PT<:HPoly{N}}
 tovrep(::HPoly{N}) where {N<:Real}
 polyhedron(::HPoly{N}) where {N<:Real}
-remove_redundant_constraints
-remove_redundant_constraints!
+remove_redundant_constraints(::PT) where {N<:Real, PT<:HPoly{N}}
+remove_redundant_constraints!(::HPoly{N}) where {N<:Real}
 ```
 
 Inherited from [`LazySet`](@ref):

--- a/docs/src/lib/representations.md
+++ b/docs/src/lib/representations.md
@@ -456,6 +456,7 @@ Inherited from [`LazySet`](@ref):
 
 Inherited from [`AbstractPolyhedron`](@ref):
 * [`∈`](@ref ∈(::AbstractVector{N}, ::AbstractPolyhedron{N}) where {N<:Real})
+* [`constrained_dimensions`](@ref constrained_dimensions(::AbstractPolyhedron{N}) where {N<:Real})
 
 #### Polytopes in constraint representation
 
@@ -479,7 +480,6 @@ rand(::Type{HPolyhedron})
 isbounded(::HPolyhedron)
 vertices_list(::HPolyhedron{N}) where {N<:Real}
 singleton_list(::HPolyhedron{N}) where {N<:Real}
-constrained_dimensions(::HPolyhedron{N}) where {N<:Real}
 ```
 
 ### Vertex representation

--- a/docs/src/lib/representations.md
+++ b/docs/src/lib/representations.md
@@ -437,7 +437,6 @@ The following methods are shared between `HPolytope` and `HPolyhedron`.
 dim(::HPoly{N}) where {N<:Real}
 ρ(::AbstractVector{N}, ::HPoly{N}) where {N<:Real}
 σ(::AbstractVector{N}, ::HPoly{N}) where {N<:Real}
-∈(::AbstractVector{N}, ::HPoly{N}) where {N<:Real}
 addconstraint!(::HPoly{N}, ::LinearConstraint{N}) where {N<:Real}
 constraints_list(::HPoly{N}) where {N<:Real}
 tohrep(::HPoly{N}) where {N<:Real}
@@ -454,6 +453,9 @@ Inherited from [`LazySet`](@ref):
 * [`norm`](@ref norm(::LazySet, ::Real))
 * [`radius`](@ref radius(::LazySet, ::Real))
 * [`diameter`](@ref diameter(::LazySet, ::Real))
+
+Inherited from [`AbstractPolyhedron`](@ref):
+* [`∈`](@ref ∈(::AbstractVector{N}, ::AbstractPolyhedron{N}) where {N<:Real})
 
 #### Polytopes in constraint representation
 

--- a/src/AbstractPolyhedron.jl
+++ b/src/AbstractPolyhedron.jl
@@ -1,0 +1,32 @@
+export AbstractPolyhedron
+
+"""
+    AbstractPolyhedron{N<:Real} <: LazySet{N}
+
+Abstract type for polyhedral sets, i.e., sets with finitely many flat facets, or
+equivalently, sets defined as an intersection of a finite number of halfspaces.
+
+### Notes
+
+Every concrete `AbstractPolyhedron` must define the following functions:
+- `constraints_list(::AbstractPolyhedron{N})::Vector{LinearConstraint{N}}` --
+    return a list of all facet constraints
+
+```jldoctest
+julia> subtypes(AbstractPolyhedron)
+5-element Array{Any,1}:
+ AbstractPolytope
+ HPolyhedron
+ HalfSpace
+ Hyperplane
+ Line
+```
+"""
+abstract type AbstractPolyhedron{N<:Real} <: LazySet{N} end
+
+
+# --- common AbstractPolyhedron functions ---
+
+
+# To account for the compilation order, functions are defined in the file
+# AbstractPolyhedron_functions.jl

--- a/src/AbstractPolyhedron_functions.jl
+++ b/src/AbstractPolyhedron_functions.jl
@@ -1,5 +1,7 @@
 import Base.∈
 
+export constrained_dimensions
+
 """
     ∈(x::AbstractVector{N}, P::AbstractPolyhedron{N})::Bool where {N<:Real}
 
@@ -28,4 +30,34 @@ function ∈(x::AbstractVector{N}, P::AbstractPolyhedron{N})::Bool where {N<:Rea
         end
     end
     return true
+end
+
+"""
+    constrained_dimensions(P::AbstractPolyhedron{N})::Vector{Int}
+        where {N<:Real}
+
+Return the indices in which a polyhedron is constrained.
+
+### Input
+
+- `P` -- polyhedron
+
+### Output
+
+A vector of ascending indices `i` such that the polyhedron is constrained in
+dimension `i`.
+
+### Examples
+
+A 2D polyhedron with constraint ``x1 ≥ 0`` is constrained in dimension 1 only.
+"""
+function constrained_dimensions(P::AbstractPolyhedron{N}
+                               )::Vector{Int} where {N<:Real}
+    zero_indices = zeros(Int, dim(P))
+    for constraint in constraints_list(P)
+        for i in constrained_dimensions(constraint)
+            zero_indices[i] = i
+        end
+    end
+    return filter(x -> x != 0, zero_indices)
 end

--- a/src/AbstractPolyhedron_functions.jl
+++ b/src/AbstractPolyhedron_functions.jl
@@ -1,6 +1,7 @@
 import Base.∈
 
-export constrained_dimensions
+export constrained_dimensions,
+       tosimplehrep
 
 """
     ∈(x::AbstractVector{N}, P::AbstractPolyhedron{N})::Bool where {N<:Real}
@@ -60,4 +61,38 @@ function constrained_dimensions(P::AbstractPolyhedron{N}
         end
     end
     return filter(x -> x != 0, zero_indices)
+end
+
+"""
+    tosimplehrep(constraints::AbstractVector{LinearConstraint{N}})
+        where {N<:Real}
+
+Return the simple H-representation ``Ax ≤ b`` from a list of linear constraints.
+
+### Input
+
+- `constraints` -- a list of linear constraints
+
+### Output
+
+The tuple `(A, b)` where `A` is the matrix of normal directions and `b` is the
+vector of offsets.
+"""
+function tosimplehrep(constraints::AbstractVector{LinearConstraint{N}}
+                     ) where {N<:Real}
+    n = length(constraints)
+    if n == 0
+        A = Matrix{N}(undef, 0, 0)
+        b = Vector{N}(undef, 0)
+        return (A, b)
+    end
+    A = zeros(N, n, dim(first(constraints)))
+    b = zeros(N, n)
+    @inbounds begin
+        for (i, Pi) in enumerate(constraints)
+            A[i, :] = Pi.a
+            b[i] = Pi.b
+        end
+    end
+    return (A, b)
 end

--- a/src/AbstractPolyhedron_functions.jl
+++ b/src/AbstractPolyhedron_functions.jl
@@ -1,7 +1,9 @@
 import Base.∈
 
 export constrained_dimensions,
-       tosimplehrep
+       tosimplehrep,
+       remove_redundant_constraints,
+       remove_redundant_constraints!
 
 """
     ∈(x::AbstractVector{N}, P::AbstractPolyhedron{N})::Bool where {N<:Real}
@@ -95,4 +97,119 @@ function tosimplehrep(constraints::AbstractVector{LinearConstraint{N}}
         end
     end
     return (A, b)
+end
+
+"""
+     remove_redundant_constraints!(
+         constraints::AbstractVector{LinearConstraint{N}};
+         [backend]=GLPKSolverLP())::Bool where {N<:Real}
+
+Remove the redundant constraints of a given list of linear constraints; the list
+is updated in-place.
+
+### Input
+
+- `constraints` -- list of constraints
+- `backend`     -- (optional, default: `GLPKSolverLP`) numeric LP solver backend
+
+### Output
+
+`true` if the function was successful and the list of constraints `constraints`
+is modified by removing the redundant constraints, and `false` only if the
+constraints are infeasible.
+
+### Notes
+
+Note that the result may be `true` even if the constraints are infeasible.
+For example, ``x ≤ 0 && x ≥ 1`` will return `true` without removing any
+constraint.
+To check if the constraints are infeasible, use
+`isempty(HPolyhedron(constraints)`.
+
+### Algorithm
+
+If there are `m` constraints in `n` dimensions, this function checks one by one
+if each of the `m` constraints is implied by the remaining ones.
+
+To check if the `k`-th constraint is redundant, an LP is formulated using the
+constraints that have not yet being removed.
+If, at an intermediate step, it is detected that a subgroup of the constraints
+is infeasible, this function returns `false`.
+If the calculation finished successfully, this function returns `true`.
+
+For details, see [Fukuda's Polyhedra
+FAQ](https://www.cs.mcgill.ca/~fukuda/soft/polyfaq/node24.html).
+"""
+function remove_redundant_constraints!(constraints::AbstractVector{LinearConstraint{N}};
+                                       backend=GLPKSolverLP()
+                                      )::Bool where {N<:Real}
+
+    A, b = tosimplehrep(constraints)
+    m, n = size(A)
+    non_redundant_indices = 1:m
+
+    i = 1 # counter over reduced constraints
+
+    for j in 1:m    # loop over original constraints
+        α = A[j, :]
+        Ar = A[non_redundant_indices, :]
+        br = b[non_redundant_indices]
+        br[i] = b[j] + one(N)
+        lp = linprog(-α, Ar, '<', br, -Inf, Inf, backend)
+        if lp.status == :Infeasible
+            # the polyhedron is empty
+            return false
+        elseif lp.status == :Optimal
+            objval = -lp.objval
+            if objval <= b[j]
+                # the constraint is redundant
+                non_redundant_indices = setdiff(non_redundant_indices, j)
+            else
+                # the constraint is not redundant
+                i = i+1
+            end
+        else
+            error("LP is not optimal; the status of the LP is $(lp.status)")
+        end
+    end
+
+    deleteat!(constraints, setdiff(1:m, non_redundant_indices))
+    return true
+end
+
+"""
+    remove_redundant_constraints(
+        constraints::AbstractVector{LinearConstraint{N}};
+        backend=GLPKSolverLP())::Union{AbstractVector{LinearConstraint{N}},
+                                       EmptySet{N}} where {N<:Real}
+
+Remove the redundant constraints of a given list of linear constraints.
+
+### Input
+
+- `constraints` -- list of constraints
+- `backend`     -- (optional, default: `GLPKSolverLP`) numeric LP solver backend
+
+### Output
+
+The list of constraints with the redundant ones removed, or an empty set if the
+constraints are infeasible.
+
+### Algorithm
+
+See
+[`remove_redundant_constraints!(::AbstractVector{LinearConstraint{<:Real}})`](@ref)
+for details.
+"""
+function remove_redundant_constraints(constraints::AbstractVector{LinearConstraint{N}};
+                                      backend=GLPKSolverLP()
+                                     )::Union{AbstractVector{LinearConstraint{N}},
+                                                             EmptySet{N}
+                                                            } where {N<:Real}
+    constraints_copy = copy(constraints)
+    if remove_redundant_constraints!(constraints_copy, backend=backend)
+        return constraints_copy
+    else  # the constraints are infeasible
+        return EmptySet{N}()
+    end
 end

--- a/src/AbstractPolyhedron_functions.jl
+++ b/src/AbstractPolyhedron_functions.jl
@@ -1,0 +1,31 @@
+import Base.∈
+
+"""
+    ∈(x::AbstractVector{N}, P::AbstractPolyhedron{N})::Bool where {N<:Real}
+
+Check whether a given point is contained in a polyhedron.
+
+### Input
+
+- `x` -- point/vector
+- `P` -- polyhedron
+
+### Output
+
+`true` iff ``x ∈ P``.
+
+### Algorithm
+
+This implementation checks if the point lies inside each defining half-space.
+"""
+function ∈(x::AbstractVector{N}, P::AbstractPolyhedron{N})::Bool where {N<:Real}
+    @assert length(x) == dim(P) "a $(length(x))-dimensional point cannot be " *
+        "an element of a $(dim(P))-dimensional set"
+
+    for c in constraints_list(P)
+        if dot(c.a, x) > c.b
+            return false
+        end
+    end
+    return true
+end

--- a/src/AbstractPolytope.jl
+++ b/src/AbstractPolytope.jl
@@ -7,11 +7,11 @@ export AbstractPolytope,
        isempty
 
 """
-    AbstractPolytope{N<:Real} <: LazySet{N}
+    AbstractPolytope{N<:Real} <: AbstractPolyhedron{N}
 
-Abstract type for polytopic sets, i.e., sets with finitely many flat facets, or
-equivalently, sets defined as an intersection of a finite number of halfspaces,
-or equivalently, sets with finitely many vertices.
+Abstract type for polytopic sets, i.e., bounded sets with finitely many flat
+facets, or equivalently, bounded sets defined as an intersection of a finite
+number of halfspaces, or equivalently, bounded sets with finitely many vertices.
 
 ### Notes
 
@@ -30,7 +30,7 @@ julia> subtypes(AbstractPolytope)
  VPolytope
 ```
 """
-abstract type AbstractPolytope{N<:Real} <: LazySet{N} end
+abstract type AbstractPolytope{N<:Real} <: AbstractPolyhedron{N} end
 
 
 # --- common AbstractPolytope functions ---

--- a/src/HPolyhedron.jl
+++ b/src/HPolyhedron.jl
@@ -218,37 +218,6 @@ function isbounded(P::HPolyhedron)::Bool
 end
 
 """
-    ∈(x::AbstractVector{N}, P::HPoly{N})::Bool where {N<:Real}
-
-Check whether a given point is contained in a polyhedron in constraint
-representation.
-
-### Input
-
-- `x` -- vector with the coordinates of the point
-- `P` -- polyhedron in constraint representation
-
-### Output
-
-`true` iff ``x ∈ P``.
-
-### Algorithm
-
-This implementation checks if the point lies on the outside of each hyperplane.
-This is equivalent to checking if the point lies in each half-space.
-"""
-function ∈(x::AbstractVector{N}, P::HPoly{N})::Bool where {N<:Real}
-    @assert length(x) == dim(P)
-
-    for c in P.constraints
-        if dot(c.a, x) > c.b
-            return false
-        end
-    end
-    return true
-end
-
-"""
     rand(::Type{HPolyhedron}; [N]::Type{<:Real}=Float64, [dim]::Int=2,
          [rng]::AbstractRNG=GLOBAL_RNG, [seed]::Union{Int, Nothing}=nothing
         )::HPolyhedron{N}

--- a/src/HPolyhedron.jl
+++ b/src/HPolyhedron.jl
@@ -311,38 +311,6 @@ function constraints_list(P::HPoly{N}
 end
 
 """
-    tosimplehrep(constraints::AbstractVector{LinearConstraint{N}}) where {N<:Real}
-
-Return the simple H-representation ``Ax ≤ b`` of a list of constraints.
-
-### Input
-
-- `constraints` -- a list of constraints
-
-### Output
-
-The tuple `(A, b)` where `A` is the matrix of normal directions and `b` are the
-offsets.
-"""
-function tosimplehrep(constraints::AbstractVector{LinearConstraint{N}}) where {N<:Real}
-    n = length(constraints)
-    if n == 0
-        A = Matrix{N}(undef, 0, 0)
-        b = Vector{N}(undef, 0)
-        return (A, b)
-    end
-    A = zeros(N, n, dim(first(constraints)))
-    b = zeros(N, n)
-    @inbounds begin
-        for (i, Pi) in enumerate(constraints)
-            A[i, :] = Pi.a
-            b[i] = Pi.b
-        end
-    end
-    return (A, b)
-end
-
-"""
     tohrep(P::HPoly{N}) where {N<:Real}
 
 Return a constraint representation of the given polyhedron in constraint

--- a/src/HPolyhedron.jl
+++ b/src/HPolyhedron.jl
@@ -259,39 +259,11 @@ function rand(::Type{HPolyhedron};
     return HPolyhedron(constraints_Q)
 end
 
-"""
-    constrained_dimensions(P::HPolyhedron{N})::Vector{Int} where {N<:Real}
-
-Return the indices in which a polyhedron in constraint representation is
-constrained.
-
-### Input
-
-- `P` -- polyhedron in constraint representation
-
-### Output
-
-A vector of ascending indices `i` such that the polyhedron is constrained in
-dimension `i`.
-
-### Examples
-
-A 2D polyhedron with constraint ``x1 ≥ 0`` is constrained in dimension 1 only.
-"""
-function constrained_dimensions(P::HPolyhedron{N})::Vector{Int} where {N<:Real}
-    zero_indices = zeros(Int, dim(P))
-    for constraint in P.constraints
-        for i in constrained_dimensions(constraint)
-            zero_indices[i] = i
-        end
-    end
-    return filter(x -> x != 0, zero_indices)
-end
-
 
 # ===========================================
 # HPolyhedron and HPolytope's shared methods
 # ===========================================
+
 
 """
     addconstraint!(P::HPoly{N},

--- a/src/HPolyhedron.jl
+++ b/src/HPolyhedron.jl
@@ -20,7 +20,7 @@ export HPolyhedron,
        constrained_dimensions
 
 """
-    HPolyhedron{N<:Real} <: LazySet{N}
+    HPolyhedron{N<:Real} <: AbstractPolyhedron{N}
 
 Type that represents a convex polyhedron in H-representation.
 
@@ -28,7 +28,7 @@ Type that represents a convex polyhedron in H-representation.
 
 - `constraints` -- vector of linear constraints
 """
-struct HPolyhedron{N<:Real} <: LazySet{N}
+struct HPolyhedron{N<:Real} <: AbstractPolyhedron{N}
     constraints::Vector{LinearConstraint{N}}
 end
 
@@ -53,7 +53,9 @@ HPolyhedron{N}(A::AbstractMatrix{N}, b::AbstractVector{N}) where {N<:Real} = HPo
 # convenience union type
 const HPoly{N} = Union{HPolytope{N}, HPolyhedron{N}}
 
+
 # --- LazySet interface functions ---
+
 
 """
     dim(P::HPoly{N})::Int where {N<:Real}

--- a/src/HalfSpace.jl
+++ b/src/HalfSpace.jl
@@ -10,7 +10,7 @@ export HalfSpace, LinearConstraint,
        linear_map
 
 """
-    HalfSpace{N<:Real} <: LazySet{N}
+    HalfSpace{N<:Real} <: AbstractPolyhedron{N}
 
 Type that represents a (closed) half-space of the form ``a⋅x ≤ b``.
 
@@ -28,7 +28,7 @@ julia> HalfSpace([0, -1.], 0.)
 HalfSpace{Float64}([0.0, -1.0], 0.0)
 ```
 """
-struct HalfSpace{N<:Real} <: LazySet{N}
+struct HalfSpace{N<:Real} <: AbstractPolyhedron{N}
     a::AbstractVector{N}
     b::N
 end

--- a/src/Hyperplane.jl
+++ b/src/Hyperplane.jl
@@ -6,7 +6,7 @@ export Hyperplane,
        an_element
 
 """
-    Hyperplane{N<:Real} <: LazySet{N}
+    Hyperplane{N<:Real} <: AbstractPolyhedron{N}
 
 Type that represents a hyperplane of the form ``a⋅x = b``.
 
@@ -24,7 +24,7 @@ julia> Hyperplane([0, 1.], 0.)
 Hyperplane{Float64}([0.0, 1.0], 0.0)
 ```
 """
-struct Hyperplane{N<:Real} <: LazySet{N}
+struct Hyperplane{N<:Real} <: AbstractPolyhedron{N}
     a::AbstractVector{N}
     b::N
 end

--- a/src/LazySet.jl
+++ b/src/LazySet.jl
@@ -34,9 +34,9 @@ Every concrete `LazySet` must define the following functions:
 
 ```jldoctest
 julia> subtypes(LazySet)
-19-element Array{Any,1}:
+15-element Array{Any,1}:
  AbstractCentrallySymmetric
- AbstractPolytope
+ AbstractPolyhedron
  CacheMinkowskiSum
  CartesianProduct
  CartesianProductArray
@@ -45,12 +45,8 @@ julia> subtypes(LazySet)
  EmptySet
  ExponentialMap
  ExponentialProjectionMap
- HPolyhedron
- HalfSpace
- Hyperplane
  Intersection
  IntersectionArray
- Line
  LinearMap
  MinkowskiSum
  MinkowskiSumArray

--- a/src/LazySet.jl
+++ b/src/LazySet.jl
@@ -321,7 +321,7 @@ copy(S::LazySet) = deepcopy(S)
 """
     tosimplehrep(S::LazySet)
 
-Return the simple H-representation ``Ax ≤ b`` of a set from its list of
+Return the simple H-representation ``Ax ≤ b`` of a set from its list of linear
 constraints.
 
 ### Input
@@ -330,14 +330,13 @@ constraints.
 
 ### Output
 
-The tuple `(A, b)` where `A` is the matrix of normal directions and `b` are the
-offsets.
+The tuple `(A, b)` where `A` is the matrix of normal directions and `b` is the
+vector of offsets.
 
 ### Notes
 
-This function uses `constraints_list(S)`. It is a fallback implementation that
-works only for those sets that can be represented exactly by a list of linear
-constraints, which is available through the `constraints_list(S)`
-function.
+This function only works for sets that can be represented exactly by a finite
+list of linear constraints.
+This fallback implementation relies on `constraints_list(S)`.
 """
 tosimplehrep(S::LazySet) = tosimplehrep(constraints_list(S))

--- a/src/LazySets.jl
+++ b/src/LazySets.jl
@@ -20,7 +20,9 @@ include("macros.jl")
 # Abstract set types
 # ==================
 include("LazySet.jl")
+include("AbstractPolyhedron.jl")
 include("HalfSpace.jl") # must be here to make LinearConstraint available
+include("AbstractPolyhedron_functions.jl")
 include("AbstractPolytope.jl")
 include("AbstractCentrallySymmetric.jl")
 include("AbstractCentrallySymmetricPolytope.jl")

--- a/src/Line.jl
+++ b/src/Line.jl
@@ -6,7 +6,7 @@ export Line,
        an_element
 
 """
-    Line{N<:Real, VN<:AbstractVector{N}} <: LazySet{N}
+    Line{N<:Real, VN<:AbstractVector{N}} <: AbstractPolyhedron{N}
 
 Type that represents a line in 2D of the form ``a⋅x = b`` (i.e., a special case
 of a `Hyperplane`).
@@ -25,7 +25,7 @@ julia> Line([1., 1.], 1.)
 Line{Float64,Array{Float64,1}}([1.0, 1.0], 1.0)
 ```
 """
-struct Line{N<:Real, VN<:AbstractVector{N}} <: LazySet{N}
+struct Line{N<:Real, VN<:AbstractVector{N}} <: AbstractPolyhedron{N}
     a::VN
     b::N
 


### PR DESCRIPTION
Closes #780.

I left out the following generalizations. I would open a new issue to keep this PR manageable, but I can also add them here.

* generalize `linear_map` to `AbstractPolyhedron`
* generalize `polyhedron` to `AbstractPolyhedron`
* generalize `isempty` to `AbstractPolyhedron`
  There are two optional implementations. The second one would just work. For the first one, we would need the `polyhedron` method above.