### PR TITLE
#1471 - No sorting for two-points convex hull

### DIFF
--- a/src/concrete_convex_hull.jl
+++ b/src/concrete_convex_hull.jl
@@ -103,7 +103,7 @@ function convex_hull!(points::Vector{VN};
     if n == 1 # dimensional check
         if m == 2
             # two points case in 1d
-            return _two_points_1d!(points, false)
+            return _two_points_1d!(points)
         else
              # general case in 1d
             return _convex_hull_1d!(points)
@@ -111,7 +111,7 @@ function convex_hull!(points::Vector{VN};
     elseif n == 2
         if m == 2
             # two points case in 2d
-            return _two_points_2d!(points, false)
+            return _two_points_2d!(points)
         elseif m == 3
             # three points case in 2d
             return _three_points_2d!(points)
@@ -128,37 +128,15 @@ function convex_hull!(points::Vector{VN};
     end
 end
 
-function _two_points_1d!(points, sort=Val(true))
+function _two_points_1d!(points)
     p1, p2 = points[1], points[2]
-    if _isapprox(p1, p2) # check for redundancy
-        pop!(points)
-    elseif p1[1] > p2[1]
-        points[1], points[2] = p2, p1
-    end
-    return points
-end
-
-function _two_points_1d!(points, sort=Val(false))
-    p1, p2 = points[1], points[2]
-    if  _isapprox(p1, p2) # check for redundancy
+    if  _isapprox(p1[1], p2[1]) # check for redundancy
         pop!(points)
     end
     return points
 end
 
-function _two_points_2d!(points, sort=Val(true))
-    p1, p2 = points[1], points[2]
-    if isapprox(p1[1], p2[1]) && _isapprox(p1[2], p2[2]) # check for redundancy
-        pop!(points)
-    elseif p1 <= p2
-        nothing
-    else
-        points[1], points[2] = p2, p1
-    end
-    return points
-end
-
-function _two_points_2d!(points, sort=Val(false))
+function _two_points_2d!(points)
     p1, p2 = points[1], points[2]
     if _isapprox(p1[1], p2[1]) && _isapprox(p1[2], p2[2]) # check for redundancy
         pop!(points)

--- a/src/concrete_convex_hull.jl
+++ b/src/concrete_convex_hull.jl
@@ -103,7 +103,7 @@ function convex_hull!(points::Vector{VN};
     if n == 1 # dimensional check
         if m == 2
             # two points case in 1d
-            return _two_points_1d!(points)
+            return _two_points_1d!(points, false)
         else
              # general case in 1d
             return _convex_hull_1d!(points)
@@ -111,7 +111,7 @@ function convex_hull!(points::Vector{VN};
     elseif n == 2
         if m == 2
             # two points case in 2d
-            return _two_points_2d!(points)
+            return _two_points_2d!(points, false)
         elseif m == 3
             # three points case in 2d
             return _three_points_2d!(points)
@@ -128,10 +128,9 @@ function convex_hull!(points::Vector{VN};
     end
 end
 
-function _two_points_1d!(points)
+function _two_points_1d!(points, sort=Val(true))
     p1, p2 = points[1], points[2]
-    if p1 == p2
-        # check for redundancy
+    if _isapprox(p1, p2) # check for redundancy
         pop!(points)
     elseif p1[1] > p2[1]
         points[1], points[2] = p2, p1
@@ -139,16 +138,30 @@ function _two_points_1d!(points)
     return points
 end
 
-function _two_points_2d!(points)
-    # special case, see #876
+function _two_points_1d!(points, sort=Val(false))
     p1, p2 = points[1], points[2]
-    if p1 == p2
-        # check for redundancy
+    if  _isapprox(p1, p2) # check for redundancy
+        pop!(points)
+    end
+    return points
+end
+
+function _two_points_2d!(points, sort=Val(true))
+    p1, p2 = points[1], points[2]
+    if isapprox(p1[1], p2[1]) && _isapprox(p1[2], p2[2]) # check for redundancy
         pop!(points)
     elseif p1 <= p2
         nothing
     else
         points[1], points[2] = p2, p1
+    end
+    return points
+end
+
+function _two_points_2d!(points, sort=Val(false))
+    p1, p2 = points[1], points[2]
+    if _isapprox(p1[1], p2[1]) && _isapprox(p1[2], p2[2]) # check for redundancy
+        pop!(points)
     end
     return points
 end

--- a/test/unit_Zonotope.jl
+++ b/test/unit_Zonotope.jl
@@ -219,6 +219,6 @@ for N in [Float64]
         # constraints_list for generator matrix with a zero row
         Z = Zonotope(N[0, 0], N[2 3; 0 0])
         P = tovrep(HPolygon(constraints_list(Z)))
-        @test vertices_list(P) ≈ [N[5, 0], [-5, 0]]
+        @test ispermutation(vertices_list(P), [N[5, 0], [-5, 0]])
     end
 end

--- a/test/unit_convex_hull.jl
+++ b/test/unit_convex_hull.jl
@@ -6,7 +6,7 @@ for N in [Float64, Rational{Int}]
     # corner cases in dimension 1
     @test convex_hull([Vector{N}(undef, 0)]) == [Vector{N}(undef, 0)]
     @test convex_hull([[N(0)]]) == [[N(0)]]
-    @test convex_hull([[N(2)], [N(1)]]) == [[N(2)], [N(1)]]
+    @test ispermutation(convex_hull([N[2], N[1]]), [N[2], N[1]])
     @test convex_hull([[N(2)], [N(2)]]) == [[N(2)]]
 
     # corner cases in dimension 2
@@ -18,8 +18,7 @@ for N in [Float64, Rational{Int}]
     p1 = [1., 2.]
     p2 = [1., 3.]
     @test convex_hull([p1]) == [p1]
-    @test convex_hull([p1, p2]) == [p1, p2]
-    @test convex_hull([p2, p1]) == [p2, p1] # no sorting
+    @test ispermutation(convex_hull([p1, p2]), [p1, p2])
 
     # corner cases in higher dimension
     @test convex_hull([[N(0), N(0), N(0)]]) == [[N(0), N(0), N(0)]]

--- a/test/unit_convex_hull.jl
+++ b/test/unit_convex_hull.jl
@@ -6,7 +6,7 @@ for N in [Float64, Rational{Int}]
     # corner cases in dimension 1
     @test convex_hull([Vector{N}(undef, 0)]) == [Vector{N}(undef, 0)]
     @test convex_hull([[N(0)]]) == [[N(0)]]
-    @test convex_hull([[N(2)], [N(1)]]) == [[N(1)], [N(2)]]
+    @test convex_hull([[N(2)], [N(1)]]) == [[N(2)], [N(1)]]
     @test convex_hull([[N(2)], [N(2)]]) == [[N(2)]]
 
     # corner cases in dimension 2
@@ -19,7 +19,7 @@ for N in [Float64, Rational{Int}]
     p2 = [1., 3.]
     @test convex_hull([p1]) == [p1]
     @test convex_hull([p1, p2]) == [p1, p2]
-    @test convex_hull([p2, p1]) == [p1, p2]
+    @test convex_hull([p2, p1]) == [p2, p1] # no sorting
 
     # corner cases in higher dimension
     @test convex_hull([[N(0), N(0), N(0)]]) == [[N(0), N(0), N(0)]]


### PR DESCRIPTION
Closes #1471.

Requires: ~~#1484.~~

---

I hesitated to keep the current version and use dispatch on values, and finally decided against it. If we have an application that requires sorting, it is easy to reimplement it.