### PR TITLE
WIP - Revise msa

### DIFF
--- a/src/MinkowskiSum.jl
+++ b/src/MinkowskiSum.jl
@@ -640,7 +640,7 @@ end
 
 @inline function σ_helper(d::AbstractVector{N},
                           array::AbstractVector{<:LazySet}) where {N<:Real}
-    svec = zeros(N, length(d))
+    svec = similar(d)
     @inbounds for sj in array
         svec += σ(d, sj)
     end

--- a/src/MinkowskiSum.jl
+++ b/src/MinkowskiSum.jl
@@ -298,7 +298,11 @@ The support function of the Minkowski sum of sets is the sum of the support
 functions of each set. 
 """
 function ρ(d::AbstractVector{N}, msa::MinkowskiSumArray{N}) where {N<:Real}
-    return sum([ρ(d, Xi) for Xi in msa.array])
+    res = zero(N)
+    @inbounds for Xi in msa.array
+        res = res + ρ(d, Xi)::N
+    end
+    return res
 end
 
 """
@@ -635,10 +639,9 @@ end
 # ================
 
 @inline function σ_helper(d::AbstractVector{N},
-                          array::AbstractVector{<:LazySet}
-                         )::Vector{N} where {N<:Real}
+                          array::AbstractVector{<:LazySet}) where {N<:Real}
     svec = zeros(N, length(d))
-    for sj in array
+    @inbounds for sj in array
         svec += σ(d, sj)
     end
     return svec


### PR DESCRIPTION
This branch makes the support function of msa a bit faster:

```julia
julia> using LazySets, BenchmarkTools
julia> msa = MinkowskiSumArray([rand(Hyperrectangle) for _ in 1:10]);
julia>  @btime ρ(rand(2), $msa)
  638.899 ns (11 allocations: 1.03 KiB)
10.184097859097406
```

vs (master)

```julia
julia> @btime ρ(rand(2), $msa)
  722.187 ns (14 allocations: 1.23 KiB)
10.731613830299803
```

---

There is also a change in the output annotation of sigma_helper : i don't see why the output should always be a `Vector`? I made it similar to `d`.