### PR TITLE
#1344 - Efficient intersection with intervals

### DIFF
--- a/docs/src/lib/binary_functions.md
+++ b/docs/src/lib/binary_functions.md
@@ -54,6 +54,9 @@ intersection(::AbstractSingleton{N}, ::LazySet{N}) where {N<:Real}
 intersection(::Line{N}, ::Line{N}) where {N<:Real}
 intersection(::AbstractHyperrectangle{N}, ::AbstractHyperrectangle{N}) where {N<:Real}
 intersection(::Interval{N}, ::Interval{N}) where {N<:Real}
+intersection(::Interval{N}, ::HalfSpace{N}) where {N<:Real}
+intersection(::Interval{N}, ::Hyperplane{N}) where {N<:Real}
+intersection(::Interval{N}, ::LazySet{N}) where {N<:Real}
 intersection(::AbstractHPolygon{N}, ::AbstractHPolygon{N}, ::Bool=true) where {N<:Real}
 intersection(::AbstractPolyhedron{N}, ::AbstractPolyhedron{N}) where {N<:Real}
 intersection(::Union{VPolytope{N}, VPolygon{N}}, ::Union{VPolytope{N}, VPolygon{N}}) where {N<:Real}

--- a/test/unit_Interval.jl
+++ b/test/unit_Interval.jl
@@ -92,6 +92,24 @@ for N in [Float64, Float32, Rational{Int}]
     # check empty intersection
     E = intersection(A, Interval(N(0), N(1)))
     @test isempty(E)
+    # intersection with half-space
+    i = Interval(N(1), N(2))
+    hs = HalfSpace(N[1], N(1.5))
+    @test intersection(i, hs) == Interval(N(1), N(1.5))
+    hs = HalfSpace(N[-2], N(-5))
+    @test intersection(i, hs) == EmptySet{N}()
+    hs = HalfSpace(N[2], N(5))
+    @test intersection(i, hs) == i
+    # intersection with hyperplane
+    hp = Hyperplane(N[2], N(3))
+    @test intersection(i, hp) == Singleton(N[1.5])
+    hp = Hyperplane(N[-1], N(-3))
+    @test intersection(i, hp) == EmptySet{N}()
+    # other intersections
+    Y = Ball1(N[2], N(0.5))
+    @test intersection(i, Y) == Interval(N(1.5), N(2))
+    Y = ConvexHull(Singleton(N[-5]), Singleton(N[-1]))
+    @test intersection(i, Y) == EmptySet{N}()
 
     # disjointness check
     @test !isdisjoint(A, B)


### PR DESCRIPTION
Closes #1344.

```julia
julia> using LazySets, BenchmarkTools

julia> i = Interval([1., 2.]);

julia> hs = HalfSpace([1.], 1.5);

julia> hp = Hyperplane([-1.], -1.5);

julia> b = Ball1([2.], 0.5);

julia> c = ConvexHull(Singleton([-5.]), Singleton([-1.]));

julia> @btime intersection(i, hs)  # master
  60.737 μs (210 allocations: 14.02 KiB)
HPolytope{Float64}(HalfSpace{Float64}[HalfSpace{Float64}([-1.0], -1.0), HalfSpace{Float64}([1.0], 1.5)])

julia> @which intersection(i, hs)  # uses generic intersection of polyhedra
intersection(P1::AbstractPolyhedron{N}, P2::AbstractPolyhedron{N}) where N<:Real in LazySets at LazySets/src/concrete_intersection.jl:345

julia> @btime intersection(i, hs)  # new
  338.991 ns (9 allocations: 160 bytes)
Interval{Float64,IntervalArithmetic.Interval{Float64}}([1, 1.5])

julia> @btime intersection(i, hp)  # master
  81.807 μs (276 allocations: 18.55 KiB)
HPolytope{Float64}(HalfSpace{Float64}[HalfSpace{Float64}([-1.0], -1.5), HalfSpace{Float64}([1.0], 1.5)])

julia> @which intersection(i, hp)  # uses generic intersection of polyhedra
intersection(P1::AbstractPolyhedron{N}, P2::AbstractPolyhedron{N}) where N<:Real in LazySets at LazySets/src/concrete_intersection.jl:345

julia> @btime intersection(i, hp)  # new
  1.962 μs (5 allocations: 160 bytes)
Singleton{Float64,Array{Float64,1}}([1.5])

julia> @btime intersection(i, b)  # master
  86.117 μs (295 allocations: 19.34 KiB)
HPolytope{Float64}(HalfSpace{Float64}[HalfSpace{Float64}([1.0], 2.0), HalfSpace{Float64}([-1.0], -1.5)])

julia> @btime intersection(i, b)  # new
  309.758 ns (7 allocations: 608 bytes)
Interval{Float64,IntervalArithmetic.Interval{Float64}}([1.5, 2])

julia> @btime intersection(i, c)  # master
ERROR: MethodError: no method matching intersection(::Interval{Float64,IntervalArithmetic.Interval{Float64}}, ::ConvexHull{Float64,Singleton{Float64,Array{Float64,1}},Singleton{Float64,Array{Float64,1}}})

julia> @btime intersection(i, c)  # new
  160.299 ns (2 allocations: 192 bytes)
EmptySet{Float64}()
```