### PR TITLE
#1729 - Faster support function/vector of CartesianProductArray and sparse direction

### DIFF
--- a/test/unit_CartesianProduct.jl
+++ b/test/unit_CartesianProduct.jl
@@ -181,6 +181,14 @@ for N in [Float64, Float32, Rational{Int}]
     # array getter
     @test array(cpa) ≡ v
 
+    # support function & support vector
+    svec = N[1, 2, 3, 4]
+    for dd in [N[1, 1, 0, 0], N[0, 0, 1, 1], N[0, 1, 0, 1], N[0, 0, 1, 0], N[0, 0, 0, 0]]
+        ds = sparse(dd)
+        @test σ(dd, cpa) == σ(ds, cpa) == svec
+        @test ρ(dd, cpa) == ρ(ds, cpa) == dot(svec, dd)
+    end
+
     # boundedness
     @test isbounded(cpa)
     @test !isbounded(CartesianProductArray([Singleton(N[1]), HalfSpace(N[1], N(1))]))


### PR DESCRIPTION
Closes #1729.

```julia
N = Float64
n = 100
cpa = CartesianProductArray([BallInf(zeros(N, 1), N(1)) for _ in 1:n])
dd = zeros(N, n); dd[1] = N(1); dd[3] = N(1)
ds = sparsevec([1, 3], N[1, 1], n)

@btime ρ(dd, cpa)
  4.046 μs (101 allocations: 9.39 KiB)

@btime ρ(ds, cpa)  # master
  8.558 μs (301 allocations: 18.83 KiB)

@btime ρ(ds, cpa)  # this branch
  296.284 ns (9 allocations: 656 bytes)
```

Notice that the old implementation was even considerably slower for sparse vectors than for dense vectors due to many allocations of new small sparse vectors.