### PR TITLE
WIP  - #1235 - Use CDDLib as default and update Project.toml

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -19,6 +19,7 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 [compat]
 julia = "≥ 1.0.0"
 Compat = "≥ 1.0.0"
+CDDLib = "≥ 0.4.1"
 Expokit = "≥ 0.1.0"
 GLPKMathProgInterface = "≥ 0.4.0"
 IntervalArithmetic = "≥ 0.14.0"
@@ -29,6 +30,7 @@ RecipesBase = "≥ 0.3.0"
 Requires = "≥ 0.4.0"
 
 [extras]
+CDDLib = "3391f64e-dcde-5f30-b752-e11513730f60"
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 Expokit = "a1e7a1ef-7a5d-5822-a38c-be74e1bb89f4"
@@ -44,4 +46,4 @@ RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 
 [targets]
-test = ["Expokit", "Pkg", "IntervalArithmetic", "GLPKMathProgInterface", "Compat", "RecipesBase", "MathProgBase", "Requires", "Optim", "Polyhedra", "Documenter", "Plots", "GR"]
+test = ["CDDLib", "Expokit", "Pkg", "IntervalArithmetic", "GLPKMathProgInterface", "Compat", "RecipesBase", "MathProgBase", "Requires", "Optim", "Polyhedra", "Documenter", "Plots", "GR"]

--- a/src/AbstractPolytope.jl
+++ b/src/AbstractPolytope.jl
@@ -163,7 +163,7 @@ else
                       convexhull,
                       hcartesianproduct, vcartesianproduct,
                       points
-    import CDDLib # default backend
+    import .CDDLib # default backend
 
     # to use Polyhedra's default library, set
     # default_library(LazySets.dim(P), Float64)

--- a/src/AbstractPolytope.jl
+++ b/src/AbstractPolytope.jl
@@ -162,15 +162,19 @@ else
                       intersect,
                       convexhull,
                       hcartesianproduct, vcartesianproduct,
-                      points,
-                      default_library
+                      points
+    import CDDLib # default backend
 
+    # to use Polyhedra's default library, set
+    # default_library(LazySets.dim(P), Float64)
     function default_polyhedra_backend(P, N::Type{<:AbstractFloat})
-        return default_library(LazySets.dim(P), Float64)
+        return CDDLib.Library()
     end
 
+    # to use Polyhedra's default library, set
+    # default_library(LazySets.dim(P), Rational{Int})
     function default_polyhedra_backend(P, N::Type{<:Rational})
-        return default_library(LazySets.dim(P), Rational{Int})
+        return CDDLib.Library(:exact)
     end
 end
 end # quote


### PR DESCRIPTION
Closes #1235.

Marked as WIP because it is still giving a warning after loading Polyhedra, even if i updated the Project.toml file and did `] resolve`  ¯\_(ツ)_/¯ 


```julia
julia> using LazySets
[ Info: Recompiling stale cache file /Users/forets/.julia/compiled/v1.1/LazySets/NjrGc.ji for LazySets [b4f0291d-fe17-52bc-9479-3d1a343d9043]

julia> using Polyhedra
┌ Warning: Package LazySets does not have CDDLib in its dependencies:
│ - If you have LazySets checked out for development and have
│   added CDDLib as a dependency but haven't updated your primary
│   environment's manifest file, try `Pkg.resolve()`.
│ - Otherwise you may need to report an issue with LazySets
└ Loading CDDLib into LazySets from project dependency, future warnings for LazySets are suppressed.
```