### PR TITLE
Fix SphericalDirections in v0.6

### DIFF
--- a/src/Approximations/template_directions.jl
+++ b/src/Approximations/template_directions.jl
@@ -438,7 +438,7 @@ dim(::SphericalDirections) = 3
 
 @static if VERSION < v"0.7-"
     @eval begin
-        Base.start(sd::SphericalDirections) = sd[1]
+        Base.start(sd::SphericalDirections) = 1
         Base.next(sd::SphericalDirections, state::Int) = (sd.stack[state], state+1)
         Base.done(sd::SphericalDirections, state) = state == length(sd.stack)+1
     end


### PR DESCRIPTION
This brings back Julia v0.6 support.

~I do not know what happened to Travis. The build is [here](https://travis-ci.org/JuliaReach/LazySets.jl/builds/514307364).~ Welcome back, Travis :wave: