### PR TITLE
#1463 - Rename iscounterclockwise -> is_cyclic_permutation

### DIFF
--- a/docs/src/lib/utils.md
+++ b/docs/src/lib/utils.md
@@ -17,7 +17,7 @@ cross_product(::AbstractMatrix{N}) where {N<:Real}
 delete_zero_columns!
 dot_zero
 inner
-iscounterclockwise
+is_cyclic_permutation
 isinvertible
 ispermutation
 issquare

--- a/src/Arrays/vector_operations.jl
+++ b/src/Arrays/vector_operations.jl
@@ -5,7 +5,7 @@ export dot_zero,
        samedir,
        nonzero_indices,
        rectify,
-       iscounterclockwise
+       is_cyclic_permutation
 
 """
     dot_zero(x::AbstractVector{N}, y::AbstractVector{N}) where{N<:Real}
@@ -219,23 +219,26 @@ function rectify(x::AbstractVector{N}) where {N<:Real}
 end
 
 """
-    iscounterclockwise(result::AbstractVector,
-                       correct_expr::AbstractVector) where {N<:Real}
+    is_cyclic_permutation(candidate::AbstractVector, paragon::AbstractVector)
 
-Returns a boolean, true if the elements in `result` are ordered in
-a couter-clockwise fashion and in the same order as `correct_expr`.
+Checks if the elements in `candidate` are a cyclic permutation of the elements
+in `paragon`.
 
 ### Input
 
-- `result` -- vector
-- `correct_expr` -- paragon vector with elements in ccw order
+- `candidate` -- candidate vector
+- `paragon`   -- paragon vector
 
 ### Output
 
-A boolean indicating if the elements of `result` are in the same order as
-`correct_expr` or any of its cyclic permutations.
+A boolean indicating if the elements of `candidate` are in the same order as in
+`paragon` or any of its cyclic permutations.
 """
-function iscounterclockwise(result::AbstractVector,
-                            correct_expr::AbstractVector)
-    return any([result == circshift(correct_expr, i) for i in 0:length(result)-1])
+function is_cyclic_permutation(candidate::AbstractVector,
+                               paragon::AbstractVector)
+    m = length(candidate)
+    if length(paragon) != m
+        return false
+    end
+    return any(candidate == circshift(paragon, i) for i in 0:m-1)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,8 +8,8 @@ import TaylorModels
 using TaylorModels: set_variables, TaylorModelN
 
 # non-exported helper functions
-using LazySets.Arrays: ispermutation, isinvertible, inner, iscounterclockwise,
-                       SingleEntryVector
+using LazySets.Arrays: ispermutation, isinvertible, inner,
+                       is_cyclic_permutation, SingleEntryVector
 
 # conversion between numeric types
 include("to_N.jl")

--- a/test/unit_convex_hull.jl
+++ b/test/unit_convex_hull.jl
@@ -42,11 +42,11 @@ for N in [Float64, Rational{Int}]
     ccw_points = [N[1, 1], N[-1, 1], N[-1, 0]]
     ccw_p = convex_hull!(ccw_points)
     ccw_expr = [N[1, 1], N[-1, 1], N[-1, 0]]
-    @test  iscounterclockwise(ccw_p, ccw_expr) # points sorted in a counter-clockwise fashion
+    @test is_cyclic_permutation(ccw_p, ccw_expr) # points sorted in a counter-clockwise fashion
     cw_points = [N[-1, 1], N[1, 1], N[-1, 0]]
     cw_p = convex_hull!(cw_points)
     cw_expr = [N[1, 1], N[-1, 1], N[-1, 0]]
-    @test  iscounterclockwise(cw_p, cw_expr) # points sorted in clockwise fashion
+    @test is_cyclic_permutation(cw_p, cw_expr) # points sorted in clockwise fashion
     @test ispermutation(convex_hull!([N[1, 1], N[2, 2], N[3, 3]]), [N[1, 1], N[3, 3]]) # points aligned
     @test ispermutation(convex_hull!([N[0, 1], N[0, 2], N[0, 3]]), [N[0, 1], N[0, 3]]) # three points on a vertical line
     @test convex_hull!([N[0, 1], N[0, 1], N[0, 1]]) == [N[0, 1]] # three equal points
@@ -58,38 +58,38 @@ for N in [Float64, Rational{Int}]
     D = N[-1, 0]
     expr = [A, B, C, D]
     points = [A, B, C, D]
-    @test  iscounterclockwise(convex_hull!(points), expr) # ABCD
+    @test is_cyclic_permutation(convex_hull!(points), expr) # ABCD
     points = [A, D, C, B]
-    @test  iscounterclockwise(convex_hull!(points), expr) # ADCB
+    @test is_cyclic_permutation(convex_hull!(points), expr) # ADCB
     points = [A, B, D, C]
-    @test  iscounterclockwise(convex_hull!(points), expr) # ABDC
+    @test is_cyclic_permutation(convex_hull!(points), expr) # ABDC
     points = [A, D, B, C]
-    @test  iscounterclockwise(convex_hull!(points), expr) # ADBC
+    @test is_cyclic_permutation(convex_hull!(points), expr) # ADBC
     points = [D, A, C, B]
-    @test  iscounterclockwise(convex_hull!(points), expr) # DACB
+    @test is_cyclic_permutation(convex_hull!(points), expr) # DACB
     points = [A, C, D, B]
-    @test  iscounterclockwise(convex_hull!(points), expr) # ACDB
+    @test is_cyclic_permutation(convex_hull!(points), expr) # ACDB
     A = N[0, 1]
     B = N[-1, -1]
     C = N[1, -1]
     D = N[0, 0]
     expr = [A, B, C]
     points = [A, B, C, D]
-    @test iscounterclockwise(convex_hull!(points), expr) # ABC
+    @test is_cyclic_permutation(convex_hull!(points), expr) # ABC
     points = [A, C, B, D]
-    @test iscounterclockwise(convex_hull!(points), expr) # CBA
+    @test is_cyclic_permutation(convex_hull!(points), expr) # CBA
     points = [D, B, C, A]
-    @test iscounterclockwise(convex_hull!(points), expr) # BCD
+    @test is_cyclic_permutation(convex_hull!(points), expr) # BCD
     points = [D, C, B, A]
-    @test iscounterclockwise(convex_hull!(points), expr) # DCB
+    @test is_cyclic_permutation(convex_hull!(points), expr) # DCB
     points = [B, D, C, A]
-    @test iscounterclockwise(convex_hull!(points), expr) # ACD
+    @test is_cyclic_permutation(convex_hull!(points), expr) # ACD
     points = [C, D, B, A]
-    @test iscounterclockwise(convex_hull!(points), expr) # CAD
+    @test is_cyclic_permutation(convex_hull!(points), expr) # CAD
     points = [B, C, D, A]
-    @test iscounterclockwise(convex_hull!(points), expr) # ABD
+    @test is_cyclic_permutation(convex_hull!(points), expr) # ABD
     points = [C, B, D, A]
-    @test iscounterclockwise(convex_hull!(points), expr) # ADB
+    @test is_cyclic_permutation(convex_hull!(points), expr) # ADB
     @test ispermutation(convex_hull!([N[1, 1], N[2, 2], N[3, 3], N[4, 4]]), [N[1, 1], N[4, 4]]) # points aligned
 
     # five-vertices case in 2D


### PR DESCRIPTION
Closes #1463.

As a bonus, by removing the array allocation the implementation became more efficient:

```julia
@btime is_cyclic_permutation(ccw_p, ccw_expr);  # first example in test/unit_convex_hull.jl
  309.650 ns (6 allocations: 496 bytes)  # master
  126.715 ns (3 allocations: 176 bytes)  # this branch
```