### PR TITLE
#1055 - Add global default LP solver

### DIFF
--- a/src/AbstractPolyhedron_functions.jl
+++ b/src/AbstractPolyhedron_functions.jl
@@ -6,6 +6,16 @@ export constrained_dimensions,
        remove_redundant_constraints!,
        linear_map
 
+# default LP solver for floating-point numbers
+function default_lp_solver(N::Type{<:AbstractFloat})
+    GLPKSolverLP(method=:Simplex)
+end
+
+# default LP solver for rational numbers
+function default_lp_solver(N::Type{<:Rational})
+    GLPKSolverLP(method=:Exact)
+end
+
 """
     ∈(x::AbstractVector{N}, P::AbstractPolyhedron{N})::Bool where {N<:Real}
 

--- a/src/AbstractPolyhedron_functions.jl
+++ b/src/AbstractPolyhedron_functions.jl
@@ -110,8 +110,8 @@ end
 
 """
      remove_redundant_constraints!(constraints::AbstractVector{LC};
-         [backend]=GLPKSolverLP())::Bool where {N<:Real,
-                                                LC<:LinearConstraint{N}}
+         [backend]=default_lp_solver(N))::Bool where {N<:Real,
+                                                      LC<:LinearConstraint{N}}
 
 Remove the redundant constraints of a given list of linear constraints; the list
 is updated in-place.
@@ -119,8 +119,8 @@ is updated in-place.
 ### Input
 
 - `constraints` -- list of constraints
-- `backend`     -- (optional, default: `GLPKSolverLP`) numeric LP solver backend
-
+- `backend`     -- (optional, default: `default_lp_solver(N)`) the backend used
+                   to solve the linear program
 ### Output
 
 `true` if the function was successful and the list of constraints `constraints`
@@ -150,7 +150,7 @@ For details, see [Fukuda's Polyhedra
 FAQ](https://www.cs.mcgill.ca/~fukuda/soft/polyfaq/node24.html).
 """
 function remove_redundant_constraints!(constraints::AbstractVector{LC};
-                                       backend=GLPKSolverLP()
+                                       backend=default_lp_solver(N)
                                       )::Bool where {N<:Real,
                                                      LC<:LinearConstraint{N}}
 
@@ -189,15 +189,15 @@ end
 
 """
     remove_redundant_constraints(constraints::AbstractVector{LC};
-        backend=GLPKSolverLP()) where {N<:Real, LC<:LinearConstraint{N}}
+        backend=default_lp_solver(N)) where {N<:Real, LC<:LinearConstraint{N}}
 
 Remove the redundant constraints of a given list of linear constraints.
 
 ### Input
 
 - `constraints` -- list of constraints
-- `backend`     -- (optional, default: `GLPKSolverLP`) numeric LP solver backend
-
+- `backend`     -- (optional, default: `default_lp_solver(N)`) the backend used
+                   to solve the linear program
 ### Output
 
 The list of constraints with the redundant ones removed, or an empty set if the
@@ -210,7 +210,7 @@ See
 for details.
 """
 function remove_redundant_constraints(constraints::AbstractVector{LC};
-                                      backend=GLPKSolverLP()
+                                      backend=default_lp_solver(N)
                                      ) where {N<:Real, LC<:LinearConstraint{N}}
     constraints_copy = copy(constraints)
     if remove_redundant_constraints!(constraints_copy, backend=backend)

--- a/src/HPolyhedron.jl
+++ b/src/HPolyhedron.jl
@@ -138,7 +138,13 @@ function σ(d::AbstractVector{N}, P::HPoly{N}; solver=default_lp_solver(N)
                   "the polytope is unbounded")
         end
         # construct the solution from the solver's ray result
-        ray = (lp == nothing) ? d : lp.attrs[:unboundedray]
+        if lp == nothing
+            ray = d
+        elseif haskey(lp.attrs, :unboundedray)
+            ray = lp.attrs[:unboundedray]
+        else
+            error("LP solver did not return an infeasibility ray")
+        end
         res = Vector{N}(undef, length(ray))
         @inbounds for i in 1:length(ray)
             if ray[i] == zero(N)

--- a/src/HPolyhedron.jl
+++ b/src/HPolyhedron.jl
@@ -81,28 +81,28 @@ function dim(P::HPoly{N})::Int where {N<:Real}
 end
 
 """
-    ρ(d::AbstractVector{N}, P::HPoly{N})::N where {N<:Real}
+    ρ(d::AbstractVector{N}, P::HPoly{N}; solver=default_lp_solver(N)
+     )::N where {N<:Real}
 
 Evaluate the support function of a polyhedron (in H-representation) in a given
 direction.
 
 ### Input
 
-- `d` -- direction
-- `P` -- polyhedron in H-representation
+- `d`      -- direction
+- `P`      -- polyhedron in H-representation
+- `solver` -- (optional, default: `default_lp_solver(N)`) the backend used to
+              solve the linear program
 
 ### Output
 
 The support function of the polyhedron.
 If a polytope is unbounded in the given direction, we throw an error.
 If a polyhedron is unbounded in the given direction, the result is `Inf`.
-
-### Algorithm
-
-This implementation uses `GLPKSolverLP` as linear programming backend.
 """
-function ρ(d::AbstractVector{N}, P::HPoly{N})::N where {N<:Real}
-    lp, unbounded = σ_helper(d, P)
+function ρ(d::AbstractVector{N}, P::HPoly{N}; solver=default_lp_solver(N)
+          )::N where {N<:Real}
+    lp, unbounded = σ_helper(d, P, solver)
     if unbounded
         if P isa HPolytope
             error("the support function in direction $(d) is undefined " *
@@ -114,26 +114,26 @@ function ρ(d::AbstractVector{N}, P::HPoly{N})::N where {N<:Real}
 end
 
 """
-    σ(d::AbstractVector{N}, P::HPoly{N}) where {N<:Real}
+    σ(d::AbstractVector{N}, P::HPoly{N}; solver=default_lp_solver(N)
+     ) where {N<:Real}
 
 Return the support vector of a polyhedron (in H-representation) in a given
 direction.
 
 ### Input
 
-- `d` -- direction
-- `P` -- polyhedron in H-representation
+- `d`      -- direction
+- `P`      -- polyhedron in H-representation
+- `solver` -- (optional, default: `default_lp_solver(N)`) the backend used to
+              solve the linear program
 
 ### Output
 
 The support vector in the given direction.
-
-### Algorithm
-
-This implementation uses `GLPKSolverLP` as linear programming backend.
 """
-function σ(d::AbstractVector{N}, P::HPoly{N}) where {N<:Real}
-    lp, unbounded = σ_helper(d, P)
+function σ(d::AbstractVector{N}, P::HPoly{N}; solver=default_lp_solver(N)
+          ) where {N<:Real}
+    lp, unbounded = σ_helper(d, P, solver)
     if unbounded
         if P isa HPolytope
             error("the support vector in direction $(d) is undefined because " *
@@ -157,7 +157,7 @@ function σ(d::AbstractVector{N}, P::HPoly{N}) where {N<:Real}
     end
 end
 
-function σ_helper(d::AbstractVector{N}, P::HPoly{N}) where {N<:Real}
+function σ_helper(d::AbstractVector{N}, P::HPoly{N}, solver) where {N<:Real}
     # let c = -d as a Vector since GLPK does not accept sparse vectors
     # (see #1011)
     c = to_negative_vector(d)
@@ -170,7 +170,6 @@ function σ_helper(d::AbstractVector{N}, P::HPoly{N}) where {N<:Real}
         sense = '<'
         l = -Inf
         u = Inf
-        solver = GLPKSolverLP()
         lp = linprog(c, A, sense, b, l, u, solver)
         if lp.status == :Unbounded
             unbounded = true
@@ -356,7 +355,7 @@ end
 
 """
     remove_redundant_constraints(P::PT;
-                                 backend=GLPKSolverLP()
+                                 backend=default_lp_solver(N)
                                 )::Union{PT, EmptySet{N}} where {N<:Real,
                                                                  PT<:HPoly{N}}
 
@@ -365,7 +364,8 @@ Remove the redundant constraints in a polyhedron in H-representation.
 ### Input
 
 - `P`       -- polyhedron
-- `backend` -- (optional, default: `GLPKSolverLP`) the numeric LP solver backend
+- `backend` -- (optional, default: `default_lp_solver(N)`) the backend used to
+               solve the linear program
 
 ### Output
 
@@ -380,7 +380,7 @@ See
 for details.
 """
 function remove_redundant_constraints(P::PT;
-                                      backend=GLPKSolverLP()
+                                      backend=default_lp_solver(N)
                                      )::Union{PT, EmptySet{N}} where {N<:Real,
                                                                       PT<:HPoly{N}}
     Pred = copy(P)
@@ -393,7 +393,7 @@ end
 
 """
     remove_redundant_constraints!(P::HPoly{N};
-                                  backend=GLPKSolverLP())::Bool where {N<:Real}
+                                  backend=default_lp_solver(N))::Bool where {N<:Real}
 
 Remove the redundant constraints in a polyhedron in H-representation; the
 polyhedron is updated in-place.
@@ -401,7 +401,8 @@ polyhedron is updated in-place.
 ### Input
 
 - `P`       -- polyhedron
-- `backend` -- (optional, default: `GLPKSolverLP`) the numeric LP solver backend
+- `backend` -- (optional, default: `default_lp_solver(N)`) the backend used to
+               solve the linear program
 
 ### Output
 
@@ -416,7 +417,7 @@ See
 for details.
 """
 function remove_redundant_constraints!(P::HPoly{N};
-                                       backend=GLPKSolverLP()
+                                       backend=default_lp_solver(N)
                                       )::Bool where {N<:Real}
     remove_redundant_constraints!(P.constraints, backend=backend)
 end
@@ -611,7 +612,7 @@ end
 
 """
    isempty(P::HPoly{N}, witness::Bool=false;
-           [use_polyhedra_interface]::Bool=false, [solver]=GLPKSolverLP(),
+           [use_polyhedra_interface]::Bool=false, [solver]=default_lp_solver(N),
            [backend]=nothing
           )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
 
@@ -623,7 +624,7 @@ Determine whether a polyhedron is empty.
 - `witness` -- (optional, default: `false`) compute a witness if activated
 - `use_polyhedra_interface` -- (optional, default: `false`) if `true`, we use
                the `Polyhedra` interface for the emptiness test
-- `solver`  -- (optional, default: `GLPKSolverLP()`) LP-solver backend
+- `solver`  -- (optional, default: `default_lp_solver(N)`) LP-solver backend
 - `backend` -- (optional, default: `nothing`) backend for polyhedral
                computations in `Polyhedra`; its value is set internally (see the
                Notes below for details)
@@ -652,7 +653,7 @@ Otherwise, we set up the LP internally.
 function isempty(P::HPoly{N},
                  witness::Bool=false;
                  use_polyhedra_interface::Bool=false,
-                 solver=GLPKSolverLP(),
+                 solver=default_lp_solver(N),
                  backend=nothing
                 )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
     if use_polyhedra_interface

--- a/src/HPolyhedron.jl
+++ b/src/HPolyhedron.jl
@@ -654,6 +654,10 @@ function isempty(P::HPoly{N},
                  solver=default_lp_solver(N),
                  backend=nothing
                 )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+    if length(constraints_list(P)) < 2
+        # catch corner case because of problems in LP solver for Rationals
+        return witness ? (false, an_element(P)) : false
+    end
     if use_polyhedra_interface
         require(:Polyhedra; fun_name="isempty", explanation="with the active " *
             "option `use_polyhedra_interface`")

--- a/src/HPolyhedron.jl
+++ b/src/HPolyhedron.jl
@@ -1,5 +1,3 @@
-using MathProgBase, GLPKMathProgInterface
-
 import Base: isempty,
              rand,
              convert

--- a/src/LazySets.jl
+++ b/src/LazySets.jl
@@ -3,7 +3,8 @@ __precompile__(true)
 # main module for `LazySets.jl`
 module LazySets
 
-using Requires, SparseArrays, LinearAlgebra, Reexport
+using Requires, SparseArrays, LinearAlgebra, Reexport, MathProgBase,
+      GLPKMathProgInterface
 using LinearAlgebra: checksquare
 import LinearAlgebra: norm, ×
 import Random

--- a/src/VPolytope.jl
+++ b/src/VPolytope.jl
@@ -404,7 +404,8 @@ Return the polytope obtained by removing the redundant vertices of the given pol
                [Polyhedra's documentation](https://juliapolyhedra.github.io/Polyhedra.jl/latest/installation.html#Getting-Libraries-1)
                for further information on the available backends
 - `solver`  -- (optional, default: `nothing`) the linear programming
-               solver used in the backend, if needed; see `default_lp_solver(N)`
+               solver used in the backend, if needed; see
+               `default_lp_solver_polyhedra(N)`
 
 ### Output
 
@@ -413,8 +414,9 @@ A new polytope such that its vertices are the convex hull of the given polytope.
 ### Notes
 
 The optimization problem associated to removing redundant vertices is handled
-by `Polyhedra`. If the polyhedral computations backend requires an LP solver but
-it has not been set, we use `default_lp_solver(N)` to define such solver.
+by `Polyhedra`.
+If the polyhedral computations backend requires an LP solver but it has not been
+set, we use `default_lp_solver_polyhedra(N)` to define such solver.
 Otherwise, the redundancy removal function of the polyhedral backend is used.
 """
 function remove_redundant_vertices(P::VPolytope{N};
@@ -427,7 +429,7 @@ function remove_redundant_vertices(P::VPolytope{N};
     Q = polyhedron(P; backend=backend)
     if Polyhedra.supportssolver(typeof(Q))
         if solver == nothing
-            solver = default_lp_solver(N)
+            solver = default_lp_solver_polyhedra(N)
         end
         vQ = Polyhedra.vrep(Q)
         Polyhedra.setvrep!(Q, Polyhedra.removevredundancy(vQ, solver))
@@ -492,8 +494,8 @@ end
 """
     minkowski_sum(P1::VPolytope{N}, P2::VPolytope{N};
                   [apply_convex_hull]=true,
-                  [backend]=default_polyhedra_backend(P1, N),
-                  [solver]=default_lp_solver(N)) where {N<:Real}
+                  [backend]=nothing,
+                  [solver]=nothing) where {N<:Real}
 
 Compute the Minkowski sum between two polytopes in vertex representation.
 
@@ -503,11 +505,12 @@ Compute the Minkowski sum between two polytopes in vertex representation.
 - `P2`                -- another polytope
 - `apply_convex_hull` -- (optional, default: `true`) if `true`, post-process the
                          pairwise sums using a convex hull algorithm 
-- `backend`           -- (optional, default: `default_polyhedra_backend(P1, N)`)
-                         the backend for polyhedral computations used to
-                         post-process with a convex hull
-- `solver`            -- (optional, default: `default_lp_solver(N)`) the linear
-                         programming solver used in the backend
+- `backend`           -- (optional, default: `nothing`) the backend for
+                         polyhedral computations used to post-process with a
+                         convex hull; see `default_polyhedra_backend(P1, N)`
+- `solver`            -- (optional, default: `nothing`) the backend used to
+                         solve the linear program; see
+                         `default_lp_solver_polyhedra(N)`
 
 ### Output
 
@@ -535,7 +538,7 @@ function minkowski_sum(P1::VPolytope{N}, P2::VPolytope{N};
     if apply_convex_hull
         if backend == nothing
             backend = default_polyhedra_backend(P1, N)
-            solver = default_lp_solver(N)
+            solver = default_lp_solver_polyhedra(N)
         end
         convex_hull!(Vout, backend=backend, solver=solver)
     end

--- a/src/VPolytope.jl
+++ b/src/VPolytope.jl
@@ -1,5 +1,3 @@
-using MathProgBase, GLPKMathProgInterface
-
 import Base: rand,
              ∈
 

--- a/src/VPolytope.jl
+++ b/src/VPolytope.jl
@@ -120,14 +120,16 @@ end
 
 """
     ∈(x::AbstractVector{N}, P::VPolytope{N};
-      solver=GLPKSolverLP(method=:Simplex))::Bool where {N<:Real}
+      solver=default_lp_solver(N))::Bool where {N<:Real}
 
 Check whether a given point is contained in a polytope in vertex representation.
 
 ### Input
 
-- `x` -- point/vector
-- `P` -- polytope in vertex representation
+- `x`      -- point/vector
+- `P`      -- polytope in vertex representation
+- `solver` -- (optional, default: `default_lp_solver(N)`) the backend used to
+              solve the linear program
 
 ### Output
 
@@ -149,7 +151,7 @@ Then we solve the following ``m``-dimensional linear program.
 ```
 """
 function ∈(x::AbstractVector{N}, P::VPolytope{N};
-           solver=GLPKSolverLP(method=:Simplex))::Bool where {N<:Real}
+           solver=default_lp_solver(N))::Bool where {N<:Real}
     vertices = P.vertices
     m = length(vertices)
 
@@ -399,8 +401,8 @@ Return the polytope obtained by removing the redundant vertices of the given pol
 ### Input
 
 - `P`       -- polytope in vertex representation
-- `backend` -- (optional, default: `nothing`) the polyhedral
-               computations backend, see `default_polyhedra_backend(P1, N)` or
+- `backend` -- (optional, default: `nothing`) the backend for polyhedral
+               computations; see `default_polyhedra_backend(P, N)` or
                [Polyhedra's documentation](https://juliapolyhedra.github.io/Polyhedra.jl/latest/installation.html#Getting-Libraries-1)
                for further information on the available backends
 - `solver`  -- (optional, default: `nothing`) the linear programming

--- a/src/Zonotope.jl
+++ b/src/Zonotope.jl
@@ -259,7 +259,7 @@ end
 
 """
     ∈(x::AbstractVector{N}, Z::Zonotope{N};
-      solver=GLPKSolverLP(method=:Simplex))::Bool where {N<:Real}
+      solver=default_lp_solver(N))::Bool where {N<:Real}
 
 Check whether a given point is contained in a zonotope.
 
@@ -267,8 +267,8 @@ Check whether a given point is contained in a zonotope.
 
 - `x`      -- point/vector
 - `Z`      -- zonotope
-- `solver` -- (optional, default: `GLPKSolverLP(method=:Simplex)`) the backend
-              used to solve the linear program
+- `solver` -- (optional, default: `default_lp_solver(N)`) the backend used to
+              solve the linear program
 
 ### Output
 
@@ -295,14 +295,9 @@ We consider the minimization of ``x_0`` in the ``p+1``-dimensional space of
 elements ``(x_0, ξ_1, …, ξ_p)`` constrained to ``0 ≤ x_0 ≤ ∞``,
 ``ξ_i ∈ [-1, 1]`` for all ``i = 1, …, p``, and such that ``x-c = Gξ`` holds.
 If a feasible solution exists, the optimal value ``x_0 = 0`` is achieved.
-
-### Notes
-
-This function is parametric in the number type `N`. For exact arithmetic use
-an appropriate backend, e.g. `solver=GLPKSolverLP(method=:Exact)`.
 """
 function ∈(x::AbstractVector{N}, Z::Zonotope{N};
-           solver=GLPKSolverLP(method=:Simplex))::Bool where {N<:Real}
+           solver=default_lp_solver(N))::Bool where {N<:Real}
     @assert length(x) == dim(Z)
 
     p, n = ngens(Z), dim(Z)

--- a/src/init_Polyhedra.jl
+++ b/src/init_Polyhedra.jl
@@ -13,11 +13,15 @@ eval(quote
         return Polyhedra.default_library(LazySets.dim(P), Rational{Int})
     end
 
-    function default_lp_solver(N::Type{<:AbstractFloat})
+    # NOTE: exists in parallel to `default_lp_solver` because we use different
+    # interfaces (see #1493)
+    function default_lp_solver_polyhedra(N::Type{<:AbstractFloat})
         return JuMP.with_optimizer(GLPK.Optimizer)
     end
 
-    function default_lp_solver(N::Type{<:Rational})
+    # NOTE: exists in parallel to `default_lp_solver` because we use different
+    # interfaces (see #1493)
+    function default_lp_solver_polyhedra(N::Type{<:Rational})
         return JuMP.with_optimizer(GLPK.Optimizer, method=:Exact)
     end
 end)

--- a/src/is_intersection_empty.jl
+++ b/src/is_intersection_empty.jl
@@ -897,7 +897,7 @@ end
     is_intersection_empty(P::AbstractPolyhedron{N},
                           X::LazySet{N},
                           witness::Bool=false;
-                          solver=GLPKSolverLP(method=:Simplex)
+                          solver=default_lp_solver(N)
                          )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
 
 Check whether two polyhedra do not intersect.
@@ -907,8 +907,8 @@ Check whether two polyhedra do not intersect.
 - `P`         -- polyhedron
 - `X`         -- another set (see the Notes section below)
 - `witness`   -- (optional, default: `false`) compute a witness if activated
-- `solver`    -- (optional, default: `GLPKSolverLP(method=:Simplex)`) LP solver
-                 backend
+- `solver`    -- (optional, default: `default_lp_solver(N)`) the backend used to
+                 solve the linear program
 - `algorithm` -- (optional, default: `"exact"`) algorithm keyword, one of:
                  * `"exact" (exact, uses a feasibility LP)
                  * `"sufficient" (sufficient, uses half-space checks)
@@ -936,7 +936,7 @@ This means one support function evaluation of `X` for each constraint of `P`.
 function is_intersection_empty(P::AbstractPolyhedron{N},
                                X::LazySet{N},
                                witness::Bool=false;
-                               solver=GLPKSolverLP(method=:Simplex),
+                               solver=default_lp_solver(N),
                                algorithm="exact"
                               )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
     if algorithm == "sufficient"
@@ -966,7 +966,7 @@ end
 function is_intersection_empty(X::LazySet{N},
                                P::AbstractPolyhedron{N},
                                witness::Bool=false;
-                               solver=GLPKSolverLP(method=:Simplex),
+                               solver=default_lp_solver(N),
                                algorithm="exact"
                               )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
     return is_intersection_empty(P, X, witness;
@@ -977,7 +977,7 @@ end
 function is_intersection_empty(P::AbstractPolyhedron{N},
                                Q::AbstractPolyhedron{N},
                                witness::Bool=false;
-                               solver=GLPKSolverLP(method=:Simplex),
+                               solver=default_lp_solver(N),
                                algorithm="exact"
                               )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
     return invoke(is_intersection_empty,
@@ -1021,7 +1021,7 @@ end
 function is_intersection_empty(P::AbstractPolyhedron{N},
                                hp::Union{Hyperplane{N}, Line{N}},
                                witness::Bool=false;
-                               solver=GLPKSolverLP(method=:Simplex),
+                               solver=default_lp_solver(N),
                                algorithm="exact"
                               )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
     return invoke(is_intersection_empty,
@@ -1033,7 +1033,7 @@ end
 function is_intersection_empty(hp::Union{Hyperplane{N}, Line{N}},
                                P::AbstractPolyhedron{N},
                                witness::Bool=false;
-                               solver=GLPKSolverLP(method=:Simplex),
+                               solver=default_lp_solver(N),
                                algorithm="exact"
                               )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
     return invoke(is_intersection_empty,

--- a/test/unit_Polygon.jl
+++ b/test/unit_Polygon.jl
@@ -246,7 +246,7 @@ for N in [Float64, Float32, Rational{Int}]
 
     # is intersection empty
     p3 = convert(HPolygon, Hyperrectangle(low=N[-1, -1], high=N[1, 1]))
-    I1 = Interval(N(9//10), N(11/10))
+    I1 = Interval(N(9//10), N(11//10))
     I2 = Interval(N(1//5), N(3//10))
     I3 = Interval(N(4), N(5))
     @test !is_intersection_empty(I1 × I2 , p3)

--- a/test/unit_Polytope.jl
+++ b/test/unit_Polytope.jl
@@ -61,12 +61,8 @@ for N in [Float64, Rational{Int}, Float32]
     @test N[5 / 4, 7 / 4] ∈ p
     @test N[4, 1] ∉ p
 
-    # singleton list (only available with Polyhedra library)
-    if test_suite_polyhedra
-        @test length(singleton_list(p)) == 4
-    else
-        @test_throws AssertionError singleton_list(p)
-    end
+    # singleton list
+    @test length(singleton_list(p)) == 4
 
     if test_suite_polyhedra
         # conversion to and from Polyhedra's VRep data structure

--- a/test/unit_Polytope.jl
+++ b/test/unit_Polytope.jl
@@ -84,7 +84,7 @@ for N in [Float64, Rational{Int}, Float32]
 
         # isempty
         @test !isempty(p)
-        @test !isempty(HPolytope{N}())
+        @test !isempty(HPolytope{N}())  # note: this object is illegal
 
         # H-representaion of an empty v-polytope
         @test tohrep(VPolytope{N}()) == EmptySet{N}()

--- a/test/unit_ResetMap.jl
+++ b/test/unit_ResetMap.jl
@@ -23,10 +23,10 @@ for N in [Float64, Rational{Int}, Float32]
     # boundedness
     @test isbounded(rm)  # bounded set
     @test isbounded(ResetMap(Singleton(N[1, 2]), r_none))  # bounded set without resets
-    @test !isbounded(ResetMap(HPolyhedron([HalfSpace(N[1, 1], N(1))]), r_none))  # unbounded set without resets
     @test !isbounded(ResetMap(Universe{N}(2), r_1))  # unbounded set without enough resets
     @test isbounded(ResetMap(Universe{N}(2), r_12))  # unbounded set with enough resets
     if N in [Float64]
+        @test !isbounded(ResetMap(HPolyhedron([HalfSpace(N[1, 1], N(1))]), r_none))  # unbounded set without resets
         @test !isbounded(ResetMap(HPolyhedron([HalfSpace(N[1, 1], N(1))]), r_1))  # unbounded set without enough resets
         @test isbounded(ResetMap(HPolyhedron([HalfSpace(N[1, 1], N(1))]), r_12))  # unbounded set, but captured by resets
     end


### PR DESCRIPTION
Closes #1055.

This is mainly a copy of #1146 with several fixes. The rational LP solver has several problems (we never used it before).
1. We now get several of these warnings:
    ```julia
    ┌ Warning: Problem is infeasible, but infeasibility ray ("Farkas proof") is unavailable; check that the proper solver options are set.
    └ @ MathProgBase.HighLevelInterface ~/.julia/packages/MathProgBase/rVlFR/src/HighLevelInterface/linprog.jl:89
    ```
    Assuming that `GLPKSolverLP(method=:Exact)` is the correct way to create the solver, there is nothing we can do I think. Hopefully this will get resolved when we switch to `MathOptInterface` in #1493.
2. The rational LP solver crashes if there are no constraints. Hence I caught this corner case explicitly to make `isempty(HPolyhedron{Rational{Int}}())` work again.

I also renamed the existing function `default_lp_solver` to `default_lp_solver_polyhedra` because we cannot mix them (`Polyhedra` uses a `JuMP` solver but we use a `MathProgBase` solver). They may be unified again in #1493.

As a bonus, this PR also adds a `solver` argument to `HPoly`'s support function/vector.

Note also https://github.com/JuliaReach/LazySets.jl/pull/1146#issuecomment-466612695, but the solution is not available anymore.