### PR TITLE
Improve binary convex hull of VPolytope

### DIFF
--- a/src/VPolytope.jl
+++ b/src/VPolytope.jl
@@ -337,12 +337,9 @@ for the `convex_hull`.
 """
 function convex_hull(P1::VPolytope{N}, P2::VPolytope{N};
                      backend=default_polyhedra_backend(P1, N)) where {N}
-    @assert isdefined(@__MODULE__, :Polyhedra) "the function `convex_hull` needs " *
-                                               "the package 'Polyhedra' to be loaded"
-    Pch = convexhull(polyhedron(P1; backend=backend),
-                     polyhedron(P2; backend=backend))
-    removevredundancy!(Pch)
-    return VPolytope(Pch)
+    vunion = [P1.vertices; P2.vertices]
+    convex_hull!(vunion; backend=backend)
+    return VPolytope(vunion)
 end
 
 """

--- a/src/VPolytope.jl
+++ b/src/VPolytope.jl
@@ -322,9 +322,8 @@ Compute the convex hull of the set union of two polytopes in V-representation.
 
 - `P1`         -- polytope
 - `P2`         -- another polytope
-- `backend`    -- (optional, default: `default_polyhedra_backend(P1, N)`) the polyhedral
-                  computations backend, see [Polyhedra's documentation](https://juliapolyhedra.github.io/Polyhedra.jl/latest/installation.html#Getting-Libraries-1)
-                  for further information
+- `backend`    -- (optional, default: `nothing`) the polyhedral
+                  computations backend
 
 ### Output
 
@@ -332,11 +331,17 @@ The `VPolytope` obtained by the concrete convex hull of `P1` and `P2`.
 
 ### Notes
 
+This function takes the union of the vertices of each polytope and then relies
+on a concrete convex hull algorithm. For low dimensions, a specialied implementation
+for polygons is used. For higher dimensions, `convex_hull` relies on the polyhedral
+computations backend specified in the `backend` keyword argument, which defaults
+to `default_polyhedra_backend(P1, N)`.
+
 For performance reasons, it is suggested to use the `CDDLib.Library()` backend
 for the `convex_hull`.
 """
 function convex_hull(P1::VPolytope{N}, P2::VPolytope{N};
-                     backend=default_polyhedra_backend(P1, N)) where {N}
+                     backend=nothing) where {N}
     vunion = [P1.vertices; P2.vertices]
     convex_hull!(vunion; backend=backend)
     return VPolytope(vunion)

--- a/src/VPolytope.jl
+++ b/src/VPolytope.jl
@@ -332,10 +332,9 @@ The `VPolytope` obtained by the concrete convex hull of `P1` and `P2`.
 ### Notes
 
 This function takes the union of the vertices of each polytope and then relies
-on a concrete convex hull algorithm. For low dimensions, a specialied implementation
+on a concrete convex hull algorithm. For low dimensions, a specialized implementation
 for polygons is used. For higher dimensions, `convex_hull` relies on the polyhedral
-computations backend specified in the `backend` keyword argument, which defaults
-to `default_polyhedra_backend(P1, N)`.
+computations backend that can be specified using the `backend` keyword argument.
 
 For performance reasons, it is suggested to use the `CDDLib.Library()` backend
 for the `convex_hull`.


### PR DESCRIPTION
This PR is related to https://github.com/JuliaReach/LazySets.jl/issues/941. 

Notes:

- the binary convex hull of two `VPolytope` now relies on the implementation of the concrete convex hull; the flow of that function is now similar to that of `VPolygon` (taking the union and calling convex hull)
- solves the `convex_hull` of empty `VPolytope` reported [here](https://github.com/JuliaReach/LazySets.jl/issues/947)
- this has the benefit that specific 1D and 2D implementations are used, while the higher-dim case uses `Polyhedra`

Some figures for a random polytope with 20 vertices:

-  in 2D: ~ 4us with Vpolygon; ~1.8ms with CDDLib; ~8.4ms with DefaultLibrary
- in 3D: ~2.2ms with CDDLib;  ~330ms with DefaultLibrary

Related to  https://github.com/JuliaReach/LazySets.jl/pull/1343 (make CDDLib default). 