### PR TITLE
Export ×

### DIFF
--- a/src/compat.jl
+++ b/src/compat.jl
@@ -11,6 +11,7 @@ import Compat.LinearAlgebra: norm, checksquare, LAPACKException,
                              SingularException, ×, cond
 import Compat.InteractiveUtils.subtypes
 export _At_mul_B
+export ×
 
 @static if VERSION < v"0.7-"
     using Compat.Random


### PR DESCRIPTION
See #1147.

Interestingly, the tests worked, but they actively load `compat.jl`.
I do not know why the `import` does not automatically `export` (usually it does). Maybe an issue with `Compat`?