### PR TITLE
#1105 - An element for HPolytope is not type stable

### DIFF
--- a/docs/src/lib/interfaces.md
+++ b/docs/src/lib/interfaces.md
@@ -144,6 +144,7 @@ This interface defines the following functions:
 isbounded(::AbstractPolytope)
 singleton_list(::AbstractPolytope{N}) where {N<:Real}
 isempty(::AbstractPolytope)
+chebyshev_center(::AbstractPolytope{N}) where {N<:Real}
 ```
 
 #### Polygon

--- a/docs/src/lib/representations.md
+++ b/docs/src/lib/representations.md
@@ -500,6 +500,7 @@ tohrep(::HPoly{N}) where {N<:Real}
 tovrep(::HPoly{N}) where {N<:Real}
 isempty(::HPoly{N}, ::Bool=false) where {N<:Real}
 translate(::PT, ::AbstractVector{N}) where {N<:Real, PT<:HPoly{N}}
+an_element(::HPolytope{N}) where {N<:Rational{Int}}
 polyhedron(::HPoly{N}) where {N<:Real}
 remove_redundant_constraints(::HPoly{N}) where {N<:Real}
 remove_redundant_constraints!(::HPoly{N}) where {N<:Real}

--- a/docs/src/lib/representations.md
+++ b/docs/src/lib/representations.md
@@ -500,7 +500,7 @@ tohrep(::HPoly{N}) where {N<:Real}
 tovrep(::HPoly{N}) where {N<:Real}
 isempty(::HPoly{N}, ::Bool=false) where {N<:Real}
 translate(::PT, ::AbstractVector{N}) where {N<:Real, PT<:HPoly{N}}
-an_element(::HPolytope{N}) where {N<:Rational{Int}}
+an_element(::HPolytope{N}) where {N<:Union{Float32, Rational{Int}}}
 polyhedron(::HPoly{N}) where {N<:Real}
 remove_redundant_constraints(::HPoly{N}) where {N<:Real}
 remove_redundant_constraints!(::HPoly{N}) where {N<:Real}

--- a/docs/src/lib/representations.md
+++ b/docs/src/lib/representations.md
@@ -23,6 +23,7 @@ center(::Ball2{N}) where {N<:AbstractFloat}
 rand(::Type{Ball2})
 sample(::Ball2{N}, ::Int) where {N<:AbstractFloat}
 translate(::Ball2{N}, ::AbstractVector{N}) where {N<:AbstractFloat}
+chebyshev_center(::Ball2{N}) where {N<:AbstractFloat}
 ```
 Inherited from [`LazySet`](@ref):
 * [`norm`](@ref norm(::LazySet, ::Real))

--- a/src/Sets/Ball2.jl
+++ b/src/Sets/Ball2.jl
@@ -275,3 +275,40 @@ function sample(B::Ball2{N}, nsamples::Int=1;
     end
     return D
 end
+
+
+# --- Ball2 functions ---
+
+
+"""
+    chebyshev_center(B::Ball2{N}; compute_radius::Bool=false
+                    ) where {N<:AbstractFloat}
+
+Compute the [Chebyshev center](https://en.wikipedia.org/wiki/Chebyshev_center)
+of a ball in the 2-norm.
+
+### Input
+
+- `B`              -- ball in the 2-norm
+- `compute_radius` -- (optional; default: `false`) option to additionally return
+                      the radius of the largest ball enclosed by `B` around the
+                      Chebyshev center
+
+### Output
+
+If `compute_radius` is `false`, the result is the Chebyshev center of `B`.
+If `compute_radius` is `true`, the result is the pair `(c, r)` where `c` is the
+Chebyshev center of `B` and `r` is the radius of the largest ball with center
+`c` enclosed by `B`.
+
+### Notes
+
+The Chebyshev center of a ball in the 2-norm is just the center of the ball.
+"""
+function chebyshev_center(B::Ball2{N}; compute_radius::Bool=false
+                         ) where {N<:AbstractFloat}
+    if compute_radius
+        return center(B), B.radius
+    end
+    return center(B)
+end

--- a/src/Sets/HPolytope.jl
+++ b/src/Sets/HPolytope.jl
@@ -134,6 +134,58 @@ function _linear_map_hrep(M::AbstractMatrix{N}, P::HPolytope{N},
     return HPolytope(constraints)
 end
 
+"""
+    an_element(P::HPolytope{N}; [backend]=nothing) where {N<:Rational{Int}}
+
+Return some element of a rational polytope in constraint representation.
+
+### Input
+
+- `P`       -- polytope in constraint representation
+- `backend` -- (optional, default: `nothing`) backend for polyhedral
+               computations (used for computing the Chebyshev center)
+
+### Output
+
+An element of the polytope.
+
+### Notes
+
+The default implementation of `an_element` uses an LP solver based on
+floating-point numbers.
+Hence the result is not a `Rational`.
+
+We first convert the result to `Rational` and then check membership.
+If that check fails, we compute the Chebyshev center and repeat the conversion
+and membership check.
+If that check fails as well, we give up.
+"""
+function an_element(P::HPolytope{N};
+                    backend=nothing
+                   ) where {N<:Rational{Int}}
+    # try the floating-point method
+    # Note: `invoke(an_element, Tuple{HPolytope}, P)` does not work
+    p = invoke(an_element, Tuple{HPolytope}, P)
+    p_rat = convert(Vector{N}, p)
+    if p_rat ∈ P
+        return p_rat
+    end
+
+    # try the Chebyshev center
+    if backend == nothing
+        p = chebyshev_center(P)
+    else
+        p = chebyshev_center(P; backend=backend)
+    end
+    p_rat = convert(Vector{N}, p)
+    if p_rat ∈ P
+        return p_rat
+    end
+
+    # give up
+    error("could not produce an element for the given input")
+end
+
 
 # --- functions that use Polyhedra.jl ---
 

--- a/src/Sets/HPolytope.jl
+++ b/src/Sets/HPolytope.jl
@@ -135,9 +135,10 @@ function _linear_map_hrep(M::AbstractMatrix{N}, P::HPolytope{N},
 end
 
 """
-    an_element(P::HPolytope{N}; [backend]=nothing) where {N<:Rational{Int}}
+    an_element(P::HPolytope{N}; [backend]=nothing)
+        where {N<:Union{Float32, Rational{Int}}}
 
-Return some element of a rational polytope in constraint representation.
+Return some element of a polytope in constraint representation.
 
 ### Input
 
@@ -151,24 +152,23 @@ An element of the polytope.
 
 ### Notes
 
-The default implementation of `an_element` uses an LP solver based on
-floating-point numbers.
-Hence the result is not a `Rational`.
+The default implementation of `an_element` uses an LP solver based on `Float64`
+numbers.
 
-We first convert the result to `Rational` and then check membership.
+We first convert the result to `N` and then check membership.
 If that check fails, we compute the Chebyshev center and repeat the conversion
 and membership check.
 If that check fails as well, we give up.
 """
 function an_element(P::HPolytope{N};
                     backend=nothing
-                   ) where {N<:Rational{Int}}
+                   ) where {N<:Union{Float32, Rational{Int}}}
     # try the floating-point method
     # Note: `invoke(an_element, Tuple{HPolytope}, P)` does not work
     p = invoke(an_element, Tuple{HPolytope}, P)
-    p_rat = convert(Vector{N}, p)
-    if p_rat ∈ P
-        return p_rat
+    p_converted = convert(Vector{N}, p)
+    if p_converted ∈ P
+        return p_converted
     end
 
     # try the Chebyshev center
@@ -177,9 +177,9 @@ function an_element(P::HPolytope{N};
     else
         p = chebyshev_center(P; backend=backend)
     end
-    p_rat = convert(Vector{N}, p)
-    if p_rat ∈ P
-        return p_rat
+    p_converted = convert(Vector{N}, p)
+    if p_converted ∈ P
+        return p_converted
     end
 
     # give up

--- a/test/unit_Ball2.jl
+++ b/test/unit_Ball2.jl
@@ -111,4 +111,7 @@ for N in [Float64, Float32]
     B = Ball2(N[1, 2, 3], N(0.5))
     s = sample(B, 100) # get 100 random elements in B
     @test all(si -> si ∈ B, s)
+
+    # Chebyshev center
+    @test chebyshev_center(B) == center(B)
 end

--- a/test/unit_Polytope.jl
+++ b/test/unit_Polytope.jl
@@ -131,9 +131,8 @@ for N in [Float64, Rational{Int}, Float32]
     L1 = linear_map(M, P, use_inv=true)  # calculates inv(M) explicitly
     L2 = linear_map(M, P, use_inv=false) # uses transpose(M) \ c.a for each constraint c of P
     L3 = linear_map(M, P, cond_tol=1e3)  # set a custom tolerance for the condition number (invertibility check)
-    # needs M * an_element(Li) to be stable for rational, see #1105
-    p = convert(Vector{N}, an_element(P))
-    @assert p ∈ P
+    p = an_element(P)
+    @test p ∈ P
     @test all([M * p ∈ Li for Li in [L1, L2, L3]])
 
     # do not check for invertibility => use the vertices

--- a/test/unit_Polytope.jl
+++ b/test/unit_Polytope.jl
@@ -394,5 +394,15 @@ if test_suite_polyhedra
                             [N[1, 1], N[0, 1], N[1, 0], N[0, 0]])
         @test ispermutation([round.(v) for v in vertices_list(cap1)],
                             [round.(v) for v in vertices_list(cap2)])
+
+        # Chebyshev center
+        H = Hyperrectangle(N[0, 0], N[1, 2])
+        @test_throws AssertionError chebyshev_center(H)
+        P1 = convert(HPolytope, H)
+        P2 = convert(VPolytope, H)
+        c1 = chebyshev_center(P1)
+        c2, r = chebyshev_center(P1; compute_radius=true)
+        @test_throws ErrorException chebyshev_center(P2)  # not implemented in Polyhedra
+        @test c1 == c2 == center(H) && c1 isa AbstractVector{N}
     end
 end


### PR DESCRIPTION
Closes #1105.

This is a reimplementation of #1108 based on #1696 (only the last two commits are new).
Note that the same problem also occurs with `Float32`, so I also added a handling for that. It is not very nice that we need to enumerate these cases...