### PR TITLE
#1252 - Add mesh.jl file

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -28,6 +28,7 @@ GLPKMathProgInterface = "≥ 0.4.0"
 GR = "≥ 0.39.1"
 IntervalArithmetic = "≥ 0.14.0"
 JuMP = "≥ 0.19.2"
+Makie = "≥ 0.9.4"
 MathProgBase = "≥ 0.7.0"
 Optim = "≥ 0.14.1"
 Plots = "≥ 0.25.1"
@@ -44,6 +45,7 @@ Expokit = "a1e7a1ef-7a5d-5822-a38c-be74e1bb89f4"
 GLPK = "60bf3e95-4087-53dc-ae20-288a0d20c6a6"
 GR = "28b8d3ca-fb5f-59d9-8090-bfdbd6d07a71"
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
+Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
 Optim = "429524aa-4258-5aef-a3af-852621145aeb"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 Polyhedra = "67491407-f73d-577b-9b50-8179a7c68029"
@@ -51,5 +53,5 @@ TaylorModels = "314ce334-5f6e-57ae-acf6-00b6e903104a"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["CDDLib", "Distributions", "Documenter", "Expokit", "GLPK", "GR", "JuMP", "Optim", "Plots", "Polyhedra",
-        "TaylorModels", "Test"]
+test = ["CDDLib", "Distributions", "Documenter", "Expokit", "GLPK", "GR", "JuMP",
+        "Makie", "Optim", "Plots", "Polyhedra", "TaylorModels", "Test"]

--- a/src/LazySets.jl
+++ b/src/LazySets.jl
@@ -26,6 +26,7 @@ include("helper_functions.jl")
 include("comparisons.jl")
 include("macros.jl")
 include("samples.jl")
+include("mesh.jl")
 
 # ==================
 # Abstract set types

--- a/src/init.jl
+++ b/src/init.jl
@@ -3,6 +3,7 @@ function __init__()
     @require Optim = "429524aa-4258-5aef-a3af-852621145aeb" load_optim()
     @require Polyhedra = "67491407-f73d-577b-9b50-8179a7c68029" load_polyhedra()
     @require Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f" load_distributions()
+    @require Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a" load_makie()
 end
 
 function load_expokit()
@@ -24,6 +25,10 @@ end
 
 function load_distributions()
     eval(load_distributions_samples())
+end
+
+function load_makie()
+    eval(load_mesh())
 end
 
 """

--- a/src/init.jl
+++ b/src/init.jl
@@ -21,6 +21,7 @@ function load_polyhedra()
     eval(load_polyhedra_hpolytope())
     eval(load_polyhedra_hpolyhedron())
     eval(load_polyhedra_vpolytope())
+    initialize_mesh()
 end
 
 function load_distributions()
@@ -28,7 +29,15 @@ function load_distributions()
 end
 
 function load_makie()
-    eval(load_mesh())
+    initialize_mesh()
+end
+
+function initialize_mesh()
+    if isdefined(@__MODULE__, :Polyhedra) &&
+       isdefined(@__MODULE__, :Makie)
+
+       eval(load_mesh())
+    end
 end
 
 """

--- a/src/mesh.jl
+++ b/src/mesh.jl
@@ -1,0 +1,78 @@
+#using .LazySets
+#using .LazySets.Approximations
+#using LazySets: default_polyhedra_backend, dim # needed?
+
+using Makie: mesh, mesh!
+using AbstractPlotting: Automatic
+using Polyhedra: Mesh
+
+export plot3d
+#import Plots: plot3d
+
+function plot3d(S::LazySet{N}, num_dirs=10; backend=default_polyhedra_backend(S, N),
+                alpha=1.0, color=:blue, colormap=:viridis, colorrange=Automatic(), interpolate=false,
+                linewidth=1, overdraw=false, shading=true, transparency=true, visible=true) where {N}
+
+    if dim(S) != 3
+        throw(ArgumentError("plot3d can only be used to plot 3D sets, but the given set is $(dim(S))-dimensional"))
+    end
+    
+    if !applicable(constraints_list, S)
+        throw(ArgumentError("the `constraints_list` function is not applicable to a set of type $S, hence plot3d cannot be used"))
+    end
+
+    P = overapproximate(S, SphericalDirections(num_dirs))
+    remove_redundant_constraints!(P)
+    return plot3d(P, backend=backend, alpha=alpha, color=color, colormap=colormap, colorrange=colorrange,
+                     interpolate=interpolate, linewidth=linewidth, transparency=transparency, visible=visible)
+end
+
+function plot3d(S::AbstractPolytope{N}; backend=default_polyhedra_backend(S, N),
+                alpha=1.0, color=:blue, colormap=:viridis, colorrange=Automatic(), interpolate=false,
+                linewidth=1, overdraw=false, shading=true, transparency=true, visible=true) where {N}
+
+    if dim(S) != 3
+        throw(ArgumentError("plot3d can only be used to plot 3D sets, but the given set is $(dim(S))-dimensional"))
+    end
+
+    P = convert(HPolytope, S)
+    P_poly = polyhedron(P, backend=backend)
+    P_poly_mesh = Mesh(P_poly)
+
+    mesh(P_poly_mesh, alpha=alpha, color=color, colormap=colormap, colorrange=colorrange,
+                      interpolate=interpolate, linewidth=linewidth, transparency=transparency, visible=visible)
+end
+
+function plot3d!(S::LazySet{N}, num_dirs=10; backend=default_polyhedra_backend(S, N),
+                alpha=1.0, color=:blue, colormap=:viridis, colorrange=Automatic(), interpolate=false,
+                linewidth=1, overdraw=false, shading=true, transparency=true, visible=true) where {N}
+
+    if dim(S) != 3
+        throw(ArgumentError("plot3d can only be used to plot 3D sets, but the given set is $(dim(S))-dimensional"))
+    end
+    
+    if !applicable(constraints_list, S)
+        throw(ArgumentError("the `constraints_list` function is not applicable to a set of type $S, hence plot3d cannot be used"))
+    end
+
+    P = overapproximate(S, SphericalDirections(num_dirs))
+    remove_redundant_constraints!(P)
+    return plot3d!(P, backend=backend, alpha=alpha, color=color, colormap=colormap, colorrange=colorrange,
+                     interpolate=interpolate, linewidth=linewidth, transparency=transparency, visible=visible)
+end
+
+function plot3d!(S::AbstractPolytope{N}; backend=default_polyhedra_backend(S, N),
+                alpha=1.0, color=:blue, colormap=:viridis, colorrange=Automatic(), interpolate=false,
+                linewidth=1, overdraw=false, shading=true, transparency=true, visible=true) where {N}
+
+    if dim(S) != 3
+        throw(ArgumentError("plot3d can only be used to plot 3D sets, but the given set is $(dim(S))-dimensional"))
+    end
+
+    P = convert(HPolytope, S)
+    P_poly = polyhedron(P, backend=backend)
+    P_poly_mesh = Mesh(P_poly)
+
+    mesh!(P_poly_mesh, alpha=alpha, color=color, colormap=colormap, colorrange=colorrange,
+                      interpolate=interpolate, linewidth=linewidth, transparency=transparency, visible=visible)
+end

--- a/src/mesh.jl
+++ b/src/mesh.jl
@@ -24,8 +24,9 @@ end
 
 """
     plot3d(S::LazySet{N}; backend=default_polyhedra_backend(S, N),
-           alpha=1.0, color=:blue, colormap=:viridis, colorrange=Automatic(), interpolate=false,
-           linewidth=1, overdraw=false, shading=true, transparency=true, visible=true) where {N}
+           alpha=1.0, color=:blue, colormap=:viridis, colorrange=Automatic(),
+           interpolate=false, linewidth=1, overdraw=false, shading=true,
+           transparency=true, visible=true) where {N}
 
 Plot a three-dimensional convex set using Makie.
 
@@ -44,17 +45,17 @@ Plot a three-dimensional convex set using Makie.
                     and it can also be used as `[:red, :black]`
 - `colorrange`   -- (optional, default: `Automatic()`) a tuple `(min, max)` where
                     `min` and `max` specify the data range to be used for indexing
-                    the colormap, e.g. `color = [-2, 4]` with `colorrange = (-2, 4)`
-                    will map to the lowest and highest color value of the colormap
+                    the colormap
 - `interpolate`  -- (optional, default: `false`) a bool for heatmap and images,
                     it toggles color interpolation between nearby pixels
 - `linewidth`    -- (optional, default: `1`) a number that specifies the width of
                     the line in `line` and `linesegments` plots
 - `overdraw`     -- (optional, default: `false`)
-- `shading`      -- (optional, default: `false`) a boolean that specifies if shading
+- `shading`      -- (optional, default: `true`) a boolean that specifies if shading
                     should be on or not (for meshes)
-- `transparency` -- (optional, default: `false`)
-- `visible`      -- (optional, default: `false`) a bool that toggles visibility
+- `transparency` -- (optional, default: `true`) if `true`, the set is transparent
+                    otherwise it is displayed as a solid object
+- `visible`      -- (optional, default: `true`) a bool that toggles visibility
                     of the plot
 
 For a complete list of attributes and usage see
@@ -89,7 +90,7 @@ julia> plot3d(Sapprox, backend=CDDLib.Library())
 
 ### Examples
 
-The functionality in this files requires *both* `Polyhedra` and `Makie`; so after
+The functionality requires *both* `Polyhedra` and `Makie`; so after
 loading `LazySets`, do `using Makie, Polyhedra` (or `using Polyhedra, Makie`, the
 order doesn't matter).
 
@@ -119,34 +120,8 @@ Plot a three-dimensional convex set using Makie.
 
 ### Input
 
-- `S`            -- convex set
-- `backend`      -- (optional, default: `default_polyhedra_backend(S, N)`) polyhedral
-                    computations backend 
-- `alpha`        -- (optional, default: `1.0`) float in `[0,1]`; the alpha or
-                    transparency value
-- `color`        -- (optional, default: `:blue`) `Symbol` or `Colorant`; the color
-                    of the main plot element (markers, lines, etc.) and it can be
-                    a color symbol/string like `:red`
-- `colormap`     -- (optional, default: `:viridis`) the color map of the main plot;
-                    call `available_gradients()` to see what gradients are available,
-                    and it can also be used as `[:red, :black]`
-- `colorrange`   -- (optional, default: `Automatic()`) a tuple `(min, max)` where
-                    `min` and `max` specify the data range to be used for indexing
-                    the colormap, e.g. `color = [-2, 4]` with `colorrange = (-2, 4)`
-                    will map to the lowest and highest color value of the colormap
-- `interpolate`  -- (optional, default: `false`) a bool for heatmap and images,
-                    it toggles color interpolation between nearby pixels
-- `linewidth`    -- (optional, default: `1`) a number that specifies the width of
-                    the line in `line` and `linesegments` plots
-- `overdraw`     -- (optional, default: `false`)
-- `shading`      -- (optional, default: `false`) a boolean that specifies if shading
-                    should be on or not (for meshes)
-- `transparency` -- (optional, default: `false`)
-- `visible`      -- (optional, default: `false`) a bool that toggles visibility
-                    of the plot
-
-For a complete list of attributes and usage see
-[Makie's documentation](http://makie.juliaplots.org/stable/plot-attributes.html).
+See `plot3d` for the description of the inputs. For a complete list of attributes
+and usage see [Makie's documentation](http://makie.juliaplots.org/stable/plot-attributes.html).
 
 ### Notes
 

--- a/src/mesh.jl
+++ b/src/mesh.jl
@@ -1,78 +1,43 @@
-#using .LazySets
-#using .LazySets.Approximations
-#using LazySets: default_polyhedra_backend, dim # needed?
+function load_mesh()
+return quote
 
-using Makie: mesh, mesh!
-using AbstractPlotting: Automatic
-using Polyhedra: Mesh
+using .Polyhedra: Mesh
+using .Makie: mesh, mesh!
+import .Makie.AbstractPlotting: Automatic
 
-export plot3d
-#import Plots: plot3d
+export plot3d, plot3d!
 
-function plot3d(S::LazySet{N}, num_dirs=10; backend=default_polyhedra_backend(S, N),
-                alpha=1.0, color=:blue, colormap=:viridis, colorrange=Automatic(), interpolate=false,
-                linewidth=1, overdraw=false, shading=true, transparency=true, visible=true) where {N}
+function plot3d_helper(S::LazySet{N}, backend) where {N}
+    @assert dim(S) <= 3 "plot3d can only be used to plot sets of dimension three (or lower); " *
+        "but the given set is $(dim(S))-dimensional"
 
-    if dim(S) != 3
-        throw(ArgumentError("plot3d can only be used to plot 3D sets, but the given set is $(dim(S))-dimensional"))
-    end
-    
-    if !applicable(constraints_list, S)
-        throw(ArgumentError("the `constraints_list` function is not applicable to a set of type $S, hence plot3d cannot be used"))
-    end
+    @assert applicable(constraints_list, S) "plot3d requires that the list of constraints of `S`, " *
+        "`constraints_list(S)` is applicable; try overapproximating with an `HPolytope` first"
 
-    P = overapproximate(S, SphericalDirections(num_dirs))
+    P = HPolytope(constraints_list(S))
     remove_redundant_constraints!(P)
-    return plot3d(P, backend=backend, alpha=alpha, color=color, colormap=colormap, colorrange=colorrange,
-                     interpolate=interpolate, linewidth=linewidth, transparency=transparency, visible=visible)
-end
-
-function plot3d(S::AbstractPolytope{N}; backend=default_polyhedra_backend(S, N),
-                alpha=1.0, color=:blue, colormap=:viridis, colorrange=Automatic(), interpolate=false,
-                linewidth=1, overdraw=false, shading=true, transparency=true, visible=true) where {N}
-
-    if dim(S) != 3
-        throw(ArgumentError("plot3d can only be used to plot 3D sets, but the given set is $(dim(S))-dimensional"))
-    end
-
-    P = convert(HPolytope, S)
     P_poly = polyhedron(P, backend=backend)
     P_poly_mesh = Mesh(P_poly)
-
-    mesh(P_poly_mesh, alpha=alpha, color=color, colormap=colormap, colorrange=colorrange,
-                      interpolate=interpolate, linewidth=linewidth, transparency=transparency, visible=visible)
+    return P_poly_mesh
 end
 
-function plot3d!(S::LazySet{N}, num_dirs=10; backend=default_polyhedra_backend(S, N),
+function plot3d(S::LazySet{N}; backend=default_polyhedra_backend(S, N),
                 alpha=1.0, color=:blue, colormap=:viridis, colorrange=Automatic(), interpolate=false,
                 linewidth=1, overdraw=false, shading=true, transparency=true, visible=true) where {N}
 
-    if dim(S) != 3
-        throw(ArgumentError("plot3d can only be used to plot 3D sets, but the given set is $(dim(S))-dimensional"))
-    end
-    
-    if !applicable(constraints_list, S)
-        throw(ArgumentError("the `constraints_list` function is not applicable to a set of type $S, hence plot3d cannot be used"))
-    end
-
-    P = overapproximate(S, SphericalDirections(num_dirs))
-    remove_redundant_constraints!(P)
-    return plot3d!(P, backend=backend, alpha=alpha, color=color, colormap=colormap, colorrange=colorrange,
-                     interpolate=interpolate, linewidth=linewidth, transparency=transparency, visible=visible)
+    P_poly_mesh = plot3d_helper(S, backend)
+    return mesh(P_poly_mesh, alpha=alpha, color=color, colormap=colormap, colorrange=colorrange,
+                interpolate=interpolate, linewidth=linewidth, transparency=transparency, visible=visible)
 end
 
-function plot3d!(S::AbstractPolytope{N}; backend=default_polyhedra_backend(S, N),
+function plot3d!(S::LazySet{N}; backend=default_polyhedra_backend(S, N),
                 alpha=1.0, color=:blue, colormap=:viridis, colorrange=Automatic(), interpolate=false,
                 linewidth=1, overdraw=false, shading=true, transparency=true, visible=true) where {N}
 
-    if dim(S) != 3
-        throw(ArgumentError("plot3d can only be used to plot 3D sets, but the given set is $(dim(S))-dimensional"))
-    end
-
-    P = convert(HPolytope, S)
-    P_poly = polyhedron(P, backend=backend)
-    P_poly_mesh = Mesh(P_poly)
-
-    mesh!(P_poly_mesh, alpha=alpha, color=color, colormap=colormap, colorrange=colorrange,
-                      interpolate=interpolate, linewidth=linewidth, transparency=transparency, visible=visible)
+    P_poly_mesh = plot3d_helper(S, backend)
+    return mesh!(P_poly_mesh, alpha=alpha, color=color, colormap=colormap, colorrange=colorrange,
+                 interpolate=interpolate, linewidth=linewidth, transparency=transparency, visible=visible)
 end
+
+end # quote
+end # function load_mesh()


### PR DESCRIPTION
Closes #1252.

This file adds functionality to plot any abstract polytope or any lazy set whose constraints list can be computed. It relies on converting an `HPolytpe` into a `Polyhedra.Mesh`, which can be plotted with `Makie`. 

It remains to see if we can refactor `plot3d` and `plot3d!`, and to load this file using a `Requires` block.