### PR TITLE
Use left division in linear map

### DIFF
--- a/src/HPolyhedron.jl
+++ b/src/HPolyhedron.jl
@@ -400,7 +400,7 @@ end
 """
     linear_map(M::AbstractMatrix{N}, P::PT;
               [cond_tol=DEFAULT_COND_TOL]::Number,
-              [use_inv]::Bool) where {N<:Real, PT<:HPoly{N}}
+              [use_inv]::Bool=!issparse(M)) where {N<:Real, PT<:HPoly{N}}
 
 Concrete linear map of a polyhedron in constraint representation.
 
@@ -443,6 +443,7 @@ function linear_map(M::AbstractMatrix{N},
     end
 
     constraints = similar(constraints_list(P))
+
     # matrix M is invertible => the normal vectors are vec(c.a' * inv(M))
     if use_inv
         invM = inv(M)

--- a/src/HPolyhedron.jl
+++ b/src/HPolyhedron.jl
@@ -433,7 +433,7 @@ function linear_map(M::AbstractMatrix{N},
     end
     # matrix M is invertible: the normal vectors are vec(c.a' * inv(M)), or taking
     # the left division for each constraint c, transpose(M) \ c.a
-    Mt = tranpose(M)
+    Mt = transpose(M)
     constraints = Vector{LinearConstraint{N}}(undef,
                                               length(constraints_list(P)))
     @inbounds for (i, c) in enumerate(constraints_list(P))

--- a/src/HPolyhedron.jl
+++ b/src/HPolyhedron.jl
@@ -431,12 +431,13 @@ function linear_map(M::AbstractMatrix{N},
         # use the implementation for general polytopes
         return invoke(linear_map, Tuple{typeof(M), AbstractPolytope{N}}, M, P)
     end
-    # matrix is invertible
-    invM = inv(M)
+    # matrix M is invertible: the normal vectors are vec(c.a' * inv(M)), or taking
+    # the left division for each constraint c, transpose(M) \ c.a
+    Mt = tranpose(M)
     constraints = Vector{LinearConstraint{N}}(undef,
                                               length(constraints_list(P)))
     @inbounds for (i, c) in enumerate(constraints_list(P))
-        constraints[i] = LinearConstraint(vec(c.a' * invM), c.b)
+        constraints[i] = LinearConstraint(Mt \ c.a, c.b)
     end
     return PT(constraints)
 end

--- a/src/HPolyhedron.jl
+++ b/src/HPolyhedron.jl
@@ -409,7 +409,7 @@ Concrete linear map of a polyhedron in constraint representation.
 - `M`        -- matrix
 - `P`        -- polyhedron in constraint representation
 - `cond_tol` -- (optional) tolerance of matrix condition (used to check whether
-                         the matrix is invertible)
+                the matrix is invertible)
 - `use_inv`  -- (optional, default: `false` if `M` is sparse and `true`
                 otherwise) whether to compute the full left division through
                 `inv(M)`, or to use the left division for each vector; see below 

--- a/src/HPolyhedron.jl
+++ b/src/HPolyhedron.jl
@@ -433,11 +433,9 @@ function linear_map(M::AbstractMatrix{N},
     end
     # matrix M is invertible: the normal vectors are vec(c.a' * inv(M)), or taking
     # the left division for each constraint c, transpose(M) \ c.a
-    Mt = transpose(M)
-    constraints = Vector{LinearConstraint{N}}(undef,
-                                              length(constraints_list(P)))
+    constraints = similar(constraints_list(P))
     @inbounds for (i, c) in enumerate(constraints_list(P))
-        constraints[i] = LinearConstraint(Mt \ c.a, c.b)
+        constraints[i] = LinearConstraint(_At_ldiv_B(M, c.a), c.b)
     end
     return PT(constraints)
 end

--- a/src/compat.jl
+++ b/src/compat.jl
@@ -14,16 +14,14 @@ export _At_mul_B
 
 @static if VERSION < v"0.7-"
     using Compat.Random
-    @inline function _At_mul_B(A, B)
-        return At_mul_B(A, B)
-    end
+    @inline _At_mul_B(A, B) = At_mul_B(A, B)
+    @inline _At_ldiv_B(A, B) = At_ldiv_B(A, B)
     expmat = expm
 else
     using SparseArrays
     using Random
     using Random: GLOBAL_RNG, SamplerType
-    @inline function _At_mul_B(A, B)
-        return transpose(A) * B
-    end
+    @inline _At_mul_B(A, B) = transpose(A) * B
+    @inline _At_ldiv_B(A, B) = transpose(A) \ B
     expmat = exp
 end

--- a/test/unit_Polytope.jl
+++ b/test/unit_Polytope.jl
@@ -112,11 +112,20 @@ for N in [Float64, Rational{Int}, Float32]
     @test BallInf(N[0, 0], N(1)) ⊆ P
     @test !(BallInf(N[0, 0], N(1.01)) ⊆ P)
 
-    # concrete linear map
-    linear_map(N[2 3; 1 2], P)  # invertible matrix
+    # =====================
+    # Concrete linear map
+    # =====================
+    linear_map(N[2 3; 1 2], P) # invertible matrix
     if test_suite_polyhedra
         linear_map(N[2 3; 0 0], P)  # noninvertible matrix
     end
+
+    M = N[2 1; 0 1]
+    linear_map(M, P)
+    L1 = linear_map(M, P, use_inv=true)  # calculates inv(M) explicitly
+    L2 = linear_map(M, P, use_inv=false) # uses transpose(M) \ c.a for each constraint c of P
+    L3 = linear_map(M, P, cond_tol=1e3)  # set a custom tolerance for the condition number (invertibility check)
+    @test all([M * an_element(P) ∈ Li for Li in [L1, L2, L3]])
 
     # -----
     # V-rep

--- a/test/unit_Polytope.jl
+++ b/test/unit_Polytope.jl
@@ -121,11 +121,11 @@ for N in [Float64, Rational{Int}, Float32]
     end
 
     M = N[2 1; 0 1]
-    linear_map(M, P)
-    L1 = linear_map(M, P, use_inv=true)  # calculates inv(M) explicitly
-    L2 = linear_map(M, P, use_inv=false) # uses transpose(M) \ c.a for each constraint c of P
-    L3 = linear_map(M, P, cond_tol=1e3)  # set a custom tolerance for the condition number (invertibility check)
-    @test all([M * an_element(P) ∈ Li for Li in [L1, L2, L3]])
+    linear_map(M, H)
+    L1 = linear_map(M, H, use_inv=true)  # calculates inv(M) explicitly
+    L2 = linear_map(M, H, use_inv=false) # uses transpose(M) \ c.a for each constraint c of P
+    L3 = linear_map(M, H, cond_tol=1e3)  # set a custom tolerance for the condition number (invertibility check)
+    @test all([M * an_element(H) ∈ Li for Li in [L1, L2, L3]])
 
     # -----
     # V-rep

--- a/test/unit_Polytope.jl
+++ b/test/unit_Polytope.jl
@@ -121,11 +121,14 @@ for N in [Float64, Rational{Int}, Float32]
     end
 
     M = N[2 1; 0 1]
-    linear_map(M, H)
-    L1 = linear_map(M, H, use_inv=true)  # calculates inv(M) explicitly
-    L2 = linear_map(M, H, use_inv=false) # uses transpose(M) \ c.a for each constraint c of P
-    L3 = linear_map(M, H, cond_tol=1e3)  # set a custom tolerance for the condition number (invertibility check)
-    @test all([M * an_element(H) ∈ Li for Li in [L1, L2, L3]])
+    linear_map(M, P)
+    L1 = linear_map(M, P, use_inv=true)  # calculates inv(M) explicitly
+    L2 = linear_map(M, P, use_inv=false) # uses transpose(M) \ c.a for each constraint c of P
+    L3 = linear_map(M, P, cond_tol=1e3)  # set a custom tolerance for the condition number (invertibility check)
+    # needs M * an_element(Li) to be stable for rational, see #1105
+    p = convert(Vector{N}, an_element(P))
+    @assert p ∈ P
+    @test all([M * p ∈ Li for Li in [L1, L2, L3]])
 
     # -----
     # V-rep


### PR DESCRIPTION
I haven't benchmarked this, but i would expect it to be more efficient to calculate the application of the linear map using the left division than calculating the full matrix inverse. 