### PR TITLE
#1672 - Overapproximation of ResetMap by CartesianProductArray

### DIFF
--- a/src/Approximations/overapproximate.jl
+++ b/src/Approximations/overapproximate.jl
@@ -1118,17 +1118,17 @@ function _overapproximate_lm_cpa!(arr, M, cpa, overapprox_option)
 end
 
 """
-    function overapproximate(rm::ResetMap{N, <:CartesianProductArray{N}},
-                             ::Type{<:CartesianProductArray}, oa) where {N}
+    overapproximate(rm::ResetMap{N, <:CartesianProductArray{N}},
+                    ::Type{<:CartesianProductArray}, oa) where {N}
 
 Overapproximate a reset map (that only resets to zero) of a Cartesian product
 by a new Cartesian product.
 
 ### Input
 
-- `rm` -- reset map
+- `rm`                    -- reset map
 - `CartesianProductArray` -- type for dispatch
-- `oa`  -- overapproximation option
+- `oa`                    -- overapproximation option
 
 ### Output
 
@@ -1164,9 +1164,9 @@ sets and a polyhedron.
 
 ### Input
 
-- `cap` -- lazy intersection of a Cartesian product array and a polyhedron
+- `cap`                   -- lazy intersection of a Cartesian product array and a polyhedron
 - `CartesianProductArray` -- type for dispatch
-- `oa`  -- overapproximation option
+- `oa`                    -- overapproximation option
 
 ### Output
 

--- a/src/Approximations/overapproximate.jl
+++ b/src/Approximations/overapproximate.jl
@@ -1118,6 +1118,42 @@ function _overapproximate_lm_cpa!(arr, M, cpa, overapprox_option)
 end
 
 """
+    function overapproximate(rm::ResetMap{N, <:CartesianProductArray{N}},
+                             ::Type{<:CartesianProductArray}, oa) where {N}
+
+Overapproximate a reset map (that only resets to zero) of a Cartesian product
+by a new Cartesian product.
+
+### Input
+
+- `rm` -- reset map
+- `CartesianProductArray` -- type for dispatch
+- `oa`  -- overapproximation option
+
+### Output
+
+A Cartesian product with the same block structure.
+
+### Notes
+
+This implementation currently only supports resets to zero.
+
+### Algorithm
+
+We convert the `ResetMap` into a `LinearMap` and then call the corresponding
+overapproximation method.
+"""
+function overapproximate(rm::ResetMap{N, <:CartesianProductArray{N}},
+                         ::Type{<:CartesianProductArray}, oa) where {N}
+    if any(!iszero, values(rm.resets))
+        error("we currently only support resets to zero")
+    end
+
+    lm = get_A(rm) * rm.X
+    return overapproximate(lm, CartesianProductArray, oa)
+end
+
+"""
     overapproximate(cap::Intersection{N,
                                       <:CartesianProductArray{N},
                                       <:AbstractPolyhedron{N}},
@@ -1128,9 +1164,9 @@ sets and a polyhedron.
 
 ### Input
 
- - `cap` -- Lazy intersection of Cartesian product array and polyhedron
- - `CartesianProductArray` -- type for dispatch
- - `oa`  -- overapproximation option
+- `cap` -- lazy intersection of a Cartesian product array and a polyhedron
+- `CartesianProductArray` -- type for dispatch
+- `oa`  -- overapproximation option
 
 ### Output
 

--- a/test/unit_overapproximate.jl
+++ b/test/unit_overapproximate.jl
@@ -223,6 +223,15 @@ for N in [Float64, Float32]
     Y_zonotope_2 = overapproximate(Y, Zonotope; algorithm="join")
     @test Y_polygon ⊆ Y_zonotope_1
     @test Y_polygon ⊆ Y_zonotope_2
+
+    # ResetMap and CPA
+    X = CartesianProductArray([Ball1(N[0, 0], N(1)), Ball1(N[0, 0], N(2)),
+                               Ball1(N[0, 0], N(3))])
+    resets = Dict(3 => N(0), 6 => N(0))
+    rm = ResetMap(X, resets)
+    Y = overapproximate(rm, CartesianProductArray, Hyperrectangle)
+    @test array(Y) == [Hyperrectangle(N[0, 0], N[1, 1]),
+        Hyperrectangle(N[0, 0], N[0, 2]), Hyperrectangle(N[0, 0], N[3, 0])]
 end
 
 for N in [Float64]


### PR DESCRIPTION
Closes #1672.

This is a quick implementation. In general it would be preferable to have an implementation for #1113.