### PR TITLE
Load TaylorModels when building the docs

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,6 +1,6 @@
 ENV["GKSwstype"] = "100"  # set 'GR environment' to 'no output' (for Travis CI)
 using Documenter, LazySets
-import Polyhedra, Optim, Expokit
+import Polyhedra, Optim, Expokit, TaylorModels
 
 makedocs(
     sitename = "LazySets.jl",


### PR DESCRIPTION
This change generates docs for functions inside the `@require` block.