### PR TITLE
#1272 - Use eps by default in plots

### DIFF
--- a/docs/src/lib/interfaces.md
+++ b/docs/src/lib/interfaces.md
@@ -59,10 +59,9 @@ diameter(::LazySet, ::Real=Inf)
 isbounded(::LazySet)
 isbounded_unit_dimensions(::LazySet{N}) where {N<:Real}
 an_element(::LazySet{N}) where {N<:Real}
-RecipesBase.apply_recipe(::Dict{Symbol,Any}, ::LazySet)
-RecipesBase.apply_recipe(::Dict{Symbol,Any}, ::Vector{S}) where {S<:LazySet}
-RecipesBase.apply_recipe(::Dict{Symbol,Any}, ::LazySet, ::Float64)
-RecipesBase.apply_recipe(::Dict{Symbol,Any}, ::Vector{S}, ::Float64) where {S<:LazySet}
+RecipesBase.apply_recipe(∅::EmptySet{Float64}, ε::Float64=0.0)
+RecipesBase.apply_recipe(::Dict{Symbol,Any}, ::LazySet{Float64}, ε::Float64=1e-3)
+RecipesBase.apply_recipe(::Dict{Symbol,Any}, ::Vector{LazySet{Float64}}, ε::Float64=1e-3)
 tosimplehrep(::LazySet)
 isuniversal(::LazySet{N}, ::Bool=false) where {N<:Real}
 ```

--- a/docs/src/lib/interfaces.md
+++ b/docs/src/lib/interfaces.md
@@ -59,11 +59,15 @@ diameter(::LazySet, ::Real=Inf)
 isbounded(::LazySet)
 isbounded_unit_dimensions(::LazySet{N}) where {N<:Real}
 an_element(::LazySet{N}) where {N<:Real}
-RecipesBase.apply_recipe(∅::EmptySet{Float64}, ε::Float64=0.0)
-RecipesBase.apply_recipe(::Dict{Symbol,Any}, ::LazySet{Float64}, ε::Float64=1e-3)
-RecipesBase.apply_recipe(::Dict{Symbol,Any}, ::Vector{LazySet{Float64}}, ε::Float64=1e-3)
 tosimplehrep(::LazySet)
 isuniversal(::LazySet{N}, ::Bool=false) where {N<:Real}
+```
+
+The following functions dispatch in a general `LazySet` and work provided that the overapproximation using iterative refinement in two dimensions is available:
+
+```@docs
+RecipesBase.apply_recipe(::Dict{Symbol,Any}, ::LazySet{N}, ::N=N(1e-3)) where {N<:Real}
+RecipesBase.apply_recipe(::Dict{Symbol,Any}, ::Vector{XN}, ::N=N(1e-3)) where {N<:Real, XN<:LazySet{N}}
 ```
 
 ### Set functions that override Base functions
@@ -134,8 +138,13 @@ This interface defines the following functions:
 isbounded(::AbstractPolytope)
 singleton_list(::AbstractPolytope{N}) where {N<:Real}
 isempty(::AbstractPolytope)
-RecipesBase.apply_recipe(::Dict{Symbol,Any}, ::AbstractPolytope)
-RecipesBase.apply_recipe(::Dict{Symbol,Any}, ::Vector{S}) where {S<:AbstractPolytope}
+```
+
+Plotting abstract polytopes is available too:
+
+```@docs
+RecipesBase.apply_recipe(::Dict{Symbol,Any}, ::AbstractPolytope{N}, ::N=zero(N)) where {N<:Real}
+RecipesBase.apply_recipe(::Dict{Symbol,Any}, ::Vector{PN}, ::N=zero(N)) where {N<:Real, PN<:AbstractPolytope{N}}
 ```
 
 #### Polygon
@@ -243,6 +252,6 @@ high(::AbstractSingleton{N}, ::Int) where {N<:Real}
 low(::AbstractSingleton{N}) where {N<:Real}
 low(::AbstractSingleton{N}, ::Int) where {N<:Real}
 linear_map(::AbstractMatrix{N}, ::AbstractSingleton{N}) where {N<:Real}
-RecipesBase.apply_recipe(::Dict{Symbol,Any}, ::AbstractSingleton)
-RecipesBase.apply_recipe(::Dict{Symbol,Any}, ::Vector{S}) where {S<:AbstractSingleton}
+RecipesBase.apply_recipe(::Dict{Symbol,Any}, ::AbstractSingleton{N}, ::N=zero(N)) where {N<:Real}
+RecipesBase.apply_recipe(::Dict{Symbol,Any}, ::Vector{SN}, ::N=zero(N)) where {N<:Real, SN<:AbstractSingleton{N}}
 ```

--- a/docs/src/lib/interfaces.md
+++ b/docs/src/lib/interfaces.md
@@ -63,7 +63,7 @@ tosimplehrep(::LazySet)
 isuniversal(::LazySet{N}, ::Bool=false) where {N<:Real}
 ```
 
-The following functions dispatch in a general `LazySet` and work provided that the overapproximation using iterative refinement in two dimensions is available:
+The following functions work with general two-dimensional `LazySet`s, provided that the overapproximation using iterative refinement is available:
 
 ```@docs
 RecipesBase.apply_recipe(::Dict{Symbol,Any}, ::LazySet{N}, ::N=N(1e-3)) where {N<:Real}

--- a/docs/src/lib/operations.md
+++ b/docs/src/lib/operations.md
@@ -127,6 +127,7 @@ use_precise_ρ
 _line_search
 _projection
 linear_map(::AbstractMatrix{N}, ::Intersection{N}) where {N}
+RecipesBase.apply_recipe(::Dict{Symbol,Any}, ::Intersection{N}, ::N=-one(N)) where {N<:Real}
 ```
 
 Inherited from [`LazySet`](@ref):

--- a/docs/src/lib/representations.md
+++ b/docs/src/lib/representations.md
@@ -156,7 +156,7 @@ radius(::EmptySet, ::Real=Inf)
 diameter(::EmptySet, ::Real=Inf)
 linear_map(::AbstractMatrix{N}, ::EmptySet{N}) where {N}
 translate(::EmptySet{N}, ::AbstractVector{N}) where {N<:Real}
-RecipesBase.apply_recipe(::Dict{Symbol,Any}, ::EmptySet, ::Float64=0.0)
+RecipesBase.apply_recipe(::Dict{Symbol,Any}, ::EmptySet{N}, ::N=zero(N)) where {N<:Real}
 ```
 Inherited from [`LazySet`](@ref):
 * [`norm`](@ref norm(::LazySet, ::Real))
@@ -185,6 +185,7 @@ halfspace_right(::AbstractVector{N}, ::AbstractVector{N}) where {N<:Real}
 tosimplehrep(::AbstractVector{HalfSpace{N}}) where {N<:Real}
 remove_redundant_constraints(::AbstractVector{LinearConstraint{N}}) where {N<:Real}
 remove_redundant_constraints!(::AbstractVector{LinearConstraint{N}}) where {N<:Real}
+RecipesBase.apply_recipe(::Dict{Symbol,Any}, ::HalfSpace{N}, ::N=zero(N)) where {N<:Real}
 ```
 Inherited from [`LazySet`](@ref):
 * [`norm`](@ref norm(::LazySet, ::Real))
@@ -206,6 +207,7 @@ isempty(::Hyperplane)
 constrained_dimensions(::Hyperplane{N}) where {N<:Real}
 constraints_list(::Hyperplane{N}) where {N<:Real}
 translate(::Hyperplane{N}, ::AbstractVector{N}) where {N<:Real}
+RecipesBase.apply_recipe(::Dict{Symbol,Any}, ::Hyperplane{N}, ::N=zero(N)) where {N<:Real}
 ```
 Inherited from [`LazySet`](@ref):
 * [`norm`](@ref norm(::LazySet, ::Real))
@@ -265,8 +267,8 @@ radius_hyperrectangle(::Interval{N}, ::Int) where {N<:Real}
 -(::Interval{N}, ::Interval{N}) where {N<:Real}
 *(::Interval{N}, ::Interval{N}) where {N<:Real}
 rand(::Type{Interval})
-RecipesBase.apply_recipe(::Dict{Symbol,Any}, ::Interval)
-RecipesBase.apply_recipe(::Dict{Symbol,Any}, ::Vector{S}) where {S<:Interval}
+RecipesBase.apply_recipe(::Dict{Symbol,Any}, ::Interval{N}, ::N=zero(N)) where {N<:Real}
+RecipesBase.apply_recipe(::Dict{Symbol,Any}, ::Vector{Interval{N}}, ::N=zero(N)) where {N<:Real}
 ```
 Inherited from [`LazySet`](@ref):
 * [`diameter`](@ref diameter(::LazySet, ::Real))
@@ -296,6 +298,7 @@ isempty(::Line)
 constrained_dimensions(::Line{N}) where {N<:Real}
 constraints_list(::Line{N}) where {N<:Real}
 translate(::Line{N}, ::AbstractVector{N}) where {N<:Real}
+RecipesBase.apply_recipe(::Dict{Symbol,Any}, ::Line{N}, ::N=zero(N)) where {N<:Real}
 ```
 Inherited from [`LazySet`](@ref):
 * [`norm`](@ref norm(::LazySet, ::Real))
@@ -317,8 +320,8 @@ halfspace_right(::LineSegment)
 vertices_list(::LineSegment{N}) where {N<:Real}
 constraints_list(::LineSegment{N}) where {N<:Real}
 translate(::LineSegment{N}, ::AbstractVector{N}) where {N<:Real}
-RecipesBase.apply_recipe(::Dict{Symbol,Any}, ::LineSegment)
-RecipesBase.apply_recipe(::Dict{Symbol,Any}, ::Vector{S}) where {S<:LineSegment}
+RecipesBase.apply_recipe(::Dict{Symbol,Any}, ::LineSegment{N}, ::N=zero(N)) where {N<:Real}
+RecipesBase.apply_recipe(::Dict{Symbol,Any}, ::Vector{LineSegment{N}}, ::N=zero(N)) where {N<:Real}
 ```
 Inherited from [`LazySet`](@ref):
 * [`norm`](@ref norm(::LazySet, ::Real))
@@ -584,6 +587,7 @@ diameter(::Universe, ::Real=Inf)
 constraints_list(::Universe{N}) where {N<:Real}
 constrained_dimensions(::Universe)
 translate(::Universe{N}, ::AbstractVector{N}) where {N<:Real}
+RecipesBase.apply_recipe(::Dict{Symbol,Any}, ::Universe{N}, ::N=zero(N)) where {N<:Real}
 ```
 
 ## Zero set

--- a/docs/src/man/reach_zonotopes.md
+++ b/docs/src/man/reach_zonotopes.md
@@ -47,8 +47,8 @@ function Algorithm1(A, X0, δ, μ, T)
     N = floor(Int, T / δ)
 
     # preallocate arrays
-    Q = Vector{LazySet}(undef, N)
-    R = Vector{LazySet}(undef, N)
+    Q = Vector{LazySet{Float64}}(undef, N)
+    R = Vector{LazySet{Float64}}(undef, N)
 
     # initial reach set in the time interval [0, δ]
     ϕp = (I+ϕ) / 2
@@ -93,7 +93,7 @@ R = Algorithm1(A, X0, δ, μ, 2 * δ); # warm-up
 
 R = Algorithm1(A, X0, δ, μ, T)
 
-plot(R, 1e-2, fillalpha=0.1)
+plot(R, fillalpha=0.1)
 ```
 
 
@@ -115,5 +115,5 @@ R = Algorithm1(A, X0, δ, μ, 2 * δ); # warm-up
 R = Algorithm1(A, X0, δ, μ, T)
 Rproj = project(R, [1, 3], 5)
 
-plot(Rproj, 1e-2, fillalpha=0.1, xlabel="x1", ylabel="x3")
+plot(Rproj, fillalpha=0.1, xlabel="x1", ylabel="x3")
 ```

--- a/src/plot_recipes.jl
+++ b/src/plot_recipes.jl
@@ -617,7 +617,7 @@ the iterative refinement is not available for lazy intersections, since it uses
 the support vector (but see #1187).
 
 Also note that if the set is a *nested* intersection, e.g., the lazy linear map,
-a nested intersection you may have to manually overapproximate this set before
+you may have to manually overapproximate this set before
 plotting, see `LazySets.Approximations.overapproximate` for details.
 
 ```julia

--- a/src/plot_recipes.jl
+++ b/src/plot_recipes.jl
@@ -612,7 +612,7 @@ A plot with the overapproximation of the given lazy intersection.
 
 ### Notes
 
-This function is separated from the main one `LazySet` plot recipe because
+This function is separated from the main `LazySet` plot recipe because
 the iterative refinement is not available for lazy intersections, since it uses
 the support vector (but see #1187).
 

--- a/src/plot_recipes.jl
+++ b/src/plot_recipes.jl
@@ -529,7 +529,7 @@ Plot the universal set.
 
 ### Output
 
-An error; plotting the universal set is not implemented.
+An error, since plotting the universal set is not implemented yet (see #576).
 """
 @recipe function plot_universe(::Universe{N}, ε::N=zero(N)) where {N<:Real}
     error("cannot plot the universal set")

--- a/src/plot_recipes.jl
+++ b/src/plot_recipes.jl
@@ -111,7 +111,7 @@ julia> plot([B1, B2])
 An iterative refinement method is applied to obtain an overapproximation of each
 set in `X` in constraint representation, which is then plotted. To change the
 default tolerance for the iterative refinement, use the second argument; it applies
-all sets in the array.
+to all sets in the array.
 
 ```julia
 julia> B1 = BallInf(zeros(2), 0.4);

--- a/src/plot_recipes.jl
+++ b/src/plot_recipes.jl
@@ -630,7 +630,7 @@ julia> plot(X)
 
 The vertices list of an `HPolygon` has known issues (until #1306 is fixed).
 Consider using the `Polyhedra` backend to compute the dual representation.
-One can specify the accuaracy of the overapproximation of the lazy intersection
+One can specify the accuracy of the overapproximation of the lazy intersection
 passing a higher value in `Nφ`, which stands for the number of polar directions chosen.
 
 ```julia

--- a/src/plot_recipes.jl
+++ b/src/plot_recipes.jl
@@ -170,7 +170,7 @@ Plot a 2D polytope as the convex hull of its vertices.
 ### Input
 
 - `P` -- polygon or polytope
-- `ε` -- (optional, default: `0.0`) ignored, used for dispatch
+- `ε` -- (optional, default: `0`) ignored, used for dispatch
 
 ### Examples
 

--- a/src/plot_recipes.jl
+++ b/src/plot_recipes.jl
@@ -618,7 +618,7 @@ the support vector (but see #1187).
 
 Also note that if the set is a *nested* intersection, e.g., the lazy linear map,
 you may have to manually overapproximate this set before
-plotting, see `LazySets.Approximations.overapproximate` for details.
+plotting (see `LazySets.Approximations.overapproximate` for details).
 
 ```julia
 julia> using Polyhedra, LazySets.Approximations

--- a/src/plot_recipes.jl
+++ b/src/plot_recipes.jl
@@ -631,7 +631,7 @@ julia> plot(X)
 The vertices list of an `HPolygon` has known issues (until #1306 is fixed).
 Consider using the `Polyhedra` backend to compute the dual representation.
 One can specify the accuaracy of the overapproximation of the lazy intersection
-passing a higher value in `Nφ`, which stands for amount of polar directions chosen.
+passing a higher value in `Nφ`, which stands for the number of polar directions chosen.
 
 ```julia
 julia> Nφ = 100; # or a bigger number

--- a/src/plot_recipes.jl
+++ b/src/plot_recipes.jl
@@ -12,7 +12,7 @@ end
 # ====================================
 
 """
-    plot_lazyset(X::LazySet, [ε]::Float64; ...)
+    plot_lazyset(X::LazySet{N}, [ε]::N=N(1e-3); ...) where {N<:Real}
 
 Plot a convex set in two dimensions.
 
@@ -66,8 +66,8 @@ returned by `vertices_list` are the same. In that case, a scatter plot is used
 (instead of a shape plot). This corner case arises, for example, when lazy linear
 maps of singletons.
 """
-@recipe function plot_lazyset(X::LazySet, ε::Float64=1e-3;
-                              color="blue", label="", grid=true, alpha=0.5)
+@recipe function plot_lazyset(X::LazySet{N}, ε::N=N(1e-3);
+                              color="blue", label="", grid=true, alpha=0.5) where {N}
 
     @assert dim(X) == 2 "cannot plot a $(dim(X))-dimensional set using iterative refinement"
 
@@ -91,7 +91,7 @@ maps of singletons.
 end
 
 """
-    plot_lazyset(Xk::Vector{LazySet}, [ε]::Float64; ...)
+    plot_lazyset(Xk::Vector{LazySet{N}}, ε::N=N(1e-3); ...) where {N<:Real}
 
 Plot an array of convex sets in two dimensions.
 
@@ -133,9 +133,9 @@ julia> plot([B1, B2], 1e-4); # slower but more accurate
 
 See the documentation of `plot_lazyset(S::LazySet, [ε]::Float64; ...)` for details.
 """
-@recipe function plot_lazyset(Xk::Vector{S}, ε::Float64=1e-3;
+@recipe function plot_lazyset(Xk::Vector{LazySet{N}}, ε::N=N(1e-3);
                               seriescolor="blue", label="", grid=true,
-                              alpha=0.5) where {S<:LazySet}
+                              alpha=0.5) where {N<:Real}
 
     seriestype := :shape
 
@@ -535,24 +535,24 @@ julia> plot(∅, 1e-2);
 
 ```
 """
-@recipe function plot_emptyset(∅::EmptySet, ε::Float64=0.0; label="", grid=true,
-                               legend=false)
+@recipe function plot_emptyset(∅::EmptySet{N}, ε::N=N(0.0); label="", grid=true,
+                               legend=false) where {N<:Real}
     return []
 end
 
-@recipe function plot_universe(::Universe, ε::Float64=0.0)
+@recipe function plot_universe(::Universe{N}, ε::N=N(0.0)) where {N<:Real}
     error("cannot plot the universal set")
 end
 
-@recipe function plot_line(::Line, ε::Float64=0.0)
+@recipe function plot_line(::Line{N}, ε::N=N(0.0)) where {N<:Real}
     error("cannot plot an infinite line")
 end
 
-@recipe function plot_halfspace(::HalfSpace, ε::Float64=0.0)
+@recipe function plot_halfspace(::HalfSpace{N}, ε::N=N(0.0)) where {N<:Real}
     error("cannot plot a half-space")
 end
 
-@recipe function plot_hyperplane(::Hyperplane, ε::Float64=0.0)
+@recipe function plot_hyperplane(::Hyperplane{N}, ε::N=N(0.0)) where {N<:Real}
     error("cannot plot a hyperplane")
 end
 
@@ -580,7 +580,7 @@ end
     x, y
 end
 
-#@recipe function plot_intersection(::Intersection, ε::Float64=0.0)
+#@recipe function plot_intersection(::Intersection{N}, ε::N=N(0.0)) where {N<:Real}
 #    error("cannot plot a lazy intersection using iterative refinement " *
 #         "(the exact support vector of an intersection is not implemented)")
 #end

--- a/src/plot_recipes.jl
+++ b/src/plot_recipes.jl
@@ -616,7 +616,7 @@ This function is separated from the main `LazySet` plot recipe because
 the iterative refinement is not available for lazy intersections, since it uses
 the support vector (but see #1187).
 
-Also note that if the set is a *nested* intersection eg. the lazy linear map
+Also note that if the set is a *nested* intersection, e.g., the lazy linear map,
 a nested intersection you may have to manually overapproximate this set before
 plotting, see `LazySets.Approximations.overapproximate` for details.
 

--- a/src/plot_recipes.jl
+++ b/src/plot_recipes.jl
@@ -651,7 +651,7 @@ julia> plot(P)
     if ε != -one(N)
         error("cannot plot a lazy intersection using iterative refinement with " *
               "error threshold `ε = $ε`, because the exact support vector of an " *
-              "intersection is not available; using instead a set of `Nφ` " *
+              "intersection is currently not available; using instead a set of `Nφ` " *
               "template directions. To control the number of directions, pass the " *
               "variable Nφ as in `plot(X, Nφ=...)`")
     end

--- a/src/plot_recipes.jl
+++ b/src/plot_recipes.jl
@@ -69,7 +69,7 @@ maps of singletons.
 @recipe function plot_lazyset(X::LazySet, ε::Float64=1e-3;
                               color="blue", label="", grid=true, alpha=0.5)
 
-    @assert dim(X) == 2 "cannot plot a $(dim(S))-dimensional set"
+    @assert dim(X) == 2 "cannot plot a $(dim(X))-dimensional set using iterative refinement"
 
     P = overapproximate(X, ε)
     vlist = transpose(hcat(convex_hull(vertices_list(P))...))
@@ -143,7 +143,7 @@ See the documentation of `plot_lazyset(S::LazySet, [ε]::Float64; ...)` for deta
         if X isa EmptySet
             continue
         end
-        @assert dim(X) == 2 "cannot plot a $(dim(X))-dimensional set"
+        @assert dim(X) == 2 "cannot plot a $(dim(X))-dimensional set using iterative refinement"
         Pi = overapproximate(X, ε)
         vlist = transpose(hcat(convex_hull(vertices_list(Pi))...))
 
@@ -538,4 +538,20 @@ julia> plot(∅, 1e-2);
 @recipe function plot_emptyset(∅::EmptySet, ε::Float64=0.0; label="", grid=true,
                                legend=false)
     return []
+end
+
+@recipe function plot_universe(::Universe, ε::Float64=0.0)
+    error("cannot plot the universal set")
+end
+
+@recipe function plot_line(::Line, ε::Float64=0.0)
+    error("cannot plot an infinite line")
+end
+
+@recipe function plot_halfspace(::HalfSpace, ε::Float64=0.0)
+    error("cannot plot a half-space")
+end
+
+@recipe function plot_hyperplane(::Hyperplane, ε::Float64=0.0)
+    error("cannot plot a hyperplane")
 end

--- a/test/unit_plot.jl
+++ b/test/unit_plot.jl
@@ -1,4 +1,4 @@
-for N in [Float64, Float32]
+for N in [Float64]
     p0 = zero(N)
     p1 = one(N)
     v0 = zeros(N, 2)
@@ -125,7 +125,7 @@ for N in [Float64, Float32]
 end
 
 # set types that do not work with Rational{Int}
-for N in [Float64, Float32]
+for N in [Float64]
     v0 = zeros(N, 2)
     p1 = one(N)
 
@@ -190,6 +190,5 @@ for N in [Float64]
 
     # ε-close
     ε = N(1e-2)
-    plot(its)
     @test_throws ErrorException plot(itsa, ε) # TODO not implemented yet
 end

--- a/test/unit_plot.jl
+++ b/test/unit_plot.jl
@@ -2,10 +2,7 @@
     using SparseArrays
 end
 
-# -------------------------
-# tests for floating points
-# -------------------------
-for N in [Float64, Float32]
+for N in [Float64, Float32, Rational{Int}]
     p0 = zero(N)
     p1 = one(N)
     v0 = zeros(N, 2)
@@ -24,6 +21,23 @@ for N in [Float64, Float32]
     st = Singleton(v1)
     zt = Zonotope(v0, Diagonal(N[1, 1]))
     zs = ZeroSet{N}(2)
+
+    # -------------------------------------------
+    # plot polytopes
+    # -------------------------------------------
+    plot(b1)
+    plot(bi)
+    plot(hr)
+    plot(itv)
+    plot(ls)
+    plot(st)
+    plot(zt)
+    plot(zs)
+    
+    if N == Rational{Int}
+        # rationals do not support epsilon-close approximation
+        continue
+    end
 
     # bounded basic set types which are not polytopes
     b2 = Ball2(v0, p1)
@@ -77,20 +91,12 @@ for N in [Float64, Float32]
     cp = CartesianProduct(itv, itv)
     cpa = CartesianProductArray([itv, itv])
 
-    # -------------------------------------------
-    # plots using the default epsilon-close value
-    # -------------------------------------------
-    plot(b1)
-    plot(bi)
-    plot(hr)
-    plot(itv)
+    # ------------------------------------------------------------------
+    # plot using epsilon-close approximation (default threshold ε value)
+    # ------------------------------------------------------------------
     if N == Float64 # Float32 requires promotion see #1304 
         plot(its)
     end
-    plot(ls)
-    plot(st)
-    plot(zt)
-    plot(zs)
     plot(hpg)
     plot(hpgo)
     if test_suite_polyhedra
@@ -118,37 +124,4 @@ for N in [Float64, Float32]
     # cases that are not implemented
     # -----
     @test_throws ErrorException plot(itsa) # TODO not implemented yet
-end
-
-# -----------------------------------------------------------------
-# tests for rationals; iterative refinement is not available
-# -----------------------------------------------------------------
-for N in [Rational{Int}]
-    p0 = zero(N)
-    p1 = one(N)
-    v0 = zeros(N, 2)
-    v1 = ones(N, 2)
-
-    # ---------------
-    # set definitions
-    # ---------------
-
-    # bounded basic set types
-    b1 = Ball1(v0, p1)
-    bi = BallInf(v0, p1)
-    hr = Hyperrectangle(v0, v1)
-    itv = Interval(p0, p1)
-    ls = LineSegment(v0, v1)
-    st = Singleton(v1)
-    zt = Zonotope(v0, Diagonal(N[1, 1]))
-    zs = ZeroSet{N}(2)
-
-    plot(b1)
-    plot(bi)
-    plot(hr)
-    plot(itv)
-    plot(ls)
-    plot(st)
-    plot(zt)
-    plot(zs)
 end

--- a/test/unit_plot.jl
+++ b/test/unit_plot.jl
@@ -1,4 +1,6 @@
-using Optim, SparseArrays
+@static if VERSION >= v"0.7-"
+    using SparseArrays
+end
 
 # -------------------------
 # tests for floating points

--- a/test/unit_plot.jl
+++ b/test/unit_plot.jl
@@ -1,4 +1,4 @@
-for N in [Float64, Rational{Int}, Float32]
+for N in [Float64, Float32]
     p0 = zero(N)
     p1 = one(N)
     v0 = zeros(N, 2)
@@ -73,10 +73,10 @@ for N in [Float64, Rational{Int}, Float32]
     plot(vpg)
     plot(vpt)
     plot(es)
-    @test_throws Exception plot(hs) # TODO see #576
-    @test_throws Exception plot(hp) # TODO see #576
+    @test_throws ErrorException plot(hs) # TODO see #576
+    @test_throws ErrorException plot(hp) # TODO see #576
     @test_throws ErrorException plot(l) # TODO see #576
-    @test_throws Exception plot(uni) # TODO see #576
+    @test_throws ErrorException plot(uni) # TODO see #576
     plot(ch)
     plot(cha)
     plot(sih)
@@ -108,7 +108,7 @@ for N in [Float64, Rational{Int}, Float32]
         @test_throws ErrorException plot(hs, ε) # TODO see #576/#578
         @test_throws ErrorException plot(hp, ε) # TODO see #576/#578
         @test_throws ErrorException plot(l, ε) # TODO see #576/#578
-        plot(uni, ε)
+        @test_throws ErrorException plot(uni, ε) # TODO see #576/#578
         plot(ch, ε)
         plot(cha, ε)
         plot(sih, ε)

--- a/test/unit_plot.jl
+++ b/test/unit_plot.jl
@@ -1,4 +1,9 @@
-for N in [Float64]
+using Optim, SparseArrays
+
+# -------------------------
+# tests for floating points
+# -------------------------
+for N in [Float64, Float32]
     p0 = zero(N)
     p1 = one(N)
     v0 = zeros(N, 2)
@@ -17,6 +22,22 @@ for N in [Float64]
     st = Singleton(v1)
     zt = Zonotope(v0, Diagonal(N[1, 1]))
     zs = ZeroSet{N}(2)
+
+    # bounded basic set types which are not polytopes
+    b2 = Ball2(v0, p1)
+    bp = Ballp(N(1.5), v0, p1)
+    el = Ellipsoid(v0, Diagonal(N[1, 1]))
+
+    # unary set operations
+    spI = SparseMatrixCSC{N}(2I, 2, 2)
+    sme = SparseMatrixExp(spI)
+    em = ExponentialMap(sme, b2)
+    psme = ProjectionSparseMatrixExp(spI, sme, spI)
+    epm = ExponentialProjectionMap(psme, b2)
+
+    # binary set operations
+    its = Intersection(b1, bi)
+    itsa = IntersectionArray([b1, bi])
 
     # polygon/polytope types
     constraints = [LinearConstraint([p1, p0], p1),
@@ -54,22 +75,25 @@ for N in [Float64]
     cp = CartesianProduct(itv, itv)
     cpa = CartesianProductArray([itv, itv])
 
-    # -----
-    # plots
-    # -----
-
-    # direct
+    # -------------------------------------------
+    # plots using the default epsilon-close value
+    # -------------------------------------------
     plot(b1)
     plot(bi)
     plot(hr)
     plot(itv)
+    if N == Float64 # Float32 requires promotion see #1304 
+        plot(its)
+    end
     plot(ls)
     plot(st)
     plot(zt)
     plot(zs)
     plot(hpg)
     plot(hpgo)
-    plot(hpt)
+    if test_suite_polyhedra
+        plot(hpt)
+    end
     plot(vpg)
     plot(vpt)
     plot(es)
@@ -88,107 +112,41 @@ for N in [Float64]
     plot(cp)
     plot(cpa)
 
-    # ε-close
-    ε = N(1e-2)
-    if N == Float64 # TODO see #578
-        plot(b1, ε)
-        plot(bi, ε)
-        plot(hr, ε)
-        plot(ls, ε)
-        @test_throws AssertionError plot(itv, ε) # TODO see #575
-        plot(st, ε)
-        plot(zt, ε)
-        plot(zs, ε)
-        plot(hpg, ε)
-        plot(hpgo, ε)
-        plot(hpt, ε)
-        plot(vpg, ε)
-        plot(vpt, ε)
-        plot(es, ε)
-        @test_throws ErrorException plot(hs, ε) # TODO see #576/#578
-        @test_throws ErrorException plot(hp, ε) # TODO see #576/#578
-        @test_throws ErrorException plot(l, ε) # TODO see #576/#578
-        @test_throws ErrorException plot(uni, ε) # TODO see #576/#578
-        plot(ch, ε)
-        plot(cha, ε)
-        plot(sih, ε)
-        plot(lm, ε)
-        plot(rm, ε)
-        plot(ms, ε)
-        plot(msa, ε)
-        plot(cms, ε)
-        plot(cp, ε)
-        plot(cpa, ε)
-    else
-        @test_throws ErrorException plot(b1, ε) # TODO see #578
-    end
+    # -----
+    # cases that are not implemented
+    # -----
+    @test_throws ErrorException plot(itsa) # TODO not implemented yet
 end
 
-# set types that do not work with Rational{Int}
-for N in [Float64]
-    v0 = zeros(N, 2)
+# -----------------------------------------------------------------
+# tests for rationals; iterative refinement is not available
+# -----------------------------------------------------------------
+for N in [Rational{Int}]
+    p0 = zero(N)
     p1 = one(N)
+    v0 = zeros(N, 2)
+    v1 = ones(N, 2)
 
     # ---------------
     # set definitions
     # ---------------
 
     # bounded basic set types
-    b2 = Ball2(v0, p1)
-    bp = Ballp(N(1.5), v0, p1)
-    el = Ellipsoid(v0, Diagonal(N[1, 1]))
-
-    # unary set operations
-    spI = SparseMatrixCSC{N}(2I, 2, 2)
-    sme = SparseMatrixExp(spI)
-    em = ExponentialMap(sme, b2)
-    psme = ProjectionSparseMatrixExp(spI, sme, spI)
-    epm = ExponentialProjectionMap(psme, b2)
-
-    # -----
-    # plots
-    # -----
-
-    # direct
-    plot(b2)
-    plot(bp)
-    plot(el)
-    plot(em)
-    plot(epm)
-
-    # ε-close
-    ε = N(1e-2)
-    if N == Float64 # TODO see #578
-        plot(b2, ε)
-        plot(bp, ε)
-        plot(el, ε)
-        plot(em, ε)
-        plot(epm, ε)
-    else
-        @test_throws ErrorException plot(b2, ε) # TODO see #578
-    end
-end
-
-# set types that only work with Float64
-for N in [Float64]
-    v0 = zeros(N, 2)
-    p1 = one(N)
-
     b1 = Ball1(v0, p1)
     bi = BallInf(v0, p1)
+    hr = Hyperrectangle(v0, v1)
+    itv = Interval(p0, p1)
+    ls = LineSegment(v0, v1)
+    st = Singleton(v1)
+    zt = Zonotope(v0, Diagonal(N[1, 1]))
+    zs = ZeroSet{N}(2)
 
-    # binary set operations
-    its = Intersection(b1, bi)
-    itsa = IntersectionArray([b1, bi])
-
-    # -----
-    # plots
-    # -----
-
-    plot(its)
-    @test_throws ErrorException plot(itsa) # TODO not implemented yet
-
-    # ε-close
-    ε = N(1e-2)
-    @test_throws ErrorException plot(itsa, ε) # TODO not implemented yet
+    plot(b1)
+    plot(bi)
+    plot(hr)
+    plot(itv)
+    plot(ls)
+    plot(st)
+    plot(zt)
+    plot(zs)
 end


### PR DESCRIPTION
Closes #1272.
Closes #578.
Closes #575.

With this change, the manual has to be updated accordingly (in several places passing the epsilon explicitly is no longer needed). We can do this in a follow-up PR -- this is now https://github.com/JuliaReach/LazySets.jl/issues/1321.