### PR TITLE
#1031 - Change vector type in halfspace's def

### DIFF
--- a/docs/src/lib/interfaces.md
+++ b/docs/src/lib/interfaces.md
@@ -180,7 +180,7 @@ rand(::Type{HPOLYGON}) where {HPOLYGON<:AbstractHPolygon}
 tohrep(::HPOLYGON) where {HPOLYGON<:AbstractHPolygon}
 tovrep(::AbstractHPolygon{N}) where {N<:Real}
 addconstraint!(::AbstractHPolygon{N}, ::LinearConstraint{N}) where {N<:Real}
-addconstraint!(::Vector{LinearConstraint{N}}, ::LinearConstraint{N}) where {N<:Real}
+addconstraint!(::Vector{LC}, ::LinearConstraint{N}) where {N<:Real, LC<:LinearConstraint{N}}
 isredundant(::LinearConstraint{N}, ::LinearConstraint{N}, ::LinearConstraint{N}) where {N<:Real}
 remove_redundant_constraints!(::AbstractHPolygon)
 constraints_list(::AbstractHPolygon{N}) where {N<:Real}

--- a/docs/src/lib/representations.md
+++ b/docs/src/lib/representations.md
@@ -183,9 +183,9 @@ constrained_dimensions(::HalfSpace{N}) where {N<:Real}
 translate(::HalfSpace{N}, ::AbstractVector{N}) where {N<:Real}
 halfspace_left(::AbstractVector{N}, ::AbstractVector{N}) where {N<:Real}
 halfspace_right(::AbstractVector{N}, ::AbstractVector{N}) where {N<:Real}
-tosimplehrep(::AbstractVector{HalfSpace{N}}) where {N<:Real}
-remove_redundant_constraints(::AbstractVector{LinearConstraint{N}}) where {N<:Real}
-remove_redundant_constraints!(::AbstractVector{LinearConstraint{N}}) where {N<:Real}
+tosimplehrep(::AbstractVector{LC}) where {N<:Real, LC<:LinearConstraint{N}}
+remove_redundant_constraints(::AbstractVector{LC}) where {N<:Real, LC<:LinearConstraint{N}}
+remove_redundant_constraints!(::AbstractVector{LC}) where {N<:Real, LC<:LinearConstraint{N}}
 ```
 Inherited from [`LazySet`](@ref):
 * [`norm`](@ref norm(::LazySet, ::Real))

--- a/src/AbstractHPolygon.jl
+++ b/src/AbstractHPolygon.jl
@@ -142,8 +142,7 @@ function vertices_list(P::AbstractHPolygon{N},
 end
 
 """
-    constraints_list(P::AbstractHPolygon{N})::Vector{LinearConstraint{N}}
-        where {N<:Real}
+    constraints_list(P::AbstractHPolygon{N}) where {N<:Real}
 
 Return the list of constraints defining a polygon in H-representation.
 
@@ -156,8 +155,7 @@ Return the list of constraints defining a polygon in H-representation.
 The list of constraints of the polygon.
 The implementation guarantees that the constraints are sorted counter-clockwise.
 """
-function constraints_list(P::AbstractHPolygon{N}
-                         )::Vector{LinearConstraint{N}} where {N<:Real}
+function constraints_list(P::AbstractHPolygon{N}) where {N<:Real}
     return P.constraints
 end
 
@@ -411,12 +409,12 @@ function addconstraint!(P::AbstractHPolygon{N},
 end
 
 """
-    addconstraint!(constraints::Vector{LinearConstraint{N}},
+    addconstraint!(constraints::Vector{LC},
                    new_constraint::LinearConstraint{N};
                    [linear_search]::Bool=(length(P.constraints) <
                                           BINARY_SEARCH_THRESHOLD),
                    [prune]::Bool=true
-                  )::Nothing where {N<:Real}
+                  )::Nothing where {N<:Real, LC<:LinearConstraint{N}}
 
 Add a linear constraint to a sorted vector of constrains, keeping the
 constraints sorted by their normal directions.
@@ -442,12 +440,12 @@ If `prune` is active, we check if the new constraint is redundant.
 If the constraint is not redundant, we perform the same check to the left and to
 the right until we find the first constraint that is not redundant.
 """
-function addconstraint!(constraints::Vector{LinearConstraint{N}},
+function addconstraint!(constraints::Vector{LC},
                         new_constraint::LinearConstraint{N};
                         linear_search::Bool=(length(constraints) <
                                              BINARY_SEARCH_THRESHOLD),
                         prune::Bool=true
-                       )::Nothing where {N<:Real}
+                       )::Nothing where {N<:Real, LC<:LinearConstraint{N}}
     m = length(constraints)
     k = m
     if k > 0
@@ -516,7 +514,7 @@ end
 
 """
     binary_search_constraints(d::AbstractVector{N},
-                              constraints::Vector{LinearConstraint{N}},
+                              constraints::Vector{<:LinearConstraint{N}},
                               n::Int,
                               k::Int;
                               [choose_lower]::Bool=false
@@ -542,7 +540,7 @@ that `constraints[k] < d`, which is equivalent to being `k-1` in the normal
 setting.
 """
 function binary_search_constraints(d::AbstractVector{N},
-                                   constraints::Vector{LinearConstraint{N}},
+                                   constraints::Vector{<:LinearConstraint{N}},
                                    n::Int,
                                    k::Int;
                                    choose_lower::Bool=false

--- a/src/AbstractHyperrectangle.jl
+++ b/src/AbstractHyperrectangle.jl
@@ -64,8 +64,7 @@ function vertices_list(H::AbstractHyperrectangle{N}
 end
 
 """
-    constraints_list(H::AbstractHyperrectangle{N})::Vector{LinearConstraint{N}}
-        where {N<:Real}
+    constraints_list(H::AbstractHyperrectangle{N}) where {N<:Real}
 
 Return the list of constraints of an axis-aligned hyperrectangular set.
 
@@ -77,7 +76,7 @@ Return the list of constraints of an axis-aligned hyperrectangular set.
 
 A list of linear constraints.
 """
-function constraints_list(H::AbstractHyperrectangle{N})::Vector{LinearConstraint{N}} where {N<:Real}
+function constraints_list(H::AbstractHyperrectangle{N}) where {N<:Real}
     n = dim(H)
     constraints = Vector{LinearConstraint{N}}(undef, 2*n)
     b, c = high(H), -low(H)

--- a/src/AbstractPolyhedron.jl
+++ b/src/AbstractPolyhedron.jl
@@ -9,8 +9,8 @@ equivalently, sets defined as an intersection of a finite number of half-spaces.
 ### Notes
 
 Every concrete `AbstractPolyhedron` must define the following functions:
-- `constraints_list(::AbstractPolyhedron{N})::Vector{LinearConstraint{N}}` --
-    return a list of all facet constraints
+- `constraints_list(::AbstractPolyhedron{N})` -- return a list of all facet
+    constraints
 
 ```jldoctest
 julia> subtypes(AbstractPolyhedron)

--- a/src/AbstractPolyhedron_functions.jl
+++ b/src/AbstractPolyhedron_functions.jl
@@ -65,8 +65,8 @@ function constrained_dimensions(P::AbstractPolyhedron)::Vector{Int}
 end
 
 """
-    tosimplehrep(constraints::AbstractVector{LinearConstraint{N}})
-        where {N<:Real}
+    tosimplehrep(constraints::AbstractVector{LC})
+        where {N<:Real, LC<:LinearConstraint{N}}
 
 Return the simple H-representation ``Ax ≤ b`` from a list of linear constraints.
 
@@ -79,8 +79,8 @@ Return the simple H-representation ``Ax ≤ b`` from a list of linear constraint
 The tuple `(A, b)` where `A` is the matrix of normal directions and `b` is the
 vector of offsets.
 """
-function tosimplehrep(constraints::AbstractVector{LinearConstraint{N}}
-                     ) where {N<:Real}
+function tosimplehrep(constraints::AbstractVector{LC}
+                     ) where {N<:Real, LC<:LinearConstraint{N}}
     n = length(constraints)
     if n == 0
         A = Matrix{N}(undef, 0, 0)
@@ -99,9 +99,9 @@ function tosimplehrep(constraints::AbstractVector{LinearConstraint{N}}
 end
 
 """
-     remove_redundant_constraints!(
-         constraints::AbstractVector{LinearConstraint{N}};
-         [backend]=GLPKSolverLP())::Bool where {N<:Real}
+     remove_redundant_constraints!(constraints::AbstractVector{LC};
+         [backend]=GLPKSolverLP())::Bool where {N<:Real,
+                                                LC<:LinearConstraint{N}}
 
 Remove the redundant constraints of a given list of linear constraints; the list
 is updated in-place.
@@ -139,9 +139,10 @@ If the calculation finished successfully, this function returns `true`.
 For details, see [Fukuda's Polyhedra
 FAQ](https://www.cs.mcgill.ca/~fukuda/soft/polyfaq/node24.html).
 """
-function remove_redundant_constraints!(constraints::AbstractVector{LinearConstraint{N}};
+function remove_redundant_constraints!(constraints::AbstractVector{LC};
                                        backend=GLPKSolverLP()
-                                      )::Bool where {N<:Real}
+                                      )::Bool where {N<:Real,
+                                                     LC<:LinearConstraint{N}}
 
     A, b = tosimplehrep(constraints)
     m, n = size(A)
@@ -177,10 +178,8 @@ function remove_redundant_constraints!(constraints::AbstractVector{LinearConstra
 end
 
 """
-    remove_redundant_constraints(
-        constraints::AbstractVector{LinearConstraint{N}};
-        backend=GLPKSolverLP())::Union{AbstractVector{LinearConstraint{N}},
-                                       EmptySet{N}} where {N<:Real}
+    remove_redundant_constraints(constraints::AbstractVector{LC};
+        backend=GLPKSolverLP()) where {N<:Real, LC<:LinearConstraint{N}}
 
 Remove the redundant constraints of a given list of linear constraints.
 
@@ -197,14 +196,12 @@ constraints are infeasible.
 ### Algorithm
 
 See
-[`remove_redundant_constraints!(::AbstractVector{LinearConstraint{<:Real}})`](@ref)
+[`remove_redundant_constraints!(::AbstractVector{<:LinearConstraint{<:Real}})`](@ref)
 for details.
 """
-function remove_redundant_constraints(constraints::AbstractVector{LinearConstraint{N}};
+function remove_redundant_constraints(constraints::AbstractVector{LC};
                                       backend=GLPKSolverLP()
-                                     )::Union{AbstractVector{LinearConstraint{N}},
-                                                             EmptySet{N}
-                                                            } where {N<:Real}
+                                     ) where {N<:Real, LC<:LinearConstraint{N}}
     constraints_copy = copy(constraints)
     if remove_redundant_constraints!(constraints_copy, backend=backend)
         return constraints_copy

--- a/src/Approximations/decompositions.jl
+++ b/src/Approximations/decompositions.jl
@@ -468,19 +468,19 @@ of variables to be `[1, 2, 3]`:
 
 ```jldoctest project_halfspace
 julia> H = HalfSpace([1.0, 1.0, 0.0], 1.0)
-HalfSpace{Float64}([1.0, 1.0, 0.0], 1.0)
+HalfSpace{Float64,Array{Float64,1}}([1.0, 1.0, 0.0], 1.0)
 
 julia> using LazySets.Approximations: project
 
 julia> project(H, [1, 2, 3])
-HalfSpace{Float64}([1.0, 1.0, 0.0], 1.0)
+HalfSpace{Float64,Array{Float64,1}}([1.0, 1.0, 0.0], 1.0)
 ```
 
 Projecting along dimensions `1` and `2` only:
 
 ```jldoctest project_halfspace
 julia> project(H, [1, 2])
-HalfSpace{Float64}([1.0, 1.0], 1.0)
+HalfSpace{Float64,Array{Float64,1}}([1.0, 1.0], 1.0)
 ```
 
 In general, use the call syntax `project(H, constrained_dimensions(H))` to return
@@ -488,7 +488,7 @@ the half-space projected on the dimensions where it is constrained only:
 
 ```jldoctest project_halfspace
 julia> project(H, constrained_dimensions(H))
-HalfSpace{Float64}([1.0, 1.0], 1.0)
+HalfSpace{Float64,Array{Float64,1}}([1.0, 1.0], 1.0)
 ```
 """
 function project(H::HalfSpace{N}, block::AbstractVector{Int}) where {N}
@@ -553,9 +553,9 @@ Now let's take a ball in the infinity norm and remove some constraints:
 julia> B = BallInf(zeros(4), 1.0);
 
 julia> c = constraints_list(B)[1:2]
-2-element Array{HalfSpace{Float64},1}:
- HalfSpace{Float64}([1.0, 0.0, 0.0, 0.0], 1.0)
- HalfSpace{Float64}([0.0, 1.0, 0.0, 0.0], 1.0)
+2-element Array{HalfSpace{Float64,VN} where VN<:AbstractArray{Float64,1},1}:
+ HalfSpace{Float64,LazySets.Approximations.UnitVector{Float64}}([1.0, 0.0, 0.0, 0.0], 1.0)
+ HalfSpace{Float64,LazySets.Approximations.UnitVector{Float64}}([0.0, 1.0, 0.0, 0.0], 1.0)
 
 julia> P = HPolyhedron(c);
 
@@ -569,9 +569,9 @@ Finally we take the concrete projection onto variables `1` and `2`:
 
 ```jldoctest project_hpolyhedron
 julia> project(P, [1, 2]) |> constraints_list
-2-element Array{HalfSpace{Float64},1}:
- HalfSpace{Float64}([1.0, 0.0], 1.0)
- HalfSpace{Float64}([0.0, 1.0], 1.0)
+2-element Array{HalfSpace{Float64,VN} where VN<:AbstractArray{Float64,1},1}:
+ HalfSpace{Float64,Array{Float64,1}}([1.0, 0.0], 1.0)
+ HalfSpace{Float64,Array{Float64,1}}([0.0, 1.0], 1.0)
 ```
 """
 function project(P::HPolyhedron{N}, block::AbstractVector{Int}) where {N}

--- a/src/Ball1.jl
+++ b/src/Ball1.jl
@@ -222,7 +222,7 @@ function rand(::Type{Ball1};
 end
 
 """
-    constraints_list(P::Ball1{N})::Vector{LinearConstraint{N}} where {N<:Real}
+    constraints_list(P::Ball1{N}) where {N<:Real}
 
 Return the list of constraints defining a ball in the 1-norm.
 
@@ -240,7 +240,7 @@ The constraints can be defined as ``d_i^T (x-c) ≤ r`` for all ``d_i``, where
 ``d_i`` is a vector with elements ``1`` or ``-1`` in ``n`` dimensions. To span
 all possible ``d_i``, the function `Iterators.product` is used.
 """
-function constraints_list(B::Ball1{N})::Vector{LinearConstraint{N}} where {N<:Real}
+function constraints_list(B::Ball1{N}) where {N<:Real}
     n = LazySets.dim(B)
     c, r = B.center, B.radius
     clist = Vector{LinearConstraint{N}}(undef, 2^n)

--- a/src/CartesianProduct.jl
+++ b/src/CartesianProduct.jl
@@ -180,8 +180,7 @@ function isempty(cp::CartesianProduct)::Bool
 end
 
 """
-    constraints_list(cp::CartesianProduct{N}
-                    )::Vector{LinearConstraint{N}} where {N<:Real}
+    constraints_list(cp::CartesianProduct{N}) where {N<:Real}
 
 Return the list of constraints of a (polytopic) Cartesian product.
 
@@ -193,8 +192,7 @@ Return the list of constraints of a (polytopic) Cartesian product.
 
 A list of constraints.
 """
-function constraints_list(cp::CartesianProduct{N}
-                         )::Vector{LinearConstraint{N}} where {N<:Real}
+function constraints_list(cp::CartesianProduct{N}) where {N<:Real}
     return constraints_list(CartesianProductArray([cp.X, cp.Y]))
 end
 
@@ -431,8 +429,7 @@ function isempty(cpa::CartesianProductArray)::Bool
 end
 
 """
-    constraints_list(cpa::CartesianProductArray{N}
-                    )::Vector{LinearConstraint{N}} where {N<:Real}
+    constraints_list(cpa::CartesianProductArray{N}) where {N<:Real}
 
 Return the list of constraints of a (polytopic) Cartesian product of a finite
 number of sets.
@@ -445,8 +442,7 @@ number of sets.
 
 A list of constraints.
 """
-function constraints_list(cpa::CartesianProductArray{N}
-                         )::Vector{LinearConstraint{N}} where {N<:Real}
+function constraints_list(cpa::CartesianProductArray{N}) where {N<:Real}
     clist = Vector{LinearConstraint{N}}()
     n = dim(cpa)
     sizehint!(clist, n)

--- a/src/HPolygon.jl
+++ b/src/HPolygon.jl
@@ -45,12 +45,12 @@ struct HPolygon{N<:Real} <: AbstractHPolygon{N}
 
     # default constructor that applies sorting of the given constraints and
     # (checks for and) removes redundant constraints
-    function HPolygon{N}(constraints::Vector{LinearConstraint{N}};
+    function HPolygon{N}(constraints::Vector{<:LinearConstraint{N}};
                          sort_constraints::Bool=true,
                          check_boundedness::Bool=false,
                          prune::Bool=true) where {N<:Real}
         if sort_constraints
-            sorted_constraints = Vector{LinearConstraint{N}}()
+            sorted_constraints = Vector{eltype(constraints)}()
             sizehint!(sorted_constraints, length(constraints))
             for ci in constraints
                 addconstraint!(sorted_constraints, ci; prune=prune)
@@ -66,7 +66,7 @@ struct HPolygon{N<:Real} <: AbstractHPolygon{N}
 end
 
 # convenience constructor without type parameter
-HPolygon(constraints::Vector{LinearConstraint{N}};
+HPolygon(constraints::Vector{<:LinearConstraint{N}};
          sort_constraints::Bool=true,
          check_boundedness::Bool=false,
          prune::Bool=true) where {N<:Real} =
@@ -76,7 +76,8 @@ HPolygon(constraints::Vector{LinearConstraint{N}};
                 prune=prune)
 
 # constructor for an HPolygon with no constraints
-HPolygon{N}() where {N<:Real} = HPolygon{N}(Vector{LinearConstraint{N}}())
+HPolygon{N}() where {N<:Real} =
+    HPolygon{N}(Vector{LinearConstraint{N, <:AbstractVector{N}}}())
 
 # constructor for an HPolygon with no constraints of type Float64
 HPolygon() = HPolygon{Float64}()

--- a/src/HPolygonOpt.jl
+++ b/src/HPolygonOpt.jl
@@ -53,13 +53,13 @@ mutable struct HPolygonOpt{N<:Real} <: AbstractHPolygon{N}
     ind::Int
 
     # default constructor that applies sorting of the given constraints
-    function HPolygonOpt{N}(constraints::Vector{LinearConstraint{N}},
+    function HPolygonOpt{N}(constraints::Vector{<:LinearConstraint{N}},
                             ind::Int=1;
                             sort_constraints::Bool=true,
                             check_boundedness::Bool=false,
                             prune::Bool=true) where {N<:Real}
         if sort_constraints
-            sorted_constraints = Vector{LinearConstraint{N}}()
+            sorted_constraints = Vector{eltype(constraints)}()
             sizehint!(sorted_constraints, length(constraints))
             for ci in constraints
                 addconstraint!(sorted_constraints, ci; prune=prune)
@@ -75,7 +75,7 @@ mutable struct HPolygonOpt{N<:Real} <: AbstractHPolygon{N}
 end
 
 # convenience constructor without type parameter
-HPolygonOpt(constraints::Vector{LinearConstraint{N}},
+HPolygonOpt(constraints::Vector{<:LinearConstraint{N}},
             ind::Int=1;
             sort_constraints::Bool=true,
             check_boundedness::Bool=false,
@@ -87,7 +87,8 @@ HPolygonOpt(constraints::Vector{LinearConstraint{N}},
                    prune=prune)
 
 # constructor with no constraints
-HPolygonOpt{N}() where {N<:Real} = HPolygonOpt{N}(Vector{LinearConstraint{N}}())
+HPolygonOpt{N}() where {N<:Real} =
+    HPolygonOpt{N}(Vector{LinearConstraint{N, <:AbstractVector{N}}}())
 
 # constructor with no constraints of type Float64
 HPolygonOpt() = HPolygonOpt{Float64}()

--- a/src/HPolyhedron.jl
+++ b/src/HPolyhedron.jl
@@ -30,10 +30,20 @@ Type that represents a convex polyhedron in H-representation.
 """
 struct HPolyhedron{N<:Real} <: AbstractPolyhedron{N}
     constraints::Vector{LinearConstraint{N}}
+
+    function HPolyhedron{N}(constraints::Vector{<:LinearConstraint{N}}
+                           ) where {N<:Real}
+        return new{N}(constraints)
+    end
 end
 
+# convenience constructor without type parameter
+HPolyhedron(constraints::Vector{<:LinearConstraint{N}}) where {N<:Real} =
+    HPolyhedron{N}(constraints)
+
 # constructor with no constraints
-HPolyhedron{N}() where {N<:Real} = HPolyhedron{N}(Vector{LinearConstraint{N}}())
+HPolyhedron{N}() where {N<:Real} =
+    HPolyhedron{N}(Vector{LinearConstraint{N, <:AbstractVector{N}}}())
 
 # constructor with no constraints of type Float64
 HPolyhedron() = HPolyhedron{Float64}()
@@ -247,7 +257,7 @@ function rand(::Type{HPolyhedron};
     rng = reseed(rng, seed)
     P = rand(HPolytope; N=N, dim=dim, rng=rng)
     constraints_P = constraints_list(P)
-    constraints_Q = Vector{LinearConstraint{N}}()
+    constraints_Q = Vector{eltype(constraints_P)}()
     for i in 1:length(constraints_P)
         if rand(Bool)
             push!(constraints_Q, constraints_P[i])
@@ -290,7 +300,7 @@ function addconstraint!(P::HPoly{N},
 end
 
 """
-    constraints_list(P::HPoly{N})::Vector{LinearConstraint{N}} where {N<:Real}
+    constraints_list(P::HPoly{N}) where {N<:Real}
 
 Return the list of constraints defining a polyhedron in H-representation.
 
@@ -302,8 +312,7 @@ Return the list of constraints defining a polyhedron in H-representation.
 
 The list of constraints of the polyhedron.
 """
-function constraints_list(P::HPoly{N}
-                         )::Vector{LinearConstraint{N}} where {N<:Real}
+function constraints_list(P::HPoly{N}) where {N<:Real}
     return P.constraints
 end
 

--- a/src/HPolytope.jl
+++ b/src/HPolytope.jl
@@ -24,7 +24,7 @@ assumption in this type.
 struct HPolytope{N<:Real} <: AbstractPolytope{N}
     constraints::Vector{LinearConstraint{N}}
 
-    function HPolytope{N}(constraints::Vector{LinearConstraint{N}};
+    function HPolytope{N}(constraints::Vector{<:LinearConstraint{N}};
                           check_boundedness::Bool=false
                          ) where {N<:Real}
         P = new{N}(constraints)
@@ -35,12 +35,13 @@ struct HPolytope{N<:Real} <: AbstractPolytope{N}
 end
 
 # convenience constructor without type parameter
-HPolytope(constraints::Vector{LinearConstraint{N}};
+HPolytope(constraints::Vector{<:LinearConstraint{N}};
           check_boundedness::Bool=false) where {N<:Real} =
     HPolytope{N}(constraints; check_boundedness=check_boundedness)
 
 # constructor with no constraints
-HPolytope{N}() where {N<:Real} = HPolytope{N}(Vector{LinearConstraint{N}}())
+HPolytope{N}() where {N<:Real} =
+    HPolytope{N}(Vector{LinearConstraint{N, <:AbstractVector{N}}}())
 
 # constructor with no constraints of type Float64
 HPolytope() = HPolytope{Float64}()

--- a/src/HalfSpace.jl
+++ b/src/HalfSpace.jl
@@ -32,11 +32,6 @@ struct HalfSpace{N<:Real, VN<:AbstractVector{N}} <: AbstractPolyhedron{N}
     b::N
 end
 
-function convert(::Type{HalfSpace{N, VN}}, hs::HalfSpace{T, VT}
-                ) where {N<:Real, VN<:AbstractVector{N}, T, VT<:AbstractVector{T}}
-    return HalfSpace{N, VN}(convert(VN, hs.a), convert(N, hs.b))
-end
-
 """
     LinearConstraint
 

--- a/src/Hyperplane.jl
+++ b/src/Hyperplane.jl
@@ -34,8 +34,7 @@ end
 
 
 """
-    constraints_list(hp::Hyperplane{N})::Vector{LinearConstraint{N}}
-        where {N<:Real}
+    constraints_list(hp::Hyperplane{N}) where {N<:Real}
 
 Return the list of constraints of a hyperplane.
 
@@ -47,8 +46,7 @@ Return the list of constraints of a hyperplane.
 
 A list containing two half-spaces.
 """
-function constraints_list(hp::Hyperplane{N}
-                         )::Vector{LinearConstraint{N}} where {N<:Real}
+function constraints_list(hp::Hyperplane{N}) where {N<:Real}
     return _constraints_list_hyperplane(hp.a, hp.b)
 end
 
@@ -392,11 +390,12 @@ end
 
 # internal helper function
 function _constraints_list_hyperplane(a::AbstractVector{N}, b::N
-                                     )::Vector{LinearConstraint{N}} where {N<:Real}
+                                     ) where {N<:Real}
     return [HalfSpace(a, b), HalfSpace(-a, -b)]
 end
 
-function _linear_map_hrep(M::AbstractMatrix{N}, P::Hyperplane{N}, use_inv::Bool) where {N<:Real}
+function _linear_map_hrep(M::AbstractMatrix{N}, P::Hyperplane{N}, use_inv::Bool
+                         ) where {N<:Real}
     constraint = _linear_map_hrep_helper(M, P, use_inv)[1]
     return Hyperplane(constraint.a, constraint.b)
 end

--- a/src/Line.jl
+++ b/src/Line.jl
@@ -89,8 +89,7 @@ end
 
 
 """
-    constraints_list(L::Line{N})::Vector{LinearConstraint{N}}
-        where {N<:Real}
+    constraints_list(L::Line{N}) where {N<:Real}
 
 Return the list of constraints of a line.
 
@@ -102,8 +101,7 @@ Return the list of constraints of a line.
 
 A list containing two half-spaces.
 """
-function constraints_list(L::Line{N}
-                         )::Vector{LinearConstraint{N}} where {N<:Real}
+function constraints_list(L::Line{N}) where {N<:Real}
     return _constraints_list_hyperplane(L.a, L.b)
 end
 

--- a/src/LineSegment.jl
+++ b/src/LineSegment.jl
@@ -291,7 +291,7 @@ describes the right-hand side of the directed line segment `pq`.
 halfspace_right(L::LineSegment) = halfspace_right(L.p, L.q)
 
 """
-    constraints_list(L::LineSegment{N})::Vector{LinearConstraint{N}} where {N<:Real}
+    constraints_list(L::LineSegment{N}) where {N<:Real}
 
 Return the list of constraints defining a line segment in 2D.
 
@@ -315,15 +315,11 @@ through each opposite vertex.
 This function returns a vector of halfspaces. It does not return equality
 constraints.
 """
-function constraints_list(L::LineSegment{N})::Vector{LinearConstraint{N}} where {N<:Real}
-    clist = Vector{LinearConstraint{N}}(undef, 4)
-    clist[1] = halfspace_left(L)
-    clist[2] = halfspace_right(L)
+function constraints_list(L::LineSegment{N}) where {N<:Real}
     p, q = L.p, L.q
     d = [(p[2]-q[2]), (q[1]-p[1])]
-    clist[3] = halfspace_right(p, p + d)
-    clist[4] = halfspace_left(q, q + d)
-    return clist
+    return [halfspace_left(L), halfspace_right(L),
+            halfspace_right(p, p + d), halfspace_left(q, q + d)]
 end
 
 """

--- a/src/Translation.jl
+++ b/src/Translation.jl
@@ -125,13 +125,13 @@ whose `constraints_list` is available) can be computed from a lazy translation:
 
 ```jldoctest translation
 julia> constraints_list(tr)
-6-element Array{HalfSpace{Float64},1}:
- HalfSpace{Float64}([1.0, 0.0, 0.0], 5.0)
- HalfSpace{Float64}([0.0, 1.0, 0.0], 3.0)
- HalfSpace{Float64}([0.0, 0.0, 1.0], 3.0)
- HalfSpace{Float64}([-1.0, -0.0, -0.0], -3.0)
- HalfSpace{Float64}([-0.0, -1.0, -0.0], -1.0)
- HalfSpace{Float64}([-0.0, -0.0, -1.0], -1.0)
+6-element Array{HalfSpace{Float64,VN} where VN<:AbstractArray{Float64,1},1}:
+ HalfSpace{Float64,LazySets.Approximations.UnitVector{Float64}}([1.0, 0.0, 0.0], 5.0)
+ HalfSpace{Float64,LazySets.Approximations.UnitVector{Float64}}([0.0, 1.0, 0.0], 3.0)
+ HalfSpace{Float64,LazySets.Approximations.UnitVector{Float64}}([0.0, 0.0, 1.0], 3.0)
+ HalfSpace{Float64,Array{Float64,1}}([-1.0, -0.0, -0.0], -3.0)
+ HalfSpace{Float64,Array{Float64,1}}([-0.0, -1.0, -0.0], -1.0)
+ HalfSpace{Float64,Array{Float64,1}}([-0.0, -0.0, -1.0], -1.0)
 ```
 """
 struct Translation{N<:Real, VN<:AbstractVector{N}, S<:LazySet{N}} <: LazySet{N}

--- a/src/Universe.jl
+++ b/src/Universe.jl
@@ -21,8 +21,7 @@ Universe(dim::Int) = Universe{Float64}(dim)
 
 
 """
-    constraints_list(U::Universe{N})::Vector{LinearConstraint{N}}
-        where {N<:Real}
+    constraints_list(U::Universe{N}) where {N<:Real}
 
 Return the list of constraints defining a universe.
 
@@ -34,9 +33,8 @@ Return the list of constraints defining a universe.
 
 The empty list of constraints, as the universe is unconstrained.
 """
-function constraints_list(U::Universe{N}
-                         )::Vector{LinearConstraint{N}} where {N<:Real}
-    return LinearConstraint{N}[]
+function constraints_list(U::Universe{N}) where {N<:Real}
+    return LinearConstraint{N, Vector{N}}[]
 end
 
 """

--- a/src/VPolygon.jl
+++ b/src/VPolygon.jl
@@ -479,7 +479,7 @@ function rand(::Type{VPolygon};
 end
 
 """
-    constraints_list(P::VPolygon{N})::Vector{LinearConstraint{N}} where {N<:Real}
+    constraints_list(P::VPolygon{N}) where {N<:Real}
 
 Return the list of constraints defining a polygon in V-representation.
 
@@ -496,7 +496,7 @@ The list of constraints of the polygon.
 First the H-representation of ``P`` is computed, then its list of constraints
 is returned. 
 """
-function constraints_list(P::VPolygon{N})::Vector{LinearConstraint{N}} where {N<:Real}
+function constraints_list(P::VPolygon{N}) where {N<:Real}
     return constraints_list(tohrep(P))
 end
 

--- a/src/VPolytope.jl
+++ b/src/VPolytope.jl
@@ -291,7 +291,7 @@ function vertices_list(P::VPolytope{N})::Vector{Vector{N}} where {N<:Real}
 end
 
 """
-    constraints_list(P::VPolytope{N})::Vector{LinearConstraint{N}} where {N<:Real}
+    constraints_list(P::VPolytope{N}) where {N<:Real}
 
 Return the list of constraints defining a polytope in V-representation.
 
@@ -308,7 +308,7 @@ The list of constraints of the polytope.
 First the H-representation of ``P`` is computed, then its list of constraints
 is returned. 
 """
-function constraints_list(P::VPolytope{N})::Vector{LinearConstraint{N}} where {N<:Real}
+function constraints_list(P::VPolytope{N}) where {N<:Real}
     return constraints_list(tohrep(P))
 end
 

--- a/src/Zonotope.jl
+++ b/src/Zonotope.jl
@@ -549,8 +549,7 @@ function split(Z::Zonotope, j::Int)
 end
 
 """
-    constraints_list(P::Zonotope{N}
-                    )::Vector{LinearConstraint{N}} where {N<:Real}
+    constraints_list(P::Zonotope{N}) where {N<:Real}
 
 Return the list of constraints defining a zonotope.
 
@@ -568,14 +567,12 @@ This is the (inefficient) fallback implementation for rational numbers.
 It first computes the vertices and then converts the corresponding polytope
 to constraint representation.
 """
-function constraints_list(Z::Zonotope{N}
-                         )::Vector{LinearConstraint{N}} where {N<:Real}
+function constraints_list(Z::Zonotope{N}) where {N<:Real}
     return constraints_list(VPolytope(vertices_list(Z)))
 end
 
 """
-    constraints_list(Z::Zonotope{N}
-                    )::Vector{LinearConstraint{N}} where {N<:AbstractFloat}
+    constraints_list(Z::Zonotope{N}) where {N<:AbstractFloat}
 
 Return the list of constraints defining a zonotope.
 
@@ -606,8 +603,7 @@ Reachable Sets of Hybrid Systems Using a Combination of Zonotopes and Polytopes.
 The one-dimensional case is not covered by that algorithm; we manually handle
 this case, assuming that there is only one generator.
 """
-function constraints_list(Z::Zonotope{N}
-                         )::Vector{LinearConstraint{N}} where {N<:AbstractFloat}
+function constraints_list(Z::Zonotope{N}) where {N<:AbstractFloat}
     p = ngens(Z)
     n = dim(Z)
     if p < n
@@ -615,8 +611,6 @@ function constraints_list(Z::Zonotope{N}
     end
 
     G = Z.generators
-    m = binomial(p, n - 1)
-    constraints = Vector{LinearConstraint{N}}(undef, 2 * m)
 
     # special handling of 1D case
     if n == 1
@@ -627,13 +621,15 @@ function constraints_list(Z::Zonotope{N}
 
         c = Z.center[1]
         g = G[:, 1][1]
-        constraints[1] = LinearConstraint([N(1)], c + g)
-        constraints[2] = LinearConstraint([N(-1)], g - c)
+        constraints = [LinearConstraint([N(1)], c + g),
+                       LinearConstraint([N(-1)], g - c)]
         return constraints
     end
 
     i = 0
     c = Z.center
+    m = binomial(p, n - 1)
+    constraints = Vector{LinearConstraint{N, Vector{N}}}(undef, 2 * m)
     for columns in StrictlyIncreasingIndices(p, n-1)
         i += 1
         c⁺ = cross_product(view(G, :, columns))

--- a/src/helper_functions.jl
+++ b/src/helper_functions.jl
@@ -65,7 +65,7 @@ function sign_cadlag(x::N)::N where {N<:Real}
 end
 
 """
-    ispermutation(u::AbstractVector{T}, v::AbstractVector{T})::Bool where T
+    ispermutation(u::AbstractVector{T}, v::AbstractVector)::Bool where {T}
 
 Check that two vectors contain the same elements up to reordering.
 
@@ -89,7 +89,7 @@ false
 
 ```
 """
-function ispermutation(u::AbstractVector{T}, v::AbstractVector{T})::Bool where T
+function ispermutation(u::AbstractVector{T}, v::AbstractVector)::Bool where {T}
     if length(u) != length(v)
         return false
     end

--- a/test/unit_HalfSpace.jl
+++ b/test/unit_HalfSpace.jl
@@ -5,11 +5,6 @@ for N in [Float64, Rational{Int}, Float32]
     # normal constructor
     hs = HalfSpace(ones(N, 3), N(5))
 
-    # numeric-type conversion preserves vector base type
-    hs1 = HalfSpace(spzeros(4), 1.)
-    hs2 = convert(HalfSpace{N}, hs1)
-    @test hs2.a isa SparseVector{N}
-
     # dimension
     @test dim(hs) == 3
 

--- a/test/unit_Polygon.jl
+++ b/test/unit_Polygon.jl
@@ -372,7 +372,7 @@ for N in [Float64, Float32, Rational{Int}]
     @test tohrep(VPolygon{N}()) isa EmptySet{N}
 end
 
-function same_constraints(v::Vector{LinearConstraint{N}})::Bool where N<:Real
+function same_constraints(v::Vector{<:LinearConstraint{N}})::Bool where N<:Real
     c1 = v[1]
     for k = 2:length(v)
         c2 = v[2]

--- a/test/unit_Polyhedron.jl
+++ b/test/unit_Polyhedron.jl
@@ -203,14 +203,14 @@ if test_suite_polyhedra
         @test isdisjoint(R, P) && res && w == N[]
 
         Punbdd = HPolyhedron([HalfSpace([0.68, 1.22], -0.76),
-                              HalfSpace{Float64}([-0.75, -0.46], 0.68)])
+                              HalfSpace([-0.75, -0.46], 0.68)])
         @assert !isbounded(Punbdd)
 
         Pbdd = HPolyhedron([HalfSpace([0.68, 1.22], -0.76),
-                            HalfSpace{Float64}([-0.75, -0.46], 0.68),
-                            HalfSpace{Float64}([1.72, 0.33], 0.37),
-                            HalfSpace{Float64}([-1.60, -0.41], 0.67),
-                            HalfSpace{Float64}([-0.44, 0.06], 0.78)])
+                            HalfSpace([-0.75, -0.46], 0.68),
+                            HalfSpace([1.72, 0.33], 0.37),
+                            HalfSpace([-1.60, -0.41], 0.67),
+                            HalfSpace([-0.44, 0.06], 0.78)])
         @assert isbounded(Pbdd)
 
         Mnotinv = [1.0 0.0; 2.0 0.0]


### PR DESCRIPTION
Closes #1031.
Replaces #1032.

I had to remove the `convert` method for `HalfSpace` because a generic vector cannot be converted.