### PR TITLE
#1468 - Rank of sparse matrix

### DIFF
--- a/src/Arrays/matrix_operations.jl
+++ b/src/Arrays/matrix_operations.jl
@@ -15,6 +15,9 @@ const DEFAULT_COND_TOL = 1e6
 # matrix-matrix division
 @inline _At_ldiv_B(A, B) = transpose(A) \ B
 
+# rank of sparse matrix (see JuliaLang #30415)
+LinearAlgebra.rank(M::SparseMatrixCSC) = rank(qr(M))
+
 """
     issquare(M::AbstractMatrix)::Bool
 

--- a/test/unit_Zonotope.jl
+++ b/test/unit_Zonotope.jl
@@ -210,6 +210,8 @@ for N in [Float64, Rational{Int}]
     for d in LazySets.Approximations.BoxDiagDirections{N}(2)
         @test ρ(d, P) == ρ(d, Z)
     end
+    # sparse matrix (#1468)
+    constraints_list(Zonotope(N[0, 0], sparse(N[1 0 ; 0 1])))
 end
 
 for N in [Float64]


### PR DESCRIPTION
Closes #1468.

The fix is only partial because it only works for `Float64`.
```julia
julia> LazySets.Arrays.rank(sparse(Float64[1 0; 0 1]))
2

julia> LazySets.Arrays.rank(sparse(Float32[1 0; 0 1]))
ERROR: MethodError: no method matching qr(::SparseMatrixCSC{Float32,Int64}, ::Type{Val{true}}; tol=9.536743f-6)

julia> LazySets.Arrays.rank(sparse(Rational{Int}[1 0; 0 1]))
ERROR: MethodError: no method matching eps(::Type{Rational{Int64}})
```