### PR TITLE
#1753 - Concrete intersection of CPA and polyhedron without constraints

### DIFF
--- a/src/ConcreteOperations/intersection.jl
+++ b/src/ConcreteOperations/intersection.jl
@@ -886,6 +886,9 @@ function intersection(cpa::CartesianProductArray{N}, P::AbstractPolyhedron{N}
     # "unconstrained | constrained | unconstrained" (the first and third section
     # may be empty)
     constrained_dims = constrained_dimensions(P)
+    if isempty(constrained_dims)
+        return cpa
+    end
     minimal = minimum(constrained_dims)
     maximal = maximum(constrained_dims)
     lower_bound = 1

--- a/test/unit_CartesianProduct.jl
+++ b/test/unit_CartesianProduct.jl
@@ -258,6 +258,8 @@ for N in [Float64, Float32, Rational{Int}]
     Q = array(cap)[2]
     @test ispermutation(constraints_list(Q), [HalfSpace(N[-1, 0], N(-1)),
         HalfSpace(N[0, -1], N(-2)), HalfSpace(N[1, 1], N(3))])
+    # all dimensions are unconstrained
+    @test intersection(cpa, HPolyhedron{N}()) == cpa
 
     # linear_map
     cpa = CartesianProductArray([Interval(N(0), N(1)), Interval(N(2), N(3))])


### PR DESCRIPTION
Closes #1753.

Requires: ~~https://github.com/JuliaReach/LazySets.jl/pull/1752~~