### PR TITLE
#1639 - Fix problems with type parameters on WIndows

### DIFF
--- a/docs/src/lib/representations.md
+++ b/docs/src/lib/representations.md
@@ -190,8 +190,8 @@ translate(::HalfSpace{N}, ::AbstractVector{N}) where {N<:Real}
 halfspace_left(::AbstractVector{N}, ::AbstractVector{N}) where {N<:Real}
 halfspace_right(::AbstractVector{N}, ::AbstractVector{N}) where {N<:Real}
 tosimplehrep(::AbstractVector{LC}) where {N<:Real, LC<:LinearConstraint{N}}
-remove_redundant_constraints(::AbstractVector{LC}) where {N<:Real, LC<:LinearConstraint{N}}
-remove_redundant_constraints!(::AbstractVector{LC}) where {N<:Real, LC<:LinearConstraint{N}}
+remove_redundant_constraints(::AbstractVector{<:LinearConstraint{N}}) where {N<:Real}
+remove_redundant_constraints!(::AbstractVector{<:LinearConstraint{N}}) where {N<:Real}
 ```
 Inherited from [`LazySet`](@ref):
 * [`norm`](@ref norm(::LazySet, ::Real))
@@ -489,7 +489,7 @@ tovrep(::HPoly{N}) where {N<:Real}
 isempty(::HPoly{N}, ::Bool=false) where {N<:Real}
 translate(::PT, ::AbstractVector{N}) where {N<:Real, PT<:HPoly{N}}
 polyhedron(::HPoly{N}) where {N<:Real}
-remove_redundant_constraints(::PT) where {N<:Real, PT<:HPoly{N}}
+remove_redundant_constraints(::HPoly{N}) where {N<:Real}
 remove_redundant_constraints!(::HPoly{N}) where {N<:Real}
 ```
 

--- a/docs/src/lib/representations.md
+++ b/docs/src/lib/representations.md
@@ -190,8 +190,8 @@ translate(::HalfSpace{N}, ::AbstractVector{N}) where {N<:Real}
 halfspace_left(::AbstractVector{N}, ::AbstractVector{N}) where {N<:Real}
 halfspace_right(::AbstractVector{N}, ::AbstractVector{N}) where {N<:Real}
 tosimplehrep(::AbstractVector{LC}) where {N<:Real, LC<:LinearConstraint{N}}
-remove_redundant_constraints(::AbstractVector{<:LinearConstraint{N}}) where {N<:Real}
-remove_redundant_constraints!(::AbstractVector{<:LinearConstraint{N}}) where {N<:Real}
+remove_redundant_constraints
+remove_redundant_constraints!
 ```
 Inherited from [`LazySet`](@ref):
 * [`norm`](@ref norm(::LazySet, ::Real))

--- a/src/AbstractPolyhedron_functions.jl
+++ b/src/AbstractPolyhedron_functions.jl
@@ -109,9 +109,9 @@ function tosimplehrep(constraints::AbstractVector{LC}
 end
 
 """
-     remove_redundant_constraints!(constraints::AbstractVector{LC};
-         [backend]=default_lp_solver(N))::Bool where {N<:Real,
-                                                      LC<:LinearConstraint{N}}
+     remove_redundant_constraints!(
+         constraints::AbstractVector{<:LinearConstraint{N}};
+         [backend]=default_lp_solver(N))::Bool where {N<:Real}
 
 Remove the redundant constraints of a given list of linear constraints; the list
 is updated in-place.
@@ -149,10 +149,9 @@ If the calculation finished successfully, this function returns `true`.
 For details, see [Fukuda's Polyhedra
 FAQ](https://www.cs.mcgill.ca/~fukuda/soft/polyfaq/node24.html).
 """
-function remove_redundant_constraints!(constraints::AbstractVector{LC};
-                                       backend=default_lp_solver(N)
-                                      )::Bool where {N<:Real,
-                                                     LC<:LinearConstraint{N}}
+function remove_redundant_constraints!(
+        constraints::AbstractVector{<:LinearConstraint{N}};
+        backend=default_lp_solver(N))::Bool where {N<:Real}
 
     A, b = tosimplehrep(constraints)
     m, n = size(A)
@@ -188,8 +187,9 @@ function remove_redundant_constraints!(constraints::AbstractVector{LC};
 end
 
 """
-    remove_redundant_constraints(constraints::AbstractVector{LC};
-        backend=default_lp_solver(N)) where {N<:Real, LC<:LinearConstraint{N}}
+    remove_redundant_constraints(
+        constraints::AbstractVector{<:LinearConstraint{N}};
+        backend=default_lp_solver(N)) where {N<:Real}
 
 Remove the redundant constraints of a given list of linear constraints.
 
@@ -209,9 +209,9 @@ See
 [`remove_redundant_constraints!(::AbstractVector{<:LinearConstraint{<:Real}})`](@ref)
 for details.
 """
-function remove_redundant_constraints(constraints::AbstractVector{LC};
-                                      backend=default_lp_solver(N)
-                                     ) where {N<:Real, LC<:LinearConstraint{N}}
+function remove_redundant_constraints(
+        constraints::AbstractVector{<:LinearConstraint{N}};
+        backend=default_lp_solver(N)) where {N<:Real}
     constraints_copy = copy(constraints)
     if remove_redundant_constraints!(constraints_copy, backend=backend)
         return constraints_copy

--- a/src/AbstractPolyhedron_functions.jl
+++ b/src/AbstractPolyhedron_functions.jl
@@ -205,9 +205,8 @@ constraints are infeasible.
 
 ### Algorithm
 
-See
-[`remove_redundant_constraints!(::AbstractVector{<:LinearConstraint{<:Real}})`](@ref)
-for details.
+See `remove_redundant_constraints!(::AbstractVector{<:LinearConstraint})` for
+details.
 """
 function remove_redundant_constraints(
         constraints::AbstractVector{<:LinearConstraint{N}};

--- a/src/HPolyhedron.jl
+++ b/src/HPolyhedron.jl
@@ -378,9 +378,8 @@ infeasible.
 
 ### Algorithm
 
-See
-[`remove_redundant_constraints!(::AbstractVector{LinearConstraint{<:Real}})`](@ref)
-for details.
+See `remove_redundant_constraints!(::AbstractVector{<:LinearConstraint})` for
+details.
 """
 function remove_redundant_constraints(P::HPoly{N};
                                       backend=default_lp_solver(N)
@@ -414,9 +413,8 @@ which may happen if the constraints are infeasible.
 
 ### Algorithm
 
-See
-[`remove_redundant_constraints!(::AbstractVector{LinearConstraint{<:Real}})`](@ref)
-for details.
+See `remove_redundant_constraints!(::AbstractVector{<:LinearConstraint})` for
+details.
 """
 function remove_redundant_constraints!(P::HPoly{N};
                                        backend=default_lp_solver(N)

--- a/src/HPolyhedron.jl
+++ b/src/HPolyhedron.jl
@@ -358,10 +358,9 @@ function tohrep(P::HPoly{N}) where {N<:Real}
 end
 
 """
-    remove_redundant_constraints(P::PT;
+    remove_redundant_constraints(P::HPoly{N};
                                  backend=default_lp_solver(N)
-                                )::Union{PT, EmptySet{N}} where {N<:Real,
-                                                                 PT<:HPoly{N}}
+                                ) where {N<:Real}
 
 Remove the redundant constraints in a polyhedron in H-representation.
 
@@ -380,13 +379,12 @@ infeasible.
 ### Algorithm
 
 See
-[`remove_redundant_constraints!(::Vector{LinearConstraint{<:Real}})`](@ref)
+[`remove_redundant_constraints!(::AbstractVector{LinearConstraint{<:Real}})`](@ref)
 for details.
 """
-function remove_redundant_constraints(P::PT;
+function remove_redundant_constraints(P::HPoly{N};
                                       backend=default_lp_solver(N)
-                                     )::Union{PT, EmptySet{N}} where {N<:Real,
-                                                                      PT<:HPoly{N}}
+                                     ) where {N<:Real}
     Pred = copy(P)
     if remove_redundant_constraints!(Pred, backend=backend)
         return Pred
@@ -417,7 +415,7 @@ which may happen if the constraints are infeasible.
 ### Algorithm
 
 See
-[`remove_redundant_constraints!(::Vector{LinearConstraint{<:Real}})`](@ref)
+[`remove_redundant_constraints!(::AbstractVector{LinearConstraint{<:Real}})`](@ref)
 for details.
 """
 function remove_redundant_constraints!(P::HPoly{N};


### PR DESCRIPTION
Closes #1639 

@ueliwechsler: Can you try this version and report back, please? You need to `dev LazySets` and then go to `.julia/dev/LazySets/` and check out the branch `schillic/1639`.

EDIT: The build failure is unrelated - a new version of `JuMP` got released and now there is a problem (see #1642).