### PR TITLE
Decomposed intersection for CartesianProductArray

### DIFF
--- a/docs/src/lib/binary_functions.md
+++ b/docs/src/lib/binary_functions.md
@@ -37,6 +37,8 @@ is_intersection_empty(::Universe{N}, ::LazySet{N}, ::Bool=false) where {N<:Real}
 is_intersection_empty(::Complement{N}, ::LazySet{N}, ::Bool=false) where {N<:Real}
 is_intersection_empty(::Zonotope{N}, ::Zonotope{N}, ::Bool=false) where {N<:Real}
 is_intersection_empty(::Interval{N}, ::Interval{N}, ::Bool=false) where {N<:Real}
+is_intersection_empty(X::CartesianProductArray{N}, Y::HPolyhedron{N}) where {N<:Real}
+is_intersection_empty(X::CartesianProductArray{N}, Y::CartesianProductArray{N}) where {N}
 ```
 
 ## Convex hull
@@ -64,6 +66,7 @@ intersection(::UnionSet{N}, ::LazySet{N}) where {N<:Real}
 intersection(::UnionSetArray{N}, ::LazySet{N}) where {N<:Real}
 intersection(::Universe{N}, ::LazySet{N}) where {N<:Real}
 intersection(::AbstractPolyhedron{N}, ::ResetMap{N}) where {N<:Real}
+intersection(X::CartesianProductArray{N}, Y::CartesianProductArray{N}) where {N<:Real}
 ```
 
 ## Subset check

--- a/docs/src/lib/operations.md
+++ b/docs/src/lib/operations.md
@@ -52,6 +52,10 @@ isempty(::CartesianProductArray)
 constraints_list(::CartesianProductArray{N}) where {N<:Real}
 vertices_list(::CartesianProductArray{N}) where {N<:Real}
 array(::CartesianProductArray{N, S}) where {N<:Real, S<:LazySet{N}}
+block_structure(cpa::CartesianProductArray{N}) where {N}
+block_to_dimension_indices(cpa::CartesianProductArray{N}, vars::Vector{Int}) where {N}
+substitute_blocks(low_dim_cpa::CartesianProductArray{N}, orig_cpa::CartesianProductArray{N},
+blocks::Vector{Tuple{Int,Int}}) where {N}
 ```
 Inherited from [`LazySet`](@ref):
 * [`norm`](@ref norm(::LazySet, ::Real))

--- a/docs/src/lib/utils.md
+++ b/docs/src/lib/utils.md
@@ -35,6 +35,7 @@ same_block_structure
 substitute
 substitute!
 σ_helper
+get_constrained_lowdimset
 @neutral
 @absorbing
 @neutral_absorbing

--- a/src/Approximations/overapproximate.jl
+++ b/src/Approximations/overapproximate.jl
@@ -1,3 +1,4 @@
+using LazySets: block_to_dimension_indices, substitute_blocks, get_constrained_lowdimset
 """
     overapproximate(X::S, ::Type{S}) where {S<:LazySet}
 
@@ -910,4 +911,61 @@ function _overapproximate_lm_cpa!(arr, M, cpa, overapprox_option)
     end
 
     return CartesianProductArray(arr)
+end
+
+"""
+    overapproximate(cap::Intersection{N,
+                            <:CartesianProductArray{N},
+                            <:AbstractPolyhedron{N}},
+                       ::Type{CartesianProductArray}, oa) where {N}
+
+Return the intersection of the cartesian product of a finite number of convex sets and a polyhedron.
+
+### Input
+
+ - `cap` -- Lazy intersection of cartesian product array and polyhedron
+ - `CartesianProductArray` -- type for dispatch
+ - `oa`  -- template directions
+
+### Output
+
+The intersection between `cpa` and `P` with overapproximation in each constrained block.
+
+### Algorithm
+
+The intersection is only needed to be taken in the elements of the cartesian product array (subsets of
+variables, or "blocks") which are constrained in `P`.
+Hence we first search for constrained blocks and then take the intersection of
+a lower-dimensional Cartesian product of these blocks with the projection of `Y`
+onto the variables of these blocks. (This projection is syntactic and exact.)
+The result is a `CartesianProductArray` with the same block structure as in `X`.
+However, when we decompose back our set we overapproximate during projection operation,
+therefore we need to specify overapproximation strategy (it is Hyperrectangle by default)
+"""
+function overapproximate(cap::Intersection{N,
+                                            <:CartesianProductArray{N},
+                                            <:AbstractPolyhedron{N}},
+                            ::Type{CartesianProductArray}, oa) where {N}
+
+    cpa, P = cap.X, cap.Y
+
+    cpa_low_dim, vars, block_structure, blocks = get_constrained_lowdimset(cpa, P)
+
+    low_intersection = intersection(cpa_low_dim, project(P, vars))
+
+    if isempty(low_intersection)
+        return EmptySet{N}()
+    end
+
+    decomposed_low_set = decompose(low_intersection, block_structure, oa)
+
+    return substitute_blocks(decomposed_low_set, cpa, blocks)
+end
+
+# symmetric method
+function overapproximate(cap::Intersection{N,
+                                            <:AbstractPolyhedron{N},
+                                            <:CartesianProductArray{N}},
+                            ::Type{CartesianProductArray}, oa) where {N}
+    overapproximate(Intersection(cap.Y, cap.X), oa)
 end

--- a/src/LazySets.jl
+++ b/src/LazySets.jl
@@ -89,7 +89,13 @@ include("Rectification.jl")
 # =============================
 # Conversions between set types
 # =============================
+include("intersection_helper.jl")
 include("convert.jl")
+
+# =====================
+# Approximations module
+# =====================
+include("Approximations/Approximations.jl")
 
 # ===========================
 # Concrete operations on sets
@@ -103,11 +109,6 @@ include("difference.jl")
 # Aliases
 # =======
 include("aliases.jl")
-
-# =====================
-# Approximations module
-# =====================
-include("Approximations/Approximations.jl")
 
 # ==========================
 # Parallel algorithms module

--- a/src/LinearMap.jl
+++ b/src/LinearMap.jl
@@ -391,7 +391,7 @@ Return the linear map of a lazy linear map.
 
 ### Output
 
-The polytope representing the linear map of the lazy linear map of a set.  
+The polytope representing the linear map of the lazy linear map of a set.
 """
 function linear_map(M::AbstractMatrix{N}, lm::LinearMap{N}) where {N<:Real}
      return linear_map(M * lm.M, lm.X)

--- a/src/Translation.jl
+++ b/src/Translation.jl
@@ -10,7 +10,7 @@ export Translation,
 
 Type that represents a lazy translation.
 
-The translation of set `X` along vector `v` is the map: 
+The translation of set `X` along vector `v` is the map:
 
 ```math
 x ↦ x + v,\\qquad x ∈ X
@@ -142,7 +142,7 @@ struct Translation{N<:Real, VN<:AbstractVector{N}, S<:LazySet{N}} <: LazySet{N}
     # default constructor with dimension check
     function Translation(X::S, v::VN) where {N, VN<:AbstractVector{N}, S<:LazySet{N}}
         @assert dim(X) == length(v) "cannot create a translation of a set of dimension $(dim(X)) " *
-                                    "along a vector of length $(length(v))" 
+                                    "along a vector of length $(length(v))"
         return new{N, VN, S}(X, v)
     end
 end
@@ -180,7 +180,7 @@ Unicode alias constructor ⊕ (`oplus`) for the lazy translation operator.
 # translation from the left
 ⊕(v::AbstractVector, X::LazySet) = Translation(X, v)
 
-# ============================ 
+# ============================
 # LazySet interface functions
 # ============================
 
@@ -278,7 +278,7 @@ An element in the translation.
 ### Notes
 
 This function first asks for `an_element` function of the wrapped set, then
-translates this element according to the given translation vector. 
+translates this element according to the given translation vector.
 """
 function an_element(tr::Translation)
     return an_element(tr.X) + tr.v

--- a/src/concrete_intersection.jl
+++ b/src/concrete_intersection.jl
@@ -678,7 +678,7 @@ Return the intersection of a lazy linear map and a convex set.
 
 - `L` -- linear map
 - `S` -- convex set
-  
+
 ### Output
 
 The polytope obtained by the intersection of `l.M * L.X` and `S`.
@@ -781,4 +781,37 @@ end
 function intersection(rm::ResetMap{N, <:AbstractPolytope},
                       P::AbstractPolyhedron{N}) where {N<:Real}
     return intersection(P, rm)
+end
+
+function intersection(U::Universe{N}, X::CartesianProductArray{N}) where {N<:Real}
+    return X
+end
+
+# symmetric method
+function intersection(X::CartesianProductArray{N}, U::Universe{N}) where {N<:Real}
+    return intersection(U, X)
+end
+
+"""
+        intersection(X::CartesianProductArray{N}, Y::CartesianProductArray{N})
+
+Return the intersection between cartesian products of a finite number of convex sets.
+
+### Input
+
+ - `X` -- cartesian product of a finite number of convex sets
+ - `Y` -- cartesian product of a finite number of convex sets
+
+### Output
+
+The decomposed set which represents concrete intersection between `X` and `Y`
+
+### Algorithm
+
+This algorithm intersect corresponding blocks between sets.
+"""
+function intersection(X::CartesianProductArray{N}, Y::CartesianProductArray{N}) where {N<:Real}
+    @assert same_block_structure(array(X), array(Y)) "block structure has to be the same"
+
+    return CartesianProductArray([intersection(array(X)[i], array(Y)[i]) for i in eachindex(array(X))])
 end

--- a/src/helper_functions.jl
+++ b/src/helper_functions.jl
@@ -542,9 +542,9 @@ julia> subtypes(AbstractPolytope, true)
 function subtypes(interface, concrete::Bool)
 
     subtypes_to_test = subtypes(interface)
-    
+
     # do not seek the concrete subtypes further
-    if !concrete 
+    if !concrete
         return sort(subtypes_to_test, by=string)
     end
 

--- a/src/intersection_helper.jl
+++ b/src/intersection_helper.jl
@@ -1,0 +1,49 @@
+"""
+    get_constrained_lowdimset(cpa::CartesianProductArray{N, S}, P::AbstractPolyhedron{N}) where {N<:Real, S<:LazySet{N}}
+
+Preprocess step for intersection between cartesian product array and H-polyhedron.
+Returns low-dimensional HPolytope in constrained dimensions of original cpa,
+constrained variables and variables in corresponding blocks, original block structure
+of low-dimensional set and list of constrained blocks.
+
+### Input
+
+- `cpa` -- Cartesian product array of convex sets
+- `P` -- polyhedron
+
+### Output
+
+A tuple of low-dimensional set, list of constrained dimensions, original block
+structure of low-dimensional set and corresponding blocks indices.
+"""
+function get_constrained_lowdimset(cpa::CartesianProductArray{N, S}, P::AbstractPolyhedron{N}) where {N<:Real, S<:LazySet{N}}
+
+    if isbounded(P)
+        blocks, non_empty_length = block_to_dimension_indices(cpa)
+    else
+        constrained_vars = constrained_dimensions(P)
+        blocks, non_empty_length = block_to_dimension_indices(cpa, constrained_vars)
+    end
+
+    array = Vector{S}()
+    sizehint!(array, non_empty_length)
+    vars = Vector{Int}()
+    block_structure = Vector{UnitRange{Int}}()
+    sizehint!(block_structure, non_empty_length)
+
+    last_var = 1
+    for i in 1:length(blocks)
+        start_index, end_index = blocks[i]
+        block_end = last_var + end_index - start_index
+        if start_index != -1
+            push!(array, cpa.array[i])
+            append!(vars, start_index : end_index)
+            push!(block_structure, last_var : block_end)
+            last_var = block_end + 1
+        end
+    end
+
+    cpa_low_dim = HPolytope(constraints_list(CartesianProductArray(array)));
+
+    return cpa_low_dim, vars, block_structure, blocks
+end

--- a/src/is_intersection_empty.jl
+++ b/src/is_intersection_empty.jl
@@ -1,3 +1,4 @@
+using LazySets.Approximations: project
 export is_intersection_empty,
        isdisjoint
 
@@ -1364,4 +1365,58 @@ function is_intersection_empty(X::LazySet{N},
                               )::Union{Bool, Tuple{Bool, Vector{N}}} where
                                   {N<:Real}
     return is_intersection_empty(C, X, witness)
+end
+
+"""
+    is_intersection_empty(X::CartesianProductArray{N, S},
+                          P::HPolyhedron{N}) where {N<:Real, S<:LazySet{N}}
+
+Check whether a Cartesian product array intersects with a H-polyhedron.
+
+### Input
+
+- `X` -- Cartesian product array of convex sets
+- `P` -- H-polyhedron
+
+### Output
+
+`true` iff ``X ∩ Y = ∅ ``.
+"""
+function is_intersection_empty(X::CartesianProductArray{N},
+                               P::HPolyhedron{N}) where {N<:Real}
+    cpa_low_dim, vars, block_structure = get_constrained_lowdimset(X, P)
+
+    return isdisjoint(cpa_low_dim, project(P, vars))
+end
+
+# symmetric method
+function is_intersection_empty(P::HPolyhedron{N},
+                               X::CartesianProductArray{N, S}) where {N<:Real, S<:LazySet{N}}
+        is_intersection_empty(X, P)
+end
+
+"""
+    is_intersection_empty(X::CartesianProductArray{N}, Y::CartesianProductArray{N}) where {N}
+
+Check whether two Cartesian products of a finite number of convex sets do not intersect.
+
+### Input
+
+- `X` -- Cartesian product array of convex sets
+- `Y` -- Cartesian product array of convex sets
+
+### Output
+
+`true` iff ``X ∩ Y = ∅ ``.
+"""
+function is_intersection_empty(X::CartesianProductArray{N}, Y::CartesianProductArray{N}) where {N}
+    @assert same_block_structure(array(X), array(Y)) "block structure has to be the same"
+
+    for i in 1:length(X.array)
+        if isdisjoint(X.array[i], Y.array[i])
+            return true
+        end
+    end
+
+    return false
 end

--- a/test/unit_CartesianProduct.jl
+++ b/test/unit_CartesianProduct.jl
@@ -1,3 +1,5 @@
+using LazySets.Approximations: overapproximate
+
 for N in [Float64, Float32, Rational{Int}]
     # Cartesian Product of a centered 1D BallInf and a centered 2D BallInf
     # Here a 3D BallInf
@@ -261,7 +263,7 @@ for N in [Float64, Float32, Rational{Int}]
     Hcp = convert(CartesianProductArray{N, Interval{N}}, H)
     @test Hcp isa CartesianProductArray &&
           all([array(Hcp)[i] == Interval(N(-1), N(2*i-1)) for i in 1:3])
-              
+
     # ================
     # common functions
     # ================
@@ -272,4 +274,22 @@ for N in [Float64, Float32, Rational{Int}]
     @test absorbing(CartesianProduct) == absorbing(CartesianProductArray) ==
           EmptySet
     @test b × e == e × b == cpa × e == e × cpa == e × e == e
+end
+
+for N in [Float64, Float32]
+    # is_intersection_empty
+    i1 = Interval(N[0, 1])
+    i2 = Interval(N[2, 3])
+    h1 = Hyperrectangle(low=N[3, 4], high=N[5, 7])
+    h2 = Hyperrectangle(low=N[5, 5], high=N[6, 8])
+    cpa1 = CartesianProductArray([i1, i2, h1])
+    cpa2 = CartesianProductArray([i1, i2, h2])
+    G = HPolyhedron([HalfSpace(N[1, 0, 0, 0], N(1))])
+    G_empty = HPolyhedron([HalfSpace(N[1, 0, 0, 0], N(-1))])
+	cpa1_box = overapproximate(cpa1)
+	cpa2_box = overapproximate(cpa2)
+
+    @test is_intersection_empty(cpa1, cpa2) == is_intersection_empty(cpa1_box, cpa2_box) == false
+    @test is_intersection_empty(cpa1, G_empty) == is_intersection_empty(cpa1_box, G_empty) == true
+    @test is_intersection_empty(cpa1, G) == is_intersection_empty(Approximations.overapproximate(cpa1), G) == false
 end

--- a/test/unit_Translation.jl
+++ b/test/unit_Translation.jl
@@ -10,7 +10,7 @@ for N in [Float64, Rational{Int}, Float32]
     # test alternative constructors
     @test tr == B + v == B ⊕ v
     # check that translation from the left works as well
-    @test tr == v + B == v ⊕ B 
+    @test tr == v + B == v ⊕ B
 
     # dimension check
     @test_throws AssertionError Translation(B, N[0, 0])


### PR DESCRIPTION
Example of the algorithm:

Assume we have a cartesian product array: `I_1 \times I_2 \times I_3 \cap Y` where `Y = Halfspace([1.,1., 0.], 1.)`. It means we take union of I_1 and I_2. Basically for union I run `HPolytope(constraints_list(CartesianProductArray(I_1, I_2)))`. Resulted set I intersect with projection of `Y` onto variables 1 and 2.  Now we need to decompose it back to the original blocks`\hat{I_1} \times \hat{I_2} `.  This is the place where we cannot get exact result and need an overapproximation. 
In last step we take `\hat{I_1} \times \hat{I_2} ` and merge it with unused blocks (here it is `I_3`). So the final set is `\hat{I_1} \times \hat{I_2} \times I_3`