### PR TITLE
#1220 - Convert cartesian product of two hyperrectangles

### DIFF
--- a/docs/src/lib/conversion.md
+++ b/docs/src/lib/conversion.md
@@ -41,6 +41,6 @@ convert(::Type{IntervalArithmetic.IntervalBox}, ::AbstractHyperrectangle)
 convert(::Type{Hyperrectangle}, ::IntervalArithmetic.IntervalBox)
 convert(::Type{Zonotope}, ::CartesianProduct{N, Zonotope{N}, Zonotope{N}}) where {N<:Real}
 convert(::Type{Hyperrectangle}, ::CartesianProduct{N, HN1, HN2}) where {N<:Real, HN1<:AbstractHyperrectangle{N}, HN2<:AbstractHyperrectangle{N}}
-convert(::Type{Zonotope}, ::CartesianProduct{N, HN1, HN2) where {N<:Real, HN1<:AbstractHyperrectangle{N}, HN2<:AbstractHyperrectangle{N}}
+convert(::Type{Zonotope}, ::CartesianProduct{N, HN1, HN2}) where {N<:Real, HN1<:AbstractHyperrectangle{N}, HN2<:AbstractHyperrectangle{N}}
 convert(::Type{Zonotope}, ::CartesianProductArray{N, HN}) where {N<:Real, HN<:AbstractHyperrectangle{N}}
 ```

--- a/docs/src/lib/conversion.md
+++ b/docs/src/lib/conversion.md
@@ -40,4 +40,5 @@ convert(::Type{Zonotope}, ::AbstractHyperrectangle)
 convert(::Type{IntervalArithmetic.IntervalBox}, ::AbstractHyperrectangle)
 convert(::Type{Hyperrectangle}, ::IntervalArithmetic.IntervalBox)
 convert(::Type{Zonotope}, ::CartesianProduct{N, Zonotope{N}, Zonotope{N}}) where {N<:Real}
+convert(::Type{Hyperrectangle}, ::CartesianProduct{N, HN1, HN2}) where {N<:Real, HN1<:AbstractHyperrectangle{N}, HN2<:AbstractHyperrectangle{N}}
 ```

--- a/docs/src/lib/conversion.md
+++ b/docs/src/lib/conversion.md
@@ -41,4 +41,6 @@ convert(::Type{IntervalArithmetic.IntervalBox}, ::AbstractHyperrectangle)
 convert(::Type{Hyperrectangle}, ::IntervalArithmetic.IntervalBox)
 convert(::Type{Zonotope}, ::CartesianProduct{N, Zonotope{N}, Zonotope{N}}) where {N<:Real}
 convert(::Type{Hyperrectangle}, ::CartesianProduct{N, HN1, HN2}) where {N<:Real, HN1<:AbstractHyperrectangle{N}, HN2<:AbstractHyperrectangle{N}}
+convert(::Type{Zonotope}, ::CartesianProduct{N, HN1, HN2) where {N<:Real, HN1<:AbstractHyperrectangle{N}, HN2<:AbstractHyperrectangle{N}}
+convert(::Type{Zonotope}, ::CartesianProductArray{N, HN}) where {N<:Real, HN<:AbstractHyperrectangle{N}}
 ```

--- a/src/Approximations/overapproximate.jl
+++ b/src/Approximations/overapproximate.jl
@@ -116,7 +116,7 @@ end
                     ::Type{<:Hyperrectangle}) where {N<:Real}
 
 Return a tight overapproximation of the cartesian product of two
-hyperrectangles with one hyperrectangle.
+hyperrectangles by a new hyperrectangle.
 
 ### Input
 

--- a/src/Approximations/overapproximate.jl
+++ b/src/Approximations/overapproximate.jl
@@ -115,7 +115,7 @@ end
     overapproximate(S::CartesianProduct{N, <:AbstractHyperrectangle{N}, <:AbstractHyperrectangle{N}},
                     ::Type{<:Hyperrectangle}) where {N<:Real}
 
-Return a tight overapproximation of the cartesian product array of two
+Return a tight overapproximation of the cartesian product of two
 hyperrectangles with one hyperrectangle.
 
 ### Input

--- a/src/Approximations/overapproximate.jl
+++ b/src/Approximations/overapproximate.jl
@@ -112,6 +112,33 @@ function overapproximate(S::CartesianProductArray{N, <:AbstractHyperrectangle{N}
 end
 
 """
+    overapproximate(S::CartesianProduct{N, <:AbstractHyperrectangle{N}, <:AbstractHyperrectangle{N}},
+                    ::Type{<:Hyperrectangle}) where {N<:Real}
+
+Return a tight overapproximation of the cartesian product array of two
+hyperrectangles with one hyperrectangle.
+
+### Input
+
+- `S`              -- cartesian product of two hyperrectangular sets
+- `Hyperrectangle` -- type for dispatch
+
+### Output
+
+A hyperrectangle.
+
+### Algorithm
+
+This method falls back to the corresponding `convert` method. Since the sets wrapped
+by the cartesian product are hyperrectangles, it can be done efficiently
+without overapproximation.
+"""
+function overapproximate(S::CartesianProduct{N, <:AbstractHyperrectangle{N}, <:AbstractHyperrectangle{N}},
+                          ::Type{<:Hyperrectangle}) where {N<:Real}
+    return convert(Hyperrectangle, S)
+end
+
+"""
     overapproximate(lm::LinearMap{N, <:AbstractHyperrectangle{N}},
                     ::Type{Hyperrectangle}) where {N}
 

--- a/src/convert.jl
+++ b/src/convert.jl
@@ -269,7 +269,7 @@ Converts the cartesian product of two hyperrectangular sets to a zonotope.
 ### Output
 
 This method falls back to the conversion of the cartesian product to a single
-hyperrectnagle, and then from a hyperrectangle to a zonotope.
+hyperrectangle, and then from a hyperrectangle to a zonotope.
 """
 function convert(::Type{Zonotope}, cp::CartesianProduct{N, <:AbstractHyperrectangle{N}, <:AbstractHyperrectangle{N}}) where {N<:Real}
     return convert(Zonotope, convert(Hyperrectangle, cp))

--- a/src/convert.jl
+++ b/src/convert.jl
@@ -292,7 +292,7 @@ A zonotope.
 ### Algorithm
 
 This method falls back to the conversion of the cartesian product to a single
-hyperrectnagle, and then from a hyperrectangle to a zonotope.
+hyperrectangle, and then from a hyperrectangle to a zonotope.
 """
 function convert(::Type{Zonotope}, cpa::CartesianProductArray{N, <:AbstractHyperrectangle{N}}) where {N<:Real}
     return convert(Zonotope, convert(Hyperrectangle, cpa))

--- a/src/convert.jl
+++ b/src/convert.jl
@@ -256,12 +256,46 @@ function convert(::Type{Zonotope}, H::AbstractHyperrectangle)
     return Zonotope(center(H), Diagonal(radius_hyperrectangle(H)))
 end
 
+"""
+    convert(::Type{Zonotope}, cp::CartesianProduct{N, <:AbstractHyperrectangle{N}, <:AbstractHyperrectangle{N}}) where {N<:Real}
+
+Converts the cartesian product of two hyperrectangular sets to a zonotope.
+
+### Input
+
+- `Zonotope` -- type, used for dispatch
+- `cp`       -- cartesian product of two hyperrectangular sets
+
+### Output
+
+This method falls back to the conversion of the cartesian product to a single
+hyperrectnagle, and then from a hyperrectangle to a zonotope.
+"""
 function convert(::Type{Zonotope}, cp::CartesianProduct{N, <:AbstractHyperrectangle{N}, <:AbstractHyperrectangle{N}}) where {N<:Real}
     return convert(Zonotope, convert(Hyperrectangle, cp))
 end
 
-function convert(::Type{Zonotope}, cp::CartesianProductArray{N, <:AbstractHyperrectangle{N}}) where {N<:Real}
-    return convert(Zonotope, convert(Hyperrectangle, cp))
+"""
+    convert(::Type{Zonotope}, ca::CartesianProductArray{N, <:AbstractHyperrectangle{N}}) where {N<:Real}
+
+Converts the cartesian product array of hyperrectangular sets to a zonotope.
+
+### Input
+
+- `Zonotope` -- type, used for dispatch
+- `cpa`      -- cartesian product array of hyperrectangular sets
+
+### Output
+
+A zonotope.
+
+### Algorithm
+
+This method falls back to the conversion of the cartesian product to a single
+hyperrectnagle, and then from a hyperrectangle to a zonotope.
+"""
+function convert(::Type{Zonotope}, cpa::CartesianProductArray{N, <:AbstractHyperrectangle{N}}) where {N<:Real}
+    return convert(Zonotope, convert(Hyperrectangle, cpa))
 end
 
 """

--- a/src/convert.jl
+++ b/src/convert.jl
@@ -257,7 +257,8 @@ function convert(::Type{Zonotope}, H::AbstractHyperrectangle)
 end
 
 """
-    convert(::Type{Zonotope}, cp::CartesianProduct{N, <:AbstractHyperrectangle{N}, <:AbstractHyperrectangle{N}}) where {N<:Real}
+    convert(::Type{Zonotope}, cp::CartesianProduct{N, HN1, HN2}) where {N<:Real,
+        HN1<:AbstractHyperrectangle{N}, HN2<:AbstractHyperrectangle{N}}
 
 Converts the cartesian product of two hyperrectangular sets to a zonotope.
 
@@ -271,12 +272,15 @@ Converts the cartesian product of two hyperrectangular sets to a zonotope.
 This method falls back to the conversion of the cartesian product to a single
 hyperrectangle, and then from a hyperrectangle to a zonotope.
 """
-function convert(::Type{Zonotope}, cp::CartesianProduct{N, <:AbstractHyperrectangle{N}, <:AbstractHyperrectangle{N}}) where {N<:Real}
+function convert(::Type{Zonotope}, cp::CartesianProduct{N, HN1, HN2}
+                ) where {N<:Real, HN1<:AbstractHyperrectangle{N},
+                         HN2<:AbstractHyperrectangle{N}}
     return convert(Zonotope, convert(Hyperrectangle, cp))
 end
 
 """
-    convert(::Type{Zonotope}, ca::CartesianProductArray{N, <:AbstractHyperrectangle{N}}) where {N<:Real}
+    convert(::Type{Zonotope}, cpa::CartesianProductArray{N, HN})
+        where {N<:Real, HN<:AbstractHyperrectangle{N}}
 
 Converts the cartesian product array of hyperrectangular sets to a zonotope.
 
@@ -294,7 +298,8 @@ A zonotope.
 This method falls back to the conversion of the cartesian product to a single
 hyperrectangle, and then from a hyperrectangle to a zonotope.
 """
-function convert(::Type{Zonotope}, cpa::CartesianProductArray{N, <:AbstractHyperrectangle{N}}) where {N<:Real}
+function convert(::Type{Zonotope}, cpa::CartesianProductArray{N, HN}
+                ) where {N<:Real, HN<:AbstractHyperrectangle{N}}
     return convert(Zonotope, convert(Hyperrectangle, cpa))
 end
 

--- a/src/convert.jl
+++ b/src/convert.jl
@@ -256,6 +256,14 @@ function convert(::Type{Zonotope}, H::AbstractHyperrectangle)
     return Zonotope(center(H), Diagonal(radius_hyperrectangle(H)))
 end
 
+function convert(::Type{Zonotope}, cp::CartesianProduct{N, <:AbstractHyperrectangle{N}, <:AbstractHyperrectangle{N}}) where {N<:Real}
+    return convert(Zonotope, convert(Hyperrectangle, cp))
+end
+
+function convert(::Type{Zonotope}, cp::CartesianProductArray{N, <:AbstractHyperrectangle{N}}) where {N<:Real}
+    return convert(Zonotope, convert(Hyperrectangle, cp))
+end
+
 """
     convert(::Type{HPOLYGON}, S::AbstractSingleton{N}
            ) where {N<:Real, HPOLYGON<:AbstractHPolygon}
@@ -418,6 +426,35 @@ function convert(::Type{Hyperrectangle},
          r[i:j] = radius_hyperrectangle(block_set)
          i = j + 1
      end
+     return Hyperrectangle(c, r)
+end
+
+"""
+    convert(::Type{Hyperrectangle},
+            cp::CartesianProduct{N, HN1, HN2}) where {N<:Real, HN1<:AbstractHyperrectangle{N}, HN2<:AbstractHyperrectangle{N}}
+
+Converts the cartesian product of two hyperrectangular sets to a single hyperrectangle.
+
+### Input
+
+- `Hyperrectangle` -- type used for dispatch
+- `S`              -- cartesian product of two hyperrectangular sets
+
+### Output
+
+A hyperrectangle.
+
+### Algorithm
+
+The result is obtained by concatenating the center and radius of each hyperrectangle.
+This implementation uses the `center` and `radius_hyperrectangle` methods of
+`AbstractHyperrectangle`.
+"""
+function convert(::Type{Hyperrectangle},
+                 cp::CartesianProduct{N, HN1, HN2}) where {N<:Real, HN1<:AbstractHyperrectangle{N}, HN2<:AbstractHyperrectangle{N}}
+     X, Y = cp.X, cp.Y
+     c = vcat(center(X), center(Y))
+     r = vcat(radius_hyperrectangle(X), radius_hyperrectangle(Y))
      return Hyperrectangle(c, r)
 end
 

--- a/test/unit_CartesianProduct.jl
+++ b/test/unit_CartesianProduct.jl
@@ -129,6 +129,12 @@ for N in [Float64, Float32, Rational{Int}]
         LinearConstraint(sparsevec(N[2], N[-1], 2), N(-2))])
     @test all(H -> dim(H) == 2, hlist)
 
+    # convert the cartesian product of two hyperrectangles to one hyperrectangle
+    h1 = Hyperrectangle(N[1/2],  N[1/2])
+    h2 = Hyperrectangle(N[2.5, 4.5],  N[1/2, 1/2])
+    H = convert(Hyperrectangle, h1 × h2)
+    @test low(H) == N[0, 2, 4] && high(H) == N[1, 3, 5]
+
     # =====================
     # CartesianProductArray
     # =====================

--- a/test/unit_CartesianProduct.jl
+++ b/test/unit_CartesianProduct.jl
@@ -135,6 +135,12 @@ for N in [Float64, Float32, Rational{Int}]
     H = convert(Hyperrectangle, h1 × h2)
     @test low(H) == N[0, 2, 4] && high(H) == N[1, 3, 5]
 
+    # make one of the sets a BallInf, to test that the conversion does
+    # not depend on the Hyperrectangle type
+    b1 = BallInf(N[1/2],  N(1/2))
+    H = convert(Hyperrectangle, b1 × h2)
+    @test low(H) == N[0, 2, 4] && high(H) == N[1, 3, 5]
+
     # =====================
     # CartesianProductArray
     # =====================

--- a/test/unit_Zonotope.jl
+++ b/test/unit_Zonotope.jl
@@ -101,6 +101,17 @@ for N in [Float64, Rational{Int}, Float32]
     @test Z.center == N[2, 3] && diag(Z.generators) == N[4, 5]
     convert(Zonotope, BallInf(N[5, 3], N(2)))
 
+    # convert the cartesian product of two hyperrectangles to a zonotope
+    h1 = Hyperrectangle(N[1/2],  N[1/2])
+    h2 = Hyperrectangle(N[2.5, 4.5],  N[1/2, 1/2])
+    H = convert(Hyperrectangle, h1 × h2)
+    Z = convert(Zonotope, h1 × h2)
+    @test Z ⊆ H && H ⊆ Z
+
+    # same for CartesianProductArray
+    Z2 = convert(Zonotope, CartesianProductArray([h1, h2]))
+    @test Z == Z2
+
     # split a zonotope
     Z = Zonotope(N[0, 0], N[1 1; -1 1])
     Z1, Z2 = split(Z, 1) # in this case the splitting is exact

--- a/test/unit_overapproximate.jl
+++ b/test/unit_overapproximate.jl
@@ -42,6 +42,12 @@ for N in [Float64, Rational{Int}, Float32]
     Zba = box_approximation(Z) # default o.a. implementation that uses supp function
     @test Zoa.center ≈ Zba.center && Zoa.radius ≈ Zba.radius
 
+    # same but using cartesian product
+    h1 = Hyperrectangle(N[1/2],  N[1/2])
+    h2 = Hyperrectangle(N[2.5, 4.5],  N[1/2, 1/2])
+    H = overapproximate(h1 × h2, Hyperrectangle) # defaults to convert method
+    @test low(H) == N[0, 2, 4] && high(H) == N[1, 3, 5]
+    
     # overapproximation of the lazy linear map of a hyperrectangular set
     H = Hyperrectangle(N[0, 0], N[1/2, 1])
     M = Diagonal(N[2, 2])


### PR DESCRIPTION
Closes #1220.

Convert cartesian product of two hyperrectangles to a single hyperrectangle or to a single zonotope.