### PR TITLE
Check for emptiness in concrete intersection using Polyhedra

### DIFF
--- a/src/concrete_intersection.jl
+++ b/src/concrete_intersection.jl
@@ -538,8 +538,12 @@ function intersection(P1::AbstractPolyhedron{N},
         # remove the redundancies
         removehredundancy!(Qph)
 
-        # convert back to HPOLY
-        return convert(HPOLY, Qph)
+        if isempty(Qph)
+            return EmptySet{N}()
+        else
+            # convert back to HPOLY
+            return convert(HPOLY, Qph)
+        end
     end
 end
 

--- a/test/unit_Polytope.jl
+++ b/test/unit_Polytope.jl
@@ -222,25 +222,23 @@ if test_suite_polyhedra
                                   LinearConstraint(N[-1], N(-1))])
         @test_throws ErrorException σ(N[1], p_infeasible)
 
-        # intersection
-        A = [N(0) N(1); N(1) N(0); N(2) N(2)]
+        # empty intersection
+        A = [N(0) N(-1); N(-1) N(0); N(1) N(1)]
         b = N[0, 0, 1]
         p1 = HPolytope(A, b)
-        A = [N(0) N(-1); N(-1) N(0); N(1) N(1)]
-        b = N[-0.25, -0.25, -0]
+        A = [N(0) N(1); N(1) N(0); N(-1) N(-1)]
+        b = N[2, 2, -2]
         p2 = HPolytope(A, b)
-        cap = intersection(p1, p2)
-        # currently broken, see #565
+        @test intersection(p1, p2) isa EmptySet{N}
+        @test intersection(p1, p2; backend=Polyhedra.default_library(2, N)) isa EmptySet{N}
+        # @test intersection(p1, p2; backend=CDDLib.Library()) isa EmptySet{N}
+        # commented because we do not load CDDLib at the moment
 
         # intersection with half-space
-        hs = HalfSpace(N[2, 2], N(-1))
+        hs = HalfSpace(N[2, -2], N(-1))
         c1 = constraints_list(intersection(p1, hs))
         c2 = constraints_list(intersection(hs, p1))
         @test length(c1) == 3 && ispermutation(c1, c2)
-
-        # convex hull
-        ch = convex_hull(p1, p2)
-        # currently broken, see #566
 
         # Cartesian product
         A = [N(1) N(-1)]'


### PR DESCRIPTION
Resolves the last part of #565.

When we take the concrete intersection of two polyhedra whose intersection is empty, we returned
* an `EmptySet` with our custom LP-solver implementation,
* an `HPolytope` with no constraints with the default `Polyhedra` backend, and
* an `HPolytope` with infeasible constraints with the `CDDLib` backend.

Now we always return an `EmptySet` in all three cases.