### PR TITLE
#237 - Clean up plot_recipes

### DIFF
--- a/docs/src/lib/interfaces.md
+++ b/docs/src/lib/interfaces.md
@@ -69,7 +69,7 @@ that the overapproximation using iterative refinement is available:
 ```@docs
 plot_recipe(::LazySet{N}, ::N=N(1e-3)) where {N<:Real}
 RecipesBase.apply_recipe(::Dict{Symbol,Any}, ::LazySet{N}, ::N=N(1e-3)) where {N<:Real}
-RecipesBase.apply_recipe(::Dict{Symbol,Any}, ::AbstractVector{VN}, ::N=N(1e-3), ::Int=40) where {N<:Real, VN<:LazySet{N}}
+RecipesBase.apply_recipe(::Dict{Symbol,Any}, ::AbstractVector{VN}, ::N=N(1e-3), ::Int=40, ::Bool=false) where {N<:Real, VN<:LazySet{N}}
 ```
 
 ### Set functions that override Base functions

--- a/docs/src/lib/interfaces.md
+++ b/docs/src/lib/interfaces.md
@@ -67,7 +67,7 @@ The following functions work with general two-dimensional `LazySet`s, provided t
 
 ```@docs
 RecipesBase.apply_recipe(::Dict{Symbol,Any}, ::LazySet{N}, ::N=N(1e-3)) where {N<:Real}
-RecipesBase.apply_recipe(::Dict{Symbol,Any}, ::Vector{XN}, ::N=N(1e-3)) where {N<:Real, XN<:LazySet{N}}
+RecipesBase.apply_recipe(::Dict{Symbol,Any}, ::AbstractVector{VN}, ::N=N(1e-3), ::Int=40) where {N<:Real, VN<:LazySet{N}}
 ```
 
 ### Set functions that override Base functions
@@ -121,6 +121,12 @@ constrained_dimensions(::AbstractPolyhedron)
 linear_map(::AbstractMatrix{N}, ::AbstractPolyhedron{N}) where {N<:Real}
 ```
 
+Plotting polyhedra is available, too:
+
+```@docs
+RecipesBase.apply_recipe(::Dict{Symbol,Any}, ::AbstractPolyhedron{N}, ::N=zero(N)) where {N<:Real}
+```
+
 ### Polytope
 
 A polytope is a bounded set with finitely many vertices (*V-representation*)
@@ -138,13 +144,6 @@ This interface defines the following functions:
 isbounded(::AbstractPolytope)
 singleton_list(::AbstractPolytope{N}) where {N<:Real}
 isempty(::AbstractPolytope)
-```
-
-Plotting abstract polytopes is available too:
-
-```@docs
-RecipesBase.apply_recipe(::Dict{Symbol,Any}, ::AbstractPolytope{N}, ::N=zero(N)) where {N<:Real}
-RecipesBase.apply_recipe(::Dict{Symbol,Any}, ::Vector{PN}, ::N=zero(N)) where {N<:Real, PN<:AbstractPolytope{N}}
 ```
 
 #### Polygon
@@ -253,5 +252,4 @@ low(::AbstractSingleton{N}) where {N<:Real}
 low(::AbstractSingleton{N}, ::Int) where {N<:Real}
 linear_map(::AbstractMatrix{N}, ::AbstractSingleton{N}) where {N<:Real}
 RecipesBase.apply_recipe(::Dict{Symbol,Any}, ::AbstractSingleton{N}, ::N=zero(N)) where {N<:Real}
-RecipesBase.apply_recipe(::Dict{Symbol,Any}, ::Vector{SN}, ::N=zero(N)) where {N<:Real, SN<:AbstractSingleton{N}}
 ```

--- a/docs/src/lib/interfaces.md
+++ b/docs/src/lib/interfaces.md
@@ -63,9 +63,11 @@ tosimplehrep(::LazySet)
 isuniversal(::LazySet{N}, ::Bool=false) where {N<:Real}
 ```
 
-The following functions work with general two-dimensional `LazySet`s, provided that the overapproximation using iterative refinement is available:
+Plotting is available for general one- or two-dimensional `LazySet`s, provided
+that the overapproximation using iterative refinement is available:
 
 ```@docs
+plot_recipe(::LazySet{N}, ::N=N(1e-3)) where {N<:Real}
 RecipesBase.apply_recipe(::Dict{Symbol,Any}, ::LazySet{N}, ::N=N(1e-3)) where {N<:Real}
 RecipesBase.apply_recipe(::Dict{Symbol,Any}, ::AbstractVector{VN}, ::N=N(1e-3), ::Int=40) where {N<:Real, VN<:LazySet{N}}
 ```
@@ -121,10 +123,10 @@ constrained_dimensions(::AbstractPolyhedron)
 linear_map(::AbstractMatrix{N}, ::AbstractPolyhedron{N}) where {N<:Real}
 ```
 
-Plotting polyhedra is available, too:
+Plotting (bounded) polyhedra is available, too:
 
 ```@docs
-RecipesBase.apply_recipe(::Dict{Symbol,Any}, ::AbstractPolyhedron{N}, ::N=zero(N)) where {N<:Real}
+plot_recipe(::AbstractPolyhedron{N}, ::N=zero(N)) where {N<:Real}
 ```
 
 ### Polytope
@@ -251,5 +253,6 @@ high(::AbstractSingleton{N}, ::Int) where {N<:Real}
 low(::AbstractSingleton{N}) where {N<:Real}
 low(::AbstractSingleton{N}, ::Int) where {N<:Real}
 linear_map(::AbstractMatrix{N}, ::AbstractSingleton{N}) where {N<:Real}
+plot_recipe(::AbstractSingleton{N}, ::N=zero(N)) where {N<:Real}
 RecipesBase.apply_recipe(::Dict{Symbol,Any}, ::AbstractSingleton{N}, ::N=zero(N)) where {N<:Real}
 ```

--- a/docs/src/lib/operations.md
+++ b/docs/src/lib/operations.md
@@ -127,7 +127,8 @@ use_precise_ρ
 _line_search
 _projection
 linear_map(::AbstractMatrix{N}, ::Intersection{N}) where {N}
-RecipesBase.apply_recipe(::Dict{Symbol,Any}, ::Intersection{N}, ::N=-one(N), ::Int=40) where {N<:Real}
+plot_recipe(::Intersection{N}, ::N=zero(N), ::Int=40) where {N<:Real}
+RecipesBase.apply_recipe(::Dict{Symbol,Any}, ::Intersection{N}, ::N=zero(N), ::Int=40) where {N<:Real}
 ```
 
 Inherited from [`LazySet`](@ref):

--- a/docs/src/lib/operations.md
+++ b/docs/src/lib/operations.md
@@ -127,7 +127,7 @@ use_precise_ρ
 _line_search
 _projection
 linear_map(::AbstractMatrix{N}, ::Intersection{N}) where {N}
-RecipesBase.apply_recipe(::Dict{Symbol,Any}, ::Intersection{N}, ::N=-one(N)) where {N<:Real}
+RecipesBase.apply_recipe(::Dict{Symbol,Any}, ::Intersection{N}, ::N=-one(N), ::Int=40) where {N<:Real}
 ```
 
 Inherited from [`LazySet`](@ref):

--- a/docs/src/lib/representations.md
+++ b/docs/src/lib/representations.md
@@ -185,7 +185,6 @@ halfspace_right(::AbstractVector{N}, ::AbstractVector{N}) where {N<:Real}
 tosimplehrep(::AbstractVector{HalfSpace{N}}) where {N<:Real}
 remove_redundant_constraints(::AbstractVector{LinearConstraint{N}}) where {N<:Real}
 remove_redundant_constraints!(::AbstractVector{LinearConstraint{N}}) where {N<:Real}
-RecipesBase.apply_recipe(::Dict{Symbol,Any}, ::HalfSpace{N}, ::N=zero(N)) where {N<:Real}
 ```
 Inherited from [`LazySet`](@ref):
 * [`norm`](@ref norm(::LazySet, ::Real))
@@ -207,7 +206,6 @@ isempty(::Hyperplane)
 constrained_dimensions(::Hyperplane{N}) where {N<:Real}
 constraints_list(::Hyperplane{N}) where {N<:Real}
 translate(::Hyperplane{N}, ::AbstractVector{N}) where {N<:Real}
-RecipesBase.apply_recipe(::Dict{Symbol,Any}, ::Hyperplane{N}, ::N=zero(N)) where {N<:Real}
 ```
 Inherited from [`LazySet`](@ref):
 * [`norm`](@ref norm(::LazySet, ::Real))
@@ -268,7 +266,6 @@ radius_hyperrectangle(::Interval{N}, ::Int) where {N<:Real}
 *(::Interval{N}, ::Interval{N}) where {N<:Real}
 rand(::Type{Interval})
 RecipesBase.apply_recipe(::Dict{Symbol,Any}, ::Interval{N}, ::N=zero(N)) where {N<:Real}
-RecipesBase.apply_recipe(::Dict{Symbol,Any}, ::Vector{Interval{N}}, ::N=zero(N)) where {N<:Real}
 isflat(::Interval)
 ```
 Inherited from [`LazySet`](@ref):
@@ -299,7 +296,6 @@ isempty(::Line)
 constrained_dimensions(::Line{N}) where {N<:Real}
 constraints_list(::Line{N}) where {N<:Real}
 translate(::Line{N}, ::AbstractVector{N}) where {N<:Real}
-RecipesBase.apply_recipe(::Dict{Symbol,Any}, ::Line{N}, ::N=zero(N)) where {N<:Real}
 ```
 Inherited from [`LazySet`](@ref):
 * [`norm`](@ref norm(::LazySet, ::Real))
@@ -322,7 +318,6 @@ vertices_list(::LineSegment{N}) where {N<:Real}
 constraints_list(::LineSegment{N}) where {N<:Real}
 translate(::LineSegment{N}, ::AbstractVector{N}) where {N<:Real}
 RecipesBase.apply_recipe(::Dict{Symbol,Any}, ::LineSegment{N}, ::N=zero(N)) where {N<:Real}
-RecipesBase.apply_recipe(::Dict{Symbol,Any}, ::Vector{LineSegment{N}}, ::N=zero(N)) where {N<:Real}
 ```
 Inherited from [`LazySet`](@ref):
 * [`norm`](@ref norm(::LazySet, ::Real))
@@ -603,7 +598,6 @@ diameter(::Universe, ::Real=Inf)
 constraints_list(::Universe{N}) where {N<:Real}
 constrained_dimensions(::Universe)
 translate(::Universe{N}, ::AbstractVector{N}) where {N<:Real}
-RecipesBase.apply_recipe(::Dict{Symbol,Any}, ::Universe{N}, ::N=zero(N)) where {N<:Real}
 ```
 
 ## Zero set

--- a/docs/src/lib/representations.md
+++ b/docs/src/lib/representations.md
@@ -156,6 +156,7 @@ radius(::EmptySet, ::Real=Inf)
 diameter(::EmptySet, ::Real=Inf)
 linear_map(::AbstractMatrix{N}, ::EmptySet{N}) where {N}
 translate(::EmptySet{N}, ::AbstractVector{N}) where {N<:Real}
+plot_recipe(::EmptySet{N}, ::N=zero(N)) where {N<:Real}
 RecipesBase.apply_recipe(::Dict{Symbol,Any}, ::EmptySet{N}, ::N=zero(N)) where {N<:Real}
 ```
 Inherited from [`LazySet`](@ref):
@@ -265,8 +266,8 @@ radius_hyperrectangle(::Interval{N}, ::Int) where {N<:Real}
 -(::Interval{N}, ::Interval{N}) where {N<:Real}
 *(::Interval{N}, ::Interval{N}) where {N<:Real}
 rand(::Type{Interval})
-RecipesBase.apply_recipe(::Dict{Symbol,Any}, ::Interval{N}, ::N=zero(N)) where {N<:Real}
 isflat(::Interval)
+plot_recipe(::Interval{N}, ::N=zero(N)) where {N<:Real}
 ```
 Inherited from [`LazySet`](@ref):
 * [`diameter`](@ref diameter(::LazySet, ::Real))
@@ -317,7 +318,8 @@ halfspace_right(::LineSegment)
 vertices_list(::LineSegment{N}) where {N<:Real}
 constraints_list(::LineSegment{N}) where {N<:Real}
 translate(::LineSegment{N}, ::AbstractVector{N}) where {N<:Real}
-RecipesBase.apply_recipe(::Dict{Symbol,Any}, ::LineSegment{N}, ::N=zero(N)) where {N<:Real}
+plot_recipe(::LineSegment{N}, ::N=zero(N)) where {N<:Real}
+RecipesBase.apply_recipe(::Dict{Symbol,Any}, ::Union{LineSegment{N}, Interval{N}}, ::N=zero(N)) where {N<:Real}
 ```
 Inherited from [`LazySet`](@ref):
 * [`norm`](@ref norm(::LazySet, ::Real))

--- a/docs/src/man/reach_zonotopes.md
+++ b/docs/src/man/reach_zonotopes.md
@@ -92,7 +92,7 @@ R = Algorithm1(A, X0, δ, μ, 2 * δ); # warm-up
 
 R = Algorithm1(A, X0, δ, μ, T)
 
-plot(R, fillalpha=0.1)
+plot(R, 1e-2, 0, true; fillalpha=0.1)
 ```
 
 
@@ -114,5 +114,5 @@ R = Algorithm1(A, X0, δ, μ, 2 * δ); # warm-up
 R = Algorithm1(A, X0, δ, μ, T)
 Rproj = project(R, [1, 3], 5)
 
-plot(Rproj, fillalpha=0.1, xlabel="x1", ylabel="x3")
+plot(Rproj, 1e-2, 0, true; fillalpha=0.1, xlabel="x1", ylabel="x3")
 ```

--- a/src/AbstractSingleton.jl
+++ b/src/AbstractSingleton.jl
@@ -259,6 +259,30 @@ end
 function ∈(S::AbstractSingleton{N}, X::LazySet{N})::Bool where {N<:Real}
     error("cannot make a point-in-set check if the left-hand side is " *
           "a set; either check for set inclusion, as in `S ⊆ X`, or check for " *
-          "membership, as in `element(S) ∈ X` (they behave equivalently although " *
+          "membership, as in `element(S) ∈ X` (the results are equivalent but " *
           "the implementations may differ)")
+end
+
+"""
+    plot_recipe(S::AbstractSingleton{N}, [ε]::N=zero(N)) where {N<:Real}
+
+Convert a singleton to a pair `(x, y)` of points for plotting.
+
+### Input
+
+- `S` -- singleton
+- `ε` -- (optional, default: `0`) ignored, used for dispatch
+
+### Output
+
+A pair `(x, y)` of one point that can be plotted.
+"""
+function plot_recipe(S::AbstractSingleton{N}, ε::N=zero(N)) where {N<:Real}
+    @assert dim(S) <= 3 "cannot plot a $(dim(S))-dimensional $(typeof(S))"
+
+    if dim(S) == 1
+        return [element(S)[1]], [zero(N)]
+    else
+        return [element(S)[1]], [element(S)[2]]
+    end
 end

--- a/src/EmptySet.jl
+++ b/src/EmptySet.jl
@@ -261,3 +261,22 @@ The empty set.
 function translate(∅::EmptySet{N}, v::AbstractVector{N}) where {N<:Real}
     return ∅
 end
+
+"""
+    plot_recipe(∅::EmptySet{N}, [ε]::N=zero(N)) where {N<:Real}
+
+Convert an empty set to a sequence of points for plotting.
+In the special case of an empty set, we define the sequence as `nothing`.
+
+### Input
+
+- `∅` -- empty set
+- `ε` -- (optional, default: `0`) ignored, used for dispatch
+
+### Output
+
+`nothing`.
+"""
+function plot_recipe(∅::EmptySet{N}, ε::N=zero(N)) where {N<:Real}
+    return nothing
+end

--- a/src/Intersection.jl
+++ b/src/Intersection.jl
@@ -590,6 +590,38 @@ function isempty(cap::Intersection)::Bool
     return empty_intersection
 end
 
+"""
+    plot_recipe(cap::Intersection{N}, [ε]::N=-one(N),
+                [Nφ]::Int=PLOT_POLAR_DIRECTIONS) where {N<:Real}
+
+Convert a lazy intersection to a pair `(x, y)` of points for plotting.
+
+### Input
+
+- `cap`  -- lazy intersection
+- `ε`    -- (optional, default `0`) ignored, used for dispatch
+- `Nφ`   -- (optional, default: `PLOT_POLAR_DIRECTIONS`) number of polar
+            directions used in the template overapproximation
+
+### Output
+
+A pair `(x, y)` of points that can be plotted.
+"""
+function plot_recipe(cap::Intersection{N}, ε::N=zero(N),
+                     Nφ::Int=PLOT_POLAR_DIRECTIONS) where {N<:Real}
+    @assert dim(cap) <= 2 "cannot plot a $(dim(cap))-dimensional intersection"
+
+    if isempty(cap)
+        return plot_recipe(EmptySet{N}(), ε)
+    elseif dim(cap) == 1
+        return plot_recipe(convert(Interval, cap), ε)
+    else
+        # construct polygon approximation using polar directions
+        P = overapproximate(cap, PolarDirections{N}(Nφ))
+        return plot_recipe(P, ε)
+    end
+end
+
 
 # ================================
 # intersection of an array of sets

--- a/src/Interval.jl
+++ b/src/Interval.jl
@@ -472,3 +472,25 @@ this function depends on the absolute zero tolerance `ABSZTOL`.
 function isflat(I::Interval)::Bool
     return isapproxzero(IntervalArithmetic.diam(I.dat))
 end
+
+"""
+    plot_recipe(I::Interval{N}, [ε]::N=zero(N)) where {N<:Real}
+
+Convert an interval to a pair `(x, y)` of points for plotting.
+
+### Input
+
+- `I` -- interval
+- `ε` -- (optional, default: `0`) ignored, used for dispatch
+
+### Output
+
+A pair `(x, y)` of two points that can be plotted.
+
+### Notes
+
+We consider the interval as a line segment with y coordinate equal to zero.
+"""
+function plot_recipe(I::Interval{N}, ε::N=zero(N)) where {N<:Real}
+    return [min(I), max(I)], zeros(N, 2)
+end

--- a/src/LazySet.jl
+++ b/src/LazySet.jl
@@ -437,3 +437,50 @@ function isuniversal(X::LazySet{N}, witness::Bool=false
         return false
     end
 end
+
+"""
+    plot_recipe(X::LazySet{N}, [ε]::N=N(PLOT_PRECISION)) where {N<:Real}
+
+Convert a convex set to a pair `(x, y)` of points for plotting.
+
+### Input
+
+- `X` -- convex set
+- `ε` -- (optional, default: `PLOT_PRECISION`) approximation error bound
+
+### Output
+
+A pair `(x, y)` of points that can be plotted.
+
+### Notes
+
+Plotting of unbounded sets is not implemented yet (see
+[#576](https://github.com/JuliaReach/LazySets.jl/issues/576)).
+
+### Algorithm
+
+We first assert that `X` is bounded.
+
+One-dimensional sets are converted to an `Interval`.
+We do not support three-dimensional or higher-dimensional sets at the moment.
+
+For two-dimensional sets, we first compute a polygonal overapproximation.
+The second argument, `ε`, corresponds to the error in Hausdorff distance between
+the overapproximating set and `X`.
+The default value `PLOT_PRECISION` is chosen such that the unit ball in the
+2-norm is approximated with reasonable accuracy.
+On the other hand, if you only want to produce a fast box-overapproximation of
+`X`, pass `ε=Inf`.
+Finally, we use the plot recipe for polygons.
+"""
+function plot_recipe(X::LazySet{N}, ε::N=N(PLOT_PRECISION)) where {N<:Real}
+    @assert dim(X) <= 2 "cannot plot a $(dim(X))-dimensional $(typeof(X))"
+    @assert isbounded(X) "cannot plot an unbounded $(typeof(X))"
+
+    if dim(X) == 1
+        Y = convert(Interval, X)
+    else
+        Y = overapproximate(X, ε)
+    end
+    return plot_recipe(Y, ε)
+end

--- a/src/LineSegment.jl
+++ b/src/LineSegment.jl
@@ -349,3 +349,21 @@ function translate(L::LineSegment{N}, v::AbstractVector{N}) where {N<:Real}
                                 "set by a $(length(v))-dimensional vector"
     return LineSegment(L.p + v, L.q + v)
 end
+
+"""
+    plot_recipe(L::LineSegment{N}, [ε]::N=zero(N)) where {N<:Real}
+
+Convert a line segment to a pair `(x, y)` of points for plotting.
+
+### Input
+
+- `L` -- line segment
+- `ε` -- (optional, default: `0`) ignored, used for dispatch
+
+### Output
+
+A pair `(x, y)` of two points that can be plotted.
+"""
+function plot_recipe(L::LineSegment{N}, ε::N=zero(N)) where {N<:Real}
+    return [L.p[1], L.q[1]], [L.p[2], L.q[2]]
+end

--- a/src/plot_recipes.jl
+++ b/src/plot_recipes.jl
@@ -3,106 +3,32 @@ import RecipesBase.apply_recipe
 
 using LazySets.Approximations: overapproximate, PolarDirections
 
-function warn_empty_polytope()
-    @warn "received a polytope with no vertices during plotting"
-end
-
-# ====================================
-# Plot recipes for an abstract LazySet
-# ====================================
+# global values
+DEFAULT_COLOR = :auto
+DEFAULT_ALPHA = 0.5
+DEFAULT_LABEL = ""
+DEFAULT_GRID = true
+DEFAULT_ASPECT_RATIO = 1.0
+DEFAULT_EPSILON = 1e-3
+DEFAULT_POLAR_DIRECTIONS = 40
 
 """
-    plot_lazyset(X::LazySet{N}, [ε]::N=N(1e-3); ...) where {N<:Real}
+    plot_list(list::AbstractVector{VN}, [ε]::N=N(DEFAULT_EPSILON),
+              [Nφ]::Int=DEFAULT_POLAR_DIRECTIONS; ...) where {N<:Real,
+                                                              VN<:LazySet{N}}
 
-Plot a convex set in two dimensions.
+Plot a list of convex sets.
 
 ### Input
 
-- `X` -- convex set
-- `ε` -- (optional, default: `1e-3`) approximation error bound
-
-### Examples
-
-```julia
-julia> B = BallInf(ones(2), 0.1);
-
-julia> plot(2.0 * B)
-```
-
-An iterative refinement method is applied to obtain an overapproximation of `X`
-in constraint representation, which is then plotted. To improve the accuracy
-of the iterative refinement, use the second argument using a small value:
-
-```julia
-julia> B = Ball2(ones(2), 0.1);
-
-julia> plot(B, 1e-3);
-
-julia> plot(B, 1e-2); # faster than the previous try, but less accurate
-```
-
-### Algorithm
-
-In a first stage, an overapproximation of the given set to a polygon in constraint
-representation is computed. The second argument, `ε`, corresponds to the error
-in Hausdorff distance between the overapproximating set and `X`. The default
-value `1e-3` is chosen such that the unit ball in the 2-norm is plotted with
-reasonable accuracy. On the other hand, if you only want to produce a fast
-box-overapproximation of `X`, pass `ε=Inf`.
-
-In a second stage, the list of vertices of the overapproximation is computed
-with the `vertices_list` function of the polygon.
-
-A post-processing `convex_hull` is applied to the vertices list to ensure
-that the shaded area inside the convex hull of the vertices is covered
-correctly.
+- `list` -- list of convex sets (1D or 2D)
+- `ε`    -- (optional, default: `DEFAULT_EPSILON`) approximation error bound
+- `Nφ`   -- (optional, default: `DEFAULT_POLAR_DIRECTIONS`) number of polar
+            directions (used to plot lazy intersections)
 
 ### Notes
 
-This recipe detects if overapproximation is such that the first two vertices
-returned by `vertices_list` are the same. In that case, a scatter plot is used
-(instead of a shape plot). This corner case arises, for example, when lazy linear
-maps of singletons.
-"""
-@recipe function plot_lazyset(X::LazySet{N}, ε::N=N(1e-3);
-                              color=:auto, alpha=0.5) where {N<:Real}
-
-    @assert dim(X) == 2 "cannot plot a $(dim(X))-dimensional set using iterative refinement"
-
-    seriescolor --> color
-    seriesalpha --> alpha
-    label --> ""
-    grid --> true
-    aspect_ratio --> 1.0
-
-    P = overapproximate(X, ε)
-    vlist = transpose(hcat(convex_hull(vertices_list(P))...))
-
-    if isempty(vlist)
-        warn_empty_polytope()
-        return []
-    end
-
-    (x, y) = vlist[:, 1], vlist[:, 2]
-
-    # add first vertex to "close" the polygon
-    push!(x, vlist[1, 1])
-    push!(y, vlist[1, 2])
-
-    seriestype := norm(vlist[1, :] - vlist[2, :]) ≈ 0 ? :scatter : :shape
-
-    x, y
-end
-
-"""
-    plot_lazyset(X::Vector{XN}, ε::N=N(1e-3); ...) where {N<:Real, XN<:LazySet{N}}
-
-Plot an array of convex sets in two dimensions.
-
-### Input
-
-- `X` -- array of convex sets
-- `ε` -- (optional, default: `1e-3`) approximation error bound
+For each set in the list we apply an individual plot recipe.
 
 ### Examples
 
@@ -114,139 +40,111 @@ julia> B2 = BallInf(ones(2), 0.4);
 julia> plot([B1, B2])
 ```
 
-An iterative refinement method is applied to obtain an overapproximation of each
-set in `X` in constraint representation, which is then plotted. To change the
-default tolerance for the iterative refinement, use the second argument; it applies
-to all sets in the array.
+Some of the sets in the list may not be plotted precisely but rather
+overapproximated first.
+The second argument `ε` controls the accuracy of this overapproximation.
 
 ```julia
-julia> B1 = BallInf(zeros(2), 0.4);
+julia> Bs = [BallInf(zeros(2), 0.4), Ball2(ones(2), 0.4)];
 
-julia> B2 = Ball2(ones(2), 0.4);
+julia> plot(Bs, 1e-3)  # default accuracy value (explicitly given for clarity)
 
-julia> plot([B1, B2], 1e-1) # faster but less accurate 
-
-julia> plot([B1, B2], 1e-4) # slower but more accurate 
+julia> plot(Bs, 1e-2)  # faster but less accurate than the previous call
 ```
-
-### Algorithm
-
-Refer to the documentation of `plot_lazyset(S::LazySet, [ε]::Float64; ...)` for
-further details.
 """
-@recipe function plot_lazysets(X::Vector{XN}, ε::N=N(1e-3);
-                               color=:auto, alpha=0.5) where {N<:Real, XN<:LazySet{N}}
-
-    seriestype := :shape
-    seriescolor --> color
-    seriesalpha --> alpha
-    label --> ""
-    grid --> true
-    aspect_ratio --> 1.0
-
-    for Xi in X
-        if Xi isa EmptySet
-            continue
+@recipe function plot_list(list::AbstractVector{VN}, ε::N=N(DEFAULT_EPSILON),
+                           Nφ::Int=DEFAULT_POLAR_DIRECTIONS
+                          ) where {N<:Real, VN<:LazySet{N}}
+    for Xi in list
+        if Xi isa Intersection
+            @series Xi, -one(N), Nφ
+        else
+            @series Xi, ε
         end
-        @assert dim(Xi) == 2 "cannot plot a $(dim(Xi))-dimensional set using " *
-                             "iterative refinement"
-        Pi = overapproximate(Xi, ε)
-        vlist = transpose(hcat(convex_hull(vertices_list(Pi))...))
-
-        if isempty(vlist)
-            warn_empty_polytope()
-            continue
-        end
-
-        x, y = vlist[:, 1], vlist[:, 2]
-
-        # add first vertex to "close" the polygon
-        push!(x, vlist[1, 1])
-        push!(y, vlist[1, 2])
-
-        @series (x, y)
     end
 end
 
-# ==============================
-# Plot recipes for 2D polytopes
-# ==============================
-
 """
-    plot_polytope(P::AbstractPolytope, [ε]::N=zero(N); ...) where {N<:Real}
+    plot_lazyset(X::LazySet{N}, [ε]::N=N(DEFAULT_EPSILON); ...) where {N<:Real}
 
-Plot a 2D polytope as the convex hull of its vertices.
+Plot a convex set.
 
 ### Input
 
-- `P` -- polygon or polytope
+- `X` -- convex set
+- `ε` -- (optional, default: `DEFAULT_EPSILON`) approximation error bound
+
+### Notes
+
+This recipe detects if the overapproximation contains duplicate vertices.
+In that case, a scatter plot is used (instead of a shape plot).
+This corner case arises, for example, from lazy linear maps of singletons.
+
+Plotting of unbounded sets is not implemented yet (see
+[#576](https://github.com/JuliaReach/LazySets.jl/issues/576)).
+
+### Algorithm
+
+We first assert that `X` is bounded.
+
+One-dimensional sets are converted to an `Interval`.
+Three-dimensional or higher-dimensional sets cannot be plotted.
+
+For two-dimensional sets, we first compute a polygonal overapproximation.
+The second argument, `ε`, corresponds to the error in Hausdorff distance between
+the overapproximating set and `X`.
+The default value `DEFAULT_EPSILON` is chosen such that the unit ball in the
+2-norm is plotted with reasonable accuracy.
+On the other hand, if you only want to produce a fast box-overapproximation of
+`X`, pass `ε=Inf`.
+
+In a second stage, we use the plot recipe for polygons.
+
+### Examples
+
+```julia
+julia> B = Ball2(ones(2), 0.1);
+
+julia> plot(B, 1e-3)  # default accuracy value (explicitly given for clarity)
+
+julia> plot(B, 1e-2)  # faster but less accurate than the previous call
+```
+"""
+@recipe function plot_lazyset(X::LazySet{N}, ε::N=N(DEFAULT_EPSILON)
+                             ) where {N<:Real}
+    @assert dim(X) <= 2 "cannot plot a $(dim(X))-dimensional set"
+    @assert isbounded(X) "cannot plot an unbounded $(typeof(X))"
+
+    if dim(X) == 1
+        @series convert(Interval, X), ε
+    else
+        # construct epsilon-close polygon
+        P = overapproximate(X, ε)
+        # use polygon plot recipe
+        @series P, ε
+    end
+end
+
+"""
+    plot_polyhedron(P::AbstractPolyhedron{N}, [ε]::N=zero(N); ...)
+        where {N<:Real}
+
+Plot a (bounded) polyhedron.
+
+### Input
+
+- `P` -- bounded polyhedron
 - `ε` -- (optional, default: `0`) ignored, used for dispatch
 
-### Examples
-
-```julia
-julia> P = HPolygon([LinearConstraint([1.0, 0.0], 0.6),
-                     LinearConstraint([0.0, 1.0], 0.6),
-                     LinearConstraint([-1.0, 0.0], -0.4),
-                     LinearConstraint([0.0, -1.0], -0.4)]);
-
-julia> plot(P)
-```
-
-This recipe also applies if the polygon is given in vertex representation:
-    
-```julia
-julia> P = VPolygon([[0.6, 0.6], [0.4, 0.6], [0.4, 0.4], [0.6, 0.4]]);
-
-julia> plot(P);
-```
-
 ### Algorithm
 
-This function checks that the polytope received is two-dimensional, then
-computes its vertices accessing its `vertices_list` function and takes their
-convex hull. The set is plotted and shaded using the `:shape` series type from
-`Plots`. 
-"""
-@recipe function plot_polytope(P::AbstractPolytope{N}, ε::N=zero(N);
-                               color=:auto, alpha=0.5) where {N<:Real}
+We first assert that `P` is bounded (i.e., that `P` is a polytope).
 
-    # for polytopes
-    @assert dim(P) == 2 "cannot plot a $(dim(P))-dimensional polytope"
+One-dimensional polytopes are converted to an `Interval`.
+Three-dimensional or higher-dimensional polytopes are not supported.
 
-    seriestype := :shape
-    seriescolor --> color
-    seriesalpha --> alpha
-    label --> ""
-    grid --> true
-    aspect_ratio --> 1.0
-
-    points = convex_hull(vertices_list(P))
-    vlist = transpose(hcat(points...))
-
-    if isempty(vlist)
-        warn_empty_polytope()
-        return []
-    end
-
-    (x, y) = vlist[:, 1], vlist[:, 2]
-
-    # add first vertex to "close" the polygon
-    push!(x, vlist[1, 1])
-    push!(y, vlist[1, 2])
-
-    x, y
-end
-
-"""
-    plot_polytopes(P::Vector{PN}, [ε]::N=zero(N); ...) where {N<:Real, PN<:AbstractPolytope{N}}
-
-Plot an array of 2D polytopes as the convex hull of their vertices.
-
-### Input
-
-- `P` -- vector of polygons or polytopes
-- `ε` -- (optional, default: `0.0`) ignored, used for dispatch
+For two-dimensional polytopes (i.e., polygons) we compute their set of vertices
+using `vertices_list` and then plot the convex hull of these vertices.
 
 ### Examples
 
@@ -257,68 +155,59 @@ julia> P = HPolygon([LinearConstraint([1.0, 0.0], 0.6),
                      LinearConstraint([0.0, -1.0], -0.4)]);
 
 julia> plot(P)
-```
 
-This recipe also applies if the polygon is given in vertex representation:
-    
-```julia
 julia> P = VPolygon([[0.6, 0.6], [0.4, 0.6], [0.4, 0.4], [0.6, 0.4]]);
 
 julia> plot(P)
 ```
-
-### Algorithm
-
-This function checks that the polytope received is two-dimensional, then
-computes its vertices accessing its `vertices_list` function and takes their
-convex hull. The set is plotted and shaded using the `:shape` series type from
-`Plots`. 
 """
-@recipe function plot_polytopes(P::Vector{PN}, ε::N=zero(N);
-                                color=:auto, alpha=0.5) where {N<:Real, PN<:AbstractPolytope{N}}
+@recipe function plot_polyhedron(P::AbstractPolyhedron{N}, ε::N=zero(N)
+                                ) where {N<:Real}
+    @assert dim(P) <= 2 "cannot plot a $(dim(P))-dimensional polyhedron"
+    @assert isbounded(P) "cannot plot an unbounded $(typeof(P))"
 
-    # it is assumed that the polytopes are two-dimensional
-    seriestype := :shape
+    if dim(P) == 1
+        @series convert(Interval, P), ε
+    else
+        label --> DEFAULT_LABEL
+        grid --> DEFAULT_GRID
+        aspect_ratio --> DEFAULT_ASPECT_RATIO
+        seriesalpha --> DEFAULT_ALPHA
+        seriescolor --> DEFAULT_COLOR
 
-    seriescolor --> color
-    seriesalpha --> alpha
-    label --> ""
-    grid --> true
-    aspect_ratio --> 1.0
-
-    for Pi in P
-        @assert dim(Pi) == 2 "cannot plot a $(dim(Pi))-dimensional polytope"
-        points = convex_hull(vertices_list(Pi))
-        vlist = transpose(hcat(points...))
-
+        vlist = transpose(hcat(convex_hull(vertices_list(P))...))
         if isempty(vlist)
-            warn_empty_polytope()
-            continue
+            @warn "received a polyhedron with no vertices during plotting"
+            return []
         end
-
         x, y = vlist[:, 1], vlist[:, 2]
 
-        # add first vertex to "close" the polygon
-        push!(x, vlist[1, 1])
-        push!(y, vlist[1, 2])
-
-        @series (x, y)
+        if length(x) == 1
+            # a single point
+            seriestype := :scatter
+        else
+            # add first vertex to "close" the polygon
+            push!(x, vlist[1, 1])
+            push!(y, vlist[1, 2])
+            if norm(vlist[1, :] - vlist[2, :]) ≈ 0
+                seriestype := :scatter
+            else
+                seriestype := :shape
+            end
+        end
+        @series x, y
     end
 end
 
-# ============================
-# Plot recipes for singletons
-# ============================
-
 """
-    plot_singleton(S::AbstractSingleton{N}, [ε]::N=zero(N);; ...) where {N<:Real}
+    plot_singleton(S::AbstractSingleton{N}, [ε]::N=zero(N); ...) where {N<:Real}
 
 Plot a singleton.
 
 ### Input
 
-- `S` -- singleton wrapping a point, i.e., a one-element set
-- `ε` -- (optional, default: `0.0`) ignored, used for dispatch
+- `S` -- singleton
+- `ε` -- (optional, default: `0`) ignored, used for dispatch
 
 ### Examples
 
@@ -326,71 +215,23 @@ Plot a singleton.
 julia> plot(Singleton([0.5, 1.0]))
 ```
 """
-@recipe function plot_singleton(S::AbstractSingleton{N}, ε::N=zero(N);
-                                color=:auto, alpha=1.0) where {N<:Real}
-
+@recipe function plot_singleton(S::AbstractSingleton{N}, ε::N=zero(N)
+                               ) where {N<:Real}
+    label --> DEFAULT_LABEL
+    grid --> DEFAULT_GRID
+    aspect_ratio --> DEFAULT_ASPECT_RATIO
+    seriesalpha --> DEFAULT_ALPHA
+    seriescolor --> DEFAULT_COLOR
     seriestype := :scatter
-    seriescolor --> color
-    seriesalpha --> alpha
-    label --> ""
-    grid --> true
-    aspect_ratio --> 1.0
 
-    @assert dim(S) == 2 ||
-            dim(S) == 3 "cannot plot a $(dim(S))-dimensional singleton"
-    [Tuple(element(S))]
-end
-
-"""
-    plot_singletons(S::Vector{SN}, ε::N=zero(N); ...) where {N<:Real, SN<:AbstractSingleton{N}}
-
-Plot a list of singletons.
-
-### Input
-
-- `S` -- list of singletons, i.e., a vector of one-element sets
-- `ε` -- (optional, default: `0.0`) ignored, used for dispatch
-
-### Examples
-
-```julia
-julia> plot([Singleton([0.0, 0.0]), Singleton([1., 0]), Singleton([0.5, .5])])
-```
-
-Three-dimensional singletons can be plotted as well, with this same recipe:
-
-```julia
-julia> a, b, c = [0.0, 0, 0], [1.0, 0, 0], [0.0, 1., 0];
-
-julia> plot([Singleton(a), Singleton(b), Singleton(c)])
-```
-"""
-@recipe function plot_singletons(S::Vector{SN}, ε::N=zero(N);
-                                 color=:auto, alpha=1.0) where {N<:Real, SN<:AbstractSingleton{N}}
-
-    seriestype := :scatter
-    seriescolor --> color
-    seriesalpha --> alpha
-    label --> ""
-    grid --> true
-    aspect_ratio --> 1.0
-
-    if dim(S[1]) == 2
-        @assert all([dim(p) == 2 for p in S]) "all points in this vector " *
-            "should have the same dimension"
-    elseif dim(S[1]) == 3
-        @assert all([dim(p) == 3 for p in S]) "all points in this vector " *
-            "should have the same dimension"
+    if dim(S) == 1
+        @series [Tuple([element(S)[1], N(0)])]
     else
-        error("can only plot 2D or 3D vectors of singletons")
+        @assert dim(S) ∈ [2, 3] "cannot plot a $(dim(S))-dimensional singleton"
+
+        @series [Tuple(element(S))]
     end
-
-    [Tuple(element(p)) for p in S]
 end
-
-# ==============================================
-# Plot recipes for line segments and intervals
-# ==============================================
 
 """
     plot_linesegment(L::LineSegment{N}, [ε]::N=zero(N); ...) where {N<:Real}
@@ -400,7 +241,7 @@ Plot a line segment.
 ### Input
 
 - `L` -- line segment
-- `ε` -- (optional, default: `0.0`) ignored, used for dispatch
+- `ε` -- (optional, default: `0`) ignored, used for dispatch
 
 ### Examples
 
@@ -411,67 +252,40 @@ julia> plot(L)
 ```
 
 To control the color of the line, use the `linecolor` keyword argument, and to
-control the color of the endpoints, use the `markercolor` keyword argument.
+control the color of the end points, use the `markercolor` keyword argument.
 To control the width, use `linewidth`.
 
 ```julia
 julia> plot(L, markercolor="green", linecolor="red", linewidth=2.)
 ```
 
-The option `add_marker` (optional, default: `true`) can be used to specify if
-endpoint markers should be plotted or not.
-```julia
-julia> plot(L, add_marker=false, linecolor="red", linewidth=2.)
-```
-"""
-@recipe function plot_linesegment(L::LineSegment{N}, ε::N=zero(N);
-                                  color=:auto, alpha=0.5, add_marker=true) where {N<:Real}
-
-    seriestype := :path
-    linecolor   --> color
-    markercolor --> color
-    markershape --> (add_marker ? :circle : :none)
-    label --> ""
-    grid --> true
-
-    [Tuple(L.p); Tuple(L.q)]
-end
-
-"""
-    plot_linesegments(L::Vector{LineSegment{N}}, [ε]::N=zero(N); ...) where {N<:Real}
-
-Plot an array of line segments.
-
-### Input
-
-- `L` -- vector of line segments
-- `ε` -- (optional, default: `0.0`) ignored, used for dispatch
-
-### Examples
+To omit the markers, use `markershape=:none`.
+You also need to pass a value for `seriestype=:path` explicitly (this seems to
+be an external bug).
 
 ```julia
-julia> L1 = LineSegment([0., 0.], [1., 1.]);
-
-julia> L2 = LineSegment([1., 0.], [0., 1.]);
-
-julia> plot([L1, L2])
+julia> plot(L, seriestype=:path, markershape=:none)
 ```
 
-For other options, see the documentation of `plot_linesegment(L::LineSegment)`.
+A shorter alternative is to pass `marker=0`, but this may result in small dots
+as markers based on the plotting backend.
+
+```julia
+julia> plot(L, marker=0)
+```
 """
-@recipe function plot_linesegments(L::Vector{LineSegment{N}}, ε::N=zero(N);
-                                   color=:auto, alpha=0.5, add_marker=true) where {N<:Real}
-
+@recipe function plot_linesegment(L::LineSegment{N}, ε::N=zero(N)
+                                 ) where {N<:Real}
+    label --> DEFAULT_LABEL
+    grid --> DEFAULT_GRID
+    aspect_ratio --> DEFAULT_ASPECT_RATIO
+    seriesalpha --> DEFAULT_ALPHA
+    linecolor   --> DEFAULT_COLOR
+    markercolor --> DEFAULT_COLOR
+    markershape --> :circle
     seriestype := :path
-    linecolor   --> color
-    markercolor --> color
-    label --> ""
-    grid --> true
-    markershape --> (add_marker ? :circle : :none)
 
-    for Li in L
-        @series [Tuple(Li.p); Tuple(Li.q)]
-    end
+    @series [Tuple(L.p); Tuple(L.q)]
 end
 
 """
@@ -482,7 +296,12 @@ Plot an interval.
 ### Input
 
 - `I` -- interval
-- `ε` -- (optional, default: `0.0`) ignored, used for dispatch
+- `ε` -- (optional, default: `0`) ignored, used for dispatch
+
+### Notes
+
+We convert the interval to a `LineSegment` with y coordinate equal to zero.
+See the corresponding plot recipe for more discussion.
 
 ### Examples
 
@@ -491,63 +310,13 @@ julia> I = Interval(0.0, 1.0);
 
 julia> plot(I)
 ```
-
-For other options, see the documentation of `plot_linesegment(L::LineSegment)`.
 """
-@recipe function plot_interval(I::Interval{N}, ε::N=zero(N);
-                               color=:auto, alpha=0.5, add_marker=true) where {N<:Real}
-
-    seriestype := :path
-    linecolor   --> color
-    markercolor --> color
-    markershape --> (add_marker ? :circle : :none)
-
-    [Tuple([min(I), 0.0]); Tuple([max(I), 0.0])]
+@recipe function plot_interval(I::Interval{N}, ε::N=zero(N)) where {N<:Real}
+    @series LineSegment([min(I), N(0)], [max(I), N(0)]), ε
 end
 
 """
-    plot_intervals(I::Vector{Interval{N}}, [ε]::N=zero(N); ...); ...) where {N<:Real}
-
-Plot an array of intervals.
-
-### Input
-
-- `I` -- vector of intervals
-- `ε` -- (optional, default: `0.0`) ignored, used for dispatch
-
-### Examples
-
-```julia
-julia> I1 = Interval([0., 1.]);
-
-julia> I2 = Interval([0.5, 2.]);
-
-julia> plot([I1, I2])
-```
-
-For other options, see the documentation of `plot_linesegment(L::LineSegment)`.
-"""
-@recipe function plot_intervals(I::Vector{Interval{N}}, ε::N=zero(N);
-                                color=:auto, alpha=0.5, add_marker=true) where {N<:Real}
-
-    seriestype := :path
-    linecolor   --> color
-    markercolor --> color
-    label --> ""
-    grid --> true
-    markershape --> (add_marker ? :circle : :none)
-
-    for Ii in I
-        @series [Tuple([min(Ii), 0.0]); Tuple([max(Ii), 0.0])]
-    end
-end
-
-# ==============================
-# Plot recipe for the empty set
-# ==============================
-
-"""
-    plot_emptyset(∅::EmptySet, [ε]; ...)
+    plot_emptyset(∅::EmptySet, [ε]::N=zero(N); ...)
 
 Plot an empty set.
 
@@ -555,179 +324,89 @@ Plot an empty set.
 
 - `∅` -- empty set
 - `ε` -- (optional, default: `0`) ignored, used for dispatch
-
-### Output
-
-An empty figure.
 """
 @recipe function plot_emptyset(∅::EmptySet{N}, ε::N=zero(N)) where {N<:Real}
-    label --> ""
-    grid --> true
+    label --> DEFAULT_LABEL
+    grid --> DEFAULT_GRID
+    aspect_ratio --> DEFAULT_ASPECT_RATIO
+
     return []
 end
 
-# ===============================
-# Plot recipe for unbounded sets
-# ===============================
-
 """
-    plot_universe(U::Universe, [ε]; ...)
-
-Plot the universal set.
-
-### Input
-
-- `U` -- universal set
-- `ε` -- (optional, default: `0`) ignored, used for dispatch
-
-### Output
-
-An error, since plotting the universal set is not implemented yet (see #576).
-"""
-@recipe function plot_universe(::Universe{N}, ε::N=zero(N)) where {N<:Real}
-    error("cannot plot the universal set")
-end
-
-"""
-    plot_line(L::Line, [ε]; ...)
-
-Plot a line in 2D.
-
-### Input
-
-- `L` -- line
-- `ε` -- (optional, default: `0`) ignored, used for dispatch
-
-### Output
-
-An error, since plotting a line is not implemented yet (see #576).
-"""
-@recipe function plot_line(::Line{N}, ε::N=zero(N)) where {N<:Real}
-    error("cannot plot an infinite line")
-end
-
-"""
-    plot_halfspace(H::HalfSpace, [ε]; ...)
-
-Plot a half-space in 2D.
-
-### Input
-
-- `H` -- half-space
-- `ε` -- (optional, default: `0`) ignored, used for dispatch
-
-### Output
-
-An error, since plotting a half-space is not implemented yet (see #576).
-"""
-@recipe function plot_halfspace(::HalfSpace{N}, ε::N=zero(N)) where {N<:Real}
-    error("cannot plot a half-space")
-end
-
-"""
-    plot_hyperplane(H::Hyperplane, [ε]; ...)
-
-Plot a hyperplane in 2D.
-
-### Input
-
-- `H` -- hyperplane
-- `ε` -- (optional, default: `0`) ignored, used for dispatch
-
-### Output
-
-An error, since plotting a hyperplane is not implemented yet (see #576).
-"""
-@recipe function plot_hyperplane(::Hyperplane{N}, ε::N=zero(N)) where {N<:Real}
-    error("cannot plot a hyperplane")
-end
-
-# ===================================
-# Plot recipe for lazy intersections
-# ===================================
-
-"""
-    plot_intersection(X::Intersection{N}, [ε]::N=-one(N); Nφ=40,
-                      color=:auto, alpha=0.5) where {N<:Real}
+    plot_intersection(cap::Intersection{N}, [ε]::N=-one(N),
+                      [Nφ]::Int=DEFAULT_POLAR_DIRECTIONS) where {N<:Real}
 
 Plot a lazy intersection.
 
 ### Input
 
-- `X`  -- lazy intersection
-- `ε`  -- (optional, default -1) ignored, used only for dispatch
-- `Nφ` -- (optional, default: `40`) number of template directions used in the
-          template overapproximation
-
-### Output
-
-A plot with the overapproximation of the given lazy intersection.
+- `cap`  -- lazy intersection
+- `ε`    -- (optional, default `-1`) ignored, used for dispatch
+- `Nφ`   -- (optional, default: `DEFAULT_POLAR_DIRECTIONS`) number of polar
+            directions used in the template overapproximation
 
 ### Notes
 
-This function is separated from the main `LazySet` plot recipe because
-the iterative refinement is not available for lazy intersections, since it uses
-the support vector (but see #1187).
+This function is separated from the main `LazySet` plot recipe because iterative
+refinement is not available for lazy intersections (since it uses the support
+vector (but see
+[#1187](https://github.com/JuliaReach/LazySets.jl/issues/1187))).
 
-Also note that if the set is a *nested* intersection, e.g., the lazy linear map,
-you may have to manually overapproximate this set before
-plotting (see `LazySets.Approximations.overapproximate` for details).
+Also note that if the set is a *nested* intersection, you may have to manually
+overapproximate this set before plotting (see
+`LazySets.Approximations.overapproximate` for details).
+
+### Examples
 
 ```julia
-julia> using Polyhedra, LazySets.Approximations
+julia> using LazySets.Approximations
 
-julia> X = rand(Ball2) ∩ rand(Ball2); # lazy intersection
+julia> X = Ball2(zeros(2), 1.) ∩ Ball2(ones(2), 1.5);  # lazy intersection
 
 julia> plot(X)
 ```
 
-One can specify the accuracy of the overapproximation of the lazy intersection
-passing a higher value in `Nφ`, which stands for the number of polar directions chosen.
+You can specify the accuracy of the overapproximation of the lazy intersection
+by passing a higher value for `Nφ`, which stands for the number of polar
+directions used in the overapproximation.
+This number can also be passed to the `plot` function directly.
 
 ```julia
-julia> Nφ = 100; # or a bigger number
+julia> plot(overapproximate(X, PolarDirections(100)))
 
-julia> Po = overapproximate(X, PolarDirections(Nφ));
-
-julia> P = convert(HPolytope, Po) # see issue #1306
-
-julia> plot(P)
+julia> plot(X, -1., 100)  # equivalent to the above line
 ```
 """
-@recipe function plot_intersection(X::Intersection{N}, ε::N=-one(N); Nφ=40,
-                                   color=:auto, alpha=0.5) where {N<:Real}
-
-    @assert dim(X) == 2 "this recipe only plots two-dimensional sets"
-
+@recipe function plot_intersection(cap::Intersection{N},
+                                   ε::N=-one(N),
+                                   Nφ::Int=DEFAULT_POLAR_DIRECTIONS
+                                  ) where {N<:Real}
     if ε != -one(N)
-        error("cannot plot a lazy intersection using iterative refinement with " *
-              "error threshold `ε = $ε`, because the exact support vector of an " *
-              "intersection is currently not available; using instead a set of `Nφ` " *
-              "template directions. To control the number of directions, pass the " *
-              "variable Nφ as in `plot(X, Nφ=...)`")
+        error("cannot plot a lazy intersection using iterative refinement " *
+              "with accuracy threshold `ε = $ε`, because the exact support " *
+              "vector of an intersection is currently not available; using " *
+              "instead a set of `Nφ` template directions. To control the " *
+              "number of directions, pass another integer argument as in " *
+              "`plot(cap, -1., 40)`")
     end
 
-    seriescolor --> color
-    seriesalpha --> alpha
-    label --> ""
-    grid --> true
-    aspect_ratio --> 1.0
+    label --> DEFAULT_LABEL
+    grid --> DEFAULT_GRID
+    aspect_ratio --> DEFAULT_ASPECT_RATIO
+    seriesalpha --> DEFAULT_ALPHA
+    seriescolor --> DEFAULT_COLOR
 
-    P = convert(HPolygon, overapproximate(X, PolarDirections{N}(Nφ)))
-    vlist = transpose(hcat(convex_hull(vertices_list(P))...))
-
-    if isempty(vlist)
-        warn_empty_polytope()
+    if isempty(cap)
         return []
+    elseif dim(cap) == 1
+        @series convert(Interval, cap)
+    else
+        @assert dim(cap) == 2 "cannot plot a $(dim(S))-dimensional intersection"
+
+        # construct polygon approximation using polar directions
+        P = overapproximate(cap, PolarDirections{N}(Nφ))
+        # use polygon plot recipe
+        @series P, ε
     end
-
-    (x, y) = vlist[:, 1], vlist[:, 2]
-
-    # add first vertex to "close" the polygon
-    push!(x, vlist[1, 1])
-    push!(y, vlist[1, 2])
-
-    seriestype := norm(vlist[1, :] - vlist[2, :]) ≈ 0 ? :scatter : :shape
-
-    x, y
 end

--- a/test/unit_plot.jl
+++ b/test/unit_plot.jl
@@ -103,10 +103,10 @@ for N in [Float64, Float32, Rational{Int}]
     plot(vpg)
     plot(vpt)
     plot(es)
-    @test_throws ErrorException plot(hs) # TODO see #576
-    @test_throws ErrorException plot(hp) # TODO see #576
-    @test_throws ErrorException plot(l) # TODO see #576
-    @test_throws ErrorException plot(uni) # TODO see #576
+    @test_throws AssertionError plot(hs) # TODO see #576
+    @test_throws AssertionError plot(hp) # TODO see #576
+    @test_throws AssertionError plot(l) # TODO see #576
+    @test_throws AssertionError plot(uni) # TODO see #576
     plot(ch)
     plot(cha)
     plot(sih)


### PR DESCRIPTION
See #237.

Most important changes:
* Plotting a vector of sets now falls back to the plot recipes for each individual set. This saves lots of code duplication and is generally preferable for both efficiency and consistency. In particular, this allows to plot  vectors containing lazy `Intersection`s.
* Arbitrary 1D sets can now be plotted.
* Common plotting options are unified.