### PR TITLE
Move method

### DIFF
--- a/src/Interfaces/AbstractPolyhedron_functions.jl
+++ b/src/Interfaces/AbstractPolyhedron_functions.jl
@@ -16,6 +16,12 @@ function default_lp_solver(N::Type{<:Rational})
     GLPKSolverLP(method=:Exact)
 end
 
+# fallback method
+function default_polyhedra_backend(P, N)
+    require(:Polyhedra; fun_name="default_polyhedra_backend")
+    error("no default backend for numeric type $N")
+end
+
 """
     ∈(x::AbstractVector{N}, P::AbstractPolyhedron{N})::Bool where {N<:Real}
 

--- a/src/Interfaces/AbstractPolytope.jl
+++ b/src/Interfaces/AbstractPolytope.jl
@@ -96,11 +96,6 @@ function isempty(P::AbstractPolytope)::Bool
     return isempty(vertices_list(P))
 end
 
-function default_polyhedra_backend(P, N)
-    require(:Polyhedra; fun_name="default_polyhedra_backend")
-    error("no default backend for numeric type $N")
-end
-
 # given a polytope P, apply the linear map P to each vertex of P
 # it is assumed that the interface function `vertices_list(P)` is available 
 @inline function _linear_map_vrep(M::AbstractMatrix{N}, P::AbstractPolytope{N}) where {N<:Real}


### PR DESCRIPTION
I think the method fits better in `AbstractPolyhedron_functions.jl` because we also use `Polyhedra` for polyhedra and we also define the default LP solvers there.