### PR TITLE
#1699 - Add benchmark mode

### DIFF
--- a/src/Approximations/Approximations.jl
+++ b/src/Approximations/Approximations.jl
@@ -8,6 +8,9 @@ module Approximations
 
 using LazySets, LazySets.Arrays, Requires, LinearAlgebra, SparseArrays
 using LazySets: _rtol
+using ..Assertions: @assert, activate_assertions
+# activate assertions by default
+activate_assertions(Approximations)
 
 export approximate,
        project,

--- a/src/Arrays/Arrays.jl
+++ b/src/Arrays/Arrays.jl
@@ -6,6 +6,9 @@ Module `Arrays.jl` -- Auxiliary machinery for vectors and matrices.
 module Arrays
 
 using LinearAlgebra, SparseArrays
+using ..Assertions: @assert, activate_assertions
+# activate assertions by default
+activate_assertions(Arrays)
 
 include("matrix_operations.jl")
 include("vector_operations.jl")

--- a/src/Assertions/Assertions.jl
+++ b/src/Assertions/Assertions.jl
@@ -1,27 +1,28 @@
+module Assertions
+
 export activate_assertions,
        deactivate_assertions,
        are_assertions_enabled
 
 # source: https://discourse.julialang.org/t/defensive-programming-assert/8383/11
 
-# enable assertions by default
-are_assertions_enabled() = true
-
 # functions to (de)activate assertions
-function activate_assertions()
-    LazySets.eval(:(are_assertions_enabled() = true))
+function activate_assertions(m::Module)
+    m.eval(:(are_assertions_enabled() = true))
     nothing
 end
-function deactivate_assertions()
-    LazySets.eval(:(are_assertions_enabled() = false))
+function deactivate_assertions(m::Module)
+    m.eval(:(are_assertions_enabled() = false))
     nothing
 end
 
 # override Base.@assert
 macro assert(exs...)
     quote
-        if $LazySets.are_assertions_enabled()
+        if $__module__.are_assertions_enabled()
             Base.@assert $(map(esc, exs)...)
         end
     end
 end
+
+end  # module

--- a/src/LazySets.jl
+++ b/src/LazySets.jl
@@ -14,6 +14,12 @@ import InteractiveUtils: subtypes
 export Arrays
 export ×
 
+# ==========
+# Assertions
+# ==========
+
+include("Utils/assertions.jl")
+
 # =======================
 # Arrays auxiliary module
 # =======================

--- a/src/LazySets.jl
+++ b/src/LazySets.jl
@@ -18,7 +18,12 @@ export ×
 # Assertions
 # ==========
 
-include("Utils/assertions.jl")
+include("Assertions/Assertions.jl")
+@reexport using .Assertions
+using .Assertions: @assert
+import .Assertions: activate_assertions, deactivate_assertions
+# activate assertions by default
+activate_assertions(LazySets)
 
 # =======================
 # Arrays auxiliary module
@@ -143,5 +148,19 @@ include("Parallel/Parallel.jl")
 # Load external packages on-demand (using 'Requires')
 # ===================================================
 include("init.jl")
+
+# ================================================
+# Convenience functions to (de)activate assertions
+# ================================================
+function activate_assertions()
+    for m in [LazySets, Arrays, Approximations, Parallel]
+        Assertions.activate_assertions(m)
+    end
+end
+function deactivate_assertions()
+    for m in [LazySets, Arrays, Approximations, Parallel]
+        Assertions.deactivate_assertions(m)
+    end
+end
 
 end # module

--- a/src/Parallel/Parallel.jl
+++ b/src/Parallel/Parallel.jl
@@ -6,6 +6,10 @@ Module `Parallel.jl` -- LazySets algorithms that are parallelized.
 module Parallel
 
 using LazySets
+using ..Assertions: @assert, activate_assertions
+# activate assertions by default
+activate_assertions(Parallel)
+
 using SharedArrays: SharedMatrix, SharedVector, indexpids
 using Distributed: remotecall_wait, procs
 

--- a/src/Utils/assertions.jl
+++ b/src/Utils/assertions.jl
@@ -1,25 +1,26 @@
-export activate_benchmark_mode,
-       deactivate_benchmark_mode
+export activate_assertions,
+       deactivate_assertions,
+       are_assertions_enabled
 
 # source: https://discourse.julialang.org/t/defensive-programming-assert/8383/11
 
-# functions to (de)activate assertions
-function activate_benchmark_mode()
-    LazySets.eval(:(_debug_disabled() = true))
-    nothing
-end
-function deactivate_benchmark_mode()
-    LazySets.eval(:(_debug_disabled() = false))
-    nothing
-end
-
 # enable assertions by default
-deactivate_benchmark_mode()
+are_assertions_enabled() = true
+
+# functions to (de)activate assertions
+function activate_assertions()
+    LazySets.eval(:(are_assertions_enabled() = true))
+    nothing
+end
+function deactivate_assertions()
+    LazySets.eval(:(are_assertions_enabled() = false))
+    nothing
+end
 
 # override Base.@assert
 macro assert(exs...)
     quote
-        if !$LazySets._debug_disabled()
+        if $LazySets.are_assertions_enabled()
             Base.@assert $(map(esc, exs)...)
         end
     end

--- a/src/Utils/assertions.jl
+++ b/src/Utils/assertions.jl
@@ -1,0 +1,26 @@
+export activate_benchmark_mode,
+       deactivate_benchmark_mode
+
+# source: https://discourse.julialang.org/t/defensive-programming-assert/8383/11
+
+# functions to (de)activate assertions
+function activate_benchmark_mode()
+    LazySets.eval(:(_debug_disabled() = true))
+    nothing
+end
+function deactivate_benchmark_mode()
+    LazySets.eval(:(_debug_disabled() = false))
+    nothing
+end
+
+# enable assertions by default
+deactivate_benchmark_mode()
+
+# override Base.@assert
+macro assert(exs...)
+    quote
+        if !$LazySets._debug_disabled()
+            Base.@assert $(map(esc, exs)...)
+        end
+    end
+end


### PR DESCRIPTION
First part of #1699.

```julia
julia> using LazySets

julia> @time Hyperplane(ones(2), 1.)  # warm-up
  0.036591 seconds (47.90 k allocations: 2.362 MiB, 15.39% gc time)
Hyperplane{Float64}([1.0, 1.0], 1.0)

julia> @time Hyperplane(ones(2), 1.)  # normal runtime
  0.000013 seconds (6 allocations: 288 bytes)
Hyperplane{Float64}([1.0, 1.0], 1.0)

julia> @time Hyperplane(zeros(2), 1.)  # illegal argument, triggers assertion
ERROR: AssertionError: a hyperplane needs a non-zero normal vector
Stacktrace:
 [1] macro expansion at .julia/dev/LazySets/src/Utils/assertions.jl:22 [inlined]
 [2] Hyperplane{Float64}(::Array{Float64,1}, ::Float64) at .julia/dev/LazySets/src/Sets/Hyperplane.jl:32
 [3] Hyperplane(::Array{Float64,1}, ::Float64) at .julia/dev/LazySets/src/Sets/Hyperplane.jl:38
 [4] top-level scope at util.jl:156

julia> deactivate_assertions()

julia> @time Hyperplane(zeros(2), 1.)  # warm-up
  0.012239 seconds (4.71 k allocations: 277.524 KiB)
Hyperplane{Float64}([0.0, 0.0], 1.0)

julia> @time Hyperplane(zeros(2), 1.)  # illegal argument, but assertions are ignored
  0.000007 seconds (6 allocations: 288 bytes)
Hyperplane{Float64}([0.0, 0.0], 1.0)

julia> activate_assertions()

julia> @time Hyperplane(zeros(2), 1.)  # illegal argument, assertions are active again
ERROR: AssertionError: a hyperplane needs a non-zero normal vector
Stacktrace:
 [1] macro expansion at .julia/dev/LazySets/src/Utils/assertions.jl:22 [inlined]
 [2] Hyperplane{Float64}(::Array{Float64,1}, ::Float64) at .julia/dev/LazySets/src/Sets/Hyperplane.jl:32
 [3] Hyperplane(::Array{Float64,1}, ::Float64) at .julia/dev/LazySets/src/Sets/Hyperplane.jl:38
 [4] top-level scope at util.jl:156
```

I also checked that deactivating the assertions really avoids evaluating the code inside `@assert` completely.

This implements [the proposal here](https://discourse.julialang.org/t/defensive-programming-assert/8383/11), which is however more general because now this feature only works for `LazySets` and not for its submodules or other packages like `Reachability`. Enumerating all submodules of `LazySets` would not be a problem but I do not know whether we always want to copy-paste this code to all packages. Maybe we should create a helper package?