### PR TITLE
#1117 - Concrete intersection of (abstract) polyhedra

### DIFF
--- a/docs/src/lib/binary_functions.md
+++ b/docs/src/lib/binary_functions.md
@@ -51,11 +51,8 @@ intersection(::Line{N}, ::Line{N}) where {N<:Real}
 intersection(::AbstractHyperrectangle{N}, ::AbstractHyperrectangle{N}) where {N<:Real}
 intersection(::Interval{N}, ::Interval{N}) where {N<:Real}
 intersection(::AbstractHPolygon{N}, ::AbstractHPolygon{N}, ::Bool=true) where {N<:Real}
-intersection(::HPoly{N}, ::HalfSpace{N}) where {N<:Real}
-intersection(::HPoly{N}, ::HPoly{N}) where {N<:Real}
-intersection(::HPoly{N}, ::VPolytope{N}) where {N<:Real}
-intersection(::HPoly{N}, ::AbstractPolytope{N}) where {N<:Real}
-intersection(::S1, ::S2) where {N<:Real, S1<:AbstractPolytope{N}, S2<:AbstractPolytope{N}}
+intersection(::AbstractPolyhedron{N}, ::AbstractPolyhedron{N}) where {N<:Real}
+intersection(::Union{VPolytope{N}, VPolygon{N}}, ::Union{VPolytope{N}, VPolygon{N}}) where {N<:Real}
 intersection(::UnionSet{N}, ::LazySet{N}) where {N<:Real}
 intersection(::UnionSetArray{N}, ::LazySet{N}) where {N<:Real}
 ```

--- a/src/concrete_intersection.jl
+++ b/src/concrete_intersection.jl
@@ -298,88 +298,51 @@ function intersection(P1::AbstractHPolygon{N},
 end
 
 """
-    intersection(P::HPoly{N},
-                 hs::HalfSpace{N};
-                 backend=default_polyhedra_backend(P, N),
-                 prunefunc=removehredundancy!) where {N<:Real}
-
-Compute the intersection of a polytope in H-representation and a half-space.
-
-### Input
-
-- `P`         -- polytope
-- `hs`        -- half-space
-- `backend`   -- (optional, default: `nothing`) the LP solver or the the
-                 polyhedral computations backend; its value is set internally,
-                 see see below in the Notes for details
-- `use_polyhedra_interface` -- (optional, default: `false`) if `true`, use the
-                 `Polyhedra` interface for the removal of constraints
-### Output
-
-The same polytope in H-representation with just one more constraint.
-"""
-function intersection(P::HPoly{N},
-                      hs::HalfSpace{N};
-                      backend=nothing,
-                      use_polyhedra_interface=false) where {N<:Real}
-    return intersection(P, HPolyhedron([hs]), backend=backend, use_polyhedra_interface=use_polyhedra_interface)
-end
-
-# symmetric method
-function intersection(hs::HalfSpace{N},
-                      P::HPoly{N};
-                      backend=nothing,
-                      use_polyhedra_interface=false) where {N<:Real}
-    return intersection(P, hs, backend=backend, use_polyhedra_interface=use_polyhedra_interface)
-end
-
-"""
-    intersection(P1::HPoly{N},
-                 P2::HPoly{N};
+    intersection(P1::AbstractPolyhedron{N},
+                 P2::AbstractPolyhedron{N};
                  backend=nothing,
                  use_polyhedra_interface=false) where {N<:Real}
 
-Compute the intersection of two polyhedra in H-representation.
+Compute the intersection of two polyhedra.
 
 ### Input
 
 - `P1`        -- polyhedron
 - `P2`        -- polyhedron
-- `backend`   -- (optional, default: `nothing`) the LP solver or the the
-                 polyhedral computations backend; its value is set internally,
-                 see see below in the Notes for details
+- `backend`   -- (optional, default: `nothing`) the LP solver or the backend for
+                 polyhedral computations; its value is set internally, see the
+                 Notes below for details
 - `use_polyhedra_interface` -- (optional, default: `false`) if `true`, use the
                  `Polyhedra` interface for the removal of constraints
 
 ### Output
 
-A polyhedron resulting from the intersection of `P1` and `P2`, with the redundant
-constraints removed, or an empty set if the intersection is empty.
+An `HPolyhedron` resulting from the intersection of `P1` and `P2`, with the
+redundant constraints removed, or an empty set if the intersection is empty.
+If one of the arguments is a polytope, the result is an `HPolytope` instead.
 
 ### Notes
 
 The default value of the backend is set internally and depends on whether the
 Polyhedra backend is used or not. The default backends are `GLPKSolverLP()`
-and `default_polyhedra_backend(P1, N)` respectively.
+and `default_polyhedra_backend(P1, N)`, respectively.
 
 Note that if `use_polyhedra_interface` is set to `true`, there is no guarantee
-that the removal of constraints keep the set empty (see #1038 and Polyhedra#146),
-so it is better to check for emptiness of intersection before using this function
-in that case.
+that the removal of constraints keep the set empty (see #1038 and
+Polyhedra#146), so it is better to check for emptiness of intersection before
+using this function in that case.
 
-The method implemented in this function can be used for any pair of sets that can
-handle the `constraints_list` option.
+### Algorithm
+
+This implementation unifies the constraints of the two sets obtained from the
+`constraints_list` method.
 """
-function intersection(P1::HPoly{N},
-                      P2::HPoly{N};
+function intersection(P1::AbstractPolyhedron{N},
+                      P2::AbstractPolyhedron{N};
                       backend=nothing,
                       use_polyhedra_interface=false) where {N<:Real}
-    if typeof(P1) == typeof(P2)
-        HPOLY = typeof(P1)
-    else
-        # one of them must be a polytope, so the intersection will be bounded
-        HPOLY = HPolytope{N}
-    end
+    HPOLY = (P1 isa AbstractPolytope || P2 isa AbstractPolytope) ?
+        HPolytope{N} : HPolyhedron{N}
 
     # concatenate the linear constraints
     Q = HPOLY([constraints_list(P1); constraints_list(P2)])
@@ -406,159 +369,52 @@ function intersection(P1::HPoly{N},
     end
 end
 
-"""
-    intersection(P1::HPoly{N},
-                 P2::VPolytope{N};
-                 backend=default_polyhedra_backend(P1, N),
-                 prunefunc=removehredundancy!) where {N<:Real}
-
-Compute the intersection of two polytopes in either H-representation or
-V-representation.
-
-### Input
-
-- `P1`        -- polytope
-- `P2`        -- polytope
-- `backend`   -- (optional, default: `default_polyhedra_backend(P1, N)`) the
-                 polyhedral computations backend, see
-                 [Polyhedra's documentation](https://juliapolyhedra.github.io/Polyhedra.jl/latest/installation.html#Getting-Libraries-1)
-                 for further information
-- `prunefunc` -- (optional, default: `removehredundancy!`) function to
-                 post-process the output of `intersect`
-
-### Output
-
-The polytope obtained by the intersection of `P1` and `P2`.
-"""
-function intersection(P1::HPoly{N},
-                      P2::VPolytope{N};
-                      backend=default_polyhedra_backend(P1, N),
-                      prunefunc=removehredundancy!) where {N<:Real}
-
-    Q1 = polyhedron(P1; backend=backend)
-    Q2 = polyhedron(P2; backend=backend)
-    Pint = Polyhedra.intersect(Q1, Q2)
-    prunefunc(Pint)
-    return convert(typeof(P1), Pint)
-end
-
-# symmetric one
-function intersection(P1::VPolytope{N},
-                      P2::HPoly{N};
-                      backend=default_polyhedra_backend(P1, N),
-                      prunefunc=removehredundancy!) where {N<:Real}
-    return intersection(P2, P1; backend=backend, prunefunc=prunefunc)
-end
-
-# missing case: VRep with VRep
-function intersection(P1::VPolytope{N},
-                      P2::VPolytope{N};
-                      backend=default_polyhedra_backend(P1, N),
-                      prunefunc=removehredundancy!) where {N<:Real}
-    Q1 = polyhedron(P1; backend=backend)
-    Q2 = polyhedron(P2; backend=backend)
-    Pint = Polyhedra.intersect(Q1, Q2)
-    prunefunc(Pint)
-    return VPolytope(Pint)
-end
-
-"""
-    intersection(P1::HPoly{N},
-                 P2::AbstractPolytope{N};
-                 backend=default_polyhedra_backend(P1, N),
-                 prunefunc=removehredundancy!) where {N<:Real}
-
-Compute the intersection of a polyhedron and a polytope.
-
-### Input
-
-- `P1`        -- polyhedron
-- `P2`        -- polytope
-- `backend`   -- (optional, default: `default_polyhedra_backend(P1, N)`) the
-                 polyhedral computations backend, see
-                 [Polyhedra's documentation](https://juliapolyhedra.github.io/Polyhedra.jl/latest/installation.html#Getting-Libraries-1)
-                 for further information
-- `prunefunc` -- (optional, default: `removehredundancy!`) function to
-                 post-process the output of `intersect`
-
-### Output
-
-The polytope in H-representation obtained by the intersection of `P1` and `P2`.
-"""
-function intersection(P1::HPoly{N},
-                      P2::AbstractPolytope{N};
-                      backend=default_polyhedra_backend(P1, N),
-                      prunefunc=removehredundancy!) where {N<:Real}
-    return intersection(P1, HPolytope(constraints_list(P2)))
-end
-
-# symmetric function
-function intersection(P1::AbstractPolytope{N},
-                      P2::HPoly{N};
-                      backend=default_polyhedra_backend(P1, N),
-                      prunefunc=removehredundancy!) where {N<:Real}
-    return intersection(P2, P1)
-end
-
 # disambiguation
 function intersection(S::AbstractSingleton{N},
-                      P::HPoly{N}
+                      P::AbstractPolyhedron{N}
                      )::Union{Singleton{N}, EmptySet{N}} where {N<:Real}
     return invoke(intersection, Tuple{typeof(S), LazySet{N}}, S, P)
 end
-function intersection(P::HPoly{N},
+function intersection(P::AbstractPolyhedron{N},
                       S::AbstractSingleton{N}
                      )::Union{Singleton{N}, EmptySet{N}} where {N<:Real}
     return invoke(intersection, Tuple{typeof(S), LazySet{N}}, S, P)
 end
 
-
 """
-    intersection(P1::S1, P2::S2) where {S1<:AbstractPolytope{N},
-                                        S2<:AbstractPolytope{N}} where {N<:Real}
+    intersection(P1::Union{VPolytope{N}, VPolygon{N}},
+                 P2::Union{VPolytope{N}, VPolygon{N}};
+                 [backend]=default_polyhedra_backend(P1, N),
+                 [prunefunc]=removevredundancy!) where {N<:Real}
 
-Compute the intersection of two polytopic sets.
+Compute the intersection of two polytopes in vertex representation.
 
 ### Input
 
-- `P1` -- polytope
-- `P2` -- another polytope
+- `P1`        -- polytope in vertex representation
+- `P2`        -- polytope in vertex representation
+- `backend`   -- (optional, default: `default_polyhedra_backend(P1, N)`) the
+                 backend for polyhedral computations
+- `prunefunc` -- (optional, default: `removevredundancy!`) function to prune
+                 the vertices of the result
 
 ### Output
 
-The polytope obtained by the intersection of `P1` and `P2`.
-Usually the V-representation is used.
-
-### Notes
-
-This fallback implementation requires `Polyhedra` to evaluate the concrete
-intersection.
-Inputs that are not of type `HPolytope` or `VPolytope` are converted to an
-`HPolytope` through the `constraints_list` function.
+A `VPolygon` if both arguments are `VPolygon`s, and a `VPolytope` otherwise.
 """
-function intersection(P1::S1, P2::S2) where {S1<:AbstractPolytope{N},
-                                             S2<:AbstractPolytope{N}} where
-                                            {N<:Real}
-    function get_polytope(P::Union{HPolytope, VPolytope})
-        return P
+function intersection(P1::Union{VPolytope{N}, VPolygon{N}},
+                      P2::Union{VPolytope{N}, VPolygon{N}};
+                      backend=default_polyhedra_backend(P1, N),
+                      prunefunc=removevredundancy!) where {N<:Real}
+    Q1 = polyhedron(convert(VPolytope, P1); backend=backend)
+    Q2 = polyhedron(convert(VPolytope, P2); backend=backend)
+    Pint = Polyhedra.intersect(Q1, Q2)
+    prunefunc(Pint)
+    res = VPolytope(Pint)
+    if P1 isa VPolygon && P2 isa VPolygon
+        return convert(VPolygon, res)
     end
-    function get_polytope(P::AbstractPolytope)
-        return HPolytope(constraints_list(P))
-    end
-    return intersection(get_polytope(P1), get_polytope(P2))
-end
-
-# disambiguation
-function intersection(S::AbstractSingleton{N},
-                      P::AbstractPolytope{N}
-                     )::Union{Singleton{N}, EmptySet{N}} where {N<:Real}
-    return invoke(intersection, Tuple{typeof(S), LazySet{N}}, S, P)
-end
-
-function intersection(P::AbstractPolytope{N},
-                      S::AbstractSingleton{N}
-                     )::Union{Singleton{N}, EmptySet{N}} where {N<:Real}
-    return invoke(intersection, Tuple{typeof(S), LazySet{N}}, S, P)
+    return res
 end
 
 """

--- a/test/unit_Polytope.jl
+++ b/test/unit_Polytope.jl
@@ -307,7 +307,7 @@ if test_suite_polyhedra
         # other polytopic sets
         p3 = VPolygon(vertices_list(p2))
         cap = intersection(p1, p3)
-        @test vertices_list(cap) == [N[1, 1]]
+        @test vertices_list(cap) ≈ [N[1, 1]]
         @static if VERSION < v"1.0" # does not work in v1.0 (see #834)
             p4 = BallInf(N[2, 2], N(1))
             cap = intersection(p1, p4)


### PR DESCRIPTION
Closes #1117.

I removed a good bunch of methods, but I think they were not helpful now that we have the `AbstractPolyhedron` interface.
I also added the concrete intersection between `VPolygon`s (in `master` this goes to `HPolytope`).