### PR TITLE
#1446 - Print error message if required external package is missing

### DIFF
--- a/docs/src/lib/interfaces.md
+++ b/docs/src/lib/interfaces.md
@@ -73,6 +73,13 @@ RecipesBase.apply_recipe(::Dict{Symbol,Any}, ::LazySet{N}, ::N=N(1e-3)) where {N
 RecipesBase.apply_recipe(::Dict{Symbol,Any}, ::AbstractVector{VN}, ::N=N(1e-3), ::Int=40, ::Bool=false) where {N<:Real, VN<:LazySet{N}}
 ```
 
+For three-dimensional sets, we support `Makie`:
+
+```@docs
+plot3d
+plot3d!
+```
+
 ### Set functions that override Base functions
 
 ```@docs

--- a/src/Approximations/init.jl
+++ b/src/Approximations/init.jl
@@ -1,8 +1,4 @@
 function __init__()
-    @require TaylorModels = "314ce334-5f6e-57ae-acf6-00b6e903104a" load_taylormodels()
+    @require TaylorModels = "314ce334-5f6e-57ae-acf6-00b6e903104a" include("init_TaylorModels.jl")
     @require IntervalMatrices = "5c1f47dc-42dd-5697-8aaa-4d102d140ba9" include("init_IntervalMatrices.jl")
-end
-
-function load_taylormodels()
-    eval(load_taylormodels_overapproximation())
 end

--- a/src/Approximations/init_TaylorModels.jl
+++ b/src/Approximations/init_TaylorModels.jl
@@ -1,0 +1,1 @@
+eval(load_taylormodels_overapproximation())

--- a/src/Initialization/init_Expokit.jl
+++ b/src/Initialization/init_Expokit.jl
@@ -1,7 +1,1 @@
-eval(quote
-    using .Expokit: expmv
-end)
-
-eval(load_expokit_sparsematrixexp())
-eval(load_expokit_exponentialmap())
-eval(load_expokit_exponentialprojectionmap())
+eval(load_expokit())

--- a/src/Initialization/init_Makie.jl
+++ b/src/Initialization/init_Makie.jl
@@ -1,1 +1,1 @@
-eval(initialize_mesh())
+eval(load_makie())

--- a/src/Initialization/init_Polyhedra.jl
+++ b/src/Initialization/init_Polyhedra.jl
@@ -29,5 +29,4 @@ end)
 eval(load_polyhedra_hpolytope())
 eval(load_polyhedra_hpolyhedron())
 eval(load_polyhedra_vpolytope())
-
-eval(initialize_mesh())
+eval(load_polyhedra_mesh())

--- a/src/LazyOperations/ExponentialMap.jl
+++ b/src/LazyOperations/ExponentialMap.jl
@@ -10,6 +10,14 @@ export SparseMatrixExp,
        get_column,
        get_columns
 
+function load_expokit()
+return quote
+
+using .Expokit: expmv
+
+end end  # quote / load_expokit
+
+
 # --- SparseMatrixExp & ExponentialMap ---
 
 """
@@ -84,10 +92,9 @@ function size(spmexp::SparseMatrixExp, ax::Int)::Int
     return size(spmexp.M, ax)
 end
 
-function load_expokit_sparsematrixexp()
-return quote
-
 function get_column(spmexp::SparseMatrixExp{N}, j::Int)::Vector{N} where {N}
+    require(:Expokit; fun_name="get_column")
+
     n = size(spmexp, 1)
     aux = zeros(N, n)
     aux[j] = one(N)
@@ -96,6 +103,7 @@ end
 
 function get_columns(spmexp::SparseMatrixExp{N},
                      J::AbstractArray)::Matrix{N} where {N}
+    require(:Expokit; fun_name="get_columns")
 
     n = size(spmexp, 1)
     aux = zeros(N, n)
@@ -133,6 +141,8 @@ The result is of type `Transpose`; in Julia versions older than v0.7, the result
 was of type `RowVector`.
 """
 function get_row(spmexp::SparseMatrixExp{N}, i::Int) where {N}
+    require(:Expokit; fun_name="get_row")
+
     n = size(spmexp, 1)
     aux = zeros(N, n)
     aux[i] = one(N)
@@ -141,6 +151,8 @@ end
 
 function get_rows(spmexp::SparseMatrixExp{N},
                   I::AbstractArray{Int})::Matrix{N} where {N}
+    require(:Expokit; fun_name="get_rows")
+
     n = size(spmexp, 1)
     aux = zeros(N, n)
     ans = zeros(N, length(I), n)
@@ -156,8 +168,6 @@ function get_rows(spmexp::SparseMatrixExp{N},
     end
     return ans
 end
-
-end end  # quote / load_expokit_sparsematrixexp
 
 """
     ExponentialMap{N<:Real, S<:LazySet{N}} <: LazySet{N}
@@ -261,9 +271,6 @@ function dim(em::ExponentialMap)::Int
     return size(em.spmexp.M, 1)
 end
 
-function load_expokit_exponentialmap()
-return quote
-
 """
     σ(d::AbstractVector{N}, em::ExponentialMap{N}) where {N<:Real}
 
@@ -288,6 +295,8 @@ We allow sparse direction vectors, but will convert them to dense vectors to be
 able to use `expmv`.
 """
 function σ(d::AbstractVector{N}, em::ExponentialMap{N}) where {N<:Real}
+    require(:Expokit; fun_name="σ")
+
     d_dense = d isa Vector ? d : Vector(d)
     v = expmv(one(N), transpose(em.spmexp.M), d_dense) # v   <- exp(M') * d
     return expmv(one(N), em.spmexp.M, σ(v, em.X)) # res <- exp(M) * σ(v, S)
@@ -316,6 +325,8 @@ We allow sparse direction vectors, but will convert them to dense vectors to be
 able to use `expmv`.
 """
 function ρ(d::AbstractVector{N}, em::ExponentialMap{N}) where {N<:Real}
+    require(:Expokit; fun_name="ρ")
+
     d_dense = d isa Vector ? d : Vector(d)
     v = expmv(one(N), transpose(em.spmexp.M), d_dense) # v <- exp(M^T) * d
     return ρ(v, em.X)
@@ -356,6 +367,8 @@ true
 ```
 """
 function ∈(x::AbstractVector{N}, em::ExponentialMap{N})::Bool where {N<:Real}
+    require(:Expokit; fun_name="∈")
+
     @assert length(x) == dim(em)
     return expmv(-one(N), em.spmexp.M, x) ∈ em.X
 end
@@ -379,6 +392,8 @@ We assume that the underlying set `X` is polytopic.
 Then the result is just the exponential map applied to the vertices of `X`.
 """
 function vertices_list(em::ExponentialMap{N})::Vector{Vector{N}} where {N<:Real}
+    require(:Expokit; fun_name="vertices_list")
+
     # collect low-dimensional vertices lists
     vlist_X = vertices_list(em.X)
 
@@ -391,8 +406,6 @@ function vertices_list(em::ExponentialMap{N})::Vector{Vector{N}} where {N<:Real}
 
     return vlist
 end
-
-end end  # quote / load_expokit_exponentialmap
 
 """
     isbounded(em::ExponentialMap)::Bool
@@ -507,9 +520,6 @@ function dim(eprojmap::ExponentialProjectionMap)::Int
     return size(eprojmap.projspmexp.L, 1)
 end
 
-function load_expokit_exponentialprojectionmap()
-return quote
-
 """
     σ(d::AbstractVector{N},
       eprojmap::ExponentialProjectionMap{N}) where {N<:Real}
@@ -537,6 +547,8 @@ able to use `expmv`.
 """
 function σ(d::AbstractVector{N},
            eprojmap::ExponentialProjectionMap{N}) where {N<:Real}
+    require(:Expokit; fun_name="σ")
+
     d_dense = d isa Vector ? d : Vector(d)
     daux = transpose(eprojmap.projspmexp.L) * d_dense
     aux1 = expmv(one(N), transpose(eprojmap.projspmexp.spmexp.M), daux)
@@ -547,8 +559,6 @@ function σ(d::AbstractVector{N},
     daux = expmv(one(N), eprojmap.projspmexp.spmexp.M, aux2)
     return eprojmap.projspmexp.L * daux
 end
-
-end end  # quote / load_expokit_exponentialprojectionmap
 
 """
     isbounded(eprojmap::ExponentialProjectionMap)::Bool

--- a/src/LazySets.jl
+++ b/src/LazySets.jl
@@ -37,7 +37,6 @@ using .Arrays
 include("Utils/helper_functions.jl")
 include("Utils/comparisons.jl")
 include("Utils/macros.jl")
-include("Utils/samples.jl")
 
 # ==================
 # Abstract set types
@@ -124,6 +123,7 @@ include("ConcreteOperations/issubset.jl")
 include("ConcreteOperations/minkowski_difference.jl")
 include("ConcreteOperations/minkowski_sum.jl")
 include("ConcreteOperations/reflection.jl")
+include("Utils/samples.jl")
 
 # =====================
 # Approximations module

--- a/src/Plotting/mesh.jl
+++ b/src/Plotting/mesh.jl
@@ -1,14 +1,25 @@
-function load_mesh()
+export plot3d, plot3d!
+
+
+function load_polyhedra_mesh()
 return quote
 
 using .Polyhedra: Mesh
-using .Makie: mesh, mesh!
-import .Makie.AbstractPlotting: Automatic
 
-export plot3d, plot3d!
+end end  # quote / function load_polyhedra_mesh()
+
+
+function load_makie()
+return quote
+
+using .Makie: mesh, mesh!
+using .Makie.AbstractPlotting: Automatic
+
+end end  # quote / function load_makie()
+
 
 # helper function for 3D plotting; converts S to a polytope in H-representation
-function plot3d_helper(S::LazySet{N}, backend) where {N}
+function _plot3d_helper(S::LazySet{N}, backend) where {N}
     @assert dim(S) <= 3 "plot3d can only be used to plot sets of dimension three (or lower); " *
         "but the given set is $(dim(S))-dimensional"
 
@@ -24,11 +35,11 @@ end
 
 """
     plot3d(S::LazySet{N}; backend=default_polyhedra_backend(S, N),
-           alpha=1.0, color=:blue, colormap=:viridis, colorrange=Automatic(),
+           alpha=1.0, color=:blue, colormap=:viridis, colorrange=nothing,
            interpolate=false, linewidth=1, overdraw=false, shading=true,
            transparency=true, visible=true) where {N}
 
-Plot a three-dimensional convex set using Makie.
+Plot a three-dimensional convex set using `Makie`.
 
 ### Input
 
@@ -43,9 +54,10 @@ Plot a three-dimensional convex set using Makie.
 - `colormap`     -- (optional, default: `:viridis`) the color map of the main plot;
                     call `available_gradients()` to see what gradients are available,
                     and it can also be used as `[:red, :black]`
-- `colorrange`   -- (optional, default: `Automatic()`) a tuple `(min, max)` where
-                    `min` and `max` specify the data range to be used for indexing
-                    the colormap
+- `colorrange`   -- (optional, default: `nothing`, which falls back to
+                    `Makie.AbstractPlotting.Automatic()`) a tuple `(min, max)`
+                    where `min` and `max` specify the data range to be used for
+                    indexing the colormap
 - `interpolate`  -- (optional, default: `false`) a bool for heatmap and images,
                     it toggles color interpolation between nearby pixels
 - `linewidth`    -- (optional, default: `1`) a number that specifies the width of
@@ -103,17 +115,22 @@ julia> plot3d!(10. * rand(Hyperrectangle, dim=3), color=:red)
 ```
 """
 function plot3d(S::LazySet{N}; backend=default_polyhedra_backend(S, N),
-                alpha=1.0, color=:blue, colormap=:viridis, colorrange=Automatic(), interpolate=false,
+                alpha=1.0, color=:blue, colormap=:viridis, colorrange=nothing, interpolate=false,
                 linewidth=1, overdraw=false, shading=true, transparency=true, visible=true) where {N}
+    require(:Makie; fun_name="plot3d")
+    require(:Polyhedra; fun_name="plot3d")
 
-    P_poly_mesh = plot3d_helper(S, backend)
+    if colorrange == nothing
+        colorrange = Automatic()
+    end
+    P_poly_mesh = _plot3d_helper(S, backend)
     return mesh(P_poly_mesh, alpha=alpha, color=color, colormap=colormap, colorrange=colorrange,
                 interpolate=interpolate, linewidth=linewidth, transparency=transparency, visible=visible)
 end
 
 """
     plot3d!(S::LazySet{N}; backend=default_polyhedra_backend(S, N),
-            alpha=1.0, color=:blue, colormap=:viridis, colorrange=Automatic(), interpolate=false,
+            alpha=1.0, color=:blue, colormap=:viridis, colorrange=nothing, interpolate=false,
             linewidth=1, overdraw=false, shading=true, transparency=true, visible=true) where {N}
 
 Plot a three-dimensional convex set using Makie.
@@ -129,13 +146,15 @@ documentation](http://makie.juliaplots.org/stable/plot-attributes).
 See the documentation of `plot3d` for examples.
 """
 function plot3d!(S::LazySet{N}; backend=default_polyhedra_backend(S, N),
-                alpha=1.0, color=:blue, colormap=:viridis, colorrange=Automatic(), interpolate=false,
+                alpha=1.0, color=:blue, colormap=:viridis, colorrange=nothing, interpolate=false,
                 linewidth=1, overdraw=false, shading=true, transparency=true, visible=true) where {N}
+    require(:Makie; fun_name="plot3d!")
+    require(:Polyhedra; fun_name="plot3d!")
 
-    P_poly_mesh = plot3d_helper(S, backend)
+    if colorrange == nothing
+        colorrange = Automatic()
+    end
+    P_poly_mesh = _plot3d_helper(S, backend)
     return mesh!(P_poly_mesh, alpha=alpha, color=color, colormap=colormap, colorrange=colorrange,
                  interpolate=interpolate, linewidth=linewidth, transparency=transparency, visible=visible)
 end
-
-end # quote
-end # function load_mesh()

--- a/src/Sets/VPolytope.jl
+++ b/src/Sets/VPolytope.jl
@@ -7,7 +7,9 @@ export VPolytope,
        cartesian_product,
        linear_map,
        remove_redundant_vertices,
-       minkowski_sum
+       minkowski_sum,
+       tohrep,
+       tovrep
 
 """
     VPolytope{N<:Real} <: AbstractPolytope{N}
@@ -554,10 +556,6 @@ end
 function load_polyhedra_vpolytope() # function to be loaded by Requires
 return quote
 # see the interface file AbstractPolytope.jl for the imports
-
-export vertices_list,
-       tohrep,
-       tovrep
 
 # VPolytope from a VRep
 function VPolytope(P::VRep{N}) where {N}

--- a/src/init.jl
+++ b/src/init.jl
@@ -7,12 +7,6 @@ function __init__()
     @require Polyhedra = "67491407-f73d-577b-9b50-8179a7c68029" include("Initialization/init_Polyhedra.jl")
 end
 
-function initialize_mesh()
-    if isdefined(@__MODULE__, :Polyhedra) && isdefined(@__MODULE__, :Makie)
-       eval(load_mesh())
-    end
-end
-
 """
     require(package::Symbol; fun_name::String="", explanation::String="")
 


### PR DESCRIPTION
Closes #1446.

I defined new methods outside the `Requires` wrappers for better error printing. Alternatively, we could sometimes remove the `Requires` wrappers altogether and instead use our `require` helper function.

The only cases I did not add are functions that are clearly package specific (`default_cddlib_backend`, `default_polyhedra_backend`, `default_lp_solver_polyhedra`, and `polyhedron`).