### PR TITLE
Remove axes function

### DIFF
--- a/src/concrete_convex_hull.jl
+++ b/src/concrete_convex_hull.jl
@@ -447,11 +447,13 @@ function monotone_chain!(points::Vector{VN}; sort::Bool=true
 
     # build lower hull
     lower = Vector{VN}()
-    build_hull!(lower, axes(points)[1], points)
+    iterator = 1:length(points)
+    build_hull!(lower, iterator, points)
 
     # build upper hull
     upper = Vector{VN}()
-    build_hull!(upper, reverse(axes(points)[1]), points)
+    iterator = length(points):-1:1
+    build_hull!(upper, iterator, points)
 
     # remove the last point of each segment because they are repeated
     copyto!(points, @view(lower[1:end-1]))


### PR DESCRIPTION
I found this easier to read (I had to look up the meaning of `axes`. (Side note: There is also a better method that also takes the dimension, so one need not access the first dimension of the result.)

As a small bonus, the new version uses fewer allocations.

```julia
julia> using LazySets, BenchmarkTools
julia> P = [rand(2) for i in 1:100]
julia> @btime convex_hull($P);

  9.753 μs (12 allocations: 2.03 KiB)  # this branch

  9.768 μs (13 allocations: 2.17 KiB)  # master
```
