### PR TITLE
#1379 - Revise (is_)right_turn

### DIFF
--- a/docs/src/lib/operations.md
+++ b/docs/src/lib/operations.md
@@ -104,7 +104,6 @@ Inherited from [`LazySet`](@ref):
 
 ```@docs
 convex_hull(::Vector{VN}) where {N<:Real, VN<:AbstractVector{N}}
-right_turn
 monotone_chain!
 ```
 

--- a/docs/src/lib/utils.md
+++ b/docs/src/lib/utils.md
@@ -18,9 +18,11 @@ inner
 is_cyclic_permutation
 isinvertible
 ispermutation
+is_right_turn
 issquare
 nonzero_indices
 remove_duplicates_sorted!
+right_turn
 samedir
 SingleEntryVector
 to_negative_vector
@@ -35,7 +37,6 @@ _above
 an_element_helper
 binary_search_constraints
 get_radius!
-is_right_turn
 is_tighter_same_dir_2D
 sign_cadlag
 _random_zero_sum_vector

--- a/src/AbstractPolygon.jl
+++ b/src/AbstractPolygon.jl
@@ -114,27 +114,6 @@ This function is inspired from AGPX's answer in:
 end
 
 """
-    is_right_turn(u::AbstractVector{N},
-                  v::AbstractVector{N})::Bool where {N<:Real}
-
-Determine if the acute angle defined by two 2D vectors is a right turn (< 180°
-counter-clockwise).
-
-### Input
-
-- `u` -- first 2D direction
-- `v` -- second 2D direction
-
-### Output
-
-`true` iff the two vectors constitute a right turn.
-"""
-@inline function is_right_turn(u::AbstractVector{N},
-                               v::AbstractVector{N})::Bool where {N<:Real}
-    return u[1] * v[2] - v[1] * u[2] >= zero(N)
-end
-
-"""
     <=(u::AbstractVector{N}, v::AbstractVector{N})::Bool where {N<:Real}
 
 Compare two 2D vectors by their direction.

--- a/src/Arrays/vector_operations.jl
+++ b/src/Arrays/vector_operations.jl
@@ -4,7 +4,9 @@ export dot_zero,
        samedir,
        nonzero_indices,
        rectify,
+       right_turn,
        is_cyclic_permutation,
+       is_right_turn,
        to_negative_vector,
        _above,
        _dr,
@@ -282,4 +284,74 @@ end
         u[i] = -v.nzval[ni]
     end
     return u
+end
+
+"""
+    right_turn([O::AbstractVector{N}=[0, 0]], u::AbstractVector{N},
+               v::AbstractVector{N})::N where {N<:Real}
+
+Compute a scalar that determines whether the acute angle defined by three 2D
+points `O`, `u`, `v` in the plane is a right turn (< 180° counter-clockwise)
+with respect to the center `O`.
+
+### Input
+
+- `O` -- (optional; default: `[0, 0]`) 2D center point
+- `u` -- first 2D point
+- `v` -- second 2D point
+
+### Output
+
+A scalar representing the rotation.
+If the result is 0, the points are collinear; if it is positive, the points
+constitute a positive angle of rotation around `O` from `u` to `v`; otherwise
+they constitute a negative angle.
+
+### Algorithm
+
+The [cross product](https://en.wikipedia.org/wiki/Cross_product) is used to
+determine the sense of rotation.
+"""
+@inline function right_turn(O::AbstractVector{N},
+                            u::AbstractVector{N},
+                            v::AbstractVector{N})::N where {N<:Real}
+    return (u[1] - O[1]) * (v[2] - O[2]) - (u[2] - O[2]) * (v[1] - O[1])
+end
+
+# version for O = origin
+@inline function right_turn(u::AbstractVector{N},
+                            v::AbstractVector{N})::N where {N<:Real}
+    return u[1] * v[2] - u[2] * v[1]
+end
+
+"""
+    is_right_turn([O::AbstractVector{N}=[0, 0]], u::AbstractVector{N},
+                  v::AbstractVector{N})::Bool where {N<:Real}
+
+Determine whether the acute angle defined by three 2D points `O`, `u`, `v`
+in the plane is a right turn (< 180° counter-clockwise) with
+respect to the center `O`.
+Determine if the acute angle defined by two 2D vectors is a right turn (< 180°
+counter-clockwise) with respect to the center `O`.
+
+### Input
+
+- `O` -- (optional; default: `[0, 0]`) 2D center point
+- `u` -- first 2D direction
+- `v` -- second 2D direction
+
+### Output
+
+`true` iff the vectors constitute a right turn.
+"""
+@inline function is_right_turn(O::AbstractVector{N},
+                               u::AbstractVector{N},
+                               v::AbstractVector{N})::Bool where {N<:Real}
+    return right_turn(O, u, v) >= zero(N)
+end
+
+# version for O = origin
+@inline function is_right_turn(u::AbstractVector{N},
+                               v::AbstractVector{N})::Bool where {N<:Real}
+    return right_turn(u, v) >= zero(N)
 end

--- a/src/VPolygon.jl
+++ b/src/VPolygon.jl
@@ -377,12 +377,11 @@ function ∈(x::AbstractVector{N}, P::VPolygon{N})::Bool where {N<:Real}
         return x == P.vertices[1]
     end
 
-    zero_N = zero(N)
-    if right_turn(P.vertices[1], x, P.vertices[end]) < zero_N
+    if !is_right_turn(P.vertices[1], x, P.vertices[end])
         return false
     end
     for i in 2:length(P.vertices)
-        if right_turn(P.vertices[i], x, P.vertices[i-1]) < zero_N
+        if !is_right_turn(P.vertices[i], x, P.vertices[i-1])
             return false
         end
     end

--- a/src/concrete_convex_hull.jl
+++ b/src/concrete_convex_hull.jl
@@ -229,20 +229,17 @@ function _four_points_2d!(points::AbstractVector{<:AbstractVector{N}}) where {N<
     if tri_CAD > zero(N)
         key = key + 1
     end
-    
+
     if isapproxzero(tri_ABC)
         return _collinear_case!(points, A, B, C, D)
-    end
-    if isapproxzero(tri_ABD)
+    elseif isapproxzero(tri_ABD)
         return _collinear_case!(points, A, B, D, C)
-    end
-    if isapproxzero(tri_BCD)
+    elseif isapproxzero(tri_BCD)
         return _collinear_case!(points, B, C, D, A)
-    end
-    if isapproxzero(tri_CAD)
+    elseif isapproxzero(tri_CAD)
         return _collinear_case!(points, C, A, D, B)
     end
-    
+
     # ABC  ABD  BCD  CAD  hull
     # ------------------------
     #  +    +    +    +   ABC
@@ -368,11 +365,11 @@ For further details see
 function monotone_chain!(points::Vector{VN}; sort::Bool=true
                         )::Vector{VN} where {N<:Real, VN<:AbstractVector{N}}
 
-    @inline function build_hull!(semihull, iterator, points, zero_N)
+    @inline function build_hull!(semihull, iterator, points)
         @inbounds for i in iterator
             while length(semihull) >= 2 &&
                     (right_turn(semihull[end-1], semihull[end], points[i])
-                         <= zero_N)
+                         <= zero(N))
                 pop!(semihull)
             end
             push!(semihull, points[i])
@@ -384,15 +381,13 @@ function monotone_chain!(points::Vector{VN}; sort::Bool=true
         sort!(points, by=x->(x[1], x[2]))
     end
 
-    zero_N = zero(N)
-
     # build lower hull
     lower = Vector{VN}()
-    build_hull!(lower, axes(points)[1], points, zero_N)
+    build_hull!(lower, axes(points)[1], points)
 
     # build upper hull
     upper = Vector{VN}()
-    build_hull!(upper, reverse(axes(points)[1]), points, zero_N)
+    build_hull!(upper, reverse(axes(points)[1]), points)
 
     # remove the last point of each segment because they are repeated
     copyto!(points, @view(lower[1:end-1]))

--- a/src/concrete_convex_hull.jl
+++ b/src/concrete_convex_hull.jl
@@ -332,36 +332,6 @@ function _convex_hull_2d!(points::Vector{VN};
 end
 
 """
-    right_turn(O::AbstractVector{N}, A::AbstractVector{N}, B::AbstractVector{N}
-              )::N where {N<:Real}
-
-Determine if the acute angle defined by the three points `O`, `A`, `B` in the
-plane is a right turn (counter-clockwise) with respect to the center `O`.
-
-### Input
-
-- `O` -- 2D center point
-- `A` -- 2D one point
-- `B` -- 2D another point
-
-### Output
-
-Scalar representing the rotation.
-
-### Algorithm
-
-The [cross product](https://en.wikipedia.org/wiki/Cross_product) is used to
-determine the sense of rotation. If the result is 0, the points are collinear;
-if it is positive, the three points constitute a positive angle of rotation
-around `O` from `A` to `B`; otherwise they constitute a negative angle.
-"""
-@inline function right_turn(O::AbstractVector{N},
-                            A::AbstractVector{N},
-                            B::AbstractVector{N})::N where {N<:Real}
-    return (A[1] - O[1]) * (B[2] - O[2]) - (A[2] - O[2]) * (B[1] - O[1])
-end
-
-"""
     monotone_chain!(points::Vector{VN}; sort::Bool=true
                    )::Vector{VN} where {N<:Real, VN<:AbstractVector{N}}
 


### PR DESCRIPTION
Closes #1379.

We had `right_turn(O, u, v)` and `is_right_turn(u, v)`. Here I added the two missing counterparts `right_turn(u, v)` and `is_right_turn(O, u, v)`.

I shortly considered to rename `right_turn` → `Base.cross`, but then decided against it.