### PR TITLE
Adapt to Compat change

### DIFF
--- a/src/compat.jl
+++ b/src/compat.jl
@@ -14,6 +14,7 @@ export _At_mul_B
 
 @static if VERSION < v"0.7-"
     using Compat.Random
+    import Compat.Random: GLOBAL_RNG
     @inline function _At_mul_B(A, B)
         return At_mul_B(A, B)
     end


### PR DESCRIPTION
`Compat` changed the interface to `Random`. This PR is needed to make v0.6 work again.