### PR TITLE
#593 - Faster vertices_list implementation for flat hyperrectangles

### DIFF
--- a/src/AbstractHyperrectangle.jl
+++ b/src/AbstractHyperrectangle.jl
@@ -117,7 +117,8 @@ end
 
 
 """
-    vertices_list(H::AbstractHyperrectangle{N})::Vector{Vector{N}} where {N<:Real}
+    vertices_list(H::AbstractHyperrectangle{N}
+                 )::Vector{Vector{N}} where {N<:Real}
 
 Return the list of vertices of a hyperrectangular set.
 
@@ -134,12 +135,35 @@ duplicate vertices.
 ### Notes
 
 For high dimensions, it is preferable to develop a `vertex_iterator` approach.
+
+### Algorithm
+
+First we identify the dimensions where `H` is flat, i.e., its radius is zero.
+We also compute the number of vertices that we have to create.
+
+Next we create the vertices.
+We do this by enumerating all vectors `v` of length `n` (the dimension of `H`)
+with entries `-1`/`0`/`1` and construct the corresponding vertex as follows:
+
+```math
+    \\text{vertex}(v)(i) = \\begin{cases} c(i) + r(i) & v(i) = 1 \\\\
+                                          c(i) & v(i) = 0 \\\\
+                                          c(i) - r(i) & v(i) = -1. \\end{cases}
+```
+
+For enumerating the vectors `v`, we modify the current `v` from left to right by
+changing entries `-1` to `1`, skipping entries `0`, and stopping at the first
+entry `1` (but changing it to `-1`).
+This way we only need to change the vertex in those dimensions where `v` has
+changed, which usually is a smaller number than `n`.
 """
 function vertices_list(H::AbstractHyperrectangle{N}
                       )::Vector{Vector{N}} where {N<:Real}
     n = dim(H)
 
-    # three-valued vector; initially 0 if radius is zero and 1 otherwise
+    # identify flat dimensions and store them in a binary vector whose entry in
+    # dimension i is 0 if the radius is zero and 1 otherwise
+    # the vector will later also contain entries -1
     trivector = Vector{Int8}(undef, n)
     m = 1
     c = center(H)

--- a/test/unit_Hyperrectangle.jl
+++ b/test/unit_Hyperrectangle.jl
@@ -180,11 +180,15 @@ for N in [Float64, Rational{Int}, Float32]
     @test P isa HPolytope # in 4D and for invertible map we get an HPolytope; see #631 and #1093
 
     # check that vertices_list is computed correctly if the hyperrectangle
-    # is "degenerate" in the sense that its radius is zero in all dimensions
-    # this test would take very long if all 2^100 vertices are computed (see #92)
-    H = Hyperrectangle(fill(N(1.), 100), fill(N(0.), 100))
+    # is "degenerate"/flat, i.e., its radius contains zeros
+    # these tests would crash if all 2^100 vertices were computed (see #92)
+    H = Hyperrectangle(ones(N, 100), zeros(N, 100))
     vl = vertices_list(H)
     @test vl == [H.center]
+    r = zeros(N, 100); r[1] = N(1)
+    H = Hyperrectangle(fill(N(1), 100), r)
+    vl = vertices_list(H)
+    @test ispermutation(vl, [H.center + r, H.center - r])
 
     # transform hyperrectangle into a polygon
     H1pol = convert(HPolygon, H1)


### PR DESCRIPTION
Closes #593.

The implementation is actually faster even if the radius does not contain zeros. The old implementation is only faster if the radius is all zero (because we had hard-coded that case; but I think this is such a rare case that we should not optimize for it).
(In the code piece below, `vertices_list2` is the new implementation.)

```julia
# no zeros in radius

julia> H = rand(Hyperrectangle, dim=4)
Hyperrectangle{Float64}([-1.03944, 0.108362, 1.35677, 0.492468], [0.0479897, 0.60482, 1.01331, 0.0135837])

julia> @btime vertices_list($H);
  1.661 μs (29 allocations: 2.91 KiB)

julia> @btime vertices_list2($H);
  748.148 ns (19 allocations: 2.16 KiB)


# many zeros in radius

julia> H = Hyperrectangle(H.center, [0., 0., 1., 0.])
Hyperrectangle{Float64}([-1.03944, 0.108362, 1.35677, 0.492468], [0.0, 0.0, 1.0, 0.0])

julia> length(vertices_list(H))
16

julia> length(vertices_list2(H))
2

julia> @btime vertices_list($H);
  1.676 μs (29 allocations: 2.91 KiB)

julia> @btime vertices_list2($H);
  177.610 ns (5 allocations: 528 bytes)


# radius is zero (was hard-coded before, hence the old code was faster)

julia> H = Hyperrectangle(H.center, zeros(4))
Hyperrectangle{Float64}([-1.03944, 0.108362, 1.35677, 0.492468], [0.0, 0.0, 0.0, 0.0])

julia> @btime vertices_list($H);
  79.719 ns (2 allocations: 208 bytes)

julia> @btime vertices_list2($H);
  138.946 ns (4 allocations: 416 bytes)
```