### PR TITLE
#1459 - Faster support vector/function for BallInf

### DIFF
--- a/docs/src/lib/representations.md
+++ b/docs/src/lib/representations.md
@@ -45,6 +45,7 @@ radius_hyperrectangle(::BallInf{N}) where {N<:Real}
 radius_hyperrectangle(::BallInf{N}, ::Int) where {N<:Real}
 isflat(::BallInf)
 rand(::Type{BallInf})
+σ(::AbstractVector{N}, ::BallInf{N}) where {N<:Real}
 translate(::BallInf{N}, ::AbstractVector{N}) where {N<:Real}
 ```
 Inherited from [`LazySet`](@ref):
@@ -63,8 +64,7 @@ Inherited from [`AbstractZonotope`](@ref):
 * [`ngens`](@ref ngens(::AbstractZonotope))
 
 Inherited from [`AbstractHyperrectangle`](@ref):
-* [`σ`](@ref σ(::AbstractVector{N}, ::AbstractHyperrectangle{N}) where {N<:Real})
-* [`ρ`](@ref σ(::AbstractVector{N}, ::AbstractHyperrectangle{N}) where {N<:Real})
+* [`ρ`](@ref ρ(::AbstractVector{N}, ::AbstractHyperrectangle{N}) where {N<:Real})
 * [`∈`](@ref ∈(::AbstractVector{N}, ::AbstractHyperrectangle{N}) where {N<:Real})
 * [`norm`](@ref norm(::AbstractHyperrectangle, ::Real))
 * [`vertices_list`](@ref vertices_list(::AbstractHyperrectangle{N}) where {N<:Real})
@@ -247,7 +247,7 @@ Inherited from [`AbstractZonotope`](@ref):
 
 Inherited from [`AbstractHyperrectangle`](@ref):
 * [`σ`](@ref σ(::AbstractVector{N}, ::AbstractHyperrectangle{N}) where {N<:Real})
-* [`ρ`](@ref σ(::AbstractVector{N}, ::AbstractHyperrectangle{N}) where {N<:Real})
+* [`ρ`](@ref ρ(::AbstractVector{N}, ::AbstractHyperrectangle{N}) where {N<:Real})
 * [`∈`](@ref ∈(::AbstractVector{N}, ::AbstractHyperrectangle{N}) where {N<:Real})
 * [`norm`](@ref norm(::AbstractHyperrectangle, ::Real))
 * [`radius`](@ref radius(::AbstractHyperrectangle, ::Real))

--- a/docs/src/lib/representations.md
+++ b/docs/src/lib/representations.md
@@ -46,6 +46,7 @@ radius_hyperrectangle(::BallInf{N}, ::Int) where {N<:Real}
 isflat(::BallInf)
 rand(::Type{BallInf})
 σ(::AbstractVector{N}, ::BallInf{N}) where {N<:Real}
+ρ(::AbstractVector{N}, ::BallInf{N}) where {N<:Real}
 translate(::BallInf{N}, ::AbstractVector{N}) where {N<:Real}
 ```
 Inherited from [`LazySet`](@ref):
@@ -64,7 +65,6 @@ Inherited from [`AbstractZonotope`](@ref):
 * [`ngens`](@ref ngens(::AbstractZonotope))
 
 Inherited from [`AbstractHyperrectangle`](@ref):
-* [`ρ`](@ref ρ(::AbstractVector{N}, ::AbstractHyperrectangle{N}) where {N<:Real})
 * [`∈`](@ref ∈(::AbstractVector{N}, ::AbstractHyperrectangle{N}) where {N<:Real})
 * [`norm`](@ref norm(::AbstractHyperrectangle, ::Real))
 * [`vertices_list`](@ref vertices_list(::AbstractHyperrectangle{N}) where {N<:Real})

--- a/src/BallInf.jl
+++ b/src/BallInf.jl
@@ -164,6 +164,62 @@ function σ(d::AbstractVector{N}, B::BallInf{N}) where {N<:Real}
 end
 
 """
+    ρ(d::AbstractVector{N}, B::BallInf{N}) where {N<:Real}
+
+Evaluate the support function of a ball in the infinity norm in a given
+direction.
+
+### Input
+
+- `d` -- direction
+- `B` -- ball in the infinity norm
+
+### Output
+
+Evaluation of the support function in the given direction.
+
+### Algorithm
+
+Let ``B`` be a ball in the infinity norm with center ``c`` and radius ``r`` and
+let `d` be the direction of interest.
+For balls with dimensions less than 30 we use the implementation for
+`AbstractHyperrectangle`, taylored to a `BallInf`, which computes
+
+```math
+    ∑_{i=1}^n d_i * (c_i + \\sgn(d_i) * r)
+```
+
+where ``\\sgn(α) = 1`` if ``α ≥ 0`` and ``\\sgn(α) = 1`` if ``α < 0``.
+
+For balls of higher dimension, we instead exploit that for a support vector
+``v = σ(d, B) = c + \\sgn(d) * (r, …, r)ᵀ`` we have
+
+```math
+    ρ(d, B) = ⟨d, v⟩ = ⟨d, c⟩ + ⟨d, \\sgn(d) * (r, …, r)ᵀ⟩ = ⟨d, c⟩ + r · ∑_{i=1}^n |d_i|
+```
+
+where ``⟨·, ·⟩`` denotes the dot product.
+"""
+function ρ(d::AbstractVector{N}, B::BallInf{N}) where {N<:Real}
+    @assert length(d) == dim(B) "a $(length(d))-dimensional vector is " *
+                                "incompatible with a $(dim(B))-dimensional set"
+    c = center(B)
+    if length(d) > 30
+        # more efficient for higher dimensions
+        return dot(d, c) + B.radius * sum(abs, d)
+    end
+    res = zero(N)
+    @inbounds for (i, di) in enumerate(d)
+        if di < zero(N)
+            res += di * (c[i] - B.radius)
+        elseif di > zero(N)
+            res += di * (c[i] + B.radius)
+        end
+    end
+    return res
+end
+
+"""
     radius(B::BallInf, [p]::Real=Inf)::Real
 
 Return the radius of a ball in the infinity norm.

--- a/src/BallInf.jl
+++ b/src/BallInf.jl
@@ -143,6 +143,27 @@ end
 
 
 """
+    σ(d::AbstractVector{N}, B::BallInf{N}) where {N<:Real}
+
+Return the support vector of a ball in the infinity norm in a given direction.
+
+### Input
+
+- `d` -- direction
+- `B` -- ball in the infinity norm
+
+### Output
+
+The support vector in the given direction.
+If the direction has norm zero, the vertex with biggest values is returned.
+"""
+function σ(d::AbstractVector{N}, B::BallInf{N}) where {N<:Real}
+    @assert length(d) == dim(B) "a $(length(d))-dimensional vector is " *
+                                "incompatible with a $(dim(B))-dimensional set"
+    return center(B) .+ sign_cadlag.(d) .* B.radius
+end
+
+"""
     radius(B::BallInf, [p]::Real=Inf)::Real
 
 Return the radius of a ball in the infinity norm.

--- a/test/unit_BallInf.jl
+++ b/test/unit_BallInf.jl
@@ -54,6 +54,15 @@ for N in [Float64, Rational{Int}, Float32]
     d = N[1, -1]
     @test σ(d, b) == N[2, -2]
 
+    # support function
+    B = BallInf(N[1, 2], N(1))
+    @test ρ(N[1, 1], B) == N(5)
+    @test ρ(N[1, 0], B) == N(2)
+    @test ρ(N[0, 1], B) == N(3)
+    @test ρ(N[-1, -1], B) == N(-1)
+    @test ρ(N[-1, 0], B) == N(0)
+    @test ρ(N[-1, 1], B) == N(3)
+
     # boundedness
     @test isbounded(b)
 


### PR DESCRIPTION
Closes #1459.

```julia
julia> using LazySets, BenchmarkTools
julia> for n in [1, 10, 100, 1000]
           B = rand(BallInf, dim=n)
           @btime σ($(ones(n)), $B)
       end
  # master
  79.740 ns (2 allocations: 192 bytes)
  97.977 ns (2 allocations: 320 bytes)
  236.966 ns (2 allocations: 1.75 KiB)
  2.022 μs (2 allocations: 15.88 KiB)
  # this branch
  48.857 ns (1 allocation: 96 bytes)
  61.066 ns (1 allocation: 160 bytes)
  116.163 ns (1 allocation: 896 bytes)
  971.600 ns (1 allocation: 7.94 KiB)
```