### PR TITLE
Fix namespace conflict with Plots

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -159,7 +159,7 @@ if test_suite_plotting
     using Plots: plot
 
     # fix namespace conflicts with Plots
-    using LazySets: center
+    using LazySets: center, translate
 
     @time @testset "LazySets.plotting" begin include("unit_plot.jl") end
 end


### PR DESCRIPTION
Currently there are no problems because we also load `Polyhedra` in the tests by default and resolve the conflict there.