### PR TITLE
Downgrade Distributions to v0.19.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -21,7 +21,7 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 [compat]
 julia = "≥ 1.0.0"
 CDDLib = "≥ 0.5.2"
-Distributions = "≥ 0.20.0"
+Distributions = "0.19.2"
 Documenter = "≥ 0.23.0"
 Expokit = "≥ 0.1.0"
 GLPK = "≥ 0.10.0"


### PR DESCRIPTION
There is an upstream change that brought incompatibility issues with `SpecialFunctions`. Downgrading `Distributions` is one valid solution.