### PR TITLE
Fix case 0 for linear term in taylor model

### DIFF
--- a/test/unit_overapproximate.jl
+++ b/test/unit_overapproximate.jl
@@ -333,7 +333,7 @@ for N in [Float64]
     @test Matrix(genmat(Z1)) == N[1 -1 0; -1 0 0.5]
 
     # auxiliary function to get the linear coefficients
-    t = Taylor1(0) # t.order is 0
+    t = TaylorModels.Taylor1(0) # t.order is 0
     @test get_linear_coeffs(t) == N[0]
     p = x₁ + 2x₂ - 3x₃
     @test get_linear_coeffs(p) == N[1, 2, -3]

--- a/test/unit_overapproximate.jl
+++ b/test/unit_overapproximate.jl
@@ -1,4 +1,5 @@
-using LazySets.Approximations: project
+using LazySets.Approximations: project,
+                               get_linear_coeffs
 
 for N in [Float64, Rational{Int}, Float32]
     c = N[0, 0]
@@ -330,4 +331,13 @@ for N in [Float64]
     Z1 = overapproximate(vTM, Zonotope)
     @test center(Z1) == N[3, -2.5]
     @test Matrix(genmat(Z1)) == N[1 -1 0; -1 0 0.5]
+
+    # auxiliary function to get the linear coefficients
+    t = Taylor1(0) # t.order is 0
+    @test get_linear_coeffs(t) == N[0]
+    p = x₁ + 2x₂ - 3x₃
+    @test get_linear_coeffs(p) == N[1, 2, -3]
+    y = set_variables("y", numvars=2, order=1)
+    p = zero(y[1])
+    @test get_linear_coeffs(p) == N[0, 0]
 end


### PR DESCRIPTION
This PR fixes the conversion to a zonotope for the following vector of taylor models:

```julia
2-element Array{TaylorModels.TaylorModel1{TaylorN{Float64},Float64},1}:
   10.1 + 0.09999999999999964 x₁ + [0, 0]
                             0.0 + [0, 0]
```

In principle one can't construct a taylor model with 0 order, but for whatever reason the zero polynomial, after normalization, `Q`, in [this part of the code](https://github.com/JuliaReach/LazySets.jl/blob/master/src/Approximations/overapproximate.jl#L1027), had zero order and in consequence `linear_polynomial` was failing because the implementation in Taylorseries uses `a[1]`,  but since they start at `a[0]` the term doesn't exist, see [here](https://github.com/JuliaDiff/TaylorSeries.jl/blob/53a865275d678280bfc002548bff0d7a18c99dbd/src/auxiliary.jl#L315).

cc: @lbenet 