### PR TITLE
Export 'times' symbol

### DIFF
--- a/src/LazySets.jl
+++ b/src/LazySets.jl
@@ -11,6 +11,7 @@ using Random: AbstractRNG, GLOBAL_RNG, SamplerType, shuffle
 import InteractiveUtils: subtypes
 
 export Approximations
+export ×
 
 # ===================
 # Auxiliary functions


### PR DESCRIPTION
Apparently this export got lost. You could use `×` if `LinearAlgebra` was loaded, but not by just loading `LazySets`.