### PR TITLE
#1727 - Use faster disambiguation in isdisjoint(::CPA, ::HalfSpace)

### DIFF
--- a/src/ConcreteOperations/isdisjoint.jl
+++ b/src/ConcreteOperations/isdisjoint.jl
@@ -1386,9 +1386,7 @@ end
 # disambiguation
 function is_intersection_empty(cpa::CartesianProductArray{N},
                                hs::HalfSpace{N}) where {N<:Real}
-    return invoke(is_intersection_empty,
-                  Tuple{CartesianProductArray{N}, AbstractPolyhedron{N}},
-                  cpa, hs)
+    return is_intersection_empty_helper_halfspace(hs, cpa)
 end
 function is_intersection_empty(hs::HalfSpace{N},
                                cpa::CartesianProductArray{N}) where {N<:Real}


### PR DESCRIPTION
Closes #1727.

Platooning benchmark:

`master`:
          ("PLAD01_BND42", "discrete") => TrialEstimate(282.038 ms)
          ("PLAN01_UNB50", "discrete") => TrialEstimate(7.917 s)
          ("PLAD01_BND42", "dense") => TrialEstimate(860.151 ms)
          ("PLAN01_UNB50", "dense") => TrialEstimate(11.131 s)

this branch:
          ("PLAD01_BND42", "discrete") => TrialEstimate(204.435 ms)
          ("PLAN01_UNB50", "discrete") => TrialEstimate(7.312 s)
          ("PLAD01_BND42", "dense") => TrialEstimate(699.705 ms)
          ("PLAN01_UNB50", "dense") => TrialEstimate(10.025 s)

(Note that the performance is not as good as before the commit mentioned in #1727 because there is another regression.)