### PR TITLE
#1125 - Add isuniversal methods for unbounded set types

### DIFF
--- a/docs/src/lib/representations.md
+++ b/docs/src/lib/representations.md
@@ -184,6 +184,7 @@ dim(::HalfSpace)
 an_element(::HalfSpace{N}) where {N<:Real}
 rand(::Type{HalfSpace})
 isbounded(::HalfSpace)
+isuniversal(::HalfSpace{N}, ::Bool=false) where {N<:Real}
 isempty(::HalfSpace)
 constraints_list(::HalfSpace{N}) where {N<:Real}
 constraints_list(::AbstractMatrix{N}, ::AbstractVector{N}) where {N<:Real}
@@ -211,6 +212,7 @@ dim(::Hyperplane)
 an_element(::Hyperplane{N}) where {N<:Real}
 rand(::Type{Hyperplane})
 isbounded(::Hyperplane)
+isuniversal(::Hyperplane{N}, ::Bool=false) where {N<:Real}
 isempty(::Hyperplane)
 constrained_dimensions(::Hyperplane{N}) where {N<:Real}
 constraints_list(::Hyperplane{N}) where {N<:Real}
@@ -313,6 +315,7 @@ dim(::Line)
 an_element(::Line{N}) where {N<:Real}
 rand(::Type{Line})
 isbounded(::Line)
+isuniversal(::Line{N}, ::Bool=false) where {N<:Real}
 isempty(::Line)
 constrained_dimensions(::Line{N}) where {N<:Real}
 constraints_list(::Line{N}) where {N<:Real}
@@ -522,6 +525,7 @@ The following methods are specific for `HPolyhedron`.
 ```@docs
 rand(::Type{HPolyhedron})
 isbounded(::HPolyhedron)
+isuniversal(::HPolyhedron{N}, ::Bool=false) where {N<:Real}
 vertices_list(::HPolyhedron{N}) where {N<:Real}
 singleton_list(::HPolyhedron{N}) where {N<:Real}
 ```
@@ -620,6 +624,7 @@ rand(::Type{Universe})
 an_element(::Universe{N}) where {N<:Real}
 isempty(::Universe)
 isbounded(::Universe)
+isuniversal(::Universe{N}, ::Bool=false) where {N<:Real}
 norm(::Universe, ::Real=Inf)
 radius(::Universe, ::Real=Inf)
 diameter(::Universe, ::Real=Inf)

--- a/src/HPolyhedron.jl
+++ b/src/HPolyhedron.jl
@@ -212,6 +212,40 @@ function isbounded(P::HPolyhedron)::Bool
 end
 
 """
+    isuniversal(P::HPolyhedron{N}, [witness]::Bool=false
+               )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+
+Check whether a polyhedron is universal.
+
+### Input
+
+- `P`       -- polyhedron
+- `witness` -- (optional, default: `false`) compute a witness if activated
+
+### Output
+
+* If `witness` option is deactivated: `true` iff ``P`` is universal
+* If `witness` option is activated:
+  * `(true, [])` iff ``P`` is universal
+  * `(false, v)` iff ``P`` is not universal and ``v ∉ P``
+
+### Algorithm
+
+`P` is universal iff it has no constraints.
+
+A witness is produced using `isuniversal(H)` where `H` is the first linear
+constraint of `P`.
+"""
+function isuniversal(P::HPolyhedron{N}, witness::Bool=false
+                    )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+    if isempty(P.constraints)
+        return witness ? (true, N[]) : true
+    else
+        return witness ? isuniversal(P.constraints[1], true) : false
+    end
+end
+
+"""
     rand(::Type{HPolyhedron}; [N]::Type{<:Real}=Float64, [dim]::Int=2,
          [rng]::AbstractRNG=GLOBAL_RNG, [seed]::Union{Int, Nothing}=nothing
         )::HPolyhedron{N}

--- a/src/HalfSpace.jl
+++ b/src/HalfSpace.jl
@@ -126,6 +126,35 @@ function isbounded(::HalfSpace)::Bool
 end
 
 """
+    isuniversal(hs::HalfSpace{N}, [witness]::Bool=false
+               )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+
+Check whether a half-space is universal.
+
+### Input
+
+- `P`       -- half-space
+- `witness` -- (optional, default: `false`) compute a witness if activated
+
+### Output
+
+* If `witness` option is deactivated: `false`
+* If `witness` option is activated: `(false, v)` where ``v ∉ P``
+
+### Algorithm
+
+Witness production falls back to `isuniversal(::Hyperplane)`.
+"""
+function isuniversal(hs::HalfSpace{N}, witness::Bool=false
+                    )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+    if witness
+        return isuniversal(Hyperplane(hs.a, hs.b), true)
+    else
+        return false
+    end
+end
+
+"""
     an_element(hs::HalfSpace{N})::Vector{N} where {N<:Real}
 
 Return some element of a half-space.

--- a/src/Hyperplane.jl
+++ b/src/Hyperplane.jl
@@ -136,6 +136,37 @@ function isbounded(::Hyperplane)::Bool
 end
 
 """
+    isuniversal(hp::Hyperplane{N}, [witness]::Bool=false
+               )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+
+Check whether a hyperplane is universal.
+
+### Input
+
+- `P`       -- hyperplane
+- `witness` -- (optional, default: `false`) compute a witness if activated
+
+### Output
+
+* If `witness` option is deactivated: `false`
+* If `witness` option is activated: `(false, v)` where ``v ∉ P``
+
+### Algorithm
+
+A witness is produced by adding the normal vector to an element on the
+hyperplane.
+"""
+function isuniversal(hp::Hyperplane{N}, witness::Bool=false
+                    )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+    if witness
+        v = an_element(hp) + hp.a
+        return (false, v)
+    else
+        return false
+    end
+end
+
+"""
     an_element(hp::Hyperplane{N})::Vector{N} where {N<:Real}
 
 Return some element of a hyperplane.

--- a/src/LazySet.jl
+++ b/src/LazySet.jl
@@ -475,14 +475,7 @@ This is a naive fallback implementation.
 """
 function isuniversal(X::LazySet{N}, witness::Bool=false
                     )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
-    if X isa Universe
-        result = true
-    elseif X isa HPolyhedron
-        # the polyhedron is universal iff there is no constraint at all
-        result = isempty(constraints_list(X))
-    elseif X isa HalfSpace || X isa Hyperplane || X isa Line
-        result = false
-    elseif isbounded(X)
+    if isbounded(X)
         result = false
     else
         error("cannot determine universality of the set")

--- a/src/Line.jl
+++ b/src/Line.jl
@@ -163,6 +163,35 @@ function isbounded(::Line)::Bool
 end
 
 """
+    isuniversal(L::Line{N}, [witness]::Bool=false
+               )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+
+Check whether a line is universal.
+
+### Input
+
+- `P`       -- line
+- `witness` -- (optional, default: `false`) compute a witness if activated
+
+### Output
+
+* If `witness` option is deactivated: `false`
+* If `witness` option is activated: `(false, v)` where ``v ∉ P``
+
+### Algorithm
+
+Witness production falls back to `isuniversal(::Hyperplane)`.
+"""
+function isuniversal(L::Line{N}, witness::Bool=false
+                    )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+    if witness
+        return isuniversal(Hyperplane(L.a, L.b), true)
+    else
+        return false
+    end
+end
+
+"""
     an_element(L::Line{N})::Vector{N} where {N<:Real}
 
 Return some element of a line.

--- a/src/Universe.jl
+++ b/src/Universe.jl
@@ -212,7 +212,7 @@ Determine whether a universe is bounded.
 
 ### Input
 
-- `S` -- universe
+- `U` -- universe
 
 ### Output
 
@@ -220,6 +220,27 @@ Determine whether a universe is bounded.
 """
 function isbounded(U::Universe)::Bool
     return false
+end
+
+"""
+    isuniversal(U::Universe{N}, [witness]::Bool=false
+               )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+
+Check whether a universe is universal.
+
+### Input
+
+- `U`       -- universe
+- `witness` -- (optional, default: `false`) compute a witness if activated
+
+### Output
+
+* If `witness` option is deactivated: `true`
+* If `witness` option is activated: `(true, [])`
+"""
+function isuniversal(U::Universe{N}, witness::Bool=false
+                    )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+    return witness ? (true, N[]) : true
 end
 
 """

--- a/test/unit_HalfSpace.jl
+++ b/test/unit_HalfSpace.jl
@@ -41,6 +41,11 @@ for N in [Float64, Rational{Int}, Float32]
     # boundedness
     @test !isbounded(hs)
 
+    # universality
+    @test !isuniversal(hs)
+    res, w = isuniversal(hs, true)
+    @test !res && w ∉ hs
+
     # isempty
     @test !isempty(hs)
 

--- a/test/unit_Hyperplane.jl
+++ b/test/unit_Hyperplane.jl
@@ -42,6 +42,11 @@ for N in [Float64, Rational{Int}, Float32]
     # boundedness
     @test !isbounded(hp)
 
+    # universality
+    @test !isuniversal(hp)
+    res, w = isuniversal(hp, true)
+    @test !res && w ∉ hp
+
     # isempty
     @test !isempty(hp)
 

--- a/test/unit_Line.jl
+++ b/test/unit_Line.jl
@@ -36,6 +36,11 @@ for N in [Float64, Rational{Int}, Float32]
     # boundedness
     @test !isbounded(l1)
 
+    # universality
+    @test !isuniversal(l1)
+    res, w = isuniversal(l1, true)
+    @test !res && w ∉ l1
+
     # isempty
     @test !isempty(l1)
 

--- a/test/unit_Polyhedron.jl
+++ b/test/unit_Polyhedron.jl
@@ -4,6 +4,8 @@ for N in [Float64, Rational{Int}, Float32]
     # random polyhedron
     rand(HPolyhedron)
 
+    p_univ = HPolyhedron{N}()
+
     # constructor from matrix and vector
     A = [N(1) N(2); N(-1) N(1)]
     b = [N(1), N(2)]
@@ -46,11 +48,17 @@ for N in [Float64, Rational{Int}, Float32]
     @test σ(d, p) == N[0, 0]
 
     # support vector of polyhedron with no constraints
-    @test σ(N[1], HPolyhedron{N}()) == N[Inf]
+    @test σ(N[1], p_univ) == N[Inf]
 
     # boundedness
     @test isbounded(p)
-    @test !isbounded(HPolyhedron{N}())
+    @test !isbounded(p_univ)
+
+    # universality
+    @test !isuniversal(p)
+    res, w = isuniversal(p, true)
+    @test !res && w ∉ p
+    @test isuniversal(p_univ) && isuniversal(p_univ, true) == (true, N[])
 
     # membership
     @test ∈(N[5 / 4, 7 / 4], p)

--- a/test/unit_Universe.jl
+++ b/test/unit_Universe.jl
@@ -44,7 +44,7 @@ for N in [Float64, Rational{Int}, Float32]
     @test !isempty(U)
 
     # universality
-    @test isuniversal(U)
+    @test isuniversal(U) && isuniversal(U, true) == (true, N[])
 
     # an_element
     @test an_element(U) ∈ U


### PR DESCRIPTION
See #1125.

This replaces the case split by proper dispatch methods.