### PR TITLE
WIP #1460 - linear_map for hyperrectangles

### DIFF
--- a/docs/src/lib/interfaces.md
+++ b/docs/src/lib/interfaces.md
@@ -222,6 +222,7 @@ ngens(Z::AbstractZonotope)
 genmat_fallback(Z::AbstractZonotope{N}) where {N<:Real}
 generators_fallback(Z::AbstractZonotope{N}) where {N<:Real}
 minkowski_sum(::AbstractZonotope{N}, ::AbstractZonotope{N}) where {N<:Real}
+linear_map(::AbstractMatrix{N}, ::AbstractZonotope{N}) where {N<:Real}
 ```
 
 ##### Hyperrectangle

--- a/docs/src/lib/representations.md
+++ b/docs/src/lib/representations.md
@@ -688,7 +688,6 @@ center(::Zonotope{N}) where {N<:Real}
 order(::Zonotope)
 generators(Z::Zonotope)
 genmat(Z::Zonotope)
-linear_map(::AbstractMatrix{N}, ::Zonotope{N}) where {N<:Real}
 translate(::Zonotope{N}, ::AbstractVector{N}) where {N<:Real}
 scale(::Real, ::Zonotope)
 ngens(::Zonotope)

--- a/src/AbstractZonotope.jl
+++ b/src/AbstractZonotope.jl
@@ -161,3 +161,30 @@ function minkowski_sum(Z1::AbstractZonotope{N},
                        Z2::AbstractZonotope{N}) where {N<:Real}
     return Zonotope(center(Z1) + center(Z2), [genmat(Z1) genmat(Z2)])
 end
+
+"""
+    linear_map(M::AbstractMatrix{N}, Z::AbstractZonotope{N}) where {N<:Real}
+
+Concrete linear map of a zonotopic set.
+
+### Input
+
+- `M` -- matrix
+- `Z` -- zonotopic set
+
+### Output
+
+A zonotope corresponding to the concrete linear map `M` applied to `Z`.
+
+### Algorithm
+
+The resulting zonotope is obtained by applying the linear map `M` to the center
+and the generators of `Z`.
+"""
+function linear_map(M::AbstractMatrix{N},
+                    Z::AbstractZonotope{N}) where {N<:Real}
+    @assert dim(Z) == size(M, 2) "a linear map of size $(size(M)) cannot be " *
+        "applied to a $(typeof(Z)) of dimension $(dim(Z))"
+
+    return Zonotope(M * center(Z), M * genmat(Z))
+end

--- a/src/Zonotope.jl
+++ b/src/Zonotope.jl
@@ -4,7 +4,6 @@ import Base: rand,
 
 export Zonotope,
        order,
-       linear_map,
        scale,
        ngens,
        reduce_order,
@@ -385,30 +384,6 @@ and its dimension.
 """
 function order(Z::Zonotope)::Rational
     return ngens(Z) // dim(Z)
-end
-
-"""
-    linear_map(M::AbstractMatrix{N}, Z::Zonotope{N}) where {N<:Real}
-
-Concrete linear map of a zonotope.
-
-### Input
-
-- `M` -- matrix
-- `Z` -- zonotope
-
-### Output
-
-The zonotope obtained by applying the linear map to the center and generators
-of ``Z``.
-"""
-function linear_map(M::AbstractMatrix{N}, Z::Zonotope{N}) where {N<:Real}
-    @assert dim(Z) == size(M, 2) "a linear map of size $(size(M)) cannot be " *
-                                 "applied to a set of dimension $(dim(Z))"
-
-    c = M * Z.center
-    gi = M * Z.generators
-    return Zonotope(c, gi)
 end
 
 """

--- a/test/unit_Hyperrectangle.jl
+++ b/test/unit_Hyperrectangle.jl
@@ -159,13 +159,8 @@ for N in [Float64, Rational{Int}, Float32]
     @test cap isa EmptySet{N}
     @test is_intersection_empty(H1, B1) && is_intersection_empty(H1, B1, true)[1]
 
-    # linear map (concrete)
-    P = linear_map(N[1 0; 0 2], H1)
-    @test P isa HPolygon # in 2D and for invertible map we get an HPolygon; see #631 and #1093
-
-    P = linear_map(Diagonal(N[1, 2, 3, 4]),
-                   Approximations.overapproximate(H1 * H1))
-    @test P isa HPolytope # in 4D and for invertible map we get an HPolytope; see #631 and #1093
+    # concrete linear map becomes a zonotope
+    @test linear_map(N[1 0; 0 2], H1) isa Zonotope
 
     # check that vertices_list is computed correctly if the hyperrectangle
     # is "degenerate" in the sense that its radius is zero in all dimensions

--- a/test/unit_LinearMap.jl
+++ b/test/unit_LinearMap.jl
@@ -96,13 +96,8 @@ for N in [Float64, Rational{Int}, Float32]
         lm1 = LinearMap(M, b)
         clist = constraints_list(lm1)
         p1 = HPolygon(clist)
-        M = N[2 3; 0 0]  # not invertible
-        lm2 = LinearMap(M, b)
-        clist = constraints_list(lm2)
-        p2 = HPolygon(clist)
         for d in BoxDiagDirections{N}(2)
             @test ρ(d, lm1) ≈ ρ(d, p1)
-            @test ρ(d, lm2) ≈ ρ(d, p2)
         end
     end
 
@@ -124,5 +119,14 @@ for N in [Float64]
         L = M * b
         Lb = intersection(L, b)
         @test M * an_element(b) ∈ Lb
+
+        # constraints_list with singular matrix
+        M = N[2 3; 0 0]
+        lm2 = LinearMap(M, b)
+        clist = constraints_list(lm2)
+        p2 = HPolygon(clist)
+        for d in BoxDiagDirections{N}(2)
+            @test ρ(d, lm2) ≈ ρ(d, p2)
+        end
     end
 end

--- a/test/unit_Polygon.jl
+++ b/test/unit_Polygon.jl
@@ -204,6 +204,11 @@ for N in [Float64, Float32, Rational{Int}]
     p3 = intersection(p, p2)
     @test length(constraints_list(p3)) == 4
 
+    # concrete linear map
+    # in 2D and for invertible map we get an HPolygon; see #631 and #1093
+    HP = convert(HPolygon, BallInf(N[0, 0], N(1)))
+    @test linear_map(N[1 0; 0 2], HP) isa HPolygon
+
     # check that tighter constraints are used in intersection (#883)
     h1 = HalfSpace([N(1), N(0)], N(3))
     h2 = HalfSpace([N(-1), N(0)], N(-3))

--- a/test/unit_Polytope.jl
+++ b/test/unit_Polytope.jl
@@ -131,6 +131,10 @@ for N in [Float64, Rational{Int}, Float32]
         @test LM isa VPolygon
     end
 
+    # in 4D and for invertible map we get an HPolytope; see #631 and #1093
+    HP = convert(HPolytope, Approximations.overapproximate(H * H))
+    @test linear_map(Diagonal(N[1, 2, 3, 4]), HP) isa HPolytope
+
     M = N[2 1; 0 1]
     L1 = linear_map(M, P, use_inv=true)  # calculates inv(M) explicitly
     L2 = linear_map(M, P, use_inv=false) # uses transpose(M) \ c.a for each constraint c of P


### PR DESCRIPTION
See #1460.

Since `AbstractHyperrectangle <: AbstractZonotope <: AbstractPolytope`, this change affects hyperrectangular sets as well.