### PR TITLE
#1170 - Faster hyperrectangular overapproximation of the linear map of a hyperrectangular set

### DIFF
--- a/src/Approximations/overapproximate.jl
+++ b/src/Approximations/overapproximate.jl
@@ -116,6 +116,37 @@ function overapproximate(S::CartesianProductArray{N, <:AbstractHyperrectangle{N}
 end
 
 """
+    overapproximate(lm::LinearMap{N, <:AbstractHyperrectangle{N}},
+                    ::Type{Hyperrectangle}) where {N}
+
+Return a tight overapproximation of the linear map of a hyperrectangular set
+using a hyperrectangle.
+
+### Input
+
+- `S`              -- linear map of a hyperrectangular set
+- `Hyperrectangle` -- type for dispatch
+
+### Output
+
+A hyperrectangle.
+
+### Algorithm
+
+If `c` and `r` denote the center and vector radius of a hyperrectangle `H`,
+a tight hyperrectangular overapproximation of `M * H` is obtained by transforming
+`c ↦ M*c` and `r ↦ abs.(⋅) * c`, where `abs.(⋅)` denotes the element-wise absolute
+value operator. 
+"""
+function overapproximate(lm::LinearMap{N, <:AbstractHyperrectangle{N}},
+                         ::Type{Hyperrectangle}) where {N<:Real}
+    M, X = lm.M, lm.X
+    center_MX = M * center(X)
+    radius_MX = abs.(M) * radius_hyperrectangle(X)
+    return Hyperrectangle(center_MX, radius_MX)
+end
+
+"""
     overapproximate(S::LazySet)::Union{Hyperrectangle, EmptySet}
 
 Alias for `overapproximate(S, Hyperrectangle)`.
@@ -413,3 +444,4 @@ function overapproximate(cap::Intersection{N,
                         ) where {N<:Real}
     return overapproximate(swap(cap), dir; kwargs...)
 end
+

--- a/src/Approximations/overapproximate.jl
+++ b/src/Approximations/overapproximate.jl
@@ -135,7 +135,7 @@ A hyperrectangle.
 
 If `c` and `r` denote the center and vector radius of a hyperrectangle `H`,
 a tight hyperrectangular overapproximation of `M * H` is obtained by transforming
-`c ↦ M*c` and `r ↦ abs.(⋅) * c`, where `abs.(⋅)` denotes the element-wise absolute
+`c ↦ M*c` and `r ↦ abs.(M) * c`, where `abs.(⋅)` denotes the element-wise absolute
 value operator. 
 """
 function overapproximate(lm::LinearMap{N, <:AbstractHyperrectangle{N}},

--- a/test/unit_overapproximate.jl
+++ b/test/unit_overapproximate.jl
@@ -43,6 +43,12 @@ for N in [Float64, Rational{Int}, Float32]
     Zoa = overapproximate(Z, Hyperrectangle) # faster o.a.
     Zba = box_approximation(Z) # default o.a. implementation that uses supp function
     @test Zoa.center ≈ Zba.center && Zoa.radius ≈ Zba.radius
+
+    # overapproximation of the lazy linear map of a hyperrectangular set
+    H = Hyperrectangle(N[0, 0], N[1/2, 1])
+    M = Diagonal(N[2, 2])
+    OA = overapproximate(M*H, Hyperrectangle)
+    @test OA isa Hyperrectangle && OA.center == N[0, 0] && OA.radius == N[1, 2]
 end
 
 # tests that do not work with Rational{Int}


### PR DESCRIPTION
Closes #1170.

---

For a comparison with the fallback implementation using support functions see [this notebook](https://github.com/mforets/escritoire/blob/master/sets/HyperrectangleApproxOfLinearMap.ipynb).

For a randomly generated `M*H` of dimension 10, the speedup is around 10x.