### PR TITLE
Remove cp array from cp constructor

### DIFF
--- a/src/CartesianProduct.jl
+++ b/src/CartesianProduct.jl
@@ -38,17 +38,6 @@ struct CartesianProduct{N<:Real, S1<:LazySet{N}, S2<:LazySet{N}} <: LazySet{N}
     Y::S2
 end
 
-# constructor from an array
-CartesianProduct(Xarr::Vector{S}) where {N<:Real, S<:LazySet{N}} =
-    (length(Xarr) == 0
-        ? EmptySet{N}()
-        : length(Xarr) == 1
-            ? Xarr[1]
-            : length(Xarr) == 2
-                ? CartesianProduct(Xarr[1], Xarr[2])
-                : CartesianProduct(Xarr[1],
-                                   CartesianProduct(Xarr[2:length(Xarr)])))
-
 # EmptySet is the absorbing element for CartesianProduct
 @absorbing(CartesianProduct, EmptySet)
 

--- a/src/CartesianProduct.jl
+++ b/src/CartesianProduct.jl
@@ -25,13 +25,28 @@ many sets without recursion, instead using an array.
 
 The `EmptySet` is the absorbing element for `CartesianProduct`.
 
-Constructors:
+### Examples
 
-- `CartesianProduct{N<:Real, S1<:LazySet{N}, S2<:LazySet{N}}(X1::S1, X2::S2)`
-  -- default constructor
+The Cartesian product between two sets `X` and `Y` can be constructed either
+using `CartesianProduct(X, Y)` or the short-cut notation `X × Y`:
 
-- `CartesianProduct(Xarr::Vector{S}) where {S<:LazySet}`
-  -- constructor from an array of convex sets
+```jldoctest cartesianproduct_constructor
+julia> I1 = Interval(0, 1);
+
+julia> I2 = Interval(2, 4);
+
+julia> I12 = I1 × I2;
+
+julia> typeof(I12)
+CartesianProduct{Float64,Interval{Float64,IntervalArithmetic.Interval{Float64}},Interval{Float64,IntervalArithmetic.Interval{Float64}}}
+```
+A hyperrectangle is the cartesian product of intervals, so we can convert `I12`
+exactly to a `Hyperrectangle` type:
+
+```jldoctest cartesianproduct_constructor
+julia> convert(Hyperrectangle, I12)
+Hyperrectangle{Float64}([0.5, 3.0], [0.5, 1.0])
+```
 """
 struct CartesianProduct{N<:Real, S1<:LazySet{N}, S2<:LazySet{N}} <: LazySet{N}
     X::S1

--- a/test/unit_CartesianProduct.jl
+++ b/test/unit_CartesianProduct.jl
@@ -75,22 +75,6 @@ for N in [Float64, Float32, Rational{Int}]
     @test cs1 isa EmptySet
     @test cs2 isa EmptySet
 
-    # Test Cartesian Product of an array
-    # 0-elements
-    as = LazySet{N}[]
-    cs = CartesianProduct(as)
-    @test cs isa EmptySet
-    # 1-element
-    as = [Singleton(N[1])]
-    cs = CartesianProduct(as)
-    @test cs.element == N[1]
-    # 3-elements
-    as = [Singleton(N[1]), Singleton(N[2]), Singleton(N[3])]
-    cs = CartesianProduct(as)
-    @test cs.X.element == N[1]
-    @test cs.Y.X.element == N[2]
-    @test cs.Y.Y.element == N[3]
-
     # Test containment with respect to CartesianProduct
     p1 = HPolygon{N}()
     addconstraint!(p1, LinearConstraint(N[2, 2], N(12)))


### PR DESCRIPTION
This constructor exists since earlier versions prior to `xxxArray`, but it is no longer used (and its use is not recommended), so we may as well remove it in library code.