### PR TITLE
Generalize Zonotope methods to AbstractZonotope

### DIFF
--- a/docs/src/lib/interfaces.md
+++ b/docs/src/lib/interfaces.md
@@ -219,6 +219,15 @@ This interface defines the following functions:
 ngens(::AbstractZonotope)
 genmat_fallback(::AbstractZonotope{N}) where {N<:Real}
 generators_fallback(::AbstractZonotope{N}) where {N<:Real}
+ρ(::AbstractVector{N}, ::AbstractZonotope{N}) where {N<:Real}
+σ(::AbstractVector{N}, ::AbstractZonotope{N}) where {N<:Real}
+∈(::AbstractVector{N}, ::AbstractZonotope{N}) where {N<:Real}
+linear_map(::AbstractMatrix{N}, ::AbstractZonotope{N}) where {N<:Real}
+translate(::AbstractZonotope{N}, ::AbstractVector{N}) where {N<:Real}
+constraints_list(::AbstractZonotope{N}) where {N<:Real}
+constraints_list(::AbstractZonotope{N}; ::Bool=true) where {N<:AbstractFloat}
+vertices_list(::AbstractZonotope{N}) where {N<:Real}
+order(::AbstractZonotope)
 ```
 
 ##### Hyperrectangle

--- a/docs/src/lib/operations.md
+++ b/docs/src/lib/operations.md
@@ -356,25 +356,28 @@ Inherited from [`AbstractPolytope`](@ref):
 * [`isbounded`](@ref isbounded(::AbstractPolytope))
 * [`singleton_list`](@ref singleton_list(::AbstractPolytope{N}) where {N<:Real})
 
-Inherited from [`AbstractPolyhedron`](@ref):
-* [`linear_map`](@ref linear_map(::AbstractMatrix{N}, ::AbstractPolyhedron{N}) where {N<:Real})
-
 Inherited from [`AbstractCentrallySymmetricPolytope`](@ref):
 * [`isempty`](@ref isempty(::AbstractCentrallySymmetricPolytope))
 * [`an_element`](@ref an_element(::AbstractCentrallySymmetricPolytope{N}) where {N<:Real})
 
 Inherited from [`AbstractZonotope`](@ref):
 * [`ngens`](@ref ngens(::AbstractZonotope))
+* [`linear_map`](@ref linear_map(::AbstractMatrix{N}, ::AbstractZonotope{N}) where {N<:Real})
+* [`order`](@ref order(::AbstractZonotope))
+* [`translate`](@ref translate(::AbstractZonotope{N}, ::AbstractVector{N}) where {N<:Real})
 
 Inherited from [`AbstractHyperrectangle`](@ref):
+* [`ρ`](@ref ρ(::AbstractVector{N}, ::AbstractHyperrectangle{N}) where {N<:Real})
+* [`σ`](@ref σ(::AbstractVector{N}, ::AbstractHyperrectangle{N}) where {N<:Real})
 * [`∈`](@ref ∈(::AbstractVector{N}, ::AbstractHyperrectangle{N}) where {N<:Real})
 * [`norm`](@ref norm(::AbstractHyperrectangle, ::Real))
 * [`radius`](@ref radius(::AbstractHyperrectangle, ::Real))
+* [`constraints_list`](@ref constraints_list(::AbstractHyperrectangle{N}) where {N<:Real})
 * [`vertices_list`](@ref vertices_list(::AbstractHyperrectangle{N}) where {N<:Real})
 * [`high`](@ref high(::AbstractHyperrectangle{N}) where {N<:Real})
 * [`low`](@ref low(::AbstractHyperrectangle{N}) where {N<:Real})
-* [`generators`](@ref generators(::AbstractZonotope))
-* [`genmat`](@ref genmat(::AbstractZonotope))
+* [`generators`](@ref generators(::AbstractHyperrectangle))
+* [`genmat`](@ref genmat(::AbstractHyperrectangle))
 
 ## Union
 

--- a/docs/src/lib/representations.md
+++ b/docs/src/lib/representations.md
@@ -63,6 +63,8 @@ Inherited from [`AbstractCentrallySymmetricPolytope`](@ref):
 
 Inherited from [`AbstractZonotope`](@ref):
 * [`ngens`](@ref ngens(::AbstractZonotope))
+* [`linear_map`](@ref linear_map(::AbstractMatrix{N}, ::AbstractZonotope{N}) where {N<:Real})
+* [`order`](@ref order(::AbstractZonotope))
 
 Inherited from [`AbstractHyperrectangle`](@ref):
 * [`∈`](@ref ∈(::AbstractVector{N}, ::AbstractHyperrectangle{N}) where {N<:Real})
@@ -70,8 +72,9 @@ Inherited from [`AbstractHyperrectangle`](@ref):
 * [`vertices_list`](@ref vertices_list(::AbstractHyperrectangle{N}) where {N<:Real})
 * [`high`](@ref high(::AbstractHyperrectangle{N}) where {N<:Real})
 * [`low`](@ref low(::AbstractHyperrectangle{N}) where {N<:Real})
-* [`generators`](@ref generators(::AbstractZonotope))
-* [`genmat`](@ref genmat(::AbstractZonotope))
+* [`generators`](@ref generators(::AbstractHyperrectangle))
+* [`genmat`](@ref genmat(::AbstractHyperrectangle))
+* [`constraints_list`](@ref constraints_list(::AbstractHyperrectangle{N}) where {N<:Real})
 
 ### Manhattan norm ball
 
@@ -244,6 +247,8 @@ Inherited from [`AbstractCentrallySymmetricPolytope`](@ref):
 
 Inherited from [`AbstractZonotope`](@ref):
 * [`ngens`](@ref ngens(::AbstractZonotope))
+* [`linear_map`](@ref linear_map(::AbstractMatrix{N}, ::AbstractZonotope{N}) where {N<:Real})
+* [`order`](@ref order(::AbstractZonotope))
 
 Inherited from [`AbstractHyperrectangle`](@ref):
 * [`σ`](@ref σ(::AbstractVector{N}, ::AbstractHyperrectangle{N}) where {N<:Real})
@@ -255,8 +260,9 @@ Inherited from [`AbstractHyperrectangle`](@ref):
 * [`high`](@ref high(::AbstractHyperrectangle{N}) where {N<:Real})
 * [`low`](@ref low(::AbstractHyperrectangle{N}) where {N<:Real})
 * [`isflat`](@ref isflat(::Hyperrectangle))
-* [`generators`](@ref generators(::AbstractZonotope))
-* [`genmat`](@ref genmat(::AbstractZonotope))
+* [`generators`](@ref generators(::AbstractHyperrectangle))
+* [`genmat`](@ref genmat(::AbstractHyperrectangle))
+* [`constraints_list`](@ref constraints_list(::AbstractHyperrectangle{N}) where {N<:Real})
 
 ## Interval
 
@@ -296,12 +302,15 @@ Inherited from [`AbstractCentrallySymmetricPolytope`](@ref):
 
 Inherited from [`AbstractZonotope`](@ref):
 * [`ngens`](@ref ngens(::AbstractZonotope))
+* [`linear_map`](@ref linear_map(::AbstractMatrix{N}, ::AbstractZonotope{N}) where {N<:Real})
+* [`order`](@ref order(::AbstractZonotope))
 
 Inherited from [`AbstractHyperrectangle`](@ref):
 * [`norm`](@ref norm(::AbstractHyperrectangle, ::Real))
 * [`radius`](@ref radius(::AbstractHyperrectangle, ::Real))
-* [`generators`](@ref generators(::AbstractZonotope))
-* [`genmat`](@ref genmat(::AbstractZonotope))
+* [`generators`](@ref generators(::AbstractHyperrectangle))
+* [`genmat`](@ref genmat(::AbstractHyperrectangle))
+* [`constraints_list`](@ref constraints_list(::AbstractHyperrectangle{N}) where {N<:Real})
 
 ## Line
 
@@ -357,6 +366,8 @@ Inherited from [`AbstractCentrallySymmetricPolytope`](@ref):
 
 Inherited from [`AbstractZonotope`](@ref):
 * [`ngens`](@ref ngens(::AbstractZonotope))
+* [`linear_map`](@ref linear_map(::AbstractMatrix{N}, ::AbstractZonotope{N}) where {N<:Real})
+* [`order`](@ref order(::AbstractZonotope))
 
 ## Polygons
 
@@ -591,12 +602,14 @@ Inherited from [`AbstractCentrallySymmetricPolytope`](@ref):
 
 Inherited from [`AbstractZonotope`](@ref):
 * [`ngens`](@ref ngens(::AbstractZonotope))
+* [`order`](@ref order(::AbstractZonotope))
 
 Inherited from [`AbstractHyperrectangle`](@ref):
 * [`norm`](@ref norm(::AbstractHyperrectangle, ::Real))
 * [`radius`](@ref radius(::AbstractHyperrectangle, ::Real))
 * [`high`](@ref high(::AbstractHyperrectangle{N}) where {N<:Real})
 * [`low`](@ref low(::AbstractHyperrectangle{N}) where {N<:Real})
+* [`constraints_list`](@ref constraints_list(::AbstractHyperrectangle{N}) where {N<:Real})
 
 Inherited from [`AbstractSingleton`](@ref):
 * [`σ`](@ref σ(::AbstractVector{N}, ::AbstractSingleton{N}) where {N<:Real})
@@ -657,12 +670,14 @@ Inherited from [`AbstractCentrallySymmetricPolytope`](@ref):
 
 Inherited from [`AbstractZonotope`](@ref):
 * [`ngens`](@ref ngens(::AbstractZonotope))
+* [`order`](@ref order(::AbstractZonotope))
 
 Inherited from [`AbstractHyperrectangle`](@ref):
 * [`norm`](@ref norm(::AbstractHyperrectangle, ::Real))
 * [`radius`](@ref radius(::AbstractHyperrectangle, ::Real))
 * [`high`](@ref high(::AbstractHyperrectangle{N}) where {N<:Real})
 * [`low`](@ref low(::AbstractHyperrectangle{N}) where {N<:Real})
+* [`constraints_list`](@ref constraints_list(::AbstractHyperrectangle{N}) where {N<:Real})
 
 Inherited from [`AbstractSingleton`](@ref):
 * [`radius_hyperrectangle`](@ref radius_hyperrectangle(::AbstractSingleton{N}) where {N<:Real})
@@ -677,19 +692,10 @@ Inherited from [`AbstractSingleton`](@ref):
 
 ```@docs
 Zonotope
-ρ(::AbstractVector{N}, ::Zonotope{N}) where {N<:Real}
-σ(::AbstractVector{N}, ::Zonotope{N}) where {N<:Real}
-∈(::AbstractVector{N}, ::Zonotope{N}) where {N<:Real}
-rand(::Type{Zonotope})
-vertices_list(::Zonotope{N}) where {N<:Real}
-constraints_list(::Zonotope{N}) where {N<:Real}
-constraints_list(::Zonotope{N}) where {N<:AbstractFloat}
 center(::Zonotope{N}) where {N<:Real}
-order(::Zonotope)
+rand(::Type{Zonotope})
 generators(Z::Zonotope)
 genmat(Z::Zonotope)
-linear_map(::AbstractMatrix{N}, ::Zonotope{N}) where {N<:Real}
-translate(::Zonotope{N}, ::AbstractVector{N}) where {N<:Real}
 scale(::Real, ::Zonotope)
 ngens(::Zonotope)
 reduce_order(::Zonotope, r)
@@ -709,3 +715,14 @@ Inherited from [`AbstractCentrallySymmetricPolytope`](@ref):
 * [`dim`](@ref dim(::AbstractCentrallySymmetricPolytope))
 * [`isempty`](@ref isempty(::AbstractCentrallySymmetricPolytope))
 * [`an_element`](@ref an_element(::AbstractCentrallySymmetricPolytope{N}) where {N<:Real})
+
+Inherited from [`AbstractZonotope`](@ref):
+* [`ρ`](@ref ρ(::AbstractVector{N}, ::AbstractZonotope{N}) where {N<:Real})
+* [`σ`](@ref σ(::AbstractVector{N}, ::AbstractZonotope{N}) where {N<:Real})
+* [`∈`](@ref ∈(::AbstractVector{N}, ::AbstractZonotope{N}) where {N<:Real})
+* [`linear_map`](@ref linear_map(::AbstractMatrix{N}, ::AbstractZonotope{N}) where {N<:Real})
+* [`translate`](@ref translate(::AbstractZonotope{N}, ::AbstractVector{N}) where {N<:Real})
+* [`constraints_list`](@ref constraints_list(::AbstractZonotope{N}) where {N<:Real})
+* [`constraints_list`](@ref constraints_list(::AbstractZonotope{N}; ::Bool=true) where {N<:AbstractFloat})
+* [`vertices_list`](@ref vertices_list(::AbstractZonotope{N}) where {N<:Real})
+* [`order`](@ref order(::AbstractZonotope))

--- a/src/AbstractZonotope.jl
+++ b/src/AbstractZonotope.jl
@@ -394,7 +394,8 @@ function constraints_list(Z::AbstractZonotope{N}) where {N<:Real}
 end
 
 """
-    constraints_list(Z::AbstractZonotope{N}) where {N<:AbstractFloat}
+    constraints_list(Z::AbstractZonotope{N}; check_full_rank::Bool=true
+                    ) where {N<:AbstractFloat}
 
 Return the list of constraints defining a zonotopic set.
 

--- a/src/AbstractZonotope.jl
+++ b/src/AbstractZonotope.jl
@@ -137,27 +137,3 @@ function ngens(Z::AbstractZonotope)::Int
     return length(generators(Z))
 end
 
-"""
-    minkowski_sum(Z1::AbstractZonotope{N}, Z2::AbstractZonotope{N})
-        where {N<:Real}
-
-Concrete Minkowski sum of a pair of zonotopic sets.
-
-### Input
-
-- `Z1` -- zonotopic set
-- `Z2` -- zonotopic set
-
-### Output
-
-A `Zonotope` corresponding to the concrete Minkowski sum of `Z1` and `Z2`.
-
-### Algorithm
-
-The resulting zonotope is obtained by summing up the centers and concatenating
-the generators of `Z1` and `Z2`.
-"""
-function minkowski_sum(Z1::AbstractZonotope{N},
-                       Z2::AbstractZonotope{N}) where {N<:Real}
-    return Zonotope(center(Z1) + center(Z2), [genmat(Z1) genmat(Z2)])
-end

--- a/src/AbstractZonotope.jl
+++ b/src/AbstractZonotope.jl
@@ -1,7 +1,10 @@
+import Base: ∈
+
 export AbstractZonotope,
        genmat,
        generators,
-       ngens
+       ngens,
+       order
 
 """
     AbstractZonotope{N<:Real} <: AbstractCentrallySymmetricPolytope{N}
@@ -137,3 +140,336 @@ function ngens(Z::AbstractZonotope)::Int
     return length(generators(Z))
 end
 
+"""
+    order(Z::AbstractZonotope)::Rational
+
+Return the order of a zonotope.
+
+### Input
+
+- `Z` -- zonotope
+
+### Output
+
+A rational number representing the order of the zonotope.
+
+### Notes
+
+The order of a zonotope is defined as the quotient of its number of generators
+and its dimension.
+"""
+function order(Z::AbstractZonotope)::Rational
+    return ngens(Z) // dim(Z)
+end
+
+
+# --- LazySet interface functions ---
+
+
+"""
+    ρ(d::AbstractVector{N}, Z::AbstractZonotope{N}) where {N<:Real}
+
+Return the support function of a zonotopic set in a given direction.
+
+### Input
+
+- `d` -- direction
+- `Z` -- zonotopic set
+
+### Output
+
+The support function of the zonotopic set in the given direction.
+
+### Algorithm
+
+The support value is ``cᵀ d + ‖Gᵀ d‖₁`` where ``c`` is the center and ``G`` is
+the generator matrix of `Z`.
+
+"""
+function ρ(d::AbstractVector{N}, Z::AbstractZonotope{N}) where {N<:Real}
+    return dot(center(Z), d) + sum(abs.(transpose(genmat(Z)) * d))
+end
+
+"""
+    σ(d::AbstractVector{N}, Z::AbstractZonotope{N}) where {N<:Real}
+
+Return the support vector of a zonotopic set in a given direction.
+
+### Input
+
+- `d` -- direction
+- `Z` -- zonotopic set
+
+### Output
+
+A support vector in the given direction.
+If the direction has norm zero, the vertex with ``ξ_i = 1 \\ \\ ∀ i = 1,…, p``
+is returned.
+"""
+function σ(d::AbstractVector{N}, Z::AbstractZonotope{N}) where {N<:Real}
+    G = genmat(Z)
+    return center(Z) .+ G * sign_cadlag.(_At_mul_B(G, d))
+end
+
+"""
+    ∈(x::AbstractVector{N}, Z::AbstractZonotope{N};
+      solver=default_lp_solver(N)) where {N<:Real}
+
+Check whether a given point is contained in a zonotopic set.
+
+### Input
+
+- `x`      -- point/vector
+- `Z`      -- zonotopic set
+- `solver` -- (optional, default: `default_lp_solver(N)`) the backend used to
+              solve the linear program
+
+### Output
+
+`true` iff ``x ∈ Z``.
+
+### Examples
+
+```jldoctest
+julia> Z = Zonotope([1.0, 0.0], [0.1 0.0; 0.0 0.1]);
+
+julia> [1.0, 0.2] ∈ Z
+false
+julia> [1.0, 0.1] ∈ Z
+true
+```
+
+### Algorithm
+
+The membership problem is computed by stating and solving the following linear
+program.
+Let ``p`` and ``n`` be the number of generators and ambient dimension,
+respectively.
+We consider the minimization of ``x_0`` in the ``p+1``-dimensional space of
+elements ``(x_0, ξ_1, …, ξ_p)`` constrained to ``0 ≤ x_0 ≤ ∞``,
+``ξ_i ∈ [-1, 1]`` for all ``i = 1, …, p``, and such that ``x-c = Gξ`` holds.
+If a feasible solution exists, the optimal value ``x_0 = 0`` is achieved.
+"""
+function ∈(x::AbstractVector{N}, Z::AbstractZonotope{N};
+           solver=default_lp_solver(N)) where {N<:Real}
+    @assert length(x) == dim(Z)
+
+    p, n = ngens(Z), dim(Z)
+    # (n+1) x (p+1) matrix with block-diagonal blocks 1 and genmat(Z)
+    A = [[one(N); zeros(N, p)]'; [zeros(N, n) genmat(Z)]]
+    b = [zero(N); (x - center(Z))]
+    lbounds = [zero(N); fill(-one(N), p)]
+    ubounds = [N(Inf); ones(N, p)]
+    sense = ['>'; fill('=', n)]
+    obj = [one(N); zeros(N, p)]
+
+    lp = linprog(obj, A, sense, b, lbounds, ubounds, solver)
+    return (lp.status == :Optimal) # Infeasible or Unbounded => false
+end
+
+"""
+    linear_map(M::AbstractMatrix{N}, Z::AbstractZonotope{N}) where {N<:Real}
+
+Concrete linear map of a zonotopic set.
+
+### Input
+
+- `M` -- matrix
+- `Z` -- zonotopic set
+
+### Output
+
+The zonotope obtained by applying the linear map to the center and generators
+of ``Z``.
+"""
+function linear_map(M::AbstractMatrix{N}, Z::AbstractZonotope{N}
+                   ) where {N<:Real}
+    @assert dim(Z) == size(M, 2) "a linear map of size $(size(M)) cannot be " *
+                                 "applied to a set of dimension $(dim(Z))"
+
+    c = M * center(Z)
+    gi = M * genmat(Z)
+    return Zonotope(c, gi)
+end
+
+"""
+    translate(Z::AbstractZonotope{N}, v::AbstractVector{N}; share::Bool=false
+             ) where {N<:Real}
+
+Translate (i.e., shift) a zonotope by a given vector.
+
+### Input
+
+- `Z`     -- zonotope
+- `v`     -- translation vector
+- `share` -- (optional, default: `false`) flag for sharing unmodified parts of
+             the original set representation
+
+### Output
+
+A translated zonotope.
+
+### Notes
+
+The generator matrix is shared with the original zonotope if `share == true`.
+
+### Algorithm
+
+We add the vector to the center of the zonotope.
+"""
+function translate(Z::AbstractZonotope{N}, v::AbstractVector{N};
+                   share::Bool=false) where {N<:Real}
+    @assert length(v) == dim(Z) "cannot translate a $(dim(Z))-dimensional " *
+                                "set by a $(length(v))-dimensional vector"
+    c = center(Z) + v
+    G = share ? genmat(Z) : copy(genmat(Z))
+    return Zonotope(c, G)
+end
+
+
+# --- AbstractPolytope interface functions ---
+
+
+"""
+    vertices_list(Z::AbstractZonotope{N}; [apply_convex_hull]::Bool=true
+                 ) where {N<:Real}
+
+Return the vertices of a zonotopic set.
+
+### Input
+
+- `Z`                 -- zonotopic set
+- `apply_convex_hull` -- (optional, default: `true`) if `true`, post-process the
+                         computation with the convex hull of the points
+
+### Output
+
+List of vertices as a vector of vectors.
+
+### Algorithm
+
+If the zonotopic set has ``p`` generators, each vertex is the result of summing
+the center with some linear combination of generators, where the combination
+factors are ``ξ_i ∈ \\{-1, 1\\}``.
+
+There are at most ``2^p`` distinct vertices. Use the flag `apply_convex_hull` to
+control whether a convex hull algorithm is applied to the vertices computed by
+this method; otherwise, redundant vertices may be present.
+"""
+function vertices_list(Z::AbstractZonotope{N};
+                       apply_convex_hull::Bool=true) where {N<:Real}
+    p = ngens(Z)
+    vlist = Vector{Vector{N}}()
+    sizehint!(vlist, 2^p)
+    G = genmat(Z)
+
+    for ξi in Iterators.product([[1, -1] for i = 1:p]...)
+        push!(vlist, center(Z) .+ G * collect(ξi))
+    end
+
+    return apply_convex_hull ? convex_hull!(vlist) : vlist
+end
+
+"""
+    constraints_list(P::AbstractZonotope{N}) where {N<:Real}
+
+Return the list of constraints defining a zonotopic set.
+
+### Input
+
+- `Z` -- zonotopic set
+
+### Output
+
+The list of constraints of the zonotopic set.
+
+### Algorithm
+
+This is the (inefficient) fallback implementation for rational numbers.
+It first computes the vertices and then converts the corresponding polytope
+to constraint representation.
+"""
+function constraints_list(Z::AbstractZonotope{N}) where {N<:Real}
+    return constraints_list(VPolytope(vertices_list(Z)))
+end
+
+"""
+    constraints_list(Z::AbstractZonotope{N}) where {N<:AbstractFloat}
+
+Return the list of constraints defining a zonotopic set.
+
+### Input
+
+- `Z`               -- zonotopic set
+- `check_full_rank` -- (optional; default: `true`) flag for checking whether the
+                       generator matrix has full rank
+
+### Output
+
+The list of constraints of the zonotopic set.
+
+### Notes
+
+The algorithm assumes that no generator is redundant.
+The result has ``2 \\binom{p}{n-1}`` (with ``p`` being the number of generators
+and ``n`` being the ambient dimension) constraints, which is optimal under this
+assumption.
+
+If ``p < n`` or the generator matrix is not full rank, we fall back to the
+(slower) computation based on the vertex representation.
+
+### Algorithm
+
+We follow the algorithm presented in *Althoff, Stursberg, Buss: Computing
+Reachable Sets of Hybrid Systems Using a Combination of Zonotopes and Polytopes.
+2009.*
+
+The one-dimensional case is not covered by that algorithm; we manually handle
+this case, assuming that there is only one generator.
+"""
+function constraints_list(Z::AbstractZonotope{N}; check_full_rank::Bool=true
+                         ) where {N<:AbstractFloat}
+    G = genmat(Z)
+    p = ngens(Z)
+    n = dim(Z)
+
+    # use fallback implementation if order < 1 or matrix is not full rank
+    if p < n || (check_full_rank && rank(G) < n)
+        return invoke(constraints_list, Tuple{AbstractZonotope{<:Real}}, Z)
+    end
+
+    # special handling of 1D case
+    if n == 1
+        if p > 1
+            error("1D-zonotope constraints currently only support a single " *
+                  "generator")
+        end
+
+        c = center(Z)[1]
+        g = G[:, 1][1]
+        constraints = [LinearConstraint([N(1)], c + g),
+                       LinearConstraint([N(-1)], g - c)]
+        return constraints
+    end
+
+    i = 0
+    c = center(Z)
+    m = binomial(p, n - 1)
+    constraints = Vector{LinearConstraint{N, Vector{N}}}(undef, 2 * m)
+    for columns in StrictlyIncreasingIndices(p, n-1)
+        i += 1
+        c⁺ = cross_product(view(G, :, columns))
+        normalize!(c⁺, 2)
+
+        Δd = sum(abs.(transpose(G) * c⁺))
+
+        d⁺ = dot(c⁺, c) + Δd
+        c⁻ = -c⁺
+        d⁻ = -d⁺ + 2 * Δd  # identical to dot(c⁻, c) + Δd
+
+        constraints[i] = LinearConstraint(c⁺, d⁺)
+        constraints[i + m] = LinearConstraint(c⁻, d⁻)
+    end
+    @assert i == m "expected 2*$m constraints, but only created 2*$i"
+    return constraints
+end

--- a/src/Zonotope.jl
+++ b/src/Zonotope.jl
@@ -1,15 +1,9 @@
 import Base: rand,
-             ∈,
              split
 
 export Zonotope,
-       order,
-       linear_map,
        scale,
-       ngens,
-       reduce_order,
-       constraints_list,
-       generators
+       reduce_order
 
 """
     Zonotope{N<:Real} <: AbstractZonotope{N}
@@ -168,150 +162,24 @@ function generators(Z::Zonotope)
     return generators_fallback(Z)
 end
 
-
-# --- AbstractPolytope interface functions ---
-
-
 """
-    vertices_list(Z::Zonotope{N};
-                  [apply_convex_hull]::Bool=true)::Vector{Vector{N}} where {N<:Real}
+    ngens(Z::Zonotope)::Int
 
-Return the vertices of a zonotope.
+Return the number of generators of a zonotope.
 
 ### Input
 
-- `Z`                 -- zonotope
-- `apply_convex_hull` -- (optional, default: `true`) if `true`, post-process the
-                         computation with the convex hull of the points
+- `Z` -- zonotope
 
 ### Output
 
-List of vertices as a vector of vectors.
-
-### Algorithm
-
-If the zonotope has ``p`` generators, each vertex is the result of summing the
-center with some linear combination of generators, where the combination
-factors are ``ξ_i ∈ \\{-1, 1\\}``.
-
-There are at most ``2^p`` distinct vertices. Use the flag `apply_convex_hull` to
-control whether a convex hull algorithm is applied to the vertices computed by this
-method; otherwise, redundant vertices may be present.
+Integer representing the number of generators.
 """
-function vertices_list(Z::Zonotope{N};
-                       apply_convex_hull::Bool=true)::Vector{Vector{N}} where {N<:Real}
-    p = ngens(Z)
-    vlist = Vector{Vector{N}}()
-    sizehint!(vlist, 2^p)
+ngens(Z::Zonotope)::Int = size(Z.generators, 2)
 
-    for ξi in Iterators.product([[1, -1] for i = 1:p]...)
-        push!(vlist, Z.center .+ Z.generators * collect(ξi))
-    end
-
-    return apply_convex_hull ? convex_hull!(vlist) : vlist
-end
 
 # --- LazySet interface functions ---
 
-"""
-    ρ(d::AbstractVector{N}, Z::Zonotope{N}) where {N<:Real}
-
-Return the support function of a zonotope in a given direction.
-
-### Input
-
-- `d` -- direction
-- `Z` -- zonotope
-
-### Output
-
-The support function of the zonotope in the given direction.
-
-### Algorithm
-
-The support value is ``cᵀ d + ‖Gᵀ d‖₁`` where ``c`` is the center and ``G`` is
-the generator matrix of `Z`.
-
-"""
-function ρ(d::AbstractVector{N}, Z::Zonotope{N}) where {N<:Real}
-    return dot(center(Z), d) + sum(abs.(transpose(Z.generators) * d))
-end
-
-"""
-    σ(d::AbstractVector{N}, Z::Zonotope{N}) where {N<:Real}
-
-Return the support vector of a zonotope in a given direction.
-
-### Input
-
-- `d` -- direction
-- `Z` -- zonotope
-
-### Output
-
-Support vector in the given direction.
-If the direction has norm zero, the vertex with ``ξ_i = 1 \\ \\ ∀ i = 1,…, p``
-is returned.
-"""
-function σ(d::AbstractVector{N}, Z::Zonotope{N}) where {N<:Real}
-    return Z.center .+ Z.generators * sign_cadlag.(_At_mul_B(Z.generators, d))
-end
-
-"""
-    ∈(x::AbstractVector{N}, Z::Zonotope{N};
-      solver=default_lp_solver(N))::Bool where {N<:Real}
-
-Check whether a given point is contained in a zonotope.
-
-### Input
-
-- `x`      -- point/vector
-- `Z`      -- zonotope
-- `solver` -- (optional, default: `default_lp_solver(N)`) the backend used to
-              solve the linear program
-
-### Output
-
-`true` iff ``x ∈ Z``.
-
-### Examples
-
-```jldoctest
-julia> Z = Zonotope([1.0, 0.0], [0.1 0.0; 0.0 0.1]);
-
-julia> [1.0, 0.2] ∈ Z
-false
-julia> [1.0, 0.1] ∈ Z
-true
-```
-
-### Algorithm
-
-The membership problem is computed by stating and solving the following linear
-program with the simplex method.
-Let ``p`` and ``n`` be the number of generators and ambient dimension,
-respectively.
-We consider the minimization of ``x_0`` in the ``p+1``-dimensional space of
-elements ``(x_0, ξ_1, …, ξ_p)`` constrained to ``0 ≤ x_0 ≤ ∞``,
-``ξ_i ∈ [-1, 1]`` for all ``i = 1, …, p``, and such that ``x-c = Gξ`` holds.
-If a feasible solution exists, the optimal value ``x_0 = 0`` is achieved.
-"""
-function ∈(x::AbstractVector{N}, Z::Zonotope{N};
-           solver=default_lp_solver(N))::Bool where {N<:Real}
-    @assert length(x) == dim(Z)
-
-    p, n = ngens(Z), dim(Z)
-    # (n+1) x (p+1) matrix with block-diagonal blocks 1 and Z.generators
-    A = [[one(N); zeros(N, p)]'; [zeros(N, n) Z.generators]]
-    b = [zero(N); (x - Z.center)]
-    lbounds = [zero(N); fill(-one(N), p)]
-    ubounds = [N(Inf); ones(N, p)]
-    sense = ['>'; fill('=', n)]
-    obj = [one(N); zeros(N, p)]
-
-    lp = linprog(obj, A, sense, b, lbounds, ubounds, solver)
-    return (lp.status == :Optimal) # Infeasible or Unbounded => false
-end
 
 """
     rand(::Type{Zonotope}; [N]::Type{<:Real}=Float64, [dim]::Int=2,
@@ -363,52 +231,6 @@ end
 
 
 """
-    order(Z::Zonotope)::Rational
-
-Return the order of a zonotope.
-
-### Input
-
-- `Z` -- zonotope
-
-### Output
-
-A rational number representing the order of the zonotope.
-
-### Notes
-
-The order of a zonotope is defined as the quotient of its number of generators
-and its dimension.
-"""
-function order(Z::Zonotope)::Rational
-    return ngens(Z) // dim(Z)
-end
-
-"""
-    linear_map(M::AbstractMatrix{N}, Z::Zonotope{N}) where {N<:Real}
-
-Concrete linear map of a zonotope.
-
-### Input
-
-- `M` -- matrix
-- `Z` -- zonotope
-
-### Output
-
-The zonotope obtained by applying the linear map to the center and generators
-of ``Z``.
-"""
-function linear_map(M::AbstractMatrix{N}, Z::Zonotope{N}) where {N<:Real}
-    @assert dim(Z) == size(M, 2) "a linear map of size $(size(M)) cannot be " *
-                                 "applied to a set of dimension $(dim(Z))"
-
-    c = M * Z.center
-    gi = M * Z.generators
-    return Zonotope(c, gi)
-end
-
-"""
     scale(α::Real, Z::Zonotope)
 
 Concrete scaling of a zonotope.
@@ -428,21 +250,6 @@ function scale(α::Real, Z::Zonotope)
     gi = α .* Z.generators
     return Zonotope(c, gi)
 end
-
-"""
-    ngens(Z::Zonotope)::Int
-
-Return the number of generators of a zonotope.
-
-### Input
-
-- `Z` -- zonotope
-
-### Output
-
-Integer representing the number of generators.
-"""
-ngens(Z::Zonotope)::Int = size(Z.generators, 2)
 
 """
     reduce_order(Z::Zonotope, r)::Zonotope
@@ -545,142 +352,4 @@ function split(Z::Zonotope, j::Int)
     Z₁ = Zonotope(c₁, G₁)
     Z₂ = Zonotope(c₂, G₂)
     return Z₁, Z₂
-end
-
-"""
-    constraints_list(P::Zonotope{N}) where {N<:Real}
-
-Return the list of constraints defining a zonotope.
-
-### Input
-
-- `Z` -- zonotope
-
-### Output
-
-The list of constraints of the zonotope.
-
-### Algorithm
-
-This is the (inefficient) fallback implementation for rational numbers.
-It first computes the vertices and then converts the corresponding polytope
-to constraint representation.
-"""
-function constraints_list(Z::Zonotope{N}) where {N<:Real}
-    return constraints_list(VPolytope(vertices_list(Z)))
-end
-
-"""
-    constraints_list(Z::Zonotope{N}) where {N<:AbstractFloat}
-
-Return the list of constraints defining a zonotope.
-
-### Input
-
-- `Z`               -- zonotope
-- `check_full_rank` -- (optional; default: `true`) flag for checking whether the
-                       generator matrix has full rank
-
-### Output
-
-The list of constraints of the zonotope.
-
-### Notes
-
-The algorithm assumes that no generator is redundant.
-The result has ``2 \\binom{p}{n-1}`` (with ``p`` being the number of generators
-and ``n`` being the ambient dimension) constraints, which is optimal under this
-assumption.
-
-If ``p < n`` or the generator matrix is not full rank, we fall back to the
-(slower) computation based on the vertex representation.
-
-### Algorithm
-
-We follow the algorithm presented in *Althoff, Stursberg, Buss: Computing
-Reachable Sets of Hybrid Systems Using a Combination of Zonotopes and Polytopes.
-2009.*
-
-The one-dimensional case is not covered by that algorithm; we manually handle
-this case, assuming that there is only one generator.
-"""
-function constraints_list(Z::Zonotope{N}; check_full_rank::Bool=true
-                         ) where {N<:AbstractFloat}
-    G = genmat(Z)
-    p = ngens(Z)
-    n = dim(Z)
-
-    # use fallback implementation if order < 1 or matrix is not full rank
-    if p < n || (check_full_rank && rank(G) < n)
-        return invoke(constraints_list, Tuple{Zonotope{<:Real}}, Z)
-    end
-
-    # special handling of 1D case
-    if n == 1
-        if p > 1
-            error("1D-zonotope constraints currently only support a single " *
-                  "generator")
-        end
-
-        c = Z.center[1]
-        g = G[:, 1][1]
-        constraints = [LinearConstraint([N(1)], c + g),
-                       LinearConstraint([N(-1)], g - c)]
-        return constraints
-    end
-
-    i = 0
-    c = Z.center
-    m = binomial(p, n - 1)
-    constraints = Vector{LinearConstraint{N, Vector{N}}}(undef, 2 * m)
-    for columns in StrictlyIncreasingIndices(p, n-1)
-        i += 1
-        c⁺ = cross_product(view(G, :, columns))
-        normalize!(c⁺, 2)
-
-        Δd = sum(abs.(transpose(G) * c⁺))
-
-        d⁺ = dot(c⁺, c) + Δd
-        c⁻ = -c⁺
-        d⁻ = -d⁺ + 2 * Δd  # identical to dot(c⁻, c) + Δd
-
-        constraints[i] = LinearConstraint(c⁺, d⁺)
-        constraints[i + m] = LinearConstraint(c⁻, d⁻)
-    end
-    @assert i == m "expected 2*$m constraints, but only created 2*$i"
-    return constraints
-end
-
-"""
-    translate(Z::Zonotope{N}, v::AbstractVector{N}; share::Bool=false
-             ) where {N<:Real}
-
-Translate (i.e., shift) a zonotope by a given vector.
-
-### Input
-
-- `Z`     -- zonotope
-- `v`     -- translation vector
-- `share` -- (optional, default: `false`) flag for sharing unmodified parts of
-             the original set representation
-
-### Output
-
-A translated zonotope.
-
-### Notes
-
-The generator matrix is shared with the original zonotope if `share == true`.
-
-### Algorithm
-
-We add the vector to the center of the zonotope.
-"""
-function translate(Z::Zonotope{N}, v::AbstractVector{N}; share::Bool=false
-                  ) where {N<:Real}
-    @assert length(v) == dim(Z) "cannot translate a $(dim(Z))-dimensional " *
-                                "set by a $(length(v))-dimensional vector"
-    c = center(Z) + v
-    generators = share ? Z.generators : copy(Z.generators)
-    return Zonotope(c, generators)
 end

--- a/src/concrete_minkowski_sum.jl
+++ b/src/concrete_minkowski_sum.jl
@@ -216,3 +216,28 @@ function minkowski_sum(H1::AbstractHyperrectangle{N},
     return Hyperrectangle(center(H1) + center(H2),
                           radius_hyperrectangle(H1) + radius_hyperrectangle(H2))
 end
+
+"""
+    minkowski_sum(Z1::AbstractZonotope{N}, Z2::AbstractZonotope{N})
+        where {N<:Real}
+
+Concrete Minkowski sum of a pair of zonotopic sets.
+
+### Input
+
+- `Z1` -- zonotopic set
+- `Z2` -- zonotopic set
+
+### Output
+
+A `Zonotope` corresponding to the concrete Minkowski sum of `Z1` and `Z2`.
+
+### Algorithm
+
+The resulting zonotope is obtained by summing up the centers and concatenating
+the generators of `Z1` and `Z2`.
+"""
+function minkowski_sum(Z1::AbstractZonotope{N},
+                       Z2::AbstractZonotope{N}) where {N<:Real}
+    return Zonotope(center(Z1) + center(Z2), [genmat(Z1) genmat(Z2)])
+end

--- a/test/unit_AffineMap.jl
+++ b/test/unit_AffineMap.jl
@@ -47,10 +47,6 @@ for N in [Float64, Rational{Int}, Float32]
     # Type-specific methods
     # ==================================
 
-    # the translation is the origin and the linear map is the identity => constraints remain unchanged
-    Id3 = Matrix(one(N) * I, 3, 3)
-    @test constraints_list(AffineMap(Id3, B, zeros(N, 3))) == constraints_list(B)
-
     # an affine map of the form I*X + b where I is the identity matrix is a pure translation
     #v = N[1, 0, 2]
     #am_tr = AffineMap(I, B, v) # crashes, see #1544 
@@ -69,4 +65,14 @@ for N in [Float64, Rational{Int}, Float32]
     # inclusion check
     h = Hyperrectangle(N[-1, 0], N[1, 2])
     @test h ⊆ am && am ⊆ h
+end
+
+# tests that only work with Float64 and Float32
+for N in [Float64, Float32]
+    B = BallInf(zeros(N, 3), N(1))
+
+    # the translation is the origin and the linear map is the identity => constraints remain unchanged
+    Id3 = Matrix(one(N) * I, 3, 3)
+    @test ispermutation(constraints_list(AffineMap(Id3, B, zeros(N, 3))),
+                        constraints_list(B))
 end

--- a/test/unit_Hyperrectangle.jl
+++ b/test/unit_Hyperrectangle.jl
@@ -179,11 +179,9 @@ for N in [Float64, Rational{Int}, Float32]
 
     # linear map (concrete)
     P = linear_map(N[1 0; 0 2], H1)
-    @test P isa HPolygon # in 2D and for invertible map we get an HPolygon; see #631 and #1093
-
-    P = linear_map(Diagonal(N[1, 2, 3, 4]),
-                   Approximations.overapproximate(H1 * H1))
-    @test P isa HPolytope # in 4D and for invertible map we get an HPolytope; see #631 and #1093
+    @test P isa Zonotope
+    P = linear_map(Diagonal(N[1, 2, 3, 4]), overapproximate(H1 * H1))
+    @test P isa Zonotope
 
     # check that vertices_list is computed correctly if the hyperrectangle
     # is "degenerate"/flat, i.e., its radius contains zeros

--- a/test/unit_LinearMap.jl
+++ b/test/unit_LinearMap.jl
@@ -91,23 +91,6 @@ for N in [Float64, Rational{Int}, Float32]
     M = N[0 1; 0 2]
     @test vertices_list(M * X) == [N[0, 0]]
 
-    if test_suite_polyhedra
-        # constraints_list
-        b = BallInf(N[0, 0], N(1))
-        M = N[2 3; 1 2]  # invertible
-        lm1 = LinearMap(M, b)
-        clist = constraints_list(lm1)
-        p1 = HPolygon(clist)
-        M = N[2 3; 0 0]  # not invertible
-        lm2 = LinearMap(M, b)
-        clist = constraints_list(lm2)
-        p2 = HPolygon(clist)
-        for d in BoxDiagDirections{N}(2)
-            @test ρ(d, lm1) ≈ ρ(d, p1)
-            @test ρ(d, lm2) ≈ ρ(d, p2)
-        end
-    end
-
     # concrete linear map of a LinearMap
     b = BallInf(N[0, 0], N(1))
     M = N[2 3; 1 2]
@@ -126,5 +109,20 @@ for N in [Float64]
         L = M * b
         Lb = intersection(L, b)
         @test M * an_element(b) ∈ Lb
+
+        # constraints_list
+        b = BallInf(N[0, 0], N(1))
+        M = N[2 3; 1 2]  # invertible
+        lm1 = LinearMap(M, b)
+        clist = constraints_list(lm1)
+        p1 = HPolygon(clist)
+        M = N[2 3; 0 0]  # not invertible
+        lm2 = LinearMap(M, b)
+        clist = constraints_list(lm2)
+        p2 = HPolygon(clist)
+        for d in BoxDiagDirections{N}(2)
+            @test ρ(d, lm1) ≈ ρ(d, p1)
+            @test ρ(d, lm2) ≈ ρ(d, p2)
+        end
     end
 end


### PR DESCRIPTION
I was not sure about generalizing `translate` because it is probably expected that the result is of the same type as the input. But since we can (and should) always override the implementation for subtypes, I decided to generalize it as well.