### PR TITLE
Use robust subset check

### DIFF
--- a/src/is_subset.jl
+++ b/src/is_subset.jl
@@ -233,7 +233,7 @@ function ⊆(S::LazySet{N},
     @assert dim(S) == dim(P)
 
     @inbounds for H in constraints_list(P)
-        if ρ(H.a, S) > H.b
+        if !_leq(ρ(H.a, S), H.b)
             if witness
                 return (false, σ(H.a, S))
             else

--- a/test/unit_Polygon.jl
+++ b/test/unit_Polygon.jl
@@ -110,6 +110,7 @@ for N in [Float64, Float32, Rational{Int}]
     @test subset && ⊆(p, b2) && point == N[]
     subset, point = ⊆(p, l2, true)
     @test subset && ⊆(p, l2) && point == N[]
+    @test p ⊆ p
 
     # HPolygon/HPolygonOpt tests
     for hp in [p, po]


### PR DESCRIPTION
Logic:

 - if `ρ(H.a, S)` is strictly smaller than `H.b` then `_leq` returns `true` => we can't prove that S is not contained in P
 - if `ρ(H.a, S)` is equal to within the tolerance to `H.b` then `_leq` returns `true` => we can't prove that S is not contained in P
 - if `ρ(H.a, S)` is greater to within the tolerance to `H.b` then `_leq` returns `false` => we can prove that S is not contained in P
