### PR TITLE
Export project function

### DIFF
--- a/src/Approximations/Approximations.jl
+++ b/src/Approximations/Approximations.jl
@@ -10,6 +10,7 @@ using LazySets, LazySets.Arrays, Requires, LinearAlgebra, SparseArrays
 using LazySets: _rtol
 
 export approximate,
+       project,
        ballinf_approximation,
        box_approximation, interval_hull,
        decompose,

--- a/src/is_intersection_empty.jl
+++ b/src/is_intersection_empty.jl
@@ -1,4 +1,3 @@
-using LazySets.Approximations: project
 export is_intersection_empty,
        isdisjoint
 


### PR DESCRIPTION
Note [this comment](https://github.com/JuliaReach/LazySets.jl/issues/936#issuecomment-444537307), but having to do `using LazySets.Approximations: project` all the time is annoying.