### PR TITLE
#1233 - Efficient support vector for VPolytope

### DIFF
--- a/src/VPolytope.jl
+++ b/src/VPolytope.jl
@@ -75,34 +75,27 @@ function dim(P::VPolytope)::Int
 end
 
 """
-    σ(d::AbstractVector{N}, P::VPolytope{N}; algorithm="sfun") where {N<:Real}
+    σ(d::AbstractVector{N}, P::VPolytope{N}) where {N<:Real}
 
-Return the support vector of a polyhedron (in V-representation) in a given
+Return the support vector of a polytope in V-representation in a given
 direction.
 
 ### Input
 
-- `d`         -- direction
-- `P`         -- polyhedron in V-representation
-- `algorithm` -- (optional, default: `"sfun"`) method to compute the support
-                 vector; available options:
-    * `"sfun"` - query the support function for every vertex and return the
-                 maximizing vertex
-    * `"hrep"` - convert to constraint representation
+- `d` -- direction
+- `P` -- polytope in V-representation
 
 ### Output
 
 The support vector in the given direction.
 
-### Notes
+### Algorithm
 
 A support vector maximizes the support function.
 For a polytope, the support function is always maximized in some vertex.
 Hence it is sufficient to check all vertices.
 """
-function σ(d::AbstractVector{N},
-           P::VPolytope{N};
-           algorithm="sfun") where {N<:Real}
+function σ(d::AbstractVector{N}, P::VPolytope{N}) where {N<:Real}
     # base cases
     m = length(P.vertices)
     if m == 0
@@ -111,25 +104,17 @@ function σ(d::AbstractVector{N},
         return P.vertices[1]
     end
 
-    if algorithm == "sfun"
-        # evaluate support function in every vertex
-        max_ρ = N(-Inf)
-        max_idx = 0
-        for (i, vi) in enumerate(P.vertices)
-            ρ_i = dot(d, vi)
-            if ρ_i > max_ρ
-                max_ρ = ρ_i
-                max_idx = i
-            end
+    # evaluate support function in every vertex
+    max_ρ = N(-Inf)
+    max_idx = 0
+    for (i, vi) in enumerate(P.vertices)
+        ρ_i = dot(d, vi)
+        if ρ_i > max_ρ
+            max_ρ = ρ_i
+            max_idx = i
         end
-        return P.vertices[max_idx]
-    elseif algorithm == "hrep"
-        # convert to H-representation
-        require(:Polyhedra; fun_name="σ", explanation="(algorithm $algorithm)")
-        return σ(d, tohrep(P))
-    else
-        error("the algorithm $algorithm is not known")
     end
+    return P.vertices[max_idx]
 end
 
 """

--- a/src/VPolytope.jl
+++ b/src/VPolytope.jl
@@ -206,8 +206,8 @@ end
 
 """
     rand(::Type{VPolytope}; [N]::Type{<:Real}=Float64, [dim]::Int=2,
-         [rng]::AbstractRNG=GLOBAL_RNG, [seed]::Union{Int, Nothing}=nothing
-        )::VPolytope{N}
+         [rng]::AbstractRNG=GLOBAL_RNG, [seed]::Union{Int, Nothing}=nothing,
+         [num_vertices]::Int=-1)::VPolytope{N}
 
 Create a random polytope in vertex representation.
 

--- a/test/unit_Polytope.jl
+++ b/test/unit_Polytope.jl
@@ -163,8 +163,7 @@ for N in [Float64, Rational{Int}, Float32]
 
     # support vector
     d = N[1, 0]
-    @test σ(d, p) == σ(d, p, algorithm="sfun") == N[1, 0]
-    @test_throws ErrorException σ(d, p, algorithm="xyz")
+    @test σ(d, p) == N[1, 0]
 
     # boundedness
     @test isbounded(p)
@@ -302,12 +301,6 @@ if test_suite_polyhedra
         # -----
         # V-rep
         # -----
-
-        # support vector (only available with Polyhedra library)
-        polygon = VPolygon([N[0, 0], N[1, 0], N[0, 1]])
-        p = VPolytope(polygon)
-        d = N[1, 0]
-        @test σ(d, p, algorithm="hrep") == N[1, 0]
 
         # intersection
         p1 = VPolytope(vertices_list(BallInf(N[0, 0], N(1))))

--- a/test/unit_Polytope.jl
+++ b/test/unit_Polytope.jl
@@ -161,6 +161,11 @@ for N in [Float64, Rational{Int}, Float32]
     # dim
     @test dim(p) == 2
 
+    # support vector
+    d = N[1, 0]
+    @test σ(d, p) == σ(d, p, algorithm="sfun") == N[1, 0]
+    @test_throws ErrorException σ(d, p, algorithm="xyz")
+
     # boundedness
     @test isbounded(p)
 
@@ -302,8 +307,7 @@ if test_suite_polyhedra
         polygon = VPolygon([N[0, 0], N[1, 0], N[0, 1]])
         p = VPolytope(polygon)
         d = N[1, 0]
-        @test_throws ErrorException σ(d, p, algorithm="xyz")
-        @test σ(d, p) == N[1, 0]
+        @test σ(d, p, algorithm="hrep") == N[1, 0]
 
         # intersection
         p1 = VPolytope(vertices_list(BallInf(N[0, 0], N(1))))


### PR DESCRIPTION
Closes #1233.

We might even want to drop the other algorithm because it is always inferior.

```julia
using LazySets, BenchmarkTools, Polyhedra

function benchmark(n)
    P = rand(VPolytope, dim=n, num_vertices=10)
    d = rand(n)
    @btime σ($d, $P, algorithm=$"hrep")
    @btime σ($d, $P, algorithm=$"sfun")
end

for n in 1:8
    benchmark(n)
end
```
```julia
  39.861 μs (187 allocations: 8.53 KiB)
  165.692 ns (0 allocations: 0 bytes)
  1.182 ms (13276 allocations: 828.88 KiB)
  168.392 ns (0 allocations: 0 bytes)
  4.208 ms (71792 allocations: 5.22 MiB)
  179.587 ns (0 allocations: 0 bytes)
  14.202 ms (248627 allocations: 21.41 MiB)
  194.296 ns (0 allocations: 0 bytes)
  42.561 ms (659218 allocations: 57.89 MiB)
  202.488 ns (0 allocations: 0 bytes)
  22.158 ms (346066 allocations: 32.52 MiB)
  208.631 ns (0 allocations: 0 bytes)
  28.534 ms (438832 allocations: 40.59 MiB)
  217.820 ns (0 allocations: 0 bytes)
  34.010 ms (490169 allocations: 47.85 MiB)
  224.552 ns (0 allocations: 0 bytes) 
```
The new implementation scales very well with the dimension (165.692 ns .. 224.552 ns) while the old implementation is heavily influenced by that (39.861 μs .. 34.010 ms; note the units).
Speedup in dim 8: x150,000 :tada: