### PR TITLE
#1606 - Revise lazy-map constructors

### DIFF
--- a/docs/src/lib/operations.md
+++ b/docs/src/lib/operations.md
@@ -324,8 +324,6 @@ linear_map(::AbstractMatrix{N}, ::Translation{N}) where {N<:Real}
 
 ```@docs
 AffineMap
-*(::AbstractMatrix{N}, ::AffineMap{N}) where {N<:Real}
-*(::N, ::AffineMap{N}) where {N<:Real}
 dim(::AffineMap)
 σ(::AbstractVector{N}, ::AffineMap{N}) where {N<:Real}
 ρ(::AbstractVector{N}, ::AffineMap{N}) where {N<:Real}

--- a/docs/src/lib/operations.md
+++ b/docs/src/lib/operations.md
@@ -224,9 +224,7 @@ Inherited from [`LazySet`](@ref):
 
 ```@docs
 LinearMap
-*(::AbstractMatrix{N}, ::LazySet{N}) where {N<:Real}
-*(::N, ::LazySet{N}) where {N<:Real}
-*(::N, ::LinearMap{N}) where {N<:Real}
+*(::Union{AbstractMatrix, UniformScaling, AbstractVector, Real}, ::LazySet)
 dim(::LinearMap)
 ρ(::AbstractVector{N}, ::LinearMap{N}) where {N<:Real}
 σ(::AbstractVector{N}, ::LinearMap{N}) where {N<:Real}

--- a/src/AffineMap.jl
+++ b/src/AffineMap.jl
@@ -118,17 +118,12 @@ function AffineMap(α::N, X::LazySet, v::AbstractVector) where {N<:Real}
 end
 
 # simplification for a LinearMap
-function LinearMap(map, am::AffineMap)
-    return AffineMap(map * am.M, am.X, map * am.v)
-end
-
-# disambiguation
-function LinearMap(M::AbstractMatrix, am::AffineMap)
-    return AffineMap(M * am.M, am.X, M * am.v)
-end
-
-function LinearMap(α::Real, am::AffineMap)
-    return AffineMap(α * am.M, am.X, α * am.v)
+for MAP in (:AbstractMatrix, :Real)
+    @eval begin
+        function LinearMap(map::$MAP, am::AffineMap)
+            return AffineMap(map * am.M, am.X, map * am.v)
+        end
+    end
 end
 
 # ZeroSet is "almost absorbing" for the linear map (only the dimension changes)
@@ -145,7 +140,7 @@ function AffineMap(M::AbstractMatrix{N}, Z::ZeroSet{N}, v::AbstractVector{N}
     return Singleton(v)
 end
 
-# EmptySet is absorbing for LinearMap
+# EmptySet is absorbing for AffineMap
 function AffineMap(M::AbstractMatrix{N}, ∅::EmptySet{N}, v::AbstractVector{N}
                   ) where {N<:Real}
     return ∅

--- a/src/AffineMap.jl
+++ b/src/AffineMap.jl
@@ -27,6 +27,60 @@ An affine map is the composition of a linear map and a translation. This type is
 parametric in the coefficients of the linear map, `NM`, which may be different from
 the numeric type of the wrapped set (`N`). However, the numeric type of the
 translation vector should be `NM`.
+
+### Examples
+
+For the examples we create a ``3×2`` matrix, a two-dimensional unit square, and
+a three-dimensional vector.
+Then we combine them in an `AffineMap`.
+
+```jldoctest constructors
+julia> A = [1 2; 1 3; 1 4]; X = BallInf([0, 0], 1); b2 = [1, 2]; b3 = [1, 2, 3];
+
+julia> AffineMap(A, X, b3)
+AffineMap{Int64,BallInf{Int64},Int64,Array{Int64,2},Array{Int64,1}}([1 2; 1 3; 1 4], BallInf{Int64}([0, 0], 1), [1, 2, 3])
+```
+
+For convenience, `A` does not need to be a matrix but we also allow to use
+`UniformScaling`s resp. scalars (interpreted as a scaling, i.e., a scaled
+identity matrix).
+Scaling by ``1`` is ignored and simplified to a pure `Translation`.
+
+```jldoctest constructors
+julia> using LinearAlgebra
+
+julia> am = AffineMap(2I, X, b2)
+AffineMap{Int64,BallInf{Int64},Int64,Diagonal{Int64,Array{Int64,1}},Array{Int64,1}}([2 0; 0 2], BallInf{Int64}([0, 0], 1), [1, 2])
+
+julia> AffineMap(2, X, b2) == am
+true
+
+julia> AffineMap(1, X, b2)
+Translation{Int64,Array{Int64,1},BallInf{Int64}}(BallInf{Int64}([0, 0], 1), [1, 2])
+```
+
+Applying a linear map to an `AffineMap` object combines the two maps into a new
+`AffineMap` instance.
+Again we can make use of the conversion for convenience.
+
+```jldoctest constructors
+julia> B = [2 0; 0 2]; am2 = B * am
+AffineMap{Int64,BallInf{Int64},Int64,Array{Int64,2},Array{Int64,1}}([4 0; 0 4], BallInf{Int64}([0, 0], 1), [2, 4])
+
+julia> 2 * am == am2
+true
+```
+
+The application of an `AffineMap` to a `ZeroSet` or an `EmptySet` is simplified
+automatically.
+
+```jldoctest constructors
+julia> AffineMap(A, ZeroSet{Int}(2), b3)
+Singleton{Int64,Array{Int64,1}}([1, 2, 3])
+
+julia> AffineMap(A, EmptySet{Int}(), b3)
+EmptySet{Int64}()
+```
 """
 struct AffineMap{N<:Real, S<:LazySet{N}, NM, MAT<:AbstractMatrix{NM},
                  VN<:AbstractVector{NM}} <: LazySet{N}
@@ -35,71 +89,66 @@ struct AffineMap{N<:Real, S<:LazySet{N}, NM, MAT<:AbstractMatrix{NM},
     v::VN
 
     # default constructor with dimension match check
-    function AffineMap{N, S, NM, MAT, VN}(M::MAT, X::S, v::VN) where {N<:Real,
-                       S<:LazySet{N}, NM, MAT<:AbstractMatrix{NM}, VN<:AbstractVector{NM}}
+    function AffineMap(M::MAT, X::S, v::VN) where {N<:Real, S<:LazySet{N}, NM,
+                                                   MAT<:AbstractMatrix{NM},
+                                                   VN<:AbstractVector{NM}}
 
         @assert dim(X) == size(M, 2) "a matrix of size $(size(M)) cannot be " *
             "applied to a set of dimension $(dim(X))"
 
-        @assert size(M, 1) == length(v) "a map with output dimension $(size(M, 1)) " *
-            "is incompatible with the dimension of the translation vector, $(length(v))"
+        @assert size(M, 1) == length(v) "a map with output dimension " *
+            "$(size(M, 1)) is incompatible with a translation vector of " *
+            "dimension $(length(v))"
 
         return new{N, S, NM, MAT, VN}(M, X, v)
     end
 end
 
-# convenience constructor without type parameter
-AffineMap(M::MAT, X::S, v::VN) where {N<:Real, S<:LazySet{N}, NM,
-    MAT<:AbstractMatrix{NM}, VN<:AbstractVector{NM}} = AffineMap{N, S, NM, MAT, VN}(M, X, v)
-
-# convenience constructor from the identity: a pure translation
+# convenience constructor from a UniformScaling
 function AffineMap(M::UniformScaling, X::LazySet, v::AbstractVector)
-    return Translation(X, v)
+    return AffineMap(M.λ, X, v)
 end
 
-# ============================ 
-# Arithmetic functions
-# ============================
+# convenience constructor from a scalar
+function AffineMap(α::N, X::LazySet, v::AbstractVector) where {N<:Real}
+    if α == one(N)
+        return Translation(X, v)
+    end
+    return AffineMap(Diagonal(fill(α, length(v))), X, v)
+end
 
-"""
-```
-    *(M::AbstractMatrix{N}, am::AffineMap{N}) where {N<:Real}
-```
+# simplification for a LinearMap
+function LinearMap(map, am::AffineMap)
+    return AffineMap(map * am.M, am.X, map * am.v)
+end
 
-Transform an affine map under matrix multiplication.
-
-### Input
-
-- `M`  -- matrix
-- `am` -- affine map
-
-### Output
-
-A lazy affine map, i.e. an `AffineMap`, such that the new map is related to the
-old one through `am.M ↦ M * am.M` and `am.v ↦ M * am.v`.
-"""
-function LinearMap(M::AbstractMatrix{N}, am::AffineMap{N}) where {N<:Real}
+# disambiguation
+function LinearMap(M::AbstractMatrix, am::AffineMap)
     return AffineMap(M * am.M, am.X, M * am.v)
 end
 
-"""
-```
-    *(α::N, am::AffineMap{N}) where {N<:Real}
-```
-
-Return the affine map scaled by a given number.
-
-### Input
-
-- `α`  -- scalar
-- `am` -- affine map
-
-### Output
-
-The scaled affine map.
-"""
-function *(α::N, am::AffineMap{N}) where {N<:Real}
+function LinearMap(α::Real, am::AffineMap)
     return AffineMap(α * am.M, am.X, α * am.v)
+end
+
+# ZeroSet is "almost absorbing" for the linear map (only the dimension changes)
+# such that only the translation vector remains
+function AffineMap(M::AbstractMatrix{N}, Z::ZeroSet{N}, v::AbstractVector{N}
+                  ) where {N<:Real}
+    @assert dim(Z) == size(M, 2) "a matrix of size $(size(M)) cannot be " *
+        "applied to a set of dimension $(dim(Z))"
+
+    @assert size(M, 1) == length(v) "a map with output dimension " *
+        "$(size(M, 1)) is incompatible with a translation vector of " *
+        "dimension $(length(v))"
+
+    return Singleton(v)
+end
+
+# EmptySet is absorbing for LinearMap
+function AffineMap(M::AbstractMatrix{N}, ∅::EmptySet{N}, v::AbstractVector{N}
+                  ) where {N<:Real}
+    return ∅
 end
 
 # ============================ 

--- a/src/ExponentialMap.jl
+++ b/src/ExponentialMap.jl
@@ -164,7 +164,7 @@ Type that represents the action of an exponential map on a convex set.
 The `ExponentialMap` type is overloaded to the usual times `*` operator when the
 linear map is a lazy matrix exponential. For instance,
 
-```jldoctest
+```jldoctest constructors
 julia> using SparseArrays
 
 julia> A = sprandn(100, 100, 0.1);
@@ -181,16 +181,40 @@ true
 julia> dim(M)
 100
 ```
+
+The application of an `ExponentialMap` to a `ZeroSet` or an `EmptySet` is
+simplified automatically.
+
+```jldoctest constructors
+julia> E * ZeroSet(100)
+ZeroSet{Float64}(100)
+
+julia> E * EmptySet()
+EmptySet{Float64}()
+```
 """
 struct ExponentialMap{N, S<:LazySet{N}} <: LazySet{N}
     spmexp::SparseMatrixExp{N}
     X::S
 end
 
+# ZeroSet is "almost absorbing" for ExponentialMap (only the dimension changes)
+function ExponentialMap(spmexp::SparseMatrixExp{N}, Z::ZeroSet{N}
+                       ) where {N<:Real}
+    @assert dim(Z) == size(spmexp, 2) "an exponential map of size " *
+            "$(size(spmexp)) cannot be applied to a set of dimension $(dim(Z))"
+    return ZeroSet{N}(size(spmexp, 1))
+end
+
+# EmptySet is absorbing for ExponentialMap
+function ExponentialMap(spmexp::SparseMatrixExp{N}, ∅::EmptySet{N}
+                       ) where {N<:Real}
+    return ∅
+end
+
 """
 ```
-    *(spmexp::SparseMatrixExp{N},
-      X::LazySet{N})::ExponentialMap{N} where {N<:Real}
+    *(spmexp::SparseMatrixExp{N}, X::LazySet{N}) where {N<:Real}
 ```
 
 Return the exponential map of a convex set from a sparse matrix exponential.
@@ -204,23 +228,8 @@ Return the exponential map of a convex set from a sparse matrix exponential.
 
 The exponential map of the convex set.
 """
-function *(spmexp::SparseMatrixExp{N},
-           X::LazySet{N})::ExponentialMap{N} where {N<:Real}
+function *(spmexp::SparseMatrixExp{N}, X::LazySet{N}) where {N<:Real}
     return ExponentialMap(spmexp, X)
-end
-
-# ZeroSet is absorbing for ExponentialMap
-function *(spmexp::SparseMatrixExp{N}, Z::ZeroSet{N}
-          )::ZeroSet{N} where {N<:Real}
-    @assert dim(Z) == size(spmexp, 2) "an exponential map of size " *
-            "$(size(spmexp)) cannot be applied to a set of dimension $(dim(Z))"
-    return ZeroSet{N}(size(spmexp, 1))
-end
-
-# EmptySet is absorbing for ExponentialMap
-function *(spmexp::SparseMatrixExp{N}, ∅::EmptySet{N}
-          )::EmptySet{N} where {N<:Real}
-    return ∅
 end
 
 """

--- a/src/ExponentialMap.jl
+++ b/src/ExponentialMap.jl
@@ -456,8 +456,7 @@ end
 
 """
 ```
-    *(projspmexp::ProjectionSparseMatrixExp,
-      X::LazySet)::ExponentialProjectionMap
+    *(projspmexp::ProjectionSparseMatrixExp, X::LazySet)
 ```
 
 Return the application of a projection of a sparse matrix exponential to a
@@ -473,8 +472,7 @@ convex set.
 The application of the projection of a sparse matrix exponential to the convex
 set.
 """
-function *(projspmexp::ProjectionSparseMatrixExp,
-           X::LazySet)::ExponentialProjectionMap
+function *(projspmexp::ProjectionSparseMatrixExp, X::LazySet)
     return ExponentialProjectionMap(projspmexp, X)
 end
 

--- a/src/LinearMap.jl
+++ b/src/LinearMap.jl
@@ -21,6 +21,77 @@ independent of the numeric type of the wrapped set (`N`).
 Typically `NM = N`, but there may be exceptions, e.g., if `NM` is an interval
 that holds numbers of type `N`, where `N` is a floating point number type such
 as `Float64`.
+
+### Examples
+
+For the examples we create a ``3×2`` matrix and two unit squares, one of them
+being two-dimensional and the other one being one-dimensional.
+
+```jldoctest constructors
+julia> A = [1 2; 1 3; 1 4]; X = BallInf([0, 0], 1); Y = BallInf([0], 1);
+```
+
+The function ``*`` can be used as an alias to construct a `LinearMap` object.
+
+```jldoctest constructors
+julia> lm = LinearMap(A, X)
+LinearMap{Int64,BallInf{Int64},Int64,Array{Int64,2}}([1 2; 1 3; 1 4], BallInf{Int64}([0, 0], 1))
+
+julia> lm2 = A * X
+LinearMap{Int64,BallInf{Int64},Int64,Array{Int64,2}}([1 2; 1 3; 1 4], BallInf{Int64}([0, 0], 1))
+
+julia> lm == lm2
+true
+```
+
+For convenience, `A` does not need to be a matrix but we also allow to use
+vectors (interpreted as an ``n×1`` matrix) and `UniformScaling`s resp. scalars
+(interpreted as a scaling, i.e., a scaled identity matrix).
+Scaling by ``1`` is ignored.
+
+```jldoctest constructors
+julia> using LinearAlgebra: I
+
+julia> [2, 3] * Y
+LinearMap{Int64,BallInf{Int64},Int64,Array{Int64,2}}([2; 3], BallInf{Int64}([0], 1))
+
+julia> lm3 = 2 * X
+LinearMap{Int64,BallInf{Int64},Int64,SparseArrays.SparseMatrixCSC{Int64,Int64}}(
+  [1, 1]  =  2
+  [2, 2]  =  2, BallInf{Int64}([0, 0], 1))
+
+julia> 2I * X == lm3
+true
+
+julia> 1I * X == X
+true
+```
+
+Applying a linear map to a `LinearMap` object combines the two maps into a
+single `LinearMap` instance.
+Again we can make use of the conversion for convenience.
+
+```jldoctest constructors
+julia> B = transpose(A); B * lm
+LinearMap{Int64,BallInf{Int64},Int64,Array{Int64,2}}([3 9; 9 29], BallInf{Int64}([0, 0], 1))
+
+julia> B = [3, 4, 5]; B * lm
+LinearMap{Int64,BallInf{Int64},Int64,Array{Int64,2}}([12 38], BallInf{Int64}([0, 0], 1))
+
+julia> B = 2; B * lm
+LinearMap{Int64,BallInf{Int64},Int64,Array{Int64,2}}([2 4; 2 6; 2 8], BallInf{Int64}([0, 0], 1))
+```
+
+The application of a `LinearMap` to a `ZeroSet` or an `EmptySet` is simplified
+automatically.
+
+```jldoctest constructors
+julia> A * ZeroSet{Int}(2)
+ZeroSet{Int64}(3)
+
+julia> A * EmptySet{Int}()
+EmptySet{Int64}()
+```
 """
 struct LinearMap{N<:Real, S<:LazySet{N},
                  NM, MAT<:AbstractMatrix{NM}} <: LazySet{N}
@@ -28,99 +99,91 @@ struct LinearMap{N<:Real, S<:LazySet{N},
     X::S
 
     # default constructor with dimension match check
-    function LinearMap{N, S, NM, MAT}(M::MAT, X::S) where {N<:Real,
-            S<:LazySet{N}, NM, MAT<:AbstractMatrix{NM}}
+    function LinearMap(M::MAT, X::S) where {N<:Real, S<:LazySet{N}, NM,
+                                            MAT<:AbstractMatrix{NM}}
         @assert dim(X) == size(M, 2) "a linear map of size $(size(M)) cannot " *
             "be applied to a set of dimension $(dim(X))"
         return new{N, S, NM, MAT}(M, X)
     end
 end
 
-# convenience constructor without type parameter
-LinearMap(M::MAT,
-          X::S) where {N<:Real, S<:LazySet{N}, NM, MAT<:AbstractMatrix{NM}} =
-    LinearMap{N, S, NM, MAT}(M, X)
-
-# constructor from a linear map: perform the matrix multiplication immediately
-LinearMap(M::MAT, lm::LinearMap{N, S, NM, MAT}) where {N<:Real, S<:LazySet{N},
-        NM, MAT<:AbstractMatrix{NM}} =
-    LinearMap{N, S, NM, MAT}(M * lm.M, lm.X)
-
 """
 ```
-    *(M::AbstractMatrix{N}, X::LazySet{N}) where {N<:Real}
+    *(map::Union{AbstractMatrix, UniformScaling, AbstractVector, Real}, X::LazySet)
 ```
 
-Return the linear map of a convex set.
+Alias to create a `LinearMap` object.
 
 ### Input
 
-- `M` -- matrix/linear map
-- `X` -- convex set
+- `map` -- linear map
+- `X`   -- convex set
 
 ### Output
 
-A lazy linear map, i.e. a `LinearMap` instance.
+A lazy linear map, i.e., a `LinearMap` instance.
 """
-function *(M::AbstractMatrix{N}, X::LazySet{N}) where {N<:Real}
+function *(map::Union{AbstractMatrix, UniformScaling, AbstractVector, Real}, X::LazySet)
+    return LinearMap(map, X)
+end
+
+# convenience constructor from a vector
+function LinearMap(v::AbstractVector, X::LazySet)
+    n = dim(X)
+    m = length(v)
+    if n == m
+        M = reshape(v, 1, length(v))
+    else
+        M = reshape(v, length(v), 1)
+    end
     return LinearMap(M, X)
 end
 
-function *(M::AbstractVector{N}, X::LazySet{N}) where {N<:Real}
-    return LinearMap(reshape(M, length(M), 1), X)
+# convenience constructor from a UniformScaling
+function LinearMap(M::UniformScaling{N}, X::LazySet) where {N<:Real}
+    if M.λ == one(N)
+        return X
+    end
+    return LinearMap(Diagonal(fill(M.λ, dim(X))), X)
 end
 
-"""
-```
-    *(α::N, X::LazySet{N}) where {N<:Real}
-```
-
-Return the linear map of a convex set scaled by a given number.
-
-### Input
-
-- `α` -- scalar
-- `X` -- convex set
-
-### Output
-
-The lazy linear map of the convex set, `X ↦ M * X`, such that `M` is a sparse
-matrix proportional to the identity and whose non-zero entries equal `α`.
-"""
-function *(α::N, X::LazySet{N}) where {N<:Real}
+# convenience constructor from a scalar
+function LinearMap(α::Real, X::LazySet)
     n = dim(X)
     return LinearMap(sparse(α * I, n, n), X)
 end
 
-"""
-```
-    *(α::N, lm::LinearMap{N}) where {N<:Real, LM<:LinearMap{N}}
-```
-
-Return the linear map scaled by a given value.
-
-### Input
-
-- `α`  -- scalar
-- `lm` -- linear map
-
-### Output
-
-The scaled linear map.
-"""
-function *(α::N, lm::LinearMap{N}) where {N<:Real}
-    return LinearMap(α * lm.M, lm.X)
+# combine two linear maps into a single linear map
+function LinearMap(M::AbstractMatrix, lm::LinearMap)
+    return LinearMap(M * lm.M, lm.X)
 end
 
-# ZeroSet is absorbing for LinearMap
-function *(M::AbstractMatrix{N}, Z::ZeroSet{N})::ZeroSet{N} where {N<:Real}
+# disambiguations
+function LinearMap(v::AbstractVector, lm::LinearMap)
+    return invoke(LinearMap, Tuple{AbstractVector, LazySet}, v, lm)
+end
+
+function LinearMap(α::Real, lm::LinearMap)
+    return invoke(LinearMap, Tuple{Real, LazySet}, α, lm)
+end
+
+# more efficient version
+function LinearMap(M::UniformScaling{N}, lm::LinearMap) where {N<:Real}
+    if M.λ == one(N)
+        return lm
+    end
+    return LinearMap(M.λ * lm.M, lm.X)
+end
+
+# ZeroSet is "almost absorbing" for LinearMap (only the dimension changes)
+function LinearMap(M::AbstractMatrix{N}, Z::ZeroSet{N}) where {N<:Real}
     @assert dim(Z) == size(M, 2) "a linear map of size $(size(M)) cannot " *
             "be applied to a set of dimension $(dim(Z))"
     return ZeroSet{N}(size(M, 1))
 end
 
 # EmptySet is absorbing for LinearMap
-function *(M::AbstractMatrix{N}, ∅::EmptySet{N})::EmptySet{N} where {N<:Real}
+function LinearMap(M::AbstractMatrix{N}, ∅::EmptySet{N}) where {N<:Real}
     return ∅
 end
 


### PR DESCRIPTION
Closes #1606.

* [x] `LinearMap`
* [x] `AffineMap`
* [x] `ResetMap`
* [x] `ExponentialMap`
* I skipped `ExponentialProjectionMap` because it is not used and does not have the bug.