### PR TITLE
Tolerance setting

### DIFF
--- a/docs/src/lib/comparisons.md
+++ b/docs/src/lib/comparisons.md
@@ -11,12 +11,25 @@ Depth = 3
 CurrentModule = LazySets
 ```
 
+## Tolerance type
+
+```@docs
+Tolerance
+```
+
+## Approximate inequality
+
 ```@docs
 _leq(x::N, y::N; kwargs...) where {N<:Real}
 _leq(x::N, y::M; kwargs...) where {N<:Real, M<:Real}
 _geq(x::Real, y::Real; kwargs...)
+_leq(x::N, y::N; rtol::Real=Base.rtoldefault(N), ztol::Real=ABSZTOL(N), atol::Real=zero(N)) where {N<:AbstractFloat}
+```
+
+## Approximate equality
+
+```@docs
+_isapprox(x::N, y::N; rtol::Real=Base.rtoldefault(N), ztol::Real=ABSZTOL(N), atol::Real=zero(N)) where {N<:AbstractFloat}
 isapproxzero(x::Real; kwargs...)
 isapproxzero(x::N; ztol::Real=ABSZTOL(N)) where {N<:AbstractFloat}
-_isapprox(x::N, y::N; rtol::Real=Base.rtoldefault(N), ztol::Real=ABSZTOL(N), atol::Real=zero(N)) where {N<:AbstractFloat}
-_leq(x::N, y::N; rtol::Real=Base.rtoldefault(N), ztol::Real=ABSZTOL(N), atol::Real=zero(N)) where {N<:AbstractFloat}
 ```

--- a/src/comparisons.jl
+++ b/src/comparisons.jl
@@ -2,7 +2,49 @@
 #
 export set_rtol, set_ztol, set_atol
 
-# struct to contain the tolerances for a given numberic type
+"""
+    Tolerance{N<:Number}
+
+Type that represents the tolerances for a given numeric type.
+
+### Fields
+
+- `rtol` -- relative tolerance
+- `ztol` -- zero tolerance or absolute tolerance for comparison against zero
+- `atol` -- absolute tolerance
+
+### Notes
+
+The type `Tolerance`, parametric in the numeric type `N`, is used to store default
+values for numeric comparisons. It is mutable and setting the value of a field
+affects the getter functions hence it can be used to fix the tolerance globally
+in `LazySets`.
+
+Default values are defined for the most commonly used numeric types, and for those
+cases when other numeric types are needed one can extend the default values
+as explained next.
+
+The cases `Float64` and `Rational` are special in the sense that they are the most
+commonly used types in applications. Getting and setting default tolerances
+is achieved with the functions `_rtol` and `set_rtol` (and similarly for the other
+tolerances); the implementation creates an instance of `Tolerance{Float64}`
+(resp. `Tolerance{Rational}`) and sets some default values. Again since `Tolerance`
+is mutable, setting a value is possible e.g. `set_rtol(Type{Float64}, ε)` for some
+floating-point `ε`.
+
+For all other cases, a dictionary mapping numeric types to instances of `Tolerance`
+for that numeric type is used. For floating-point types, a default value has been
+defined through `default_tolerance` as follows:
+
+```julia
+default_tolerance(N::Type{<:AbstractFloat}) = Tolerance(Base.rtoldefault(N), sqrt(eps(N)), zero(N))
+```
+Hence to set a single tolerance (either `rtol`, `ztol` or `atol`) for a given
+floating-point type, use the corresponding `set_rtol` function, while the values
+which have not been set will be pulled from `default_tolerance`. If you would like
+to define the three default values at once, or are computing with a non floating-point
+numeric type, you can just extend `default_tolerance(N::Type{<:Number})`.
+"""
 mutable struct Tolerance{N<:Number}
     rtol::N
     ztol::N

--- a/src/comparisons.jl
+++ b/src/comparisons.jl
@@ -1,6 +1,6 @@
 # Some functions in this file are inspired from Polyhedra.jl
 #
-export set_rtol
+export set_rtol, set_ztol, set_atol
 
 # struct to contain the tolerances for a given numberic type
 mutable struct Tolerance{N<:Number}

--- a/src/comparisons.jl
+++ b/src/comparisons.jl
@@ -1,5 +1,6 @@
-# Some functions in this file is inspired from Polyhedra.jl
+# Some functions in this file are inspired from Polyhedra.jl
 
+# struct to contain the tolerances for a given numberic type
 mutable struct TOL{N<:Number}
     rtol::N
     ztol::N
@@ -8,29 +9,29 @@ end
 
 # global Float64 tolerances
 const F64 = Float64
-const F64t = Type{Float64}
+const tF64 = Type{Float64}
 const _TOL_F64 = TOL(Base.rtoldefault(F64), F64(10)*sqrt(eps(F64)), zero(F64))
 
-get_rtol(N::F64t) = _TOL_F64.rtol
-get_ztol(N::F64t) = _TOL_F64.ztol
-get_atol(N::F64t) = _TOL_F64.atol
+get_rtol(N::tF64) = _TOL_F64.rtol
+get_ztol(N::tF64) = _TOL_F64.ztol
+get_atol(N::tF64) = _TOL_F64.atol
 
-set_rtol(N::F64t, ε::F64) = _TOL_F64.rtol = ε
-set_ztol(N::F64t, ε::F64) = _TOL_F64.ztol = ε
-set_atol(N::F64t, ε::F64) = _TOL_F64.atol = ε
+set_rtol(N::tF64, ε::F64) = _TOL_F64.rtol = ε
+set_ztol(N::tF64, ε::F64) = _TOL_F64.ztol = ε
+set_atol(N::tF64, ε::F64) = _TOL_F64.atol = ε
 
 # global rational tolerances
 const RAT = Rational{Int}
-const RATt = Type{Rational{Int}}
+const tRAT = Type{Rational{Int}}
 const _TOL_RAT = TOL(zero(RAT), zero(RAT), zero(RAT))
 
-get_rtol(N::RATt) = _TOL_RAT.rtol
-get_ztol(N::RATt) = _TOL_RAT.ztol
-get_atol(N::RATt) = _TOL_RAT.atol
+get_rtol(N::tRAT) = _TOL_RAT.rtol
+get_ztol(N::tRAT) = _TOL_RAT.ztol
+get_atol(N::tRAT) = _TOL_RAT.atol
 
-set_rtol(N::RATt, ε::RAT) = _TOL_RAT.rtol = ε
-set_ztol(N::RATt, ε::RAT) = _TOL_RAT.ztol = ε
-set_atol(N::RATt, ε::RAT) = _TOL_RAT.atol = ε
+set_rtol(N::tRAT, ε::RAT) = _TOL_RAT.rtol = ε
+set_ztol(N::tRAT, ε::RAT) = _TOL_RAT.ztol = ε
+set_atol(N::tRAT, ε::RAT) = _TOL_RAT.atol = ε
 
 # global default tolerances (cannot be set)
 get_rtol(N::Type{<:AbstractFloat}) = Base.rtoldefault(N)
@@ -167,7 +168,7 @@ Note that if `x = ztol` and `y = -ztol`, then `|x-y| = 2*ztol` and still
 """
 function _isapprox(x::N, y::N;
                    rtol::Real=get_rtol(N),
-                   ztol::Real=get_atol(N),
+                   ztol::Real=get_ztol(N),
                    atol::Real=get_atol(N)) where {N<:Real}
     if isapproxzero(x, ztol=ztol) && isapproxzero(y, ztol=ztol)
         return true

--- a/test/unit_Interval.jl
+++ b/test/unit_Interval.jl
@@ -140,7 +140,7 @@ for N in [Float64, Float32, Rational{Int}]
     @test dAD == UnionSet(Interval(N(5), N(6)), Interval(N(7), N(8)))
 
     # check if an interval is flat, i.e. if its endpoints coincide (to numerical precision)
-    ztol = LazySets.ABSZTOL(N) # pick up default absolute zero tolerance value
+    ztol = LazySets._ztol(N) # pick up default absolute zero tolerance value
     @test isflat(Interval(N(0), ztol))
     if N <: AbstractFloat
         @test !isflat(Interval(N(0), 2*ztol))

--- a/test/unit_comparisons.jl
+++ b/test/unit_comparisons.jl
@@ -1,4 +1,4 @@
-using LazySets: _leq, _geq, isapproxzero, _isapprox, ABSZTOL
+using LazySets: _leq, _geq, isapproxzero, _isapprox, _ztol
 
 # approximate <= and
 @test _leq(2e-15, 1e-15) && _leq(1e-15, 2e-15)
@@ -14,10 +14,10 @@ using LazySets: _leq, _geq, isapproxzero, _isapprox, ABSZTOL
 @test _geq(2e-15, 1e-15, ztol=1e-15) && !_geq(1e-15, 2e-15, ztol=1e-15)
 
 # default absolute zero tolerance for rational
-ABSZTOL(eltype(1/100)) == zero(Rational{Int})
+_ztol(eltype(1/100)) == zero(Rational{Int})
 
 # default absolute zero tolerance for FP
-ABSZTOL(eltype(0.01)) == sqrt(eps(Float64))
+_ztol(eltype(0.01)) == sqrt(eps(Float64))
 
 # approximately zero tests
 @test isapproxzero(0//1)


### PR DESCRIPTION
See #1485.

This PR is an idea for optional tolerance setting such that it extends to all functions that rely on `comparisons.jl`. It adds getter and setter functions for `Float64` since it's the type that we use in applications, and `Rational{Int}`. For other numeric types, the behavior is left unchanged (one cannot set defaults).
