### PR TITLE
#1413 - Add concrete version of zonotope algorithm to manual

### DIFF
--- a/docs/src/lib/interfaces.md
+++ b/docs/src/lib/interfaces.md
@@ -221,6 +221,7 @@ This interface defines the following functions:
 ngens(Z::AbstractZonotope)
 genmat_fallback(Z::AbstractZonotope{N}) where {N<:Real}
 generators_fallback(Z::AbstractZonotope{N}) where {N<:Real}
+minkowski_sum(::AbstractZonotope{N}, ::AbstractZonotope{N}) where {N<:Real}
 ```
 
 ##### Hyperrectangle

--- a/docs/src/lib/representations.md
+++ b/docs/src/lib/representations.md
@@ -688,7 +688,6 @@ center(::Zonotope{N}) where {N<:Real}
 order(::Zonotope)
 generators(Z::Zonotope)
 genmat(Z::Zonotope)
-minkowski_sum(::Zonotope{N}, ::Zonotope{N}) where {N<:Real}
 linear_map(::AbstractMatrix{N}, ::Zonotope{N}) where {N<:Real}
 translate(::Zonotope{N}, ::AbstractVector{N}) where {N<:Real}
 scale(::Real, ::Zonotope)

--- a/src/AbstractZonotope.jl
+++ b/src/AbstractZonotope.jl
@@ -136,3 +136,28 @@ An integer representing the number of generators.
 function ngens(Z::AbstractZonotope)::Int
     return length(generators(Z))
 end
+
+"""
+    minkowski_sum(Z1::AbstractZonotope{N}, Z2::AbstractZonotope{N})
+        where {N<:Real}
+
+Concrete Minkowski sum of a pair of zonotopic sets.
+
+### Input
+
+- `Z1` -- zonotopic set
+- `Z2` -- zonotopic set
+
+### Output
+
+A `Zonotope` corresponding to the concrete Minkowski sum of `Z1` and `Z2`.
+
+### Algorithm
+
+The resulting zonotope is obtained by summing up the centers and concatenating
+the generators of `Z1` and `Z2`.
+"""
+function minkowski_sum(Z1::AbstractZonotope{N},
+                       Z2::AbstractZonotope{N}) where {N<:Real}
+    return Zonotope(center(Z1) + center(Z2), [genmat(Z1) genmat(Z2)])
+end

--- a/src/Zonotope.jl
+++ b/src/Zonotope.jl
@@ -4,7 +4,6 @@ import Base: rand,
 
 export Zonotope,
        order,
-       minkowski_sum,
        linear_map,
        scale,
        ngens,
@@ -386,25 +385,6 @@ and its dimension.
 """
 function order(Z::Zonotope)::Rational
     return ngens(Z) // dim(Z)
-end
-
-"""
-    minkowski_sum(Z1::Zonotope{N}, Z2::Zonotope{N}) where {N<:Real}
-
-Concrete Minkowski sum of a pair of zonotopes.
-
-### Input
-
-- `Z1` -- one zonotope
-- `Z2` -- another zonotope
-
-### Output
-
-The zonotope obtained by summing the centers and concatenating the generators
-of ``Z_1`` and ``Z_2``.
-"""
-function minkowski_sum(Z1::Zonotope{N}, Z2::Zonotope{N}) where {N<:Real}
-    return Zonotope(Z1.center + Z2.center, [Z1.generators Z2.generators])
 end
 
 """


### PR DESCRIPTION
Closes #1413.

This requires:
* [x] ~#1270 to define the `minkowski_sum` of a `Zonotope` and a `BallInf`~
* [x] ~#1450~