### PR TITLE
Fix backend arguments in concrete minkowski sum

### DIFF
--- a/src/AbstractPolytope.jl
+++ b/src/AbstractPolytope.jl
@@ -165,7 +165,7 @@ function minkowski_sum(P1::AbstractPolytope{N}, P2::AbstractPolytope{N};
     vlist1, vlist2 = vertices_list(P1), vertices_list(P2)
     n, m = length(vlist1), length(vlist2)
     Vout = Vector{Vector{N}}()
-    sizehint!(Vout, n + m)
+    sizehint!(Vout, n * m)
     for vi in vlist1
         for vj in vlist2
             push!(Vout, vi + vj)

--- a/src/AbstractPolytope.jl
+++ b/src/AbstractPolytope.jl
@@ -162,7 +162,8 @@ function minkowski_sum(P1::AbstractPolytope{N}, P2::AbstractPolytope{N};
     @assert dim(P1) == dim(P2) "cannot compute the Minkowski sum between a polyotope " *
         "of dimension $(dim(P1)) and a polytope of dimension $((dim(P2)))"
 
-    vlist1, vlist2 = _minkowski_sum_input_vertices(P1, P2, backend)
+    vlist1 = _vertices_list(P1, backend)
+    vlist2 = _vertices_list(P2, backend)
     n, m = length(vlist1), length(vlist2)
     Vout = Vector{Vector{N}}()
     sizehint!(Vout, n * m)
@@ -181,10 +182,9 @@ function minkowski_sum(P1::AbstractPolytope{N}, P2::AbstractPolytope{N};
     return VPolytope(Vout)
 end
 
-function _minkowski_sum_input_vertices(P1::AbstractPolytope, P2::AbstractPolytope, backend)
-    vlist1 = vertices_list(P1)
-    vlist2 = vertices_list(P2)
-    return vlist1, vlist2
+# the "backend" argument is ignored, used for dispatch
+function _vertices_list(P::AbstractPolytope, backend)
+    return vertices_list(P)
 end
 
 # =============================================

--- a/src/AbstractPolytope.jl
+++ b/src/AbstractPolytope.jl
@@ -181,15 +181,9 @@ function minkowski_sum(P1::AbstractPolytope{N}, P2::AbstractPolytope{N};
     return VPolytope(Vout)
 end
 
-function _minkowski_sum_input_vertices(P1::AbstractPolytope{N}, P2::AbstractPolytope{N}, backend)
+function _minkowski_sum_input_vertices(P1::AbstractPolytope, P2::AbstractPolytope, backend)
     vlist1 = vertices_list(P1)
     vlist2 = vertices_list(P2)
-    return vlist1, vlist2
-end
-
-function _minkowski_sum_input_vertices(P1::HPolytope{N}, P2::HPolytope{N}, backend)
-    vlist1 = vertices_list(P1, backend=backend)
-    vlist2 = vertices_list(P2, backend=backend)
     return vlist1, vlist2
 end
 

--- a/src/AbstractPolytope.jl
+++ b/src/AbstractPolytope.jl
@@ -162,7 +162,7 @@ function minkowski_sum(P1::AbstractPolytope{N}, P2::AbstractPolytope{N};
     @assert dim(P1) == dim(P2) "cannot compute the Minkowski sum between a polyotope " *
         "of dimension $(dim(P1)) and a polytope of dimension $((dim(P2)))"
 
-    vlist1, vlist2 = vertices_list(P1), vertices_list(P2)
+    vlist1, vlist2 = _minkowski_sum_input_vertices(P1, P2, backend)
     n, m = length(vlist1), length(vlist2)
     Vout = Vector{Vector{N}}()
     sizehint!(Vout, n * m)
@@ -179,6 +179,18 @@ function minkowski_sum(P1::AbstractPolytope{N}, P2::AbstractPolytope{N};
         convex_hull!(Vout, backend=backend, solver=solver)
     end
     return VPolytope(Vout)
+end
+
+function _minkowski_sum_input_vertices(P1::AbstractPolytope{N}, P2::AbstractPolytope{N}, backend)
+    vlist1 = vertices_list(P1)
+    vlist2 = vertices_list(P2)
+    return vlist1, vlist2
+end
+
+function _minkowski_sum_input_vertices(P1::HPolytope{N}, P2::HPolytope{N}, backend)
+    vlist1 = vertices_list(P1, backend=backend)
+    vlist2 = vertices_list(P2, backend=backend)
+    return vlist1, vlist2
 end
 
 # =============================================

--- a/src/HPolytope.jl
+++ b/src/HPolytope.jl
@@ -229,8 +229,7 @@ function vertices_list(P::HPolytope{N};
     end
 end
 
-function _minkowski_sum_input_vertices(P1::HPolytope, P2::HPolytope, backend)
-    vlist1 = vertices_list(P1, backend=backend)
-    vlist2 = vertices_list(P2, backend=backend)
-    return vlist1, vlist2
+# used for dispatch, see minkowski_sum(::AbstractPolytope{N}, ::AbstractPolytope{N}; ...)
+function _vertices_list(P::HPolytope, backend)
+    return vertices_list(P, backend=backend)
 end

--- a/src/HPolytope.jl
+++ b/src/HPolytope.jl
@@ -228,3 +228,9 @@ function vertices_list(P::HPolytope{N};
         return collect(points(Q))
     end
 end
+
+function _minkowski_sum_input_vertices(P1::HPolytope, P2::HPolytope, backend)
+    vlist1 = vertices_list(P1, backend=backend)
+    vlist2 = vertices_list(P2, backend=backend)
+    return vlist1, vlist2
+end


### PR DESCRIPTION
This PR passes the `backend` argument to `vertices_list` when needed which would be otherwise ignored.

There is also a fix in the sizehint.