### PR TITLE
Variable algorithm for vertices list of HPolytope

### DIFF
--- a/src/HPolytope.jl
+++ b/src/HPolytope.jl
@@ -218,7 +218,7 @@ H-representation and then its `vertices_list` function is used. This ensures
 that, by default, the optimized two-dimensional methods are used.
 
 It is possible to use the `Polyhedra` backend in two-dimensions as well
-by passing a given backend, e.g. `backend=CDDLib.Library()`.
+by passing, e.g. `backend=CDDLib.Library()`.
 
 If the polytope is not two-dimensional, the concrete polyhedra manipulation
 library `Polyhedra` is used. The actual computation is performed by a given

--- a/src/HPolytope.jl
+++ b/src/HPolytope.jl
@@ -217,7 +217,7 @@ If the polytope is two-dimensional, the polytope is converted to a polygon in
 H-representation and then its `vertices_list` function is used. This ensures
 that, by default, the optimized two-dimensional methods are used.
 
-It is possible to use `Polyhedra` backend in two-dimensions as well; do this
+It is possible to use the `Polyhedra` backend in two-dimensions as well
 by passing a given backend, e.g. `backend=CDDLib.Library()`.
 
 If the polytope is not two-dimensional, the concrete polyhedra manipulation

--- a/src/HPolytope.jl
+++ b/src/HPolytope.jl
@@ -198,40 +198,49 @@ end # quote
 end # function load_polyhedra_hpolytope()
 
 """
-    vertices_list(P::HPolytope{N};
-                  [backend]=default_polyhedra_backend(P, N),
-                  [prunefunc]=removevredundancy!)::Vector{Vector{N}} where
-                  {N<:Real}
+    vertices_list(P::HPolytope{N}; [backend]=nothing)::Vector{Vector{N}} where {N<:Real}
 
 Return the list of vertices of a polytope in constraint representation.
 
 ### Input
 
-- `P`         -- polytope in constraint representation
-- `backend`   -- (optional, default: `default_polyhedra_backend(P, N)`)
-                  the polyhedral computations backend
-- `prunefunc` -- (optional, default: `removevredundancy!`) function to
-                 post-process the output of `vreps`
+- `P`       -- polytope in constraint representation
+- `backend` -- (optional, default: `nothing`) the polyhedral computations backend
 
 ### Output
 
 List of vertices.
 
-### Notes
+### Algorithm
 
+If the polytope is two-dimensional, the polytope is converted to a polygon in
+H-representation and then its `vertices_list` function is used. This ensures
+that, by default, the optimized two-dimensional methods are used.
+
+It is possible to use `Polyhedra` backend in two-dimensions as well; do this
+by passing a given backend, e.g. `backend=CDDLib.Library()`.
+
+If the polytope is not two-dimensional, the concrete polyhedra manipulation
+library `Polyhedra` is used. The actual computation is performed by a given
+backend; for the default backend used in `LazySets` see `default_polyhedra_backend(N)`.
 For further information on the supported backends see
 [Polyhedra's documentation](https://juliapolyhedra.github.io/Polyhedra.jl/).
 """
-function vertices_list(P::HPolytope{N};
-                       backend=default_polyhedra_backend(P, N),
-                       prunefunc=removevredundancy!
-                      )::Vector{Vector{N}} where {N<:Real}
+function vertices_list(P::HPolytope{N}; backend=nothing)::Vector{Vector{N}} where {N<:Real}
     if length(P.constraints) == 0
         return Vector{N}(Vector{N}(undef, 0))
     end
-    @assert isdefined(@__MODULE__, :Polyhedra) "the function `vertices_list` needs " *
-                                        "the package 'Polyhedra' to be loaded"
-    P = polyhedron(P; backend=backend)
-    prunefunc(P)
-    return collect(points(P))
+
+    if dim(P) == 2 && backend == nothing
+        return vertices_list(convert(HPolygon, P))
+    else
+        @assert isdefined(@__MODULE__, :Polyhedra) "the function `vertices_list` "
+        "needs the package 'Polyhedra' to be loaded"
+        if backend == nothing
+            backend == default_polyhedra_backend(N)
+        end
+        P = polyhedron(P; backend=backend)
+        removevredundancy!(P)
+        return collect(points(P))
+    end
 end

--- a/src/HPolytope.jl
+++ b/src/HPolytope.jl
@@ -198,7 +198,9 @@ end # quote
 end # function load_polyhedra_hpolytope()
 
 """
-    vertices_list(P::HPolytope{N}; [backend]=nothing)::Vector{Vector{N}} where {N<:Real}
+    vertices_list(P::HPolytope{N};
+                  [backend]=nothing,
+                  [prune]::Bool=true)::Vector{Vector{N}} where {N<:Real}
 
 Return the list of vertices of a polytope in constraint representation.
 

--- a/src/HPolytope.jl
+++ b/src/HPolytope.jl
@@ -239,8 +239,8 @@ function vertices_list(P::HPolytope{N}; backend=nothing)::Vector{Vector{N}} wher
         if backend == nothing
             backend = default_polyhedra_backend(P, N)
         end
-        P = polyhedron(P; backend=backend)
-        removevredundancy!(P)
-        return collect(points(P))
+        Q = polyhedron(P; backend=backend)
+        removevredundancy!(Q)
+        return collect(points(Q))
     end
 end

--- a/src/HPolytope.jl
+++ b/src/HPolytope.jl
@@ -229,7 +229,7 @@ For further information on the supported backends see
 """
 function vertices_list(P::HPolytope{N};
                        backend=nothing,
-                       prune=true)::Vector{Vector{N}} where {N<:Real}
+                       prune::Bool=true)::Vector{Vector{N}} where {N<:Real}
     if length(P.constraints) == 0
         return Vector{N}(Vector{N}(undef, 0))
     end

--- a/src/HPolytope.jl
+++ b/src/HPolytope.jl
@@ -237,7 +237,7 @@ function vertices_list(P::HPolytope{N}; backend=nothing)::Vector{Vector{N}} wher
         @assert isdefined(@__MODULE__, :Polyhedra) "the function `vertices_list` "
         "needs the package 'Polyhedra' to be loaded"
         if backend == nothing
-            backend == default_polyhedra_backend(N)
+            backend = default_polyhedra_backend(P, N)
         end
         P = polyhedron(P; backend=backend)
         removevredundancy!(P)

--- a/src/HPolytope.jl
+++ b/src/HPolytope.jl
@@ -206,6 +206,7 @@ Return the list of vertices of a polytope in constraint representation.
 
 - `P`       -- polytope in constraint representation
 - `backend` -- (optional, default: `nothing`) the polyhedral computations backend
+- `prune`   -- (optional, default: `true`) flag to remove redundant vertices
 
 ### Output
 
@@ -226,13 +227,15 @@ backend; for the default backend used in `LazySets` see `default_polyhedra_backe
 For further information on the supported backends see
 [Polyhedra's documentation](https://juliapolyhedra.github.io/Polyhedra.jl/).
 """
-function vertices_list(P::HPolytope{N}; backend=nothing)::Vector{Vector{N}} where {N<:Real}
+function vertices_list(P::HPolytope{N};
+                       backend=nothing,
+                       prune=true)::Vector{Vector{N}} where {N<:Real}
     if length(P.constraints) == 0
         return Vector{N}(Vector{N}(undef, 0))
     end
 
     if dim(P) == 2 && backend == nothing
-        return vertices_list(convert(HPolygon, P))
+        return vertices_list(convert(HPolygon, P, prune=prune))
     else
         @assert isdefined(@__MODULE__, :Polyhedra) "the function `vertices_list` "
         "needs the package 'Polyhedra' to be loaded"
@@ -240,7 +243,9 @@ function vertices_list(P::HPolytope{N}; backend=nothing)::Vector{Vector{N}} wher
             backend = default_polyhedra_backend(P, N)
         end
         Q = polyhedron(P; backend=backend)
-        removevredundancy!(Q)
+        if prune
+            removevredundancy!(Q)
+        end
         return collect(points(Q))
     end
 end


### PR DESCRIPTION
This change makes `vertices_list` work more efficiently with two-dimensional `HPolytope`s by default, making use of the `HPolygon` function.

A simple test shows a speedup of ~30x comparing the version in master and the one in this branch, for a polytope defined by four constraints.

The idea was originally given in: https://github.com/JuliaReach/LazySets.jl/issues/335

---

Requires https://github.com/JuliaReach/LazySets.jl/pull/1342/