### PR TITLE
#1460 - linear_map for hyperrectangles

### DIFF
--- a/docs/src/lib/interfaces.md
+++ b/docs/src/lib/interfaces.md
@@ -219,6 +219,7 @@ This interface defines the following functions:
 ngens(::AbstractZonotope)
 genmat_fallback(::AbstractZonotope{N}) where {N<:Real}
 generators_fallback(::AbstractZonotope{N}) where {N<:Real}
+linear_map(::AbstractMatrix{N}, ::AbstractZonotope{N}) where {N<:Real}
 ```
 
 ##### Hyperrectangle

--- a/docs/src/lib/representations.md
+++ b/docs/src/lib/representations.md
@@ -63,6 +63,8 @@ Inherited from [`AbstractCentrallySymmetricPolytope`](@ref):
 
 Inherited from [`AbstractZonotope`](@ref):
 * [`ngens`](@ref ngens(::AbstractZonotope))
+* [`linear_map`](@ref linear_map(::AbstractMatrix{N}, ::AbstractZonotope{N}) where {N<:Real})
+
 
 Inherited from [`AbstractHyperrectangle`](@ref):
 * [`∈`](@ref ∈(::AbstractVector{N}, ::AbstractHyperrectangle{N}) where {N<:Real})
@@ -70,8 +72,8 @@ Inherited from [`AbstractHyperrectangle`](@ref):
 * [`vertices_list`](@ref vertices_list(::AbstractHyperrectangle{N}) where {N<:Real})
 * [`high`](@ref high(::AbstractHyperrectangle{N}) where {N<:Real})
 * [`low`](@ref low(::AbstractHyperrectangle{N}) where {N<:Real})
-* [`generators`](@ref generators(::AbstractZonotope))
-* [`genmat`](@ref genmat(::AbstractZonotope))
+* [`generators`](@ref generators(::AbstractHyperrectangle))
+* [`genmat`](@ref genmat(::AbstractHyperrectangle))
 
 ### Manhattan norm ball
 
@@ -244,6 +246,7 @@ Inherited from [`AbstractCentrallySymmetricPolytope`](@ref):
 
 Inherited from [`AbstractZonotope`](@ref):
 * [`ngens`](@ref ngens(::AbstractZonotope))
+* [`linear_map`](@ref linear_map(::AbstractMatrix{N}, ::AbstractZonotope{N}) where {N<:Real})
 
 Inherited from [`AbstractHyperrectangle`](@ref):
 * [`σ`](@ref σ(::AbstractVector{N}, ::AbstractHyperrectangle{N}) where {N<:Real})
@@ -255,8 +258,8 @@ Inherited from [`AbstractHyperrectangle`](@ref):
 * [`high`](@ref high(::AbstractHyperrectangle{N}) where {N<:Real})
 * [`low`](@ref low(::AbstractHyperrectangle{N}) where {N<:Real})
 * [`isflat`](@ref isflat(::Hyperrectangle))
-* [`generators`](@ref generators(::AbstractZonotope))
-* [`genmat`](@ref genmat(::AbstractZonotope))
+* [`generators`](@ref generators(::AbstractHyperrectangle))
+* [`genmat`](@ref genmat(::AbstractHyperrectangle))
 
 ## Interval
 
@@ -296,12 +299,13 @@ Inherited from [`AbstractCentrallySymmetricPolytope`](@ref):
 
 Inherited from [`AbstractZonotope`](@ref):
 * [`ngens`](@ref ngens(::AbstractZonotope))
+* [`linear_map`](@ref linear_map(::AbstractMatrix{N}, ::AbstractZonotope{N}) where {N<:Real})
 
 Inherited from [`AbstractHyperrectangle`](@ref):
 * [`norm`](@ref norm(::AbstractHyperrectangle, ::Real))
 * [`radius`](@ref radius(::AbstractHyperrectangle, ::Real))
-* [`generators`](@ref generators(::AbstractZonotope))
-* [`genmat`](@ref genmat(::AbstractZonotope))
+* [`generators`](@ref generators(::AbstractHyperrectangle))
+* [`genmat`](@ref genmat(::AbstractHyperrectangle))
 
 ## Line
 
@@ -357,6 +361,7 @@ Inherited from [`AbstractCentrallySymmetricPolytope`](@ref):
 
 Inherited from [`AbstractZonotope`](@ref):
 * [`ngens`](@ref ngens(::AbstractZonotope))
+* [`linear_map`](@ref linear_map(::AbstractMatrix{N}, ::AbstractZonotope{N}) where {N<:Real})
 
 ## Polygons
 
@@ -688,7 +693,6 @@ center(::Zonotope{N}) where {N<:Real}
 order(::Zonotope)
 generators(Z::Zonotope)
 genmat(Z::Zonotope)
-linear_map(::AbstractMatrix{N}, ::Zonotope{N}) where {N<:Real}
 translate(::Zonotope{N}, ::AbstractVector{N}) where {N<:Real}
 scale(::Real, ::Zonotope)
 ngens(::Zonotope)
@@ -709,3 +713,6 @@ Inherited from [`AbstractCentrallySymmetricPolytope`](@ref):
 * [`dim`](@ref dim(::AbstractCentrallySymmetricPolytope))
 * [`isempty`](@ref isempty(::AbstractCentrallySymmetricPolytope))
 * [`an_element`](@ref an_element(::AbstractCentrallySymmetricPolytope{N}) where {N<:Real})
+
+Inherited from [`AbstractZonotope`](@ref):
+* [`linear_map`](@ref linear_map(::AbstractMatrix{N}, ::AbstractZonotope{N}) where {N<:Real})

--- a/src/AbstractZonotope.jl
+++ b/src/AbstractZonotope.jl
@@ -161,3 +161,24 @@ function minkowski_sum(Z1::AbstractZonotope{N},
                        Z2::AbstractZonotope{N}) where {N<:Real}
     return Zonotope(center(Z1) + center(Z2), [genmat(Z1) genmat(Z2)])
 end
+
+"""
+    linear_map(M::AbstractMatrix{N}, Z::AbstractZonotope{N}) where {N<:Real}
+
+Concrete linear map of a zonotopic set.
+
+### Input
+
+- `M` -- matrix
+- `Z` -- zonotopic set
+
+### Output
+
+A zonotope corresponding to the concrete linear map `M` applied to `Z`.
+"""
+function linear_map(M::AbstractMatrix{N}, Z::AbstractZonotope{N}
+                   ) where {N<:Real}
+    @assert dim(Z) == size(M, 2) "a linear map of size $(size(M)) cannot be " *
+                                 "applied to a set of dimension $(dim(Z))"
+    return Zonotope(M * center(Z), M * genmat(Z))
+end

--- a/src/Zonotope.jl
+++ b/src/Zonotope.jl
@@ -4,7 +4,6 @@ import Base: rand,
 
 export Zonotope,
        order,
-       linear_map,
        scale,
        ngens,
        reduce_order,
@@ -387,30 +386,6 @@ and its dimension.
 """
 function order(Z::Zonotope)::Rational
     return ngens(Z) // dim(Z)
-end
-
-"""
-    linear_map(M::AbstractMatrix{N}, Z::Zonotope{N}) where {N<:Real}
-
-Concrete linear map of a zonotope.
-
-### Input
-
-- `M` -- matrix
-- `Z` -- zonotope
-
-### Output
-
-The zonotope obtained by applying the linear map to the center and generators
-of ``Z``.
-"""
-function linear_map(M::AbstractMatrix{N}, Z::Zonotope{N}) where {N<:Real}
-    @assert dim(Z) == size(M, 2) "a linear map of size $(size(M)) cannot be " *
-                                 "applied to a set of dimension $(dim(Z))"
-
-    c = M * Z.center
-    gi = M * Z.generators
-    return Zonotope(c, gi)
 end
 
 """

--- a/test/unit_AffineMap.jl
+++ b/test/unit_AffineMap.jl
@@ -1,9 +1,8 @@
 for N in [Float64, Rational{Int}, Float32]
-
     # ==================================
     # Constructor and interface methods
     # ==================================
- 
+
     B = BallInf(zeros(N, 3), N(1))
     v = N[1, 0, 0] # translation along dimension 1
     M = Diagonal(N[1, 2, 3])
@@ -47,10 +46,6 @@ for N in [Float64, Rational{Int}, Float32]
     # Type-specific methods
     # ==================================
 
-    # the translation is the origin and the linear map is the identity => constraints remain unchanged
-    Id3 = Matrix(one(N) * I, 3, 3)
-    @test constraints_list(AffineMap(Id3, B, zeros(N, 3))) == constraints_list(B)
-
     # an affine map of the form I*X + b where I is the identity matrix is a pure translation
     #v = N[1, 0, 2]
     #am_tr = AffineMap(I, B, v) # crashes, see #1544 
@@ -69,4 +64,14 @@ for N in [Float64, Rational{Int}, Float32]
     # inclusion check
     h = Hyperrectangle(N[-1, 0], N[1, 2])
     @test h ⊆ am && am ⊆ h
+end
+
+# tests that do not work for Rational{Int}
+for N in [Float64, Float32]
+    B = BallInf(zeros(N, 3), N(1))
+
+    # the translation is the origin and the linear map is the identity => constraints remain unchanged
+    Id3 = Matrix(one(N) * I, 3, 3)
+    @test ispermutation(constraints_list(AffineMap(Id3, B, zeros(N, 3))),
+                        constraints_list(B))
 end

--- a/test/unit_Hyperrectangle.jl
+++ b/test/unit_Hyperrectangle.jl
@@ -179,11 +179,7 @@ for N in [Float64, Rational{Int}, Float32]
 
     # linear map (concrete)
     P = linear_map(N[1 0; 0 2], H1)
-    @test P isa HPolygon # in 2D and for invertible map we get an HPolygon; see #631 and #1093
-
-    P = linear_map(Diagonal(N[1, 2, 3, 4]),
-                   Approximations.overapproximate(H1 * H1))
-    @test P isa HPolytope # in 4D and for invertible map we get an HPolytope; see #631 and #1093
+    @test P isa Zonotope
 
     # check that vertices_list is computed correctly if the hyperrectangle
     # is "degenerate"/flat, i.e., its radius contains zeros

--- a/test/unit_LinearMap.jl
+++ b/test/unit_LinearMap.jl
@@ -91,6 +91,18 @@ for N in [Float64, Rational{Int}, Float32]
     M = N[0 1; 0 2]
     @test vertices_list(M * X) == [N[0, 0]]
 
+    # concrete linear map of a LinearMap
+    b = BallInf(N[0, 0], N(1))
+    M = N[2 3; 1 2]
+    L = LinearMap(M, b)
+    V = linear_map(M, LinearMap(M, b))
+    @test M * M * an_element(b) ∈ V
+end
+
+# tests that only work with Float64
+for N in [Float64]
+    b = BallInf(N[0, 0], N(1))
+
     if test_suite_polyhedra
         # constraints_list
         b = BallInf(N[0, 0], N(1))
@@ -106,21 +118,7 @@ for N in [Float64, Rational{Int}, Float32]
             @test ρ(d, lm1) ≈ ρ(d, p1)
             @test ρ(d, lm2) ≈ ρ(d, p2)
         end
-    end
 
-    # concrete linear map of a LinearMap
-    b = BallInf(N[0, 0], N(1))
-    M = N[2 3; 1 2]
-    L = LinearMap(M, b)
-    V = linear_map(M, LinearMap(M, b))
-    @test M * M * an_element(b) ∈ V
-end
-
-# tests that only work with Float64
-for N in [Float64]
-    b = BallInf(N[0, 0], N(1))
-
-    if test_suite_polyhedra
         # concrete intersection with lazy linear map
         M = N[2 3; 1 2]
         L = M * b

--- a/test/unit_Polygon.jl
+++ b/test/unit_Polygon.jl
@@ -212,6 +212,11 @@ for N in [Float64, Float32, Rational{Int}]
     p3 = intersection(p, p2)
     @test length(constraints_list(p3)) == 4
 
+    # concrete linear map
+    # in 2D and for an invertible map we get an HPolygon; see #631 and #1093
+    HP = convert(HPolygon, BallInf(N[0, 0], N(1)))
+    @test linear_map(N[1 0; 0 2], HP) isa HPolygon
+
     # check that tighter constraints are used in intersection (#883)
     h1 = HalfSpace([N(1), N(0)], N(3))
     h2 = HalfSpace([N(-1), N(0)], N(-3))

--- a/test/unit_Polytope.jl
+++ b/test/unit_Polytope.jl
@@ -131,6 +131,10 @@ for N in [Float64, Rational{Int}, Float32]
         @test LM isa VPolygon
     end
 
+    # in 4D and for an invertible map we get an HPolytope; see #631 and #1093
+    HP = convert(HPolytope, Approximations.overapproximate(H * H))
+    @test linear_map(Diagonal(N[1, 2, 3, 4]), HP) isa HPolytope
+
     M = N[2 1; 0 1]
     L1 = linear_map(M, P, use_inv=true)  # calculates inv(M) explicitly
     L2 = linear_map(M, P, use_inv=false) # uses transpose(M) \ c.a for each constraint c of P


### PR DESCRIPTION
Closes #1460.
Supersedes #1461.

```julia
julia> using LazySets, BenchmarkTools
julia> n = 10;
julia> M = 2. * ones(n, n);
julia> H = Hyperrectangle(zeros(n), ones(n));

# new branch
julia> @btime linear_map(M, H)
  4.502 μs (54 allocations: 5.77 KiB)
Zonotope{Float64}([0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], [2.0 2.0 … 2.0 2.0; 2.0 2.0 … 2.0 2.0; … ; 2.0 2.0 … 2.0 2.0; 2.0 2.0 … 2.0 2.0])

# master
  178.456 μs (2062 allocations: 343.88 KiB)
VPolytope{Float64}(Array{Float64,1}[[20.0, 20.0, 20.0, 20.0, 20.0, 20.0, 20.0, 20.0, 20.0, 20.0], [16.0, 16.0, 16.0, 16.0, 16.0, 16.0, 16.0, 16.0, 16.0, 16.0], [16.0, 16.0, 16.0, 16.0, 16.0, 16.0, 16.0, 16.0, 16.0, 16.0], [12.0, 12.0, 12.0, 12.0, 12.0, 12.0, 12.0, 12.0, 12.0, 12.0], [16.0, 16.0, 16.0, 16.0, 16.0, 16.0, 16.0, 16.0, 16.0, 16.0], [12.0, 12.0, 12.0, 12.0, 12.0, 12.0, 12.0, 12.0, 12.0, 12.0], [12.0, 12.0, 12.0, 12.0, 12.0, 12.0, 12.0, 12.0, 12.0, 12.0], [8.0, 8.0, 8.0, 8.0, 8.0, 8.0, 8.0, 8.0, 8.0, 8.0], [16.0, 16.0, 16.0, 16.0, 16.0, 16.0, 16.0, 16.0, 16.0, 16.0], [12.0, 12.0, 12.0, 12.0, 12.0, 12.0, 12.0, 12.0, 12.0, 12.0]  …  [-12.0, -12.0, -12.0, -12.0, -12.0, -12.0, -12.0, -12.0, -12.0, -12.0], [-16.0, -16.0, -16.0, -16.0, -16.0, -16.0, -16.0, -16.0, -16.0, -16.0], [-8.0, -8.0, -8.0, -8.0, -8.0, -8.0, -8.0, -8.0, -8.0, -8.0], [-12.0, -12.0, -12.0, -12.0, -12.0, -12.0, -12.0, -12.0, -12.0, -12.0], [-12.0, -12.0, -12.0, -12.0, -12.0, -12.0, -12.0, -12.0, -12.0, -12.0], [-16.0, -16.0, -16.0, -16.0, -16.0, -16.0, -16.0, -16.0, -16.0, -16.0], [-12.0, -12.0, -12.0, -12.0, -12.0, -12.0, -12.0, -12.0, -12.0, -12.0], [-16.0, -16.0, -16.0, -16.0, -16.0, -16.0, -16.0, -16.0, -16.0, -16.0], [-16.0, -16.0, -16.0, -16.0, -16.0, -16.0, -16.0, -16.0, -16.0, -16.0], [-20.0, -20.0, -20.0, -20.0, -20.0, -20.0, -20.0, -20.0, -20.0, -20.0]])
```

Since `AbstractHyperrectangle <: AbstractZonotope <: AbstractPolytope`, previously the `AbstractPolytope` implementation was used and returned an `HPolytope` (or `VPolytope`). Now we return a `Zonotope`. This change affected some tests that fall back to `constraints_list`. For `Zonotope{Rational}`s we use an inefficient `Polyhedra`-based algorithm for `constraints_list`, which would be used now. I deactivated those tests for `Rational`s. This seems like a draw-back, but I suspect that we used `Polyhedra` before as well and the tests were just not written in the right way (we only test with `Polyhedra` enabled).