### PR TITLE
#622 - Bloating set operation

### DIFF
--- a/docs/src/lib/operations.md
+++ b/docs/src/lib/operations.md
@@ -12,6 +12,18 @@ Depth = 3
 CurrentModule = LazySets
 ```
 
+## Bloating
+
+```@docs
+Bloating
+dim(::Bloating)
+σ(::AbstractVector{N}, ::Bloating{N}) where {N<:AbstractFloat}
+ρ(::AbstractVector{N}, ::Bloating{N}) where {N<:AbstractFloat}
+isbounded(::Bloating)
+isempty(::Bloating)
+an_element(::Bloating)
+```
+
 ## Cartesian Product
 
 ### Binary Cartesian Product

--- a/src/Interfaces/LazySet.jl
+++ b/src/Interfaces/LazySet.jl
@@ -43,10 +43,11 @@ The subtypes of `LazySet` (including abstract interfaces):
 
 ```jldoctest; setup = :(using LazySets: subtypes)
 julia> subtypes(LazySet, false)
-18-element Array{Any,1}:
+19-element Array{Any,1}:
  AbstractCentrallySymmetric
  AbstractPolyhedron
  AffineMap
+ Bloating
  CacheMinkowskiSum
  CartesianProduct
  CartesianProductArray
@@ -70,7 +71,7 @@ If we only consider *concrete* subtypes, then:
 julia> concrete_subtypes = subtypes(LazySet, true);
 
 julia> length(concrete_subtypes)
-38
+39
 
 julia> println.(concrete_subtypes);
 AffineMap
@@ -78,6 +79,7 @@ Ball1
 Ball2
 BallInf
 Ballp
+Bloating
 CacheMinkowskiSum
 CartesianProduct
 CartesianProductArray

--- a/src/LazyOperations/Bloating.jl
+++ b/src/LazyOperations/Bloating.jl
@@ -1,0 +1,151 @@
+export Bloating
+
+"""
+    Bloating{N<:AbstractFloat, S<:LazySet{N}} <:LazySet{N}
+
+Type that represents a uniform expansion of a convex set in a given norm (also
+known as *bloating*).
+
+### Fields
+
+- `X` -- convex set
+- `ε` -- (positive) bloating factor
+- `p` -- ``p``-norm (``≥ 1``; default: ``2``)
+
+### Notes
+
+`Bloating(X, ε, p)` is equivalent to the Minkowski sum of `X` and a ball in the
+`p`-norm of radius `ε` centered in the origin `O` (i.e., `X ⊕ Ballp(p, O, ε)`).
+"""
+struct Bloating{N<:AbstractFloat, S<:LazySet{N}} <:LazySet{N}
+    X::S
+    ε::N
+    p::N
+
+    function Bloating(X::S, ε::N, p::N=N(2)) where {N<:AbstractFloat,
+                                                    S<:LazySet{N}}
+        @assert ε > zero(N) "bloating requires a distance > 0, but $ε was given"
+        @assert p >= one(N) "bloating requires a norm >= 1, but $p was given"
+
+        return new{N, S}(X, ε, p)
+    end
+end
+
+isoperationtype(::Type{<:Bloating}) = true
+
+"""
+    dim(B::Bloating)
+
+Return the dimension of a bloated convex set.
+
+### Input
+
+- `B` -- bloated convex set
+
+### Output
+
+The ambient dimension of the bloated set.
+"""
+function dim(B::Bloating)
+    return dim(B.X)
+end
+
+# helper function to compute the bloating ball
+function _bloating_ball(B::Bloating{N}) where {N<:AbstractFloat}
+    return Ballp(B.p, zeros(N, dim(B)), B.ε)
+end
+
+"""
+    σ(d::AbstractVector{N}, B::Bloating{N}) where {N<:AbstractFloat}
+
+Return the support vector of a bloated convex set in a given direction.
+
+### Input
+
+- `d` -- direction
+- `B` -- bloated convex set
+
+### Output
+
+The support vector of the bloated set in the given direction.
+"""
+function σ(d::AbstractVector{N}, B::Bloating{N}) where {N<:AbstractFloat}
+    @assert !iszero(d) "the support vector of the zero direction is undefined"
+
+    return σ(d, B.X) + σ(d, _bloating_ball(B))
+end
+
+"""
+    ρ(d::AbstractVector{N}, B::Bloating{N}) where {N<:AbstractFloat}
+
+Return the support function of a bloated convex set in a given direction.
+
+### Input
+
+- `d` -- direction
+- `B` -- bloated convex set
+
+### Output
+
+The support function of the bloated set in the given direction.
+"""
+function ρ(d::AbstractVector{N}, B::Bloating{N}) where {N<:AbstractFloat}
+    @assert !iszero(d) "the support function of the zero direction is undefined"
+
+    return ρ(d, B.X) + ρ(d, _bloating_ball(B))
+end
+
+"""
+    isbounded(B::Bloating)
+
+Determine whether a bloated convex set is bounded.
+
+### Input
+
+- `B` -- bloated convex set
+
+### Output
+
+`true` iff the wrapped set is bounded.
+"""
+function isbounded(B::Bloating)
+    return isbounded(B.X)
+end
+
+"""
+    isempty(B::Bloating)
+
+Determine whether a bloated convex set is empty.
+
+### Input
+
+- `B` -- bloated convex set
+
+### Output
+
+`true` iff the wrapped set is empty.
+"""
+function isempty(B::Bloating)
+    return isempty(B.X)
+end
+
+"""
+    an_element(B::Bloating)
+
+Return some element of a bloated convex set.
+
+### Input
+
+- `B` -- bloated convex set
+
+### Output
+
+An element in the bloated convex set.
+
+### Algorithm
+
+The implementation returns the result of `an_element` for the wrapped set.
+"""
+function an_element(B::Bloating)
+    return an_element(B.X)
+end

--- a/src/LazySets.jl
+++ b/src/LazySets.jl
@@ -88,6 +88,7 @@ include("Sets/PolynomialZonotope.jl")
 # =================================
 # Types representing set operations
 # =================================
+include("LazyOperations/Bloating.jl")
 include("LazyOperations/CartesianProduct.jl")
 include("LazyOperations/Complement.jl")
 include("LazyOperations/ConvexHull.jl")

--- a/src/Utils/helper_functions.jl
+++ b/src/Utils/helper_functions.jl
@@ -327,9 +327,10 @@ julia> N = Rational{Int};  # restriction of the number type
 julia> dict = implementing_sets(σ; signature=Type[AbstractVector{N}], index=2, type_args=N);
 
 julia> dict["missing"]  # some set types are not available with number type N
-3-element Array{Type,1}:
+4-element Array{Type,1}:
  Ball2
  Ballp
+ Bloating
  Ellipsoid
 
 julia> dict = LazySets.implementing_sets(convex_hull; binary=true);  # binary case

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -96,6 +96,7 @@ if test_suite_basic
     # =========================================
     # Testing types representing set operations
     # =========================================
+    @time @testset "LazySets.Bloating" begin include("unit_Bloating.jl") end
     @time @testset "LazySets.Intersection" begin include("unit_Intersection.jl") end
     @time @testset "LazySets.ConvexHull" begin include("unit_ConvexHull.jl") end
     @time @testset "LazySets.ExponentialMap" begin include("unit_ExponentialMap.jl") end

--- a/test/unit_Bloating.jl
+++ b/test/unit_Bloating.jl
@@ -1,0 +1,50 @@
+for N in [Float64, Float32]
+    B = BallInf(zeros(N, 2), N(1))
+    E = HPolyhedron([HalfSpace(N[1], N(0)), HalfSpace(N[-1], N(-1))])  # empty
+    U = Universe{N}(3)
+    ε = N(1//10)
+    p = N(2)
+
+    # constructors
+    X = Bloating(B, ε, p)
+    Y = Bloating(E, ε, p)
+    Z = Bloating(U, ε, p)
+    @test_throws AssertionError Bloating(B, N(0), p)
+    @test_throws AssertionError Bloating(B, ε, N(9//10))
+
+    # dimension
+    @test dim(X) == 2 && dim(Y) == 1 && dim(Z) == 3
+
+    # isbounded
+    @test isbounded(X) && !isbounded(Z)
+    # @test isbounded(Y)  # currently crashes (see #1779)
+
+    # isempty
+    @test !isempty(X) && isempty(Y) && !isempty(Z)
+
+    # an_element
+    v = an_element(X)
+    @test v isa AbstractVector{N} && length(v) == 2
+    @test_throws ErrorException an_element(Y)
+    v = an_element(Z)
+    @test v isa AbstractVector{N} && length(v) == 3
+
+    # tests for different norms
+    for p in N[1, 2, Inf]
+        B = BallInf(zeros(N, 2), N(1))
+        X = Bloating(B, ε, p)
+        E = HPolyhedron([HalfSpace(N[1], N(0)), HalfSpace(N[-1], N(-1))])
+        Y = Bloating(E, ε, p)  # empty set
+        Bp = Ballp(p, zeros(N, 2), ε)
+
+        # support vector and support function
+        d = N[1, 0]
+        @test σ(d, X) == σ(d, B + Bp)
+        @test ρ(d, X) == ρ(d, B + Bp) == N(1 + ε)
+        @test_throws ErrorException σ(N[1], Y)
+        @test_throws ErrorException ρ(N[1], Y)
+        d = N[1, 99//100]
+        @test σ(d, X) == σ(d, B + Bp)
+        @test ρ(d, X) == ρ(d, B + Bp)
+    end
+end


### PR DESCRIPTION
Closes #622.

```julia
using LazySets, Plots
pl = plot()
for (i, p) in [(1., 2.), (4., 1.), (7., Inf)]
    B = BallInf([i, 0.], 1.);
    X = Bloating(B, 0.1, p);
    plot!(pl, B)
    plot!(pl, X)
end
plot!(; ratio=1)
```
![bloating](https://user-images.githubusercontent.com/9656686/67038090-0ca60d80-f11f-11e9-9019-20283e80f982.png)