### PR TITLE
#600 - Specialized support function computations

### DIFF
--- a/docs/src/lib/interfaces.md
+++ b/docs/src/lib/interfaces.md
@@ -263,6 +263,7 @@ This interface defines the following functions:
 
 ```@docs
 σ(::AbstractVector{N}, ::AbstractSingleton{N}) where {N<:Real}
+ρ(::AbstractVector{N}, ::AbstractSingleton{N}) where {N<:Real}
 ∈(::AbstractVector{N}, ::AbstractSingleton{N}) where {N<:Real}
 an_element(::AbstractSingleton{N}) where {N<:Real}
 center(::AbstractSingleton{N}) where {N<:Real}

--- a/docs/src/lib/interfaces.md
+++ b/docs/src/lib/interfaces.md
@@ -238,6 +238,7 @@ This interface defines the following functions:
 norm(::AbstractHyperrectangle, ::Real=Inf)
 radius(::AbstractHyperrectangle, ::Real=Inf)
 σ(::AbstractVector{N}, ::AbstractHyperrectangle{N}) where {N<:Real}
+ρ(::AbstractVector{N}, ::AbstractHyperrectangle{N}) where {N<:Real}
 ∈(::AbstractVector{N}, ::AbstractHyperrectangle{N}) where {N<:Real}
 vertices_list(::AbstractHyperrectangle{N}) where {N<:Real}
 constraints_list(::AbstractHyperrectangle{N}) where {N<:Real}

--- a/docs/src/lib/representations.md
+++ b/docs/src/lib/representations.md
@@ -633,6 +633,7 @@ translate(::Universe{N}, ::AbstractVector{N}) where {N<:Real}
 ZeroSet
 dim(::ZeroSet)
 σ(::AbstractVector{N}, ::ZeroSet{N}) where {N<:Real}
+ρ(::AbstractVector{N}, ::ZeroSet{N}) where {N<:Real}
 ∈(::AbstractVector{N}, ::ZeroSet{N}) where {N<:Real}
 rand(::Type{ZeroSet})
 element(::ZeroSet{N}) where {N<:Real}

--- a/docs/src/lib/representations.md
+++ b/docs/src/lib/representations.md
@@ -66,6 +66,7 @@ Inherited from [`AbstractZonotope`](@ref):
 
 Inherited from [`AbstractHyperrectangle`](@ref):
 * [`σ`](@ref σ(::AbstractVector{N}, ::AbstractHyperrectangle{N}) where {N<:Real})
+* [`ρ`](@ref σ(::AbstractVector{N}, ::AbstractHyperrectangle{N}) where {N<:Real})
 * [`∈`](@ref ∈(::AbstractVector{N}, ::AbstractHyperrectangle{N}) where {N<:Real})
 * [`norm`](@ref norm(::AbstractHyperrectangle, ::Real))
 * [`vertices_list`](@ref vertices_list(::AbstractHyperrectangle{N}) where {N<:Real})
@@ -246,6 +247,7 @@ Inherited from [`AbstractZonotope`](@ref):
 
 Inherited from [`AbstractHyperrectangle`](@ref):
 * [`σ`](@ref σ(::AbstractVector{N}, ::AbstractHyperrectangle{N}) where {N<:Real})
+* [`ρ`](@ref σ(::AbstractVector{N}, ::AbstractHyperrectangle{N}) where {N<:Real})
 * [`∈`](@ref ∈(::AbstractVector{N}, ::AbstractHyperrectangle{N}) where {N<:Real})
 * [`norm`](@ref norm(::AbstractHyperrectangle, ::Real))
 * [`radius`](@ref radius(::AbstractHyperrectangle, ::Real))

--- a/docs/src/lib/representations.md
+++ b/docs/src/lib/representations.md
@@ -260,6 +260,7 @@ Inherited from [`AbstractHyperrectangle`](@ref):
 Interval
 dim(::Interval)
 σ(::AbstractVector{N}, ::Interval{N}) where {N<:Real}
+ρ(::AbstractVector{N}, ::Interval{N}) where {N<:Real}
 ∈(::AbstractVector{N}, ::Interval{N}) where {N<:Real}
 ∈(::N, ::Interval{N}) where {N<:Real}
 an_element(::Interval{N}) where {N<:Real}

--- a/docs/src/lib/representations.md
+++ b/docs/src/lib/representations.md
@@ -151,6 +151,7 @@ EmptySet
 ∅
 dim(::EmptySet)
 σ(::AbstractVector{N}, ::EmptySet{N}) where {N<:Real}
+ρ(::AbstractVector{N}, ::EmptySet{N}) where {N<:Real}
 ∈(::AbstractVector{N}, ::EmptySet{N}) where {N<:Real}
 an_element(::EmptySet)
 rand(::Type{EmptySet})

--- a/src/AbstractHyperrectangle.jl
+++ b/src/AbstractHyperrectangle.jl
@@ -191,6 +191,35 @@ function σ(d::AbstractVector{N}, H::AbstractHyperrectangle{N}) where {N<:Real}
 end
 
 """
+    ρ(d::AbstractVector{N}, H::AbstractHyperrectangle{N}) where {N<:Real}
+
+Evaluate the support function of a hyperrectangular set in a given direction.
+
+### Input
+
+- `d` -- direction
+- `H` -- hyperrectangular set
+
+### Output
+
+Evaluation of the support function in the given direction.
+"""
+function ρ(d::AbstractVector{N}, H::AbstractHyperrectangle{N}) where {N<:Real}
+    @assert length(d) == dim(H) "a $(length(d))-dimensional vector is " *
+                                "incompatible with a $(dim(H))-dimensional set"
+    c = center(H)
+    res = zero(N)
+    @inbounds for (i, di) in enumerate(d)
+        if di < zero(N)
+            res += di * (c[i] - radius_hyperrectangle(H, i))
+        elseif di > zero(N)
+            res += di * (c[i] + radius_hyperrectangle(H, i))
+        end
+    end
+    return res
+end
+
+"""
     norm(H::AbstractHyperrectangle, [p]::Real=Inf)::Real
 
 Return the norm of a hyperrectangular set.

--- a/src/AbstractSingleton.jl
+++ b/src/AbstractSingleton.jl
@@ -280,6 +280,23 @@ function σ(d::AbstractVector{N}, S::AbstractSingleton{N}) where {N<:Real}
     return element(S)
 end
 
+"""
+    ρ(d::AbstractVector{N}, S::AbstractSingleton{N}) where {N<:Real}
+
+Evaluate the support function of a set with a single value in a given direction.
+
+### Input
+
+- `d` -- direction
+- `S` -- set with a single value
+
+### Output
+
+Evaluation of the support function in the given direction.
+"""
+function ρ(d::AbstractVector{N}, S::AbstractSingleton{N}) where {N<:Real}
+    return dot(d, element(S))
+end
 
 """
     ∈(x::AbstractVector{N}, S::AbstractSingleton{N})::Bool where {N<:Real}

--- a/src/EmptySet.jl
+++ b/src/EmptySet.jl
@@ -52,7 +52,7 @@ Return the support vector of an empty set.
 ### Input
 
 - `d` -- direction
-- `∅` -- an empty set
+- `∅` -- empty set
 
 ### Output
 
@@ -60,6 +60,24 @@ An error.
 """
 function σ(d::AbstractVector{N}, ∅::EmptySet{N}) where {N<:Real}
     error("the support vector of an empty set does not exist")
+end
+
+"""
+    ρ(d::AbstractVector{N}, ∅::EmptySet{N}) where {N<:Real}
+
+Evaluate the support function of an empty set in a given direction.
+
+### Input
+
+- `d` -- direction
+- `∅` -- empty set
+
+### Output
+
+An error.
+"""
+function ρ(d::AbstractVector{N}, ∅::EmptySet{N}) where {N<:Real}
+    error("the support function of an empty set does not exist")
 end
 
 """

--- a/src/Interval.jl
+++ b/src/Interval.jl
@@ -123,7 +123,7 @@ dim(x::Interval)::Int = 1
 """
     σ(d::AbstractVector{N}, x::Interval{N}) where {N<:Real}
 
-Return the support vector of an ellipsoid in a given direction.
+Return the support vector of an interval in a given direction.
 
 ### Input
 
@@ -136,7 +136,26 @@ Support vector in the given direction.
 """
 function σ(d::AbstractVector{N}, x::Interval{N}) where {N<:Real}
     @assert length(d) == dim(x)
-    return d[1] > 0 ? [x.dat.hi] : [x.dat.lo]
+    return d[1] > zero(N) ? high(x) : low(x)
+end
+
+"""
+    ρ(d::AbstractVector{N}, x::Interval{N}) where {N<:Real}
+
+Evaluate the support function of an interval in a given direction.
+
+### Input
+
+- `d` -- direction
+- `x` -- interval
+
+### Output
+
+Evaluation of the support function in the given direction.
+"""
+function ρ(d::AbstractVector{N}, x::Interval{N}) where {N<:Real}
+    @assert length(d) == dim(x)
+    return d[1] * (d[1] > zero(N) ? max(x) : min(x))
 end
 
 """

--- a/src/ZeroSet.jl
+++ b/src/ZeroSet.jl
@@ -87,6 +87,7 @@ Return the support vector of a zero set.
 
 ### Input
 
+- `d` -- direction
 - `Z` -- a zero set, i.e., a set that only contains the origin
 
 ### Output
@@ -97,6 +98,25 @@ set.
 function σ(d::AbstractVector{N}, Z::ZeroSet{N}) where {N<:Real}
     @assert length(d) == dim(Z) "the direction has the wrong dimension"
     return element(Z)
+end
+
+"""
+    ρ(d::AbstractVector{N}, Z::ZeroSet{N}) where {N<:Real}
+
+Evaluate the support function of a zero set in a given direction.
+
+### Input
+
+- `d` -- direction
+- `Z` -- a zero set, i.e., a set that only contains the origin
+
+### Output
+
+`0`.
+"""
+function ρ(d::AbstractVector{N}, Z::ZeroSet{N}) where {N<:Real}
+    @assert length(d) == dim(Z) "the direction has the wrong dimension"
+    return zero(N)
 end
 
 """


### PR DESCRIPTION
See #600.

```julia
julia> @btime ρ($[1., 0.], $(BallInf(zeros(2), 1.)))
  7.835 ns (0 allocations: 0 bytes)  # this branch
  87.346 ns (2 allocations: 192 bytes)  # master
```