### PR TITLE
#1449 - Generalize isdisjoint(::CPA, ::HPolyhedron) to AbstractPolyhedron

### DIFF
--- a/docs/src/lib/binary_functions.md
+++ b/docs/src/lib/binary_functions.md
@@ -37,7 +37,7 @@ is_intersection_empty(::Universe{N}, ::LazySet{N}, ::Bool=false) where {N<:Real}
 is_intersection_empty(::Complement{N}, ::LazySet{N}, ::Bool=false) where {N<:Real}
 is_intersection_empty(::Zonotope{N}, ::Zonotope{N}, ::Bool=false) where {N<:Real}
 is_intersection_empty(::Interval{N}, ::Interval{N}, ::Bool=false) where {N<:Real}
-is_intersection_empty(X::CartesianProductArray{N}, Y::HPolyhedron{N}) where {N<:Real}
+is_intersection_empty(X::CartesianProductArray{N}, Y::AbstractPolyhedron{N}) where {N<:Real}
 is_intersection_empty(X::CartesianProductArray{N}, Y::CartesianProductArray{N}) where {N}
 ```
 

--- a/src/Approximations/overapproximate.jl
+++ b/src/Approximations/overapproximate.jl
@@ -1,4 +1,6 @@
-using LazySets: block_to_dimension_indices, substitute_blocks, get_constrained_lowdimset
+using LazySets: block_to_dimension_indices,
+                substitute_blocks,
+                get_constrained_lowdimset
 """
     overapproximate(X::S, ::Type{S}, args...) where {S<:LazySet}
 
@@ -90,12 +92,12 @@ end
     overapproximate(S::CartesianProductArray{N, <:AbstractHyperrectangle{N}},
                     ::Type{<:Hyperrectangle}) where {N<:Real}
 
-Return a tight overapproximation of the cartesian product array of a finite
+Return a tight overapproximation of the Cartesian product array of a finite
 number of convex sets with and hyperrectangle.
 
 ### Input
 
-- `S`              -- cartesian product array of a finite number of convex set
+- `S`              -- Cartesian product array of a finite number of convex set
 - `Hyperrectangle` -- type for dispatch
 
 ### Output
@@ -105,7 +107,7 @@ A hyperrectangle.
 ### Algorithm
 
 This method falls back to the corresponding `convert` method. Since the sets wrapped
-by the cartesian product array are hyperrectangles, it can be done efficiently
+by the Cartesian product array are hyperrectangles, it can be done efficiently
 without overapproximation.
 """
 function overapproximate(S::CartesianProductArray{N, <:AbstractHyperrectangle{N}},
@@ -117,12 +119,12 @@ end
     overapproximate(S::CartesianProduct{N, <:AbstractHyperrectangle{N}, <:AbstractHyperrectangle{N}},
                     ::Type{<:Hyperrectangle}) where {N<:Real}
 
-Return a tight overapproximation of the cartesian product of two
+Return a tight overapproximation of the Cartesian product of two
 hyperrectangles by a new hyperrectangle.
 
 ### Input
 
-- `S`              -- cartesian product of two hyperrectangular sets
+- `S`              -- Cartesian product of two hyperrectangular sets
 - `Hyperrectangle` -- type for dispatch
 
 ### Output
@@ -132,7 +134,7 @@ A hyperrectangle.
 ### Algorithm
 
 This method falls back to the corresponding `convert` method. Since the sets wrapped
-by the cartesian product are hyperrectangles, it can be done efficiently
+by the Cartesian product are hyperrectangles, it can be done efficiently
 without overapproximation.
 """
 function overapproximate(S::CartesianProduct{N, <:AbstractHyperrectangle{N}, <:AbstractHyperrectangle{N}},
@@ -732,7 +734,7 @@ julia> Dx₁ = IA.Interval(0.0, 3.0) # domain for x₁
 julia> Dx₂ = IA.Interval(-1.0, 1.0) # domain for x₂
 [-1, 1]
 
-julia> D = Dx₁ × Dx₂ # take the cartesian product of the domain on each variable 
+julia> D = Dx₁ × Dx₂ # take the Cartesian product of the domain on each variable
 [0, 3] × [-1, 1]
 
 julia> r = IA.Interval(-0.5, 0.5) # interval remainder
@@ -808,7 +810,7 @@ end # quote
 end # load_taylormodels_overapproximation
 
 # ==========================================
-# Lazy linear maps of cartesian products
+# Lazy linear maps of Cartesian products
 # ==========================================
 
 """
@@ -816,12 +818,12 @@ end # load_taylormodels_overapproximation
                     ::Type{CartesianProductArray{N, S}}
                    ) where {N, S<:LazySet{N}}
 
-Decompose a lazy linear map of a cartesian product array while keeping the
+Decompose a lazy linear map of a Cartesian product array while keeping the
 original block structure.
 
 ### Input
 
-- `lm`                    -- lazy linear map of cartesian product array
+- `lm`                    -- lazy linear map of Cartesian product array
 - `CartesianProductArray` -- type for dispatch
 
 ### Output
@@ -841,12 +843,12 @@ end
                     ::Type{<:CartesianProductArray},
                     dir::Type{<:AbstractDirections}) where {N}
 
-Decompose a lazy linear map of a cartesian product array with template
+Decompose a lazy linear map of a Cartesian product array with template
 directions while keeping the original block structure.
 
 ### Input
 
-- `lm`                    -- lazy linear map of a cartesian product array
+- `lm`                    -- lazy linear map of a Cartesian product array
 - `CartesianProductArray` -- type for dispatch
 - `dir`                   -- template directions for overapproximation
 
@@ -867,12 +869,12 @@ end
                     ::Type{<:CartesianProductArray},
                     set_type::Type{<:LazySet}) where {N}
 
-Decompose a lazy linear map of a cartesian product array with a given set type
+Decompose a lazy linear map of a Cartesian product array with a given set type
 while keeping the original block structure.
 
 ### Input
 
-- `lm`                    -- lazy linear map of a cartesian product array
+- `lm`                    -- lazy linear map of a Cartesian product array
 - `CartesianProductArray` -- type for dispatch
 - `set_type`              -- set type for overapproximation
 
@@ -916,43 +918,49 @@ end
 
 """
     overapproximate(cap::Intersection{N,
-                            <:CartesianProductArray{N},
-                            <:AbstractPolyhedron{N}},
-                       ::Type{CartesianProductArray}, oa) where {N}
+                                      <:CartesianProductArray{N},
+                                      <:AbstractPolyhedron{N}},
+                    ::Type{CartesianProductArray}, oa) where {N}
 
-Return the intersection of the cartesian product of a finite number of convex sets and a polyhedron.
+Return the intersection of the Cartesian product of a finite number of convex
+sets and a polyhedron.
 
 ### Input
 
- - `cap` -- Lazy intersection of cartesian product array and polyhedron
+ - `cap` -- Lazy intersection of Cartesian product array and polyhedron
  - `CartesianProductArray` -- type for dispatch
- - `oa`  -- template directions
+ - `oa`  -- overapproximation option
 
 ### Output
 
-The intersection between `cpa` and `P` with overapproximation in each constrained block.
+A `CartesianProductArray` that overapproximates the intersection of `cpa` and
+`P`.
 
 ### Algorithm
 
-The intersection is only needed to be taken in the elements of the cartesian product array (subsets of
-variables, or "blocks") which are constrained in `P`.
-Hence we first search for constrained blocks and then take the intersection of
-a lower-dimensional Cartesian product of these blocks with the projection of `Y`
-onto the variables of these blocks. (This projection is syntactic and exact.)
+The intersection only needs to be computed in the blocks of `cpa` that are
+constrained in `P`.
+Hence we first collect those constrained blocks in a lower-dimensional Cartesian
+product array and then convert to an `HPolytope` `X`.
+Then we take the intersection of `X` and the projection of `Y` onto the
+corresponding dimensions.
+(This projection is purely syntactic and exact.)
+Finally we decompose the result again and plug together the unaffected old
+blocks and the newly computed blocks.
 The result is a `CartesianProductArray` with the same block structure as in `X`.
-However, when we decompose back our set we overapproximate during projection operation,
-therefore we need to specify overapproximation strategy (it is Hyperrectangle by default)
 """
 function overapproximate(cap::Intersection{N,
-                                            <:CartesianProductArray{N},
-                                            <:AbstractPolyhedron{N}},
+                                           <:CartesianProductArray{N},
+                                           <:AbstractPolyhedron{N}},
                             ::Type{CartesianProductArray}, oa) where {N}
 
     cpa, P = cap.X, cap.Y
 
-    cpa_low_dim, vars, block_structure, blocks = get_constrained_lowdimset(cpa, P)
+    cpa_low_dim, vars, block_structure, blocks =
+        get_constrained_lowdimset(cpa, P)
 
-    low_intersection = intersection(cpa_low_dim, project(P, vars))
+    hpoly_low_dim = HPolytope(constraints_list(cpa_low_dim))
+    low_intersection = intersection(hpoly_low_dim, project(P, vars))
 
     if isempty(low_intersection)
         return EmptySet{N}()

--- a/src/intersection_helper.jl
+++ b/src/intersection_helper.jl
@@ -1,33 +1,38 @@
 """
-    get_constrained_lowdimset(cpa::CartesianProductArray{N, S}, P::AbstractPolyhedron{N}) where {N<:Real, S<:LazySet{N}}
+    get_constrained_lowdimset(cpa::CartesianProductArray{N, S},
+                              P::AbstractPolyhedron{N}
+                             ) where {N<:Real, S<:LazySet{N}}
 
-Preprocess step for intersection between cartesian product array and H-polyhedron.
-Returns low-dimensional HPolytope in constrained dimensions of original cpa,
-constrained variables and variables in corresponding blocks, original block structure
-of low-dimensional set and list of constrained blocks.
+Preprocess step for intersection between Cartesian product array and polyhedron.
+Returns low-dimensional a `CartesianProductArray` in the constrained dimensions
+of the original cpa,
+constrained variables and variables in corresponding blocks, original block
+structure of low-dimensional set and list of constrained blocks.
 
 ### Input
 
 - `cpa` -- Cartesian product array of convex sets
-- `P` -- polyhedron
+- `P`   -- polyhedron
 
 ### Output
 
 A tuple of low-dimensional set, list of constrained dimensions, original block
 structure of low-dimensional set and corresponding blocks indices.
 """
-function get_constrained_lowdimset(cpa::CartesianProductArray{N, S}, P::AbstractPolyhedron{N}) where {N<:Real, S<:LazySet{N}}
+function get_constrained_lowdimset(cpa::CartesianProductArray{N, S},
+                                   P::AbstractPolyhedron{N}
+                                  ) where {N<:Real, S<:LazySet{N}}
 
     if isbounded(P)
         blocks, non_empty_length = block_to_dimension_indices(cpa)
     else
-        constrained_vars = constrained_dimensions(P)
-        blocks, non_empty_length = block_to_dimension_indices(cpa, constrained_vars)
+        blocks, non_empty_length =
+            block_to_dimension_indices(cpa, constrained_dimensions(P))
     end
 
     array = Vector{S}()
     sizehint!(array, non_empty_length)
-    vars = Vector{Int}()
+    variables = Vector{Int}()
     block_structure = Vector{UnitRange{Int}}()
     sizehint!(block_structure, non_empty_length)
 
@@ -37,13 +42,11 @@ function get_constrained_lowdimset(cpa::CartesianProductArray{N, S}, P::Abstract
         block_end = last_var + end_index - start_index
         if start_index != -1
             push!(array, cpa.array[i])
-            append!(vars, start_index : end_index)
+            append!(variables, start_index : end_index)
             push!(block_structure, last_var : block_end)
             last_var = block_end + 1
         end
     end
 
-    cpa_low_dim = HPolytope(constraints_list(CartesianProductArray(array)));
-
-    return cpa_low_dim, vars, block_structure, blocks
+    return CartesianProductArray(array), variables, block_structure, blocks
 end

--- a/src/is_intersection_empty.jl
+++ b/src/is_intersection_empty.jl
@@ -1371,21 +1371,29 @@ end
     is_intersection_empty(cpa::CartesianProductArray{N},
                           P::AbstractPolyhedron{N}) where {N<:Real}
 
-Check whether a Cartesian product array intersects with a polyhedron.
+Check whether a polytopic Cartesian product array intersects with a polyhedron.
 
 ### Input
 
-- `cpa` -- Cartesian product array of convex sets
+- `cpa` -- Cartesian product array of polytopes
 - `P`   -- polyhedron
 
 ### Output
 
 `true` iff ``\\text{cpa} ∩ Y = ∅ ``.
+
+### Algorithm
+
+We first identify the blocks of `cpa` in which `P` is constrained.
+Then we project `cpa` to those blocks and convert the result to an `HPolytope`
+`Q`.
+Finally we determine whether `Q` and the projected `P` intersect.
 """
 function is_intersection_empty(cpa::CartesianProductArray{N},
                                P::AbstractPolyhedron{N}) where {N<:Real}
     cpa_low_dim, vars, _block_structure = get_constrained_lowdimset(cpa, P)
-    return isdisjoint(cpa_low_dim, project(P, vars))
+    hpoly_low_dim = HPolytope(constraints_list(cpa_low_dim))
+    return isdisjoint(hpoly_low_dim, project(P, vars))
 end
 
 # symmetric method

--- a/src/is_intersection_empty.jl
+++ b/src/is_intersection_empty.jl
@@ -1368,37 +1368,50 @@ function is_intersection_empty(X::LazySet{N},
 end
 
 """
-    is_intersection_empty(X::CartesianProductArray{N, S},
-                          P::HPolyhedron{N}) where {N<:Real, S<:LazySet{N}}
+    is_intersection_empty(cpa::CartesianProductArray{N},
+                          P::AbstractPolyhedron{N}) where {N<:Real}
 
-Check whether a Cartesian product array intersects with a H-polyhedron.
+Check whether a Cartesian product array intersects with a polyhedron.
 
 ### Input
 
-- `X` -- Cartesian product array of convex sets
-- `P` -- H-polyhedron
+- `cpa` -- Cartesian product array of convex sets
+- `P`   -- polyhedron
 
 ### Output
 
-`true` iff ``X ∩ Y = ∅ ``.
+`true` iff ``\\text{cpa} ∩ Y = ∅ ``.
 """
-function is_intersection_empty(X::CartesianProductArray{N},
-                               P::HPolyhedron{N}) where {N<:Real}
-    cpa_low_dim, vars, block_structure = get_constrained_lowdimset(X, P)
-
+function is_intersection_empty(cpa::CartesianProductArray{N},
+                               P::AbstractPolyhedron{N}) where {N<:Real}
+    cpa_low_dim, vars, _block_structure = get_constrained_lowdimset(cpa, P)
     return isdisjoint(cpa_low_dim, project(P, vars))
 end
 
 # symmetric method
-function is_intersection_empty(P::HPolyhedron{N},
-                               X::CartesianProductArray{N, S}) where {N<:Real, S<:LazySet{N}}
-        is_intersection_empty(X, P)
+function is_intersection_empty(P::AbstractPolyhedron{N},
+                               cpa::CartesianProductArray{N}) where {N<:Real}
+    return is_intersection_empty(cpa, P)
+end
+
+# disambiguation
+function is_intersection_empty(cpa::CartesianProductArray{N},
+                               hs::HalfSpace{N}) where {N<:Real}
+    return invoke(is_intersection_empty,
+                  Tuple{CartesianProductArray{N}, AbstractPolyhedron{N}},
+                  cpa, hs)
+end
+function is_intersection_empty(hs::HalfSpace{N},
+                               cpa::CartesianProductArray{N}) where {N<:Real}
+    return is_intersection_empty(cpa, hs)
 end
 
 """
-    is_intersection_empty(X::CartesianProductArray{N}, Y::CartesianProductArray{N}) where {N}
+    is_intersection_empty(X::CartesianProductArray{N},
+                          Y::CartesianProductArray{N}) where {N}
 
-Check whether two Cartesian products of a finite number of convex sets do not intersect.
+Check whether two Cartesian products of a finite number of convex sets do not
+intersect.
 
 ### Input
 
@@ -1409,14 +1422,15 @@ Check whether two Cartesian products of a finite number of convex sets do not in
 
 `true` iff ``X ∩ Y = ∅ ``.
 """
-function is_intersection_empty(X::CartesianProductArray{N}, Y::CartesianProductArray{N}) where {N}
-    @assert same_block_structure(array(X), array(Y)) "block structure has to be the same"
+function is_intersection_empty(X::CartesianProductArray{N},
+                               Y::CartesianProductArray{N}) where {N}
+    @assert same_block_structure(array(X), array(Y)) "block structure has to " *
+        "be the same"
 
     for i in 1:length(X.array)
         if isdisjoint(X.array[i], Y.array[i])
             return true
         end
     end
-
     return false
 end

--- a/test/unit_CartesianProduct.jl
+++ b/test/unit_CartesianProduct.jl
@@ -284,12 +284,15 @@ for N in [Float64, Float32]
     h2 = Hyperrectangle(low=N[5, 5], high=N[6, 8])
     cpa1 = CartesianProductArray([i1, i2, h1])
     cpa2 = CartesianProductArray([i1, i2, h2])
-    G = HPolyhedron([HalfSpace(N[1, 0, 0, 0], N(1))])
-    G_empty = HPolyhedron([HalfSpace(N[1, 0, 0, 0], N(-1))])
-	cpa1_box = overapproximate(cpa1)
-	cpa2_box = overapproximate(cpa2)
+    G = HalfSpace(N[1, 0, 0, 0], N(1))
+    G_empty = HalfSpace(N[1, 0, 0, 0], N(-1))
+    cpa1_box = overapproximate(cpa1)
+    cpa2_box = overapproximate(cpa2)
 
-    @test is_intersection_empty(cpa1, cpa2) == is_intersection_empty(cpa1_box, cpa2_box) == false
-    @test is_intersection_empty(cpa1, G_empty) == is_intersection_empty(cpa1_box, G_empty) == true
-    @test is_intersection_empty(cpa1, G) == is_intersection_empty(Approximations.overapproximate(cpa1), G) == false
+    @test !is_intersection_empty(cpa1, cpa2) &&
+          !is_intersection_empty(cpa1_box, cpa2_box)
+    @test is_intersection_empty(cpa1, G_empty) &&
+          is_intersection_empty(cpa1_box, G_empty)
+    @test !is_intersection_empty(cpa1, G) &&
+          !is_intersection_empty(Approximations.overapproximate(cpa1), G)
 end

--- a/test/unit_overapproximate.jl
+++ b/test/unit_overapproximate.jl
@@ -160,34 +160,6 @@ for N in [Float64, Float32]
     @test lcl[7].b ≈ N(1)
     @test lcl[8].a ≈ N[sqrt(2)/2, -sqrt(2)/2]
     @test lcl[8].b ≈ N(1)
-
-    # decomposed intersection between cartesian product array and abstract polyhedron
-    i1 = Interval(N[0, 1])
-    i2 = Interval(N[2, 3])
-    h1 = Hyperrectangle(low=N[3, 4], high=N[5, 7])
-    h2 = Hyperrectangle(low=N[5, 5], high=N[6, 8])
-    cpa1 = CartesianProductArray([i1, i2, h1])
-    o_cpa1 = overapproximate(cpa1)
-    cpa2 = CartesianProductArray([i1, i2, h2])
-    o_cpa2 = overapproximate(cpa2)
-    G = HPolyhedron([HalfSpace(N[1, 0, 0, 0], N(1))])
-    G_3 = HPolyhedron([HalfSpace(N[0, 0, 1, 0], N(1))])
-    G_3_neg = HPolyhedron([HalfSpace(N[0, 0, -1, 0], N(0))])
-
-    d_int_g = Intersection(cpa1, G)
-    d_int_g_3 = Intersection(cpa1, G_3)
-    d_int_g_3_neg = Intersection(cpa1, G_3_neg)
-    d_int_cpa = intersection(cpa1, cpa2)
-    l_int_cpa = intersection(o_cpa1, o_cpa2)
-    o_d_int_g = overapproximate(d_int_g, CartesianProductArray, Hyperrectangle)
-    o_d_int_g_3 = overapproximate(d_int_g_3, CartesianProductArray, Hyperrectangle)
-    o_d_int_g_3_neg = overapproximate(d_int_g_3_neg, CartesianProductArray, Hyperrectangle)
-
-    @test overapproximate(o_d_int_g) == overapproximate(d_int_g)
-    @test overapproximate(o_d_int_g_3) == overapproximate(d_int_g_3) == EmptySet{N}()
-    @test overapproximate(o_d_int_g_3_neg) == overapproximate(d_int_g_3_neg)
-    @test overapproximate(d_int_cpa, Hyperrectangle) == l_int_cpa
-    @test all([X isa CartesianProductArray for X in [d_int_cpa, o_d_int_g, o_d_int_g_3_neg]])
 end
 
 for N in [Float64]
@@ -201,13 +173,34 @@ for N in [Float64]
     oa = overapproximate(lm, OctDirections)
     @test oa ⊆ d_oa
 
-    # decomposed intersection between cartesian product array and abstract polyhedron
-    i1 = Interval(N[0, 1])
-    i2 = Interval(N[2, 3])
+    # decomposed intersection between Cartesian product array and polyhedron
     h1 = Hyperrectangle(low=N[3, 4], high=N[5, 7])
-    cpa = CartesianProductArray([i1, i2, h1])
-    G_comb = HPolyhedron([HalfSpace(N[1, 1, 0, 0], N(2.5))])
-    int_g_comb = Intersection(cpa, G_comb)
+    h2 = Hyperrectangle(low=N[5, 5], high=N[6, 8])
+    cpa1 = CartesianProductArray([i1, i2, h1])
+    o_cpa1 = overapproximate(cpa1)
+    cpa2 = CartesianProductArray([i1, i2, h2])
+    o_cpa2 = overapproximate(cpa2)
+    G = HalfSpace(N[1, 0, 0, 0], N(1))
+    G_3 = HalfSpace(N[0, 0, 1, 0], N(1))
+    G_3_neg = HalfSpace(N[0, 0, -1, 0], N(0))
+    G_comb = HalfSpace(N[1, 1, 0, 0], N(2.5))
+
+    d_int_g = Intersection(cpa1, G)
+    d_int_g_3 = Intersection(cpa1, G_3)
+    d_int_g_3_neg = Intersection(cpa1, G_3_neg)
+    d_int_cpa = intersection(cpa1, cpa2)
+    l_int_cpa = intersection(o_cpa1, o_cpa2)
+    o_d_int_g = overapproximate(d_int_g, CartesianProductArray, Hyperrectangle)
+    o_d_int_g_3 = overapproximate(d_int_g_3, CartesianProductArray, Hyperrectangle)
+    o_d_int_g_3_neg = overapproximate(d_int_g_3_neg, CartesianProductArray, Hyperrectangle)
+
+    @test overapproximate(o_d_int_g) ≈ overapproximate(d_int_g)
+    @test isempty(d_int_g_3) && o_d_int_g_3 == EmptySet{N}()
+    @test overapproximate(o_d_int_g_3_neg) ≈ overapproximate(d_int_g_3_neg)
+    @test overapproximate(d_int_cpa, Hyperrectangle) == l_int_cpa
+    @test all([X isa CartesianProductArray for X in [d_int_cpa, o_d_int_g, o_d_int_g_3_neg]])
+
+    int_g_comb = Intersection(cpa1, G_comb)
     o_d_int_g_comb = overapproximate(int_g_comb, CartesianProductArray, Hyperrectangle)
     o_bd_int_g_comb = overapproximate(int_g_comb, BoxDirections)
     @test overapproximate(o_d_int_g_comb) ≈ overapproximate(o_bd_int_g_comb)


### PR DESCRIPTION
See #1449.

Some of the tests needed to be changed because we use line search for `HalfSpace` intersections (which comes with float issues) but another method for `HPolyhedron` intersection even for just one constraint (i.e., equivalent to a `HalfSpace`).