### PR TITLE
Fix polyhedra tests

### DIFF
--- a/test/unit_BallInf.jl
+++ b/test/unit_BallInf.jl
@@ -111,12 +111,12 @@ for N in [Float64, Rational{Int}, Float32]
                         [N[4, 1], N[0, 1], N[-2, -3], N[2, -3]])
 end
 
-# tests that only work with Float64 and Rational{Int}
-for N in [Float64, Rational{Int}]
+# tests that only work with Float64
+for N in [Float64]
     # concrete Minkowski sum
     b = BallInf(N[1, 2], N(1))
     p = minkowski_sum(b, N[2 0; 0 1] * b)
-    @test p isa HPolytope && ispermutation(constraints_list(p),
+    @test p isa HPolytope{N} && ispermutation(constraints_list(p),
         [HalfSpace(N[0, -1], N(-2)), HalfSpace(N[0, 1], N(6)),
          HalfSpace(N[-1, 0], N(0)), HalfSpace(N[1, 0], N(6))])
 end

--- a/test/unit_CartesianProduct.jl
+++ b/test/unit_CartesianProduct.jl
@@ -242,31 +242,7 @@ for N in [Float64, Float32, Rational{Int}]
         @test !isdisjoint(x, y) && !res && w ∈ x && w ∈ y
     end
 
-    # concrete intersection
-    # constrained dimensions cover all dimensions
-    cpa = CartesianProductArray([Interval(N[0, 1]), Interval(N[1, 2]),
-                                 Interval(N[2, 3])])
-    P = HalfSpace(N[1, 0, 1], N(2))
-    cap = intersection(cpa, P)
-    @test cap isa CartesianProductArray && length(array(cap)) == 1
-    Q = array(cap)[1]
-    @test ispermutation(constraints_list(Q), [HalfSpace(N[-1, 0, 0], N(0)),
-        HalfSpace(N[0, 1, 0], N(2)), HalfSpace(N[0, -1, 0], N(-1)),
-        HalfSpace(N[0, 0, -1], N(-2)), HalfSpace(N[1, 0, 1], N(2))])
-    # some dimensions are unconstrained
-    cpa = CartesianProductArray([Interval(N[0, 1]),
-                                 Hyperrectangle(N[2, 3], N[1, 1]),
-                                 Interval(N[3, 4])])
-    P = HalfSpace(N[0, 1, 1, 0], N(3))
-    cap = intersection(cpa, P)
-    @test cap isa CartesianProductArray && length(array(cap)) == 3
-    for i in [1, 3]
-        @test array(cap)[1] === array(cpa)[1]
-    end
-    Q = array(cap)[2]
-    @test ispermutation(constraints_list(Q), [HalfSpace(N[-1, 0], N(-1)),
-        HalfSpace(N[0, -1], N(-2)), HalfSpace(N[1, 1], N(3))])
-    # all dimensions are unconstrained
+    # concrete intersection where all dimensions are unconstrained
     @test intersection(cpa, HPolyhedron{N}()) == cpa
 
     # linear_map
@@ -354,4 +330,31 @@ for N in [Float64, Float32]
           is_intersection_empty(cpa1_box, G_empty)
     @test !is_intersection_empty(cpa1, G) &&
           !is_intersection_empty(Approximations.overapproximate(cpa1), G)
+end
+
+for N in [Float64]
+    # concrete intersection
+    # constrained dimensions cover all dimensions
+    cpa = CartesianProductArray([Interval(N[0, 1]), Interval(N[1, 2]),
+                                 Interval(N[2, 3])])
+    P = HalfSpace(N[1, 0, 1], N(2))
+    cap = intersection(cpa, P)
+    @test cap isa CartesianProductArray && length(array(cap)) == 1
+    Q = array(cap)[1]
+    @test ispermutation(constraints_list(Q), [HalfSpace(N[-1, 0, 0], N(0)),
+        HalfSpace(N[0, 1, 0], N(2)), HalfSpace(N[0, -1, 0], N(-1)),
+        HalfSpace(N[0, 0, -1], N(-2)), HalfSpace(N[1, 0, 1], N(2))])
+    # some dimensions are unconstrained
+    cpa = CartesianProductArray([Interval(N[0, 1]),
+                                 Hyperrectangle(N[2, 3], N[1, 1]),
+                                 Interval(N[3, 4])])
+    P = HalfSpace(N[0, 1, 1, 0], N(3))
+    cap = intersection(cpa, P)
+    @test cap isa CartesianProductArray && length(array(cap)) == 3
+    for i in [1, 3]
+        @test array(cap)[1] === array(cpa)[1]
+    end
+    Q = array(cap)[2]
+    @test ispermutation(constraints_list(Q), [HalfSpace(N[-1, 0], N(-1)),
+        HalfSpace(N[0, -1], N(-2)), HalfSpace(N[1, 1], N(3))])
 end

--- a/test/unit_Intersection.jl
+++ b/test/unit_Intersection.jl
@@ -29,13 +29,6 @@ for N in [Float64, Rational{Int}, Float32]
     @test isempty_known(I)
     @test !isempty(I)
 
-    # constraints_list for polytopic intersection
-    @test ispermutation(constraints_list(I),
-                        [HalfSpace(N[1, 0], N(2)),
-                         HalfSpace(N[0, 1], N(2)),
-                         HalfSpace(N[-1, 0], N(0)),
-                         HalfSpace(N[0, -1], N(0))])
-
     # =================
     # IntersectionArray
     # =================
@@ -74,11 +67,6 @@ for N in [Float64, Rational{Int}, Float32]
     IntersectionArray(10, N)
 
     # constraints_list for polytopic intersection
-    @test ispermutation(constraints_list(IA),
-                        [HalfSpace(N[1, 0], N(2)),
-                         HalfSpace(N[0, 1], N(2)),
-                         HalfSpace(N[-1, 0], N(0)),
-                         HalfSpace(N[0, -1], N(0))])
 
     # ================
     # common functions
@@ -87,19 +75,25 @@ for N in [Float64, Rational{Int}, Float32]
     # absorbing element
     @test absorbing(Intersection) == absorbing(IntersectionArray) == EmptySet
     @test I ∩ E == E ∩ I == IA ∩ E == E ∩ IA == E ∩ E == E
-
-    # =====================
-    # concrete operations
-    # =====================
-    cap =  HPolytope([HalfSpace(N[1], N(1))]) ∩ HPolytope([HalfSpace(N[-1], N(1))])  # x <= 1 && x >= -1
-    p = linear_map(reshape([N(1/2)], 1, 1), cap)
-    @test N[-0.5] ∈ p && N[0.5] ∈ p && (N[1.0] ∉ p || N[1.0] ∉ p)
 end
 
 # ======================
 # Tests for Float64 only
 # ======================
 for N in [Float64]
+    # constraints_list for polytopic intersection
+    B = BallInf(ones(N, 2), N(3))
+    H = Hyperrectangle(ones(N, 2), ones(N, 2))
+    I = B ∩ H
+    IA = IntersectionArray([B, H])
+    clist1 = constraints_list(I)
+    clist2 = constraints_list(IA)
+    @test ispermutation(clist1, clist2) &&
+          ispermutation(clist1, [HalfSpace(N[1, 0], N(2)),
+                                 HalfSpace(N[0, 1], N(2)),
+                                 HalfSpace(N[-1, 0], N(0)),
+                                 HalfSpace(N[0, -1], N(0))])
+
     # HalfSpace vs. Ball1 intersection
     X = Ball1(zeros(2), N(1));
     d = normalize(N[1, 0])
@@ -137,4 +131,11 @@ for N in [Float64]
     # need Polyhedra (in the general case), for the concrete linear map. As a valid workaround
     # if we don't want to load Polyhedra here is to convert the given set to a polygon in V-representation
     @test isapprox(ρ(d, convert(VPolygon, X) ∩ H, algorithm="projection", lazy_linear_map=false), N(0.5), atol=1e-6)
+
+    # =====================
+    # concrete operations
+    # =====================
+    cap =  HPolytope([HalfSpace(N[1], N(1))]) ∩ HPolytope([HalfSpace(N[-1], N(1))])  # x <= 1 && x >= -1
+    p = linear_map(reshape([N(1/2)], 1, 1), cap)
+    @test N[-0.5] ∈ p && N[0.5] ∈ p && (N[1.0] ∉ p || N[1.0] ∉ p)
 end

--- a/test/unit_LinearMap.jl
+++ b/test/unit_LinearMap.jl
@@ -96,7 +96,6 @@ for N in [Float64, Rational{Int}, Float32]
     M = N[2 3; 1 2]
     L = LinearMap(M, b)
     V = linear_map(M, LinearMap(M, b))
-    @test M * M * an_element(b) ∈ V
 end
 
 # tests that only work with Float64
@@ -125,4 +124,11 @@ for N in [Float64]
             @test ρ(d, lm2) ≈ ρ(d, p2)
         end
     end
+
+    # concrete linear map of a LinearMap and membership
+    b = BallInf(N[0, 0], N(1))
+    M = N[2 3; 1 2]
+    L = LinearMap(M, b)
+    V = linear_map(M, LinearMap(M, b))
+    @test M * M * N[1, 1] ∈ V
 end

--- a/test/unit_MinkowskiSum.jl
+++ b/test/unit_MinkowskiSum.jl
@@ -73,7 +73,7 @@ for N in [Float64, Rational{Int}, Float32]
     clist = constraints_list(ms)
     P = HPolytope(clist)
     H = Hyperrectangle(N[0, 0], N[2, 2])
-    @test length(clist) == 4 && P ⊆ H && H ⊆ P
+    @test length(clist) == 4
 
     # membership in the sum of a singleton and a polytopic set
     p = N[1, 2]
@@ -184,4 +184,14 @@ for N in [Float64, Rational{Int}, Float32]
           e + e == e
     # mix of neutral and absorbing element
     @test z + e == e + z == e
+end
+
+# tests that only work with Float64
+for N in [Float64]
+    # inclusion
+    ms = MinkowskiSum(BallInf(N[0, 0], N(1)), BallInf(N[0, 0], N(1)))
+    clist = constraints_list(ms)
+    P = HPolytope(clist)
+    H = Hyperrectangle(N[0, 0], N[2, 2])
+    @test length(clist) == 4 && P ⊆ H && H ⊆ P
 end

--- a/test/unit_ResetMap.jl
+++ b/test/unit_ResetMap.jl
@@ -25,11 +25,6 @@ for N in [Float64, Rational{Int}, Float32]
     @test isbounded(ResetMap(Singleton(N[1, 2]), r_none))  # bounded set without resets
     @test !isbounded(ResetMap(Universe{N}(2), r_1))  # unbounded set without enough resets
     @test isbounded(ResetMap(Universe{N}(2), r_12))  # unbounded set with enough resets
-    if N in [Float64]
-        @test !isbounded(ResetMap(HPolyhedron([HalfSpace(N[1, 1], N(1))]), r_none))  # unbounded set without resets
-        @test !isbounded(ResetMap(HPolyhedron([HalfSpace(N[1, 1], N(1))]), r_1))  # unbounded set without enough resets
-        @test isbounded(ResetMap(HPolyhedron([HalfSpace(N[1, 1], N(1))]), r_12))  # unbounded set, but captured by resets
-    end
 
     # an_element function
     an_element(rm)
@@ -56,6 +51,24 @@ for N in [Float64, Rational{Int}, Float32]
                          HalfSpace(N[0, -1, 0], N(-1)),
                          HalfSpace(N[0, 0, 1], N(0)),
                          HalfSpace(N[0, 0, -1], N(0))])
+end
+
+for N in [Float64]
+    b = BallInf(N[2, 2, 2], N(1))
+    r = Dict(1 => N(4), 3 => N(0))
+    r_none = Dict{Int, N}()  # no reset
+    r_1 = Dict{Int, N}(1 => N(1))  # reset x1
+    r_12 = Dict{Int, N}(1 => N(1), 2 => N(1))  # reset x1 and x2
+    rm = ResetMap(b, r)
+
+    # boundedness
+    P = HPolyhedron([HalfSpace(N[1, 1], N(1))])
+    @test !isbounded(ResetMap(P, r_none))  # unbounded set without resets
+    @test !isbounded(ResetMap(P, r_1))  # unbounded set without enough resets
+    @test isbounded(ResetMap(P, r_12))  # unbounded set, but captured by resets
+    @test !isbounded(ResetMap(HPolyhedron([HalfSpace(N[1, 1], N(1))]), r_none))  # unbounded set without resets
+    @test !isbounded(ResetMap(HPolyhedron([HalfSpace(N[1, 1], N(1))]), r_1))  # unbounded set without enough resets
+    @test isbounded(ResetMap(HPolyhedron([HalfSpace(N[1, 1], N(1))]), r_12))  # unbounded set, but captured by resets
 
     # intersection
     b2 = BallInf(N[4, 2, 0], N(1))

--- a/test/unit_UnionSet.jl
+++ b/test/unit_UnionSet.jl
@@ -64,6 +64,21 @@ for N in [Float64, Rational{Int}, Float32]
         @test isdisjoint(U, S) && isdisjoint(S, U) && disjoint1 &&
               disjoint2 && point1 == point2 == N[]
     end
+end
+
+for N in [Float64]
+    B1 = BallInf(zeros(N, 2), N(1))
+    B2 = Ball1(ones(N, 2), N(1))
+    B3 = Hyperrectangle(low=N[-1, -1], high=N[2, 2])
+    S = Singleton(N[10, 10])
+    UXY = UnionSet(B1, B2)
+    Uarr = UnionSetArray([B1, B2])
+
+    for U in [UXY, Uarr]
+        # intersection
+        @test !isempty(intersection(U, B3)) && !isempty(intersection(B3, U))
+        @test isempty(intersection(U, S)) && isempty(intersection(S, U))
+    end
 
     # emptiness
     emptyP = HPolyhedron([HalfSpace(N[1, 0], N(0)), HalfSpace(N[-1, 0], N(-1))])
@@ -79,23 +94,14 @@ for N in [Float64, Rational{Int}, Float32]
     @test !isbounded(UnionSetArray([unboundedP, B1])) &&
           !isbounded(UnionSetArray([B1, B2, unboundedP]))
 
-    # tests that only work with Float64
-    if N in [Float64]
-        for U in [UXY, Uarr]
-            # intersection
-            @test !isempty(intersection(U, B3)) && !isempty(intersection(B3, U))
-            @test isempty(intersection(U, S)) && isempty(intersection(S, U))
-        end
-
-        # isdisjoint
-        disjoint1, point1 = isdisjoint(UXY, UXY, true)
-        disjoint2, point2 = isdisjoint(UXY, Uarr, true)
-        disjoint3, point3 = isdisjoint(Uarr, UXY, true)
-        disjoint4, point4 = isdisjoint(Uarr, Uarr, true)
-        @test !isdisjoint(UXY, UXY) && !isdisjoint(UXY, Uarr) &&
-              !isdisjoint(Uarr, UXY) && !isdisjoint(Uarr, Uarr) && !disjoint1 &&
-              !disjoint2 && !disjoint3 && !disjoint4 && point1 ∈ UXY &&
-              point2 ∈ UXY && point2 ∈ Uarr && point3 ∈ UXY && point3 ∈ Uarr &&
-              point4 ∈ Uarr
-    end
+    # isdisjoint
+    disjoint1, point1 = isdisjoint(UXY, UXY, true)
+    disjoint2, point2 = isdisjoint(UXY, Uarr, true)
+    disjoint3, point3 = isdisjoint(Uarr, UXY, true)
+    disjoint4, point4 = isdisjoint(Uarr, Uarr, true)
+    @test !isdisjoint(UXY, UXY) && !isdisjoint(UXY, Uarr) &&
+          !isdisjoint(Uarr, UXY) && !isdisjoint(Uarr, Uarr) && !disjoint1 &&
+          !disjoint2 && !disjoint3 && !disjoint4 && point1 ∈ UXY &&
+          point2 ∈ UXY && point2 ∈ Uarr && point3 ∈ UXY && point3 ∈ Uarr &&
+          point4 ∈ Uarr
 end

--- a/test/unit_box_approximation.jl
+++ b/test/unit_box_approximation.jl
@@ -73,7 +73,7 @@ for N in [Float64, Rational{Int}, Float32]
     @test box_approximation_symmetric(E) == E
 end
 
-for N in [Float64, Float32]
+for N in [Float64]
     # empty intersection due to line search
     X = HalfSpace(N[-1], N(0)) ∩ HalfSpace(N[1], N(-1e-15))
     @test box_approximation(X) isa EmptySet{N}

--- a/test/unit_overapproximate.jl
+++ b/test/unit_overapproximate.jl
@@ -70,10 +70,8 @@ for N in [Float64, Rational{Int}, Float32]
     d_oa_d_hp = overapproximate(lm, CartesianProductArray{N, Hyperrectangle{N}})
     d_oa_d_box = overapproximate(lm, CartesianProductArray, Approximations.BoxDirections)
     oa_d_hp = overapproximate(d_oa_d_hp)
-    oa_d_box = overapproximate(d_oa_d_box, Approximations.BoxDirections)
 
     @test oa == oa_d_hp
-    @test oa_box == oa_d_box
 
     for (oax, set_type) in [(d_oa_d_hp, Hyperrectangle), (d_oa_d_box, HPolytope)]
         @test oax isa CartesianProductArray
@@ -99,13 +97,6 @@ for N in [Float64, Rational{Int}, Float32]
     lm = LinearMap(M, Z)
     Zo = overapproximate(lm, Zonotope)
     @test box_approximation(Zo) == Hyperrectangle(N[0, 0], N[3, 3])
-
-    # intersection of two polyhedra
-    P = HPolyhedron([HalfSpace(N[1, 0], N(1)), HalfSpace(N[0, 1], N(1))])
-    Q = HPolyhedron([HalfSpace(N[-1, 0], N(1)), HalfSpace(N[0, -1], N(1))])
-    oa = overapproximate(P ∩ Q, BoxDirections)
-    B = BallInf(N[0, 0], N(1))
-    @test B ⊆ oa && oa ⊆ B
 
     # rectification
     r = Rectification(EmptySet{N}())
@@ -242,6 +233,23 @@ for N in [Float64, Float32]
 end
 
 for N in [Float64]
+    i1 = Interval(N[0, 1])
+    h = Hyperrectangle(low=N[3, 4], high=N[5, 7])
+    M = N[1 2 3; 4 5 6; 7 8 9]
+    cpa = CartesianProductArray([i1, h])
+    lm = M * cpa
+    d_oa_d_box = overapproximate(lm, CartesianProductArray, Approximations.BoxDirections)
+    oa_d_box = overapproximate(d_oa_d_box, Approximations.BoxDirections)
+    oa_box = overapproximate(lm, Approximations.BoxDirections)
+    @test oa_box == oa_d_box
+
+    # intersection of two polyhedra
+    P = HPolyhedron([HalfSpace(N[1, 0], N(1)), HalfSpace(N[0, 1], N(1))])
+    Q = HPolyhedron([HalfSpace(N[-1, 0], N(1)), HalfSpace(N[0, -1], N(1))])
+    oa = overapproximate(P ∩ Q, BoxDirections)
+    B = BallInf(N[0, 0], N(1))
+    @test B ⊆ oa && oa ⊆ B
+
     # decomposed linear map approximation
     i1 = Interval(N[0, 1])
     i2 = Interval(N[2, 3])

--- a/test/unit_template_directions.jl
+++ b/test/unit_template_directions.jl
@@ -79,6 +79,14 @@ for N in [Float64, Float32, Rational{Int}]
                 overapproximate(Z, dir)
             end
         end
+    end
+end
+
+for N in [Float64]
+    for n in 1:3
+        B = BallInf(zeros(N, n), N(2))
+        A = Matrix{N}(2I, n, n) + ones(N, n, n)
+        X = A * B
 
         # custom directions
         # empty list of directions


### PR DESCRIPTION
These are the test changes outsourced from #1701. The main changes are to only use `Float64` where appropriate because other number types would be converted by the LP solver. This also removes the warnings in the tests.