### PR TITLE
Add Julia v1.1 to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ julia:
   - 0.6
   - 0.7
   - 1.0
+  - 1.1
   #- nightly
 notifications:
   email: false


### PR DESCRIPTION
Update travis script to use Julia v1.1 in the CI.

Requires: #1126.