### PR TITLE
#1366 - Approximate equality test for `Rational`s

### DIFF
--- a/src/comparisons.jl
+++ b/src/comparisons.jl
@@ -47,7 +47,8 @@ arguments to a common numeric type, returning them as a tuple. The conversion
 is such that the common type to which the values are converted can represent
 them as faithfully as possible.
 """
-_leq(x::N, y::M; kwargs...) where {N<:Real, M<:Real} = _leq(promote(x, y)...; kwargs...)
+_leq(x::N, y::M; kwargs...) where {N<:Real, M<:Real} =
+    _leq(promote(x, y)...; kwargs...)
 
 """
     _geq(x::Real, y::Real; [kwargs...])
@@ -107,8 +108,8 @@ A boolean that is `true` iff `x ≈ 0`.
 
 ### Algorithm
 
-It is considered that `x ≈ 0` whenever `x` (in absolute value) is smaller than the
-tolerance for zero, `ztol`.
+It is considered that `x ≈ 0` whenever `x` (in absolute value) is smaller than
+the tolerance for zero, `ztol`.
 """
 function isapproxzero(x::N; ztol::Real=ABSZTOL(N)) where {N<:AbstractFloat}
     return abs(x) <= ztol
@@ -127,7 +128,8 @@ Determine if `x` is approximately equal to `y`.
 - `x`    -- number
 - `y`    -- another number (of the same numeric type as `x`)
 - `rtol` -- (optional, default: `Base.rtoldefault(N)`) relative tolerance
-- `ztol` -- (optional, default: `ABSZTOL(N)`) absolute tolerance for comparison against zero
+- `ztol` -- (optional, default: `ABSZTOL(N)`) absolute tolerance for comparison
+            against zero
 - `atol` -- (optional, default: `zero(N)`) absolute tolerance
 
 ### Output
@@ -136,14 +138,16 @@ A boolean that is `true` iff `x ≈ y`.
 
 ### Algorithm
 
-We first check if `x` and `y` are both approximately zero, using `isapproxzero(x, y)`.
+We first check if `x` and `y` are both approximately zero, using
+`isapproxzero(x, y)`.
 If that fails, we check if `x ≈ y`, using Julia's `isapprox(x, y)`.
-In the latter check we use `atol` absolute tolerance and `rtol` relative tolerance.
+In the latter check we use `atol` absolute tolerance and `rtol` relative
+tolerance.
 
-Comparing to zero with default tolerances is a special case in Julia's `isapprox`,
-see the last paragraph in `?isapprox`. This function tries to combine `isapprox`
-with its default values and a branch for `x ≈ y ≈ 0` which includes
-`x == y == 0` but also admits a tolerance `ztol`.
+Comparing to zero with default tolerances is a special case in Julia's
+`isapprox`, see the last paragraph in `?isapprox`. This function tries to
+combine `isapprox` with its default values and a branch for `x ≈ y ≈ 0` which
+includes `x == y == 0` but also admits a tolerance `ztol`.
 
 Note that if `x = ztol` and `y = -ztol`, then `|x-y| = 2*ztol` and still
 `_isapprox` returns `true`.
@@ -172,7 +176,8 @@ Determine if `x` is smaller than or equal to `y`.
 - `x`    -- number
 - `y`    -- another number (of the same numeric type as `x`)
 - `rtol` -- (optional, default: `Base.rtoldefault(N)`) relative tolerance
-- `ztol` -- (optional, default: `ABSZTOL(N)`) absolute tolerance for comparison against zero
+- `ztol` -- (optional, default: `ABSZTOL(N)`) absolute tolerance for comparison
+            against zero
 - `atol` -- absolute tolerance
 
 ### Output
@@ -181,9 +186,9 @@ A boolean that is `true` iff `x <= y`.
 
 ### Algorithm
 
-The `x <= y` comparison is split into `x < y` or `x ≈ y`; the latter is implemented
-by extending Juila's built-in `isapprox(x, y)` with an absolute tolerance that is
-used to compare against zero.
+The `x <= y` comparison is split into `x < y` or `x ≈ y`; the latter is
+implemented by extending Juila's built-in `isapprox(x, y)` with an absolute
+tolerance that is used to compare against zero.
 """
 function _leq(x::N, y::N;
               rtol::Real=Base.rtoldefault(N),

--- a/src/comparisons.jl
+++ b/src/comparisons.jl
@@ -72,28 +72,7 @@ documentation of `_leq` for further details.
 _geq(x::Real, y::Real; kwargs...) = _leq(y, x; kwargs...)
 
 """
-    isapproxzero(x::Real; [kwargs...])
-
-Determine if `x` is approximately zero.
-
-### Input
-
-- `x`      -- number
-- `kwargs` -- ignored
- 
-### Output
-
-A boolean that is `true` iff `x ≈ 0`.
-
-### Algorithm
-
-This is a fallback implementation for any real `x` such that `x ≈ 0` is `true`
-whenever `x` is equal to zero in the same numeric type as `x`.
-"""
-isapproxzero(x::Real; kwargs...) = x == zero(x)
-
-"""
-    isapproxzero(x::N; ztol::Real=ABSZTOL(N)) where {N<:AbstractFloat}
+    isapproxzero(x::N; ztol::Real=ABSZTOL(N)) where {N<:Real}
 
 Determine if `x` is approximately zero.
 
@@ -111,7 +90,7 @@ A boolean that is `true` iff `x ≈ 0`.
 It is considered that `x ≈ 0` whenever `x` (in absolute value) is smaller than
 the tolerance for zero, `ztol`.
 """
-function isapproxzero(x::N; ztol::Real=ABSZTOL(N)) where {N<:AbstractFloat}
+function isapproxzero(x::N; ztol::Real=ABSZTOL(N)) where {N<:Real}
     return abs(x) <= ztol
 end
 

--- a/src/comparisons.jl
+++ b/src/comparisons.jl
@@ -119,7 +119,7 @@ end
     _isapprox(x::N, y::N;
               rtol::Real=Base.rtoldefault(N),
               ztol::Real=ABSZTOL(N),
-              atol::Real=zero(N)) where {N<:AbstractFloat}
+              atol::Real=zero(N)) where {N<:Real}
 
 Determine if `x` is approximately equal to `y`.
 
@@ -155,7 +155,7 @@ Note that if `x = ztol` and `y = -ztol`, then `|x-y| = 2*ztol` and still
 function _isapprox(x::N, y::N;
                    rtol::Real=Base.rtoldefault(N),
                    ztol::Real=ABSZTOL(N),
-                   atol::Real=zero(N)) where {N<:AbstractFloat}
+                   atol::Real=zero(N)) where {N<:Real}
     if isapproxzero(x, ztol=ztol) && isapproxzero(y, ztol=ztol)
         return true
     else

--- a/test/unit_comparisons.jl
+++ b/test/unit_comparisons.jl
@@ -23,5 +23,7 @@ ABSZTOL(eltype(0.01)) == sqrt(eps(Float64))
 @test isapproxzero(0//1)
 @test isapproxzero(1e-8) && !isapproxzero(1e-8, ztol=1e-10)
 
-# approximate numbers in FP
+# approximate equality
+@test !_isapprox(1//1, 1//1 + 1//1000000000000)
 @test _isapprox(2e-15, 1e-15)
+@test !_isapprox(2e-6, 1e-6)


### PR DESCRIPTION
Closes #1366.

The last commit is unrelated, but I found it weird that we have different (and actually inconsistent) behavior for `Rational`s. I would actually argue that we should also remove the default for `_leq` for the same reason, but I did not have a closer look at it.