### PR TITLE
#1292 - Custom template directions

### DIFF
--- a/docs/src/lib/approximations.md
+++ b/docs/src/lib/approximations.md
@@ -63,6 +63,7 @@ constraint(::LocalApproximation)
 
 ```@docs
 AbstractDirections
+isbounding
 BoxDirections
 OctDirections
 BoxDiagDirections

--- a/docs/src/lib/approximations.md
+++ b/docs/src/lib/approximations.md
@@ -68,6 +68,7 @@ OctDirections
 BoxDiagDirections
 PolarDirections
 SphericalDirections
+CustomDirections
 ```
 
 See also `overapproximate(X::LazySet, dir::AbstractDirections)::HPolytope`.

--- a/src/Approximations/Approximations.jl
+++ b/src/Approximations/Approximations.jl
@@ -9,6 +9,8 @@ module Approximations
 using LazySets, LazySets.Arrays, Requires, LinearAlgebra, SparseArrays
 using LazySets: _rtol
 
+import LazySets: isbounded
+
 export approximate,
        ballinf_approximation,
        box_approximation, interval_hull,

--- a/src/Approximations/Approximations.jl
+++ b/src/Approximations/Approximations.jl
@@ -9,8 +9,6 @@ module Approximations
 using LazySets, LazySets.Arrays, Requires, LinearAlgebra, SparseArrays
 using LazySets: _rtol
 
-import LazySets: isbounded
-
 export approximate,
        ballinf_approximation,
        box_approximation, interval_hull,
@@ -22,7 +20,8 @@ export approximate,
        OctDirections,
        PolarDirections,
        SphericalDirections,
-       CustomDirections
+       CustomDirections,
+       isbounding
 
 const DIR_EAST(N) = [one(N), zero(N)]
 const DIR_NORTH(N) = [zero(N), one(N)]

--- a/src/Approximations/Approximations.jl
+++ b/src/Approximations/Approximations.jl
@@ -21,7 +21,8 @@ export approximate,
        BoxDiagDirections,
        OctDirections,
        PolarDirections,
-       SphericalDirections
+       SphericalDirections,
+       CustomDirections
 
 const DIR_EAST(N) = [one(N), zero(N)]
 const DIR_NORTH(N) = [zero(N), one(N)]

--- a/src/Approximations/overapproximate.jl
+++ b/src/Approximations/overapproximate.jl
@@ -290,8 +290,7 @@ function overapproximate(Z::Zonotope, ::Type{<:Hyperrectangle})::Hyperrectangle
 end
 
 """
-    overapproximate(X::LazySet{N}, dir::AbstractDirections{N})::HPolytope{N}
-        where {N}
+    overapproximate(X::LazySet{N}, dir::AbstractDirections{N}) where {N}
 
 Overapproximating a set with template directions.
 
@@ -302,14 +301,15 @@ Overapproximating a set with template directions.
 
 ### Output
 
-An `HPolytope` overapproximating the set `X` with the directions from `dir`.
+A polyhedron overapproximating the set `X` with the directions from `dir`.
+If the directions are known to be bounded, the result is an `HPolytope`,
+otherwise the result is an `HPolyhedron`.
 """
-function overapproximate(X::LazySet{N},
-                         dir::AbstractDirections{N}
-                        )::HPolytope{N} where {N}
+function overapproximate(X::LazySet{N}, dir::AbstractDirections{N}) where {N}
     halfspaces = Vector{LinearConstraint{N}}()
     sizehint!(halfspaces, length(dir))
-    H = HPolytope(halfspaces)
+    T = isbounded(dir) ? HPolytope : HPolyhedron
+    H = T(halfspaces)
     for d in dir
         addconstraint!(H, LinearConstraint(d, ρ(d, X)))
     end
@@ -317,8 +317,7 @@ function overapproximate(X::LazySet{N},
 end
 
 """
-    overapproximate(X::LazySet{N},
-                    dir::Type{<:AbstractDirections})::HPolytope{N} where {N}
+    overapproximate(X::LazySet{N}, dir::Type{<:AbstractDirections}) where {N}
 
 Overapproximating a set with template directions.
 
@@ -329,11 +328,12 @@ Overapproximating a set with template directions.
 
 ### Output
 
-A `HPolytope` overapproximating the set `X` with the directions from `dir`.
+A polyhedron overapproximating the set `X` with the directions from `dir`.
+If the directions are known to be bounded, the result is an `HPolytope`,
+otherwise the result is an `HPolyhedron`.
 """
 function overapproximate(X::LazySet{N},
-                         dir::Type{<:AbstractDirections}
-                        )::HPolytope{N} where {N}
+                         dir::Type{<:AbstractDirections}) where {N}
     return overapproximate(X, dir{N}(dim(X)))
 end
 

--- a/src/Approximations/overapproximate.jl
+++ b/src/Approximations/overapproximate.jl
@@ -308,7 +308,7 @@ otherwise the result is an `HPolyhedron`.
 function overapproximate(X::LazySet{N}, dir::AbstractDirections{N}) where {N}
     halfspaces = Vector{LinearConstraint{N}}()
     sizehint!(halfspaces, length(dir))
-    T = isbounded(dir) ? HPolytope : HPolyhedron
+    T = isbounding(dir) ? HPolytope : HPolyhedron
     H = T(halfspaces)
     for d in dir
         addconstraint!(H, LinearConstraint(d, ρ(d, X)))

--- a/src/Approximations/template_directions.jl
+++ b/src/Approximations/template_directions.jl
@@ -476,19 +476,6 @@ Base.eltype(::Type{CustomDirections{N}}) where {N} = AbstractVector{N}
 Base.length(cd::CustomDirections) = length(cd.directions)
 isbounding(cd::CustomDirections) = cd.isbounding
 
-@static if VERSION < v"0.7-"
-@eval begin
-
-Base.start(cd::CustomDirections) = 1
-Base.next(cd::CustomDirections{N}, state) where {N} = (
-    cd.directions[state], # value
-    state + 1) # next state
-Base.done(cd::CustomDirections, state) = state > length(cd.directions)
-
-end # @eval
-else
-@eval begin
-
 function Base.iterate(cd::CustomDirections{N}, state::Int=1) where {N}
     if state > length(cd.directions)
         return nothing
@@ -497,6 +484,3 @@ function Base.iterate(cd::CustomDirections{N}, state::Int=1) where {N}
     state = state + 1
     return (vec, state)
 end
-
-end # @eval
-end # if

--- a/src/Approximations/template_directions.jl
+++ b/src/Approximations/template_directions.jl
@@ -20,7 +20,7 @@ Returns the dimension of the generated directions.
 
 ### Input
 
-- `ad` -- box direction representation
+- `ad` -- template directions
 
 ### Output
 
@@ -28,6 +28,35 @@ The dimension of the generated directions.
 """
 function dim(ad::AbstractDirections)::Int
     return ad.n
+end
+
+"""
+    isbounded(::AbstractDirections)::Bool
+
+Checks if a list of template directions represents a bounded set, given a
+bounded input set.
+
+### Input
+
+- `ad` -- template directions
+
+### Output
+
+Given a bounded set ``X``, we can construct an outer approximation of ``X`` by
+using the template directions `ad` as normal vectors of the facets.
+If this function returns `true`, then the result is again a bounded set (i.e., a
+polytope).
+Note that the result does not depend on the specific shape of ``X``, as long as
+it is bounded.
+
+### Notes
+
+By default, this function returns `false` in order to be conservative.
+Custom subtypes of `AbstractDirections` should hence add a method for this
+function.
+"""
+function isbounded(ad::AbstractDirections)::Bool
+    return false
 end
 
 # ==================================================
@@ -52,6 +81,7 @@ BoxDirections(n::Int) = BoxDirections{Float64}(n)
 
 Base.eltype(::Type{BoxDirections{N}}) where {N} = AbstractVector{N}
 Base.length(bd::BoxDirections) = 2 * bd.n
+isbounded(::BoxDirections) = true
 
 function Base.iterate(bd::BoxDirections{N}, state::Int=1) where {N}
     if state == 0
@@ -89,6 +119,7 @@ OctDirections(n::Int) = OctDirections{Float64}(n)
 
 Base.eltype(::Type{OctDirections{N}}) where {N} = AbstractVector{N}
 Base.length(od::OctDirections) = 2 * od.n^2
+isbounded(::OctDirections) = true
 
 function Base.iterate(od::OctDirections{N}) where {N}
     if od.n == 1
@@ -174,6 +205,7 @@ BoxDiagDirections(n::Int) = BoxDiagDirections{Float64}(n)
 
 Base.eltype(::Type{BoxDiagDirections{N}}) where {N} = AbstractVector{N}
 Base.length(bdd::BoxDiagDirections) = bdd.n == 1 ? 2 : 2^bdd.n + 2 * bdd.n
+isbounded(::BoxDiagDirections) = true
 
 Base.iterate(bdd::BoxDiagDirections{N}) where {N} =
     (ones(N, bdd.n), ones(N, bdd.n))
@@ -271,6 +303,7 @@ PolarDirections(Nφ::Int) = PolarDirections{Float64}(Nφ)
 Base.eltype(::Type{PolarDirections{N}}) where {N} = Vector{N}
 Base.length(pd::PolarDirections) = length(pd.stack)
 dim(::PolarDirections) = 2
+isbounded(pd::PolarDirections) = pd.Nφ > 2
 
 function Base.iterate(pd::PolarDirections, state::Int=1)
     state == length(pd.stack)+1 && return nothing
@@ -299,7 +332,7 @@ in ``\\mathbb{R}^3``, which is parameterized by the azimuthal and polar angles
 ``θ ∈ Dθ := [0, π]`` and ``φ ∈ Dφ := [0, 2π]`` respectively, see the wikipedia
 entry [Spherical coordinate system](https://en.wikipedia.org/wiki/Spherical_coordinate_system).
 The domains ``Dθ`` and ``Dφ`` are discretized in ``Nθ`` and ``Nφ`` respectively.
-Then the Cartesian componentes of each direction are obtained with
+Then the Cartesian components of each direction are obtained with
 
 ```math
 [sin(θᵢ)*cos(φᵢ), sin(θᵢ)*sin(φᵢ), cos(θᵢ)].
@@ -374,6 +407,7 @@ SphericalDirections(Nθ::Int, Nφ::Int) = SphericalDirections{Float64}(Nθ, Nφ)
 Base.eltype(::Type{SphericalDirections{N}}) where {N} = Vector{N}
 Base.length(sd::SphericalDirections) = length(sd.stack)
 dim(::SphericalDirections) = 3
+isbounded(sd::SphericalDirections) = sd.Nθ > 2 && sd.Nφ > 2
 
 function Base.iterate(sd::SphericalDirections, state::Int=1)
     state == length(sd.stack)+1 && return nothing

--- a/test/unit_template_directions.jl
+++ b/test/unit_template_directions.jl
@@ -23,6 +23,7 @@ for N in [Float64, Float32, Rational{Int}]
 
         # box directions
         dir = BoxDirections{N}(n)
+        @test isbounded(dir)
         @test dim(dir) == n
         box = overapproximate(X, dir)
         @test length(dir) == length(box.constraints) == 2*n
@@ -31,6 +32,7 @@ for N in [Float64, Float32, Rational{Int}]
 
         # octagon directions
         dir = OctDirections{N}(n)
+        @test isbounded(dir)
         @test dim(dir) == n
         oct = overapproximate(X, dir)
         @test length(dir) == length(oct.constraints) == 2 * n^2
@@ -39,6 +41,7 @@ for N in [Float64, Float32, Rational{Int}]
 
         # box-diagonal directions
         dir = BoxDiagDirections{N}(n)
+        @test isbounded(dir)
         @test dim(dir) == n
         boxdiag = overapproximate(X, dir)
         @test length(dir) == length(boxdiag.constraints) ==
@@ -49,14 +52,20 @@ for N in [Float64, Float32, Rational{Int}]
 
         # spherical directions approximation
         if n == 2 && N in [Float32, Float64]
+            dir = PolarDirections{N}(2)
+            @test !isbounded(dir)
             dir = PolarDirections{N}(5)
+            @test isbounded(dir)
             @test dim(dir) == 2
             polar = overapproximate(X, dir)
         end
 
         # spherical directions approximation
         if n == 3 && N in [Float32, Float64]
+            dir = SphericalDirections{N}(2, 2)
+            @test !isbounded(dir)
             dir = SphericalDirections{N}(5, 5)
+            @test isbounded(dir)
             @test dim(dir) == 3
             spherical = overapproximate(X, dir)
         end
@@ -71,7 +80,6 @@ for N in [Float64, Float32, Rational{Int}]
             end
         end
     end
-
 end
 
 # default Float64 constructors

--- a/test/unit_template_directions.jl
+++ b/test/unit_template_directions.jl
@@ -79,6 +79,24 @@ for N in [Float64, Float32, Rational{Int}]
                 overapproximate(Z, dir)
             end
         end
+
+        # custom directions
+        # empty list of directions
+        dir = CustomDirections{N}(Vector{N}[]; n=n)
+        @test dim(dir) == n
+        P = overapproximate(X, dir)
+        @test isempty(constraints_list(P))
+        # minimal number of bounded directions
+        if n == 1
+            dirs = [N[-1], N[1]]
+        elseif n == 2
+            dirs = [N[-1, 0], N[0, -1], N[1, 1]]
+        elseif n == 3
+            dirs = [N[-1, 0, 0], N[0, -1, 0], N[0, 0, -1], N[1, 1, 1]]
+        end
+        dir = CustomDirections{N}(dirs)
+        P = overapproximate(X, dir)
+        @test P isa HPolytope && length(constraints_list(P)) == length(dirs)
     end
 end
 

--- a/test/unit_template_directions.jl
+++ b/test/unit_template_directions.jl
@@ -82,7 +82,7 @@ for N in [Float64, Float32, Rational{Int}]
 
         # custom directions
         # empty list of directions
-        dir = CustomDirections{N}(Vector{N}[]; n=n)
+        dir = CustomDirections(Vector{N}[]; n=n)
         @test dim(dir) == n
         P = overapproximate(X, dir)
         @test isempty(constraints_list(P))
@@ -94,9 +94,9 @@ for N in [Float64, Float32, Rational{Int}]
         elseif n == 3
             dirs = [N[-1, 0, 0], N[0, -1, 0], N[0, 0, -1], N[1, 1, 1]]
         end
-        dir = CustomDirections{N}(dirs)
+        dir = CustomDirections(dirs)
         @test isbounding(dir)
-        @test !isbounding(CustomDirections{N}(dirs[1:end-1]))
+        @test !isbounding(CustomDirections(dirs[1:end-1]))
         P = overapproximate(X, dir)
         @test P isa HPolytope && length(constraints_list(P)) == length(dirs)
     end

--- a/test/unit_template_directions.jl
+++ b/test/unit_template_directions.jl
@@ -23,7 +23,7 @@ for N in [Float64, Float32, Rational{Int}]
 
         # box directions
         dir = BoxDirections{N}(n)
-        @test isbounded(dir)
+        @test isbounding(dir)
         @test dim(dir) == n
         box = overapproximate(X, dir)
         @test length(dir) == length(box.constraints) == 2*n
@@ -32,7 +32,7 @@ for N in [Float64, Float32, Rational{Int}]
 
         # octagon directions
         dir = OctDirections{N}(n)
-        @test isbounded(dir)
+        @test isbounding(dir)
         @test dim(dir) == n
         oct = overapproximate(X, dir)
         @test length(dir) == length(oct.constraints) == 2 * n^2
@@ -41,7 +41,7 @@ for N in [Float64, Float32, Rational{Int}]
 
         # box-diagonal directions
         dir = BoxDiagDirections{N}(n)
-        @test isbounded(dir)
+        @test isbounding(dir)
         @test dim(dir) == n
         boxdiag = overapproximate(X, dir)
         @test length(dir) == length(boxdiag.constraints) ==
@@ -53,9 +53,9 @@ for N in [Float64, Float32, Rational{Int}]
         # spherical directions approximation
         if n == 2 && N in [Float32, Float64]
             dir = PolarDirections{N}(2)
-            @test !isbounded(dir)
+            @test !isbounding(dir)
             dir = PolarDirections{N}(5)
-            @test isbounded(dir)
+            @test isbounding(dir)
             @test dim(dir) == 2
             polar = overapproximate(X, dir)
         end
@@ -63,13 +63,13 @@ for N in [Float64, Float32, Rational{Int}]
         # spherical directions approximation
         if n == 3 && N in [Float32, Float64]
             dir = SphericalDirections{N}(2, 2)
-            @test !isbounded(dir)
+            @test !isbounding(dir)
             dir = SphericalDirections{N}(5, 5)
-            @test isbounded(dir)
+            @test isbounding(dir)
             @test dim(dir) == 3
             spherical = overapproximate(X, dir)
         end
-    
+
         # overapproximate lazy polyhedral intersections
         if N in [Float64]
             Y = B ∩ Ball1(zeros(N, n), N(1))
@@ -95,6 +95,8 @@ for N in [Float64, Float32, Rational{Int}]
             dirs = [N[-1, 0, 0], N[0, -1, 0], N[0, 0, -1], N[1, 1, 1]]
         end
         dir = CustomDirections{N}(dirs)
+        @test isbounding(dir)
+        @test !isbounding(CustomDirections{N}(dirs[1:end-1]))
         P = overapproximate(X, dir)
         @test P isa HPolytope && length(constraints_list(P)) == length(dirs)
     end


### PR DESCRIPTION
Closes #1292.

@mforets: Please in particular check whether in the first commit the `isbounded` methods for polar and spherical directions are correct. I am not very familiar with them.