### PR TITLE
#1536 - Function to compute the Hausdorff distance between two sets

### DIFF
--- a/docs/src/lib/approximations.md
+++ b/docs/src/lib/approximations.md
@@ -79,3 +79,9 @@ CustomDirections
 ```
 
 See also `overapproximate(X::LazySet, dir::AbstractDirections)::HPolytope`.
+
+## Hausdorff distance
+
+```@docs
+hausdorff_distance
+```

--- a/src/Approximations/Approximations.jl
+++ b/src/Approximations/Approximations.jl
@@ -36,6 +36,7 @@ include("template_directions.jl")
 include("overapproximate.jl")
 include("underapproximate.jl")
 include("decompositions.jl")
+include("hausdorff_distance.jl")
 include("init.jl")
 
 end # module

--- a/src/Approximations/hausdorff_distance.jl
+++ b/src/Approximations/hausdorff_distance.jl
@@ -87,7 +87,7 @@ function hausdorff_distance_two_sided(X, Y, δ, n, p)
         hausdorff_distance_one_sided(Y, X, δ, n, p)
 end
 
-function hausdorff_distance_one_sided(X, Y, δ, n, p)
+function hausdorff_distance_one_sided(X::LazySet{N}, Y, δ, n, p) where {N}
     return X ⊆ Y + Ballp(p, zeros(N, n), δ)
 end
 

--- a/src/Approximations/hausdorff_distance.jl
+++ b/src/Approximations/hausdorff_distance.jl
@@ -53,6 +53,7 @@ we use a lazy `MinkowskiSum` with a `Ballp` centered in the origin.
 """
 function hausdorff_distance(X::LazySet{N}, Y::LazySet{N}; p::N=N(Inf),
                             ε::N=N(1e-3)) where {N<:Real}
+    @assert ε > zero(N) "the value ε must be positive"
     @assert isbounded(X) && isbounded(Y) "the Hausdorff distance is only " *
         "defined for compact sets"
 

--- a/src/Approximations/hausdorff_distance.jl
+++ b/src/Approximations/hausdorff_distance.jl
@@ -1,0 +1,102 @@
+export hausdorff_distance
+
+"""
+    hausdorff_distance(X::LazySet{N}, Y::LazySet{N}; [p]::N=N(Inf),
+                       [ε]::N=N(1e-3)) where {N<:Real}
+
+Compute the Hausdorff distance between two convex sets up to a given threshold.
+
+### Input
+
+- `X` -- convex set
+- `Y` -- convex set
+- `p` -- (optional, default: `Inf`) norm parameter of the Hausdorff distance
+- `ε` -- (optional, default: `1e-3`) precision threshold; the true Hausdorff
+         distance may diverge from the result by at most this value
+
+### Output
+
+A value from the ``ε``-neighborhood of the Hausdorff distance between ``X`` and
+``Y``.
+
+### Notes
+
+Given a ``p``-norm, the Hausdorff distance ``d_H^p(X, Y)`` between sets ``X``
+and ``Y`` is defined as follows:
+
+```math
+    d_H^p(X, Y) = \\inf\\{δ ≥ 0 \\mid Y ⊆ X ⊕ δ 𝐵_p^n \\text{ and } X ⊆ Y ⊕ δ 𝐵_p^n\\}
+```
+
+Here ``𝐵_p^n`` is the ``n``-dimensional unit ball in the ``p``-norm.
+
+The implementation may internally rely on the support function of ``X`` and
+``Y``; hence any imprecision in the implementation of the support function may
+affect the result.
+At the time of writing, the only set type with imprecise support function is the
+lazy [`Intersection`](@ref).
+
+### Algorithm
+
+We perform binary search for bounding the Hausdorff distance in an interval
+``[l, u]``, where initially ``l`` is ``0`` and ``u`` is described below.
+The binary search terminates when ``u - l ≤ ε``, i.e., the interval becomes
+sufficiently small.
+
+To find an upper bound ``u``, we start with the heuristics of taking the biggest
+distance in the axis-parallel directions.
+As long as this bound does not work, we increase the bound by ``2``.
+
+Given a value ``δ``, to check whether the sets are within Hausdorff distance
+``δ``, we simply check the inclusions given above, where on the right-hand side
+we use a lazy `MinkowskiSum` with a `Ballp` centered in the origin.
+"""
+function hausdorff_distance(X::LazySet{N}, Y::LazySet{N}; p::N=N(Inf),
+                            ε::N=N(1e-3)) where {N<:Real}
+    @assert isbounded(X) && isbounded(Y) "the Hausdorff distance is only " *
+        "defined for compact sets"
+
+    n = dim(X)
+    @assert dim(Y) == n "the Hausdorff distance is only defined between sets " *
+                        "of the same dimension, but they had dimensions $n " *
+                        "resp. $(dim(Y))"
+
+    # phase 1: find a finite upper bound
+    δ_upper = maximum(d -> abs(ρ(d, X) - ρ(d, Y)), BoxDirections{N}(n))
+    # verify that this is an upper bound
+    while !hausdorff_distance_two_sided(X, Y, δ_upper, n, p)
+        δ_upper *= N(2)
+    end
+
+    # phase 2: perform binary search between lower bound (initially 0) and upper
+    # bound until convergence
+    δ_lower = N(0)
+    while δ_upper - δ_lower > ε
+        δ = (δ_upper + δ_lower) / N(2)
+        if hausdorff_distance_two_sided(X, Y, δ, n, p)
+            δ_upper = δ
+        else
+            δ_lower = δ
+        end
+    end
+    return δ_upper
+end
+
+function hausdorff_distance_two_sided(X, Y, δ, n, p)
+    return hausdorff_distance_one_sided(X, Y, δ, n, p) &&
+        hausdorff_distance_one_sided(Y, X, δ, n, p)
+end
+
+function hausdorff_distance_one_sided(X, Y, δ, n, p)
+    return X ⊆ Y + Ballp(p, zeros(N, n), δ)
+end
+
+# for polytopes the default implementation of `⊆` requires membership in the rhs
+# set, which will be a MinkowskiSum and hence not available; we use the
+# alternative based on constraints_list on the right instead
+function hausdorff_distance_one_sided(X::AbstractPolytope{N}, Y, δ, n, p
+                                     ) where {N<:Real}
+    return LazySets._issubset_constraints_list(X, Y + Ballp(p, zeros(N, n), δ))
+end
+
+

--- a/src/Approximations/hausdorff_distance.jl
+++ b/src/Approximations/hausdorff_distance.jl
@@ -62,7 +62,8 @@ function hausdorff_distance(X::LazySet{N}, Y::LazySet{N}; p::N=N(Inf),
                         "resp. $(dim(Y))"
 
     # phase 1: find a finite upper bound
-    δ_upper = maximum(d -> abs(ρ(d, X) - ρ(d, Y)), BoxDirections{N}(n))
+    δ_upper = max(maximum(d -> abs(ρ(d, X) - ρ(d, Y)), BoxDirections{N}(n)),
+                  N(1e-3))  # this initial bound should be strictly positive
     # verify that this is an upper bound
     while !_mutual_issubset_in_δ_bloating(X, Y, δ_upper, n, p)
         δ_upper *= N(2)

--- a/src/Approximations/hausdorff_distance.jl
+++ b/src/Approximations/hausdorff_distance.jl
@@ -64,7 +64,7 @@ function hausdorff_distance(X::LazySet{N}, Y::LazySet{N}; p::N=N(Inf),
     # phase 1: find a finite upper bound
     δ_upper = maximum(d -> abs(ρ(d, X) - ρ(d, Y)), BoxDirections{N}(n))
     # verify that this is an upper bound
-    while !hausdorff_distance_two_sided(X, Y, δ_upper, n, p)
+    while !_mutual_issubset_in_δ_bloating(X, Y, δ_upper, n, p)
         δ_upper *= N(2)
     end
 
@@ -73,7 +73,7 @@ function hausdorff_distance(X::LazySet{N}, Y::LazySet{N}; p::N=N(Inf),
     δ_lower = N(0)
     while δ_upper - δ_lower > ε
         δ = (δ_upper + δ_lower) / N(2)
-        if hausdorff_distance_two_sided(X, Y, δ, n, p)
+        if _mutual_issubset_in_δ_bloating(X, Y, δ, n, p)
             δ_upper = δ
         else
             δ_lower = δ
@@ -82,20 +82,20 @@ function hausdorff_distance(X::LazySet{N}, Y::LazySet{N}; p::N=N(Inf),
     return δ_upper
 end
 
-function hausdorff_distance_two_sided(X, Y, δ, n, p)
-    return hausdorff_distance_one_sided(X, Y, δ, n, p) &&
-        hausdorff_distance_one_sided(Y, X, δ, n, p)
+function _mutual_issubset_in_δ_bloating(X, Y, δ, n, p)
+    return _issubset_in_δ_bloating(X, Y, δ, n, p) &&
+           _issubset_in_δ_bloating(Y, X, δ, n, p)
 end
 
-function hausdorff_distance_one_sided(X::LazySet{N}, Y, δ, n, p) where {N}
+function _issubset_in_δ_bloating(X::LazySet{N}, Y, δ, n, p) where {N}
     return X ⊆ Y + Ballp(p, zeros(N, n), δ)
 end
 
 # for polytopes the default implementation of `⊆` requires membership in the rhs
 # set, which will be a MinkowskiSum and hence not available; we use the
 # alternative based on constraints_list on the right instead
-function hausdorff_distance_one_sided(X::AbstractPolytope{N}, Y, δ, n, p
-                                     ) where {N<:Real}
+function _issubset_in_δ_bloating(X::AbstractPolytope{N}, Y, δ, n, p
+                                ) where {N<:Real}
     return LazySets._issubset_constraints_list(X, Y + Ballp(p, zeros(N, n), δ))
 end
 

--- a/src/Ballp.jl
+++ b/src/Ballp.jl
@@ -60,7 +60,7 @@ struct Ballp{N<:AbstractFloat} <: AbstractCentrallySymmetric{N}
 
     # default constructor with domain constraint for radius and p
     function Ballp{N}(p::N, center::Vector{N}, radius::N
-                     ) where {N<:AbstractFloat}
+                     ) where {N<:Real}
         @assert radius >= zero(N) "radius must not be negative"
         @assert p >= 1 "p must not be less than 1"
         if p == Inf
@@ -76,8 +76,18 @@ struct Ballp{N<:AbstractFloat} <: AbstractCentrallySymmetric{N}
 end
 
 # convenience constructor without type parameter
-Ballp(p::N, center::Vector{N}, radius::N) where {N<:AbstractFloat} =
-    Ballp{N}(p, center, radius)
+function Ballp(p::N, center::Vector{N}, radius::N) where {N<:Real}
+    if p == Inf
+        return BallInf(center, radius)
+    elseif p == 2
+        return Ball2(center, radius)
+    elseif p == 1
+        return Ball1(center, radius)
+    else
+        return Ballp{N}(p, center, radius)
+    end
+end
+
 
 # --- AbstractCentrallySymmetric interface functions ---
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -135,6 +135,7 @@ if test_suite_basic
     @time @testset "LazySets.Approximations.ballinf_approximation" begin include("unit_ballinf_approximation.jl") end
     @time @testset "LazySets.Approximations.radiusdiameter" begin include("unit_radiusdiameter.jl") end
     @time @testset "LazySets.Approximations.decompose" begin include("unit_decompose.jl") end
+    @time @testset "LazySets.Approximations.hausdorff_distance" begin include("unit_hausdorff_distance.jl") end
 
     # ========================
     # Testing method ambiguity

--- a/test/unit_hausdorff_distance.jl
+++ b/test/unit_hausdorff_distance.jl
@@ -4,11 +4,20 @@ for N in [Float64, Float32, Rational{Int}]
     ε = N(1e-3)
 
     b1 = BallInf(zeros(N, 2), N(1))
-    b1_lazy = N[1 0; 0 1] * b1
     b2 = BallInf(ones(N, 2), N(1))
 
-    for b in [b1, b1_lazy]
-        hd = hausdorff_distance(b, b2; p=N(Inf), ε=ε)
+    hd = hausdorff_distance(b1, b2; p=N(Inf), ε=ε)
+    @test _in_interval(hd, N(1), ε)
+end
+
+if test_suite_polyhedra
+    for N in [Float64]
+        ε = N(1e-3)
+
+        b1 = N[1 0; 0 1] * BallInf(zeros(N, 2), N(1))
+        b2 = BallInf(ones(N, 2), N(1))
+
+        hd = hausdorff_distance(b1, b2; p=N(Inf), ε=ε)
         @test _in_interval(hd, N(1), ε)
     end
 end

--- a/test/unit_hausdorff_distance.jl
+++ b/test/unit_hausdorff_distance.jl
@@ -8,6 +8,9 @@ for N in [Float64, Float32, Rational{Int}]
 
     hd = hausdorff_distance(b1, b2; p=N(Inf), ε=ε)
     @test _in_interval(hd, N(1), ε)
+
+    hd = hausdorff_distance(b1, b1; p=N(Inf), ε=ε)
+    @test _in_interval(hd, N(0), ε)
 end
 
 if test_suite_polyhedra

--- a/test/unit_hausdorff_distance.jl
+++ b/test/unit_hausdorff_distance.jl
@@ -1,0 +1,13 @@
+using LazySets.Approximations: hausdorff_distance
+
+_in_interval(v, x, ε) = x - ε <= v <= x + ε
+
+for N in [Float64, Float32, Rational{Int}]
+    ε = N(1e-3)
+
+    b1 = BallInf(zeros(N, 2), N(1))
+    b2 = BallInf(ones(N, 2), N(1))
+
+    hd = hausdorff_distance(b1, b2; p=N(Inf), ε=ε)
+    @test _in_interval(hd, N(1), ε)
+end

--- a/test/unit_hausdorff_distance.jl
+++ b/test/unit_hausdorff_distance.jl
@@ -1,13 +1,14 @@
-using LazySets.Approximations: hausdorff_distance
-
 _in_interval(v, x, ε) = x - ε <= v <= x + ε
 
 for N in [Float64, Float32, Rational{Int}]
     ε = N(1e-3)
 
     b1 = BallInf(zeros(N, 2), N(1))
+    b1_lazy = N[1 0; 0 1] * b1
     b2 = BallInf(ones(N, 2), N(1))
 
-    hd = hausdorff_distance(b1, b2; p=N(Inf), ε=ε)
-    @test _in_interval(hd, N(1), ε)
+    for b in [b1, b1_lazy]
+        hd = hausdorff_distance(b, b2; p=N(Inf), ε=ε)
+        @test _in_interval(hd, N(1), ε)
+    end
 end


### PR DESCRIPTION
Closes #1536.

Requires:
* ~The inclusion check fails because we do not have `constraints_list(::MinkowskiSum)`. We can start with #1563.~
* ~bugfix for `minkowski_sum` (#1592)~