### PR TITLE
#1424 - Overapproximate the interval matrix map of a zonotope

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,9 @@ notifications:
 git:
   depth: 99999999
 
+script:
+  - julia -e 'using Pkg; Pkg.add(PackageSpec(path="https://github.com/JuliaReach/IntervalMatrices.jl", rev="master")); Pkg.build("LazySets"); Pkg.test("LazySets"; coverage=true)'
+
 jobs:
   include:
     - stage: "Documentation"

--- a/Project.toml
+++ b/Project.toml
@@ -28,6 +28,7 @@ GLPK = "≥ 0.10.0"
 GLPKMathProgInterface = "≥ 0.4.0"
 GR = "≥ 0.39.1"
 IntervalArithmetic = "≥ 0.14.0"
+IntervalMatrices = "≥ 0.2.1"
 JuMP = "≥ 0.19.2"
 Makie = "≥ 0.9.4"
 MathProgBase = "≥ 0.7.0"
@@ -46,6 +47,7 @@ Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 Expokit = "a1e7a1ef-7a5d-5822-a38c-be74e1bb89f4"
 GLPK = "60bf3e95-4087-53dc-ae20-288a0d20c6a6"
 GR = "28b8d3ca-fb5f-59d9-8090-bfdbd6d07a71"
+IntervalMatrices = "5c1f47dc-42dd-5697-8aaa-4d102d140ba9"
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
 Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
 Optim = "429524aa-4258-5aef-a3af-852621145aeb"
@@ -55,5 +57,6 @@ TaylorModels = "314ce334-5f6e-57ae-acf6-00b6e903104a"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["CDDLib", "Distributions", "Documenter", "Expokit", "GLPK", "GR", "JuMP",
-        "Makie", "Optim", "Plots", "Polyhedra", "TaylorModels", "Test"]
+test = ["CDDLib", "Distributions", "Documenter", "Expokit", "GLPK", "GR",
+        "IntervalMatrices", "JuMP", "Makie", "Optim", "Plots", "Polyhedra",
+        "TaylorModels", "Test"]

--- a/src/Approximations/init.jl
+++ b/src/Approximations/init.jl
@@ -1,5 +1,6 @@
 function __init__()
     @require TaylorModels = "314ce334-5f6e-57ae-acf6-00b6e903104a" load_taylormodels()
+    @require IntervalMatrices = "5c1f47dc-42dd-5697-8aaa-4d102d140ba9" include("init_IntervalMatrices.jl")
 end
 
 function load_taylormodels()

--- a/src/Approximations/init_IntervalMatrices.jl
+++ b/src/Approximations/init_IntervalMatrices.jl
@@ -1,0 +1,1 @@
+eval(load_intervalmatrices_overapproximation())

--- a/src/Approximations/overapproximate.jl
+++ b/src/Approximations/overapproximate.jl
@@ -1,6 +1,7 @@
 using LazySets: block_to_dimension_indices,
                 substitute_blocks,
                 get_constrained_lowdimset
+
 """
     overapproximate(X::S, ::Type{S}, args...) where {S<:LazySet}
 
@@ -808,6 +809,73 @@ end
 
 end # quote
 end # load_taylormodels_overapproximation
+
+# =============================================
+# Functionality that requires IntervalMatrices
+# =============================================
+
+function load_intervalmatrices_overapproximation()
+return quote
+
+using .IntervalMatrices: AbstractIntervalMatrix, split
+
+"""
+    overapproximate(lm::LinearMap{N, <:AbstractZonotope{N}, NM,
+                                  <:AbstractIntervalMatrix{<:NM}},
+                    ::Type{<:Zonotope})::Zonotope{N} where {N<:Real, NM}
+
+Overapproximate an interval-matrix linear map of a zonotopic set by a new
+zonotope.
+
+### Input
+
+- `lm`       -- interval-matrix linear map of a zonotopic set
+- `Zonotope` -- type for dispatch
+
+### Output
+
+A zonotope overapproximating the linear map.
+
+### Algorithm
+
+This function implements the method proposed in [1].
+
+Given an interval matrix ``M = \\tilde{M} + ⟨-\\hat{M},\\hat{M}⟩`` (split into a
+conventional matrix and a symmetric interval matrix) and a zonotope
+``⟨c, g_1, …, g_m⟩``, we compute the resulting zonotope
+``⟨\\tilde{M}c, \\tilde{M}g_1, …, \\tilde{M}g_m, v_1, …, v_n⟩`` where the
+``v_j``, ``j = 1, …, n``, are defined as
+
+```math
+    v_j = \\begin{cases} 0 & i ≠ j \\\\
+          \\hat{M}_j (|c| + \\sum_{k=1}^m |g_k|) & i = j. \\end{cases}
+```
+
+[1] Althoff, Stursberg, Buss. Reachability analysis of linear systems with
+uncertain parameters and inputs. CDC 2007.
+"""
+function overapproximate(lm::LinearMap{N, <:AbstractZonotope{N}, NM,
+                                       <:AbstractIntervalMatrix{<:NM}},
+                         ::Type{<:Zonotope})::Zonotope{N} where {N<:Real, NM}
+    Mc, Ms = split(lm.M)
+    Z = lm.X
+    c = Mc * center(Z)
+    n = dim(lm)
+    nG = ngens(Z)
+    G = zeros(N, n, nG + n)
+    vector_sum = abs.(center(Z))
+    @inbounds for (j, g) in enumerate(generators(Z))
+        G[:, j] = Mc * g
+        vector_sum += abs.(g)
+    end
+    @inbounds for i in 1:n
+        row = @view Ms[i, :]
+        G[i, i + nG] = dot(row, vector_sum)
+    end
+    return Zonotope(c, G)
+end
+
+end end  # quote / load_intervalmatrices_overapproximation()
 
 # ==========================================
 # Lazy linear maps of Cartesian products

--- a/src/Approximations/overapproximate.jl
+++ b/src/Approximations/overapproximate.jl
@@ -1,3 +1,5 @@
+import Base: convert
+
 using LazySets: block_to_dimension_indices,
                 substitute_blocks,
                 get_constrained_lowdimset
@@ -818,6 +820,12 @@ function load_intervalmatrices_overapproximation()
 return quote
 
 using .IntervalMatrices: AbstractIntervalMatrix, split
+
+# temporary patch for IntervalArithmetic#317
+function convert(::Type{IntervalMatrices.Interval{T}},
+                 x::IntervalMatrices.Interval{T}) where {T<:Real}
+    return x
+end
 
 """
     overapproximate(lm::LinearMap{N, <:AbstractZonotope{N}, NM,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,12 +7,9 @@ using IntervalArithmetic: IntervalBox
 # ========================
 # Optional dependencies
 # ========================
-import Expokit, Optim
-
-import TaylorModels
+import Distributions, Expokit, IntervalMatrices, Optim, TaylorModels
+using IntervalMatrices: ±, IntervalMatrix
 using TaylorModels: set_variables, TaylorModelN
-
-import Distributions
 
 # ==============================
 # Non-exported helper functions

--- a/test/unit_overapproximate.jl
+++ b/test/unit_overapproximate.jl
@@ -93,6 +93,12 @@ for N in [Float64, Rational{Int}, Float32]
     @test overapproximate(d_oa) == oa
     @test typeof(d_oa) == CartesianProductArray{N, Interval{N}}
 
+    # interval linear map of zonotope
+    M = IntervalMatrix([(N(0) ± N(1)) (N(0) ± N(0)); (N(0) ± N(0)) (N(0) ± N(1))])
+    Z = Zonotope(N[1, 1], N[1 1; 1 -1])
+    lm = LinearMap(M, Z)
+    Zo = overapproximate(lm, Zonotope)
+    @test box_approximation(Zo) == Hyperrectangle(N[0, 0], N[3, 3])
 end
 
 # tests that do not work with Rational{Int}


### PR DESCRIPTION
Closes #1424.

Requires:
* ~https://github.com/JuliaReach/IntervalMatrices.jl/issues/14~
* external fix with `IntervalArithmetic`  (https://github.com/JuliaIntervals/IntervalArithmetic.jl/issues/317)