### PR TITLE
#1838 - Convex type function

### DIFF
--- a/docs/src/lib/interfaces.md
+++ b/docs/src/lib/interfaces.md
@@ -63,6 +63,7 @@ is_interior_point(::AbstractVector{N}, ::LazySet{N}; p=Inf, ε=_rtol(N)) where {
 isoperationtype(::Type{<:LazySet})
 isoperation(::LazySet)
 isequivalent(::LazySet, ::LazySet)
+isconvextype(::Type{<:LazySet})
 ```
 
 Plotting is available for general one- or two-dimensional `LazySet`s, provided

--- a/src/Interfaces/AbstractCentrallySymmetric.jl
+++ b/src/Interfaces/AbstractCentrallySymmetric.jl
@@ -26,6 +26,7 @@ julia> subtypes(AbstractCentrallySymmetric)
 """
 abstract type AbstractCentrallySymmetric{N<:Real} <: LazySet{N} end
 
+isconvextype(::Type{<:AbstractCentrallySymmetric}) = false
 
 """
     dim(S::AbstractCentrallySymmetric)::Int

--- a/src/Interfaces/AbstractCentrallySymmetric.jl
+++ b/src/Interfaces/AbstractCentrallySymmetric.jl
@@ -26,7 +26,7 @@ julia> subtypes(AbstractCentrallySymmetric)
 """
 abstract type AbstractCentrallySymmetric{N<:Real} <: LazySet{N} end
 
-isconvextype(::Type{<:AbstractCentrallySymmetric}) = error("the `isconvextype` function for `AbstractCentrallySymmetric` sets is not implemented")
+isconvextype(::Type{<:AbstractCentrallySymmetric}) = false
 
 """
     dim(S::AbstractCentrallySymmetric)::Int

--- a/src/Interfaces/AbstractCentrallySymmetric.jl
+++ b/src/Interfaces/AbstractCentrallySymmetric.jl
@@ -26,7 +26,7 @@ julia> subtypes(AbstractCentrallySymmetric)
 """
 abstract type AbstractCentrallySymmetric{N<:Real} <: LazySet{N} end
 
-isconvextype(::Type{<:AbstractCentrallySymmetric}) = false
+isconvextype(::Type{<:AbstractCentrallySymmetric}) = error("the `isconvextype` function for `AbstractCentrallySymmetric` sets is not implemented")
 
 """
     dim(S::AbstractCentrallySymmetric)::Int

--- a/src/Interfaces/AbstractCentrallySymmetricPolytope.jl
+++ b/src/Interfaces/AbstractCentrallySymmetricPolytope.jl
@@ -32,9 +32,9 @@ julia> subtypes(AbstractCentrallySymmetricPolytope)
  Ball1
 ```
 """
-abstract type AbstractCentrallySymmetricPolytope{N<:Real} <: AbstractPolytope{N}
-end
+abstract type AbstractCentrallySymmetricPolytope{N<:Real} <: AbstractPolytope{N} end
 
+isconvextype(::Type{<:AbstractCentrallySymmetricPolytope}) = true
 
 # --- common AbstractCentrallySymmetric functions (copy-pasted) ---
 

--- a/src/Interfaces/AbstractHPolygon.jl
+++ b/src/Interfaces/AbstractHPolygon.jl
@@ -41,6 +41,7 @@ julia> subtypes(AbstractHPolygon)
 """
 abstract type AbstractHPolygon{N<:Real} <: AbstractPolygon{N} end
 
+isconvextype(::Type{<:AbstractHPolygon}) = true
 
 # --- AbstractPolygon interface functions ---
 

--- a/src/Interfaces/AbstractHyperrectangle.jl
+++ b/src/Interfaces/AbstractHyperrectangle.jl
@@ -36,9 +36,9 @@ julia> subtypes(AbstractHyperrectangle)
  SymmetricIntervalHull
 ```
 """
-abstract type AbstractHyperrectangle{N<:Real} <: AbstractZonotope{N}
-end
+abstract type AbstractHyperrectangle{N<:Real} <: AbstractZonotope{N} end
 
+isconvextype(::Type{<:AbstractHyperrectangle}) = true
 
 # --- AbstractZonotope interface functions ---
 

--- a/src/Interfaces/AbstractPolygon.jl
+++ b/src/Interfaces/AbstractPolygon.jl
@@ -26,6 +26,7 @@ julia> subtypes(AbstractPolygon)
 """
 abstract type AbstractPolygon{N<:Real} <: AbstractPolytope{N} end
 
+isconvextype(::Type{<:AbstractPolygon}) = true
 
 # --- LazySet interface functions ---
 

--- a/src/Interfaces/AbstractPolyhedron.jl
+++ b/src/Interfaces/AbstractPolyhedron.jl
@@ -29,6 +29,7 @@ Bounded polyhedra are called *polytopes* (see [`AbstractPolytope`](@ref)).
 """
 abstract type AbstractPolyhedron{N<:Real} <: LazySet{N} end
 
+isconvextype(::Type{<:AbstractPolyhedron}) = true
 
 # --- common AbstractPolyhedron functions ---
 

--- a/src/Interfaces/AbstractPolytope.jl
+++ b/src/Interfaces/AbstractPolytope.jl
@@ -34,6 +34,7 @@ properties:
 """
 abstract type AbstractPolytope{N<:Real} <: AbstractPolyhedron{N} end
 
+isconvextype(::Type{<:AbstractPolytope}) = true
 
 # =============================================
 # Common AbstractPolytope functions
@@ -97,7 +98,7 @@ function isempty(P::AbstractPolytope)::Bool
 end
 
 # given a polytope P, apply the linear map P to each vertex of P
-# it is assumed that the interface function `vertices_list(P)` is available 
+# it is assumed that the interface function `vertices_list(P)` is available
 @inline function _linear_map_vrep(M::AbstractMatrix{N}, P::AbstractPolytope{N}) where {N<:Real}
     vertices = broadcast(v -> M * v, vertices_list(P))
     m = size(M, 1) # output dimension

--- a/src/Interfaces/AbstractSingleton.jl
+++ b/src/Interfaces/AbstractSingleton.jl
@@ -26,6 +26,7 @@ julia> subtypes(AbstractSingleton)
 """
 abstract type AbstractSingleton{N<:Real} <: AbstractHyperrectangle{N} end
 
+isconvextype(::Type{<:AbstractSingleton}) = true
 
 # --- AbstractHyperrectangle interface functions ---
 

--- a/src/Interfaces/AbstractZonotope.jl
+++ b/src/Interfaces/AbstractZonotope.jl
@@ -45,9 +45,9 @@ julia> subtypes(AbstractZonotope)
  Zonotope
 ```
 """
-abstract type AbstractZonotope{N<:Real} <: AbstractCentrallySymmetricPolytope{N}
-end
+abstract type AbstractZonotope{N<:Real} <: AbstractCentrallySymmetricPolytope{N} end
 
+isconvextype(::Type{<:AbstractZonotope}) = true
 
 # --- fallback implementations of AbstractZonotope functions ---
 

--- a/src/Interfaces/LazySet.jl
+++ b/src/Interfaces/LazySet.jl
@@ -19,7 +19,8 @@ export LazySet,
        is_interior_point,
        isoperation,
        isoperationtype,
-       isequivalent
+       isequivalent,
+       isconvextype
 
 """
     LazySet{N}
@@ -723,4 +724,56 @@ function isequivalent(X::LazySet, Y::LazySet)
         return true
     end
     return X ⊆ Y && Y ⊆ X
+end
+
+"""
+    isconvextype(X::Type{<:LazySet})
+
+Check whether the given `LazySet` type is convex.
+
+### Input
+
+- `X` -- subtype of `LazySet`
+
+### Output
+
+`true` if the given set type is guaranteed to be convex by using only type
+information, and `false` otherwise.
+
+### Notes
+
+Since this operation only acts on types (not on values), it can return false
+negatives, i.e. there may be instances where the type is convex, even though the
+answer of this function is `false`. The examples below illustrate this point.
+
+### Examples
+
+A ball in the infinity norm is always convex, hence we get:
+
+```jldoctest convex_types
+julia> isconvextype(BallInf)
+true
+```
+
+For instance, the union (`UnionSet`) of two sets may in general be either convex
+or not, since convexity cannot be decided by just using type information.
+Hence, `isconvextype` returns `false` if `X` is `Type{<:UnionSet}`.
+
+```jldoctest convex_types
+julia> isconvextype(UnionSet)
+false
+```
+
+However, the type parameters from the set operations allow to decide convexity
+in some cases, by falling back to the convexity of the type of its arguments.
+Consider for instance the lazy intersection. The intersection of two convex sets
+is always convex, hence we can get:
+
+```jldoctest convex_types
+julia> isconvextype(Intersection{Float64, BallInf{Float64}, BallInf{Float64}})
+true
+```
+"""
+function isconvextype(X::Type{<:LazySet})
+    error("`isconvextype` is not implemented for type $X")
 end

--- a/src/Interfaces/LazySet.jl
+++ b/src/Interfaces/LazySet.jl
@@ -743,7 +743,7 @@ information, and `false` otherwise.
 ### Notes
 
 Since this operation only acts on types (not on values), it can return false
-negatives, i.e. there may be instances where the type is convex, even though the
+negatives, i.e. there may be instances where the set is convex, even though the
 answer of this function is `false`. The examples below illustrate this point.
 
 ### Examples

--- a/src/Interfaces/LazySet.jl
+++ b/src/Interfaces/LazySet.jl
@@ -774,6 +774,4 @@ julia> isconvextype(Intersection{Float64, BallInf{Float64}, BallInf{Float64}})
 true
 ```
 """
-function isconvextype(X::Type{<:LazySet})
-    error("`isconvextype` is not implemented for type $X")
-end
+isconvextype(X::Type{<:LazySet}) = false

--- a/src/LazyOperations/AffineMap.jl
+++ b/src/LazyOperations/AffineMap.jl
@@ -105,7 +105,7 @@ struct AffineMap{N<:Real, S<:LazySet{N}, NM, MAT<:AbstractMatrix{NM},
 end
 
 isoperationtype(::Type{<:AffineMap}) = true
-isconvextype(::Type{AffineMap{N, S, NM, MAT, VN}}) = isconvextype(S)
+isconvextype(::Type{AffineMap{N, S, NM, MAT, VN}}) where {N, S, NM, MAT, VN} = isconvextype(S)
 
 # convenience constructor from a UniformScaling
 function AffineMap(M::UniformScaling, X::LazySet, v::AbstractVector)

--- a/src/LazyOperations/AffineMap.jl
+++ b/src/LazyOperations/AffineMap.jl
@@ -105,6 +105,7 @@ struct AffineMap{N<:Real, S<:LazySet{N}, NM, MAT<:AbstractMatrix{NM},
 end
 
 isoperationtype(::Type{<:AffineMap}) = true
+isconvextype(::Type{AffineMap{N, S, NM, MAT, VN}}) = isconvextype(S)
 
 # convenience constructor from a UniformScaling
 function AffineMap(M::UniformScaling, X::LazySet, v::AbstractVector)

--- a/src/LazyOperations/Bloating.jl
+++ b/src/LazyOperations/Bloating.jl
@@ -32,6 +32,7 @@ struct Bloating{N<:AbstractFloat, S<:LazySet{N}} <:LazySet{N}
 end
 
 isoperationtype(::Type{<:Bloating}) = true
+isconvextype(::Type{<:Bloating}) = true
 
 """
     dim(B::Bloating)

--- a/src/LazyOperations/Bloating.jl
+++ b/src/LazyOperations/Bloating.jl
@@ -32,7 +32,7 @@ struct Bloating{N<:AbstractFloat, S<:LazySet{N}} <:LazySet{N}
 end
 
 isoperationtype(::Type{<:Bloating}) = true
-isconvextype(::Type{<:Bloating}) = true
+isconvextype(::Type{Bloating{N, S}}) where {N, S} = isconvextype(S)
 
 """
     dim(B::Bloating)

--- a/src/LazyOperations/CartesianProduct.jl
+++ b/src/LazyOperations/CartesianProduct.jl
@@ -54,6 +54,7 @@ struct CartesianProduct{N<:Real, S1<:LazySet{N}, S2<:LazySet{N}} <: LazySet{N}
 end
 
 isoperationtype(::Type{<:CartesianProduct}) = true
+isconvextype(::Type{CartesianProduct{N, S1, S1}}) where {N, S1, S2} = isconvextype(S1) && isconvextype(S2)
 
 # EmptySet is the absorbing element for CartesianProduct
 @absorbing(CartesianProduct, EmptySet)
@@ -335,6 +336,7 @@ function CartesianProductArray(n::Int=0, N::Type=Float64)::CartesianProductArray
 end
 
 isoperationtype(::Type{<:CartesianProductArray}) = true
+isconvextype(::Type{CartesianProductArray{N, S}}) where {N, S} = isconvextype(S)
 
 # EmptySet is the absorbing element for CartesianProductArray
 @absorbing(CartesianProductArray, EmptySet)

--- a/src/LazyOperations/Complement.jl
+++ b/src/LazyOperations/Complement.jl
@@ -36,7 +36,7 @@ struct Complement{N<:Real, S<:LazySet{N}}
 end
 
 isoperationtype(::Type{<:Complement}) = true
-isconvextype(::Type{<:Complement) = false
+isconvextype(::Type{<:Complement}) = false
 
 # the complement of the complement is the original set again
 Complement(C::Complement) = C.X

--- a/src/LazyOperations/Complement.jl
+++ b/src/LazyOperations/Complement.jl
@@ -24,7 +24,7 @@ The complement of the complement is the original set again.
 ### Examples
 
 ```jldoctest
-julia> B = BallInf(zeros(2), 1.); C = Complement(B)
+julia> B = BallInf(zeros(2), 1.); C = Complemeisconvextype(::Type{<:Complement) = falsent(B)
 Complement{Float64,BallInf{Float64}}(BallInf{Float64}([0.0, 0.0], 1.0))
 
 julia> Complement(C)
@@ -36,6 +36,7 @@ struct Complement{N<:Real, S<:LazySet{N}}
 end
 
 isoperationtype(::Type{<:Complement}) = true
+isconvextype(::Type{<:Complement) = false
 
 # the complement of the complement is the original set again
 Complement(C::Complement) = C.X

--- a/src/LazyOperations/Complement.jl
+++ b/src/LazyOperations/Complement.jl
@@ -24,7 +24,9 @@ The complement of the complement is the original set again.
 ### Examples
 
 ```jldoctest
-julia> B = BallInf(zeros(2), 1.); C = Complemeisconvextype(::Type{<:Complement) = falsent(B)
+julia> B = BallInf(zeros(2), 1.);
+
+julia> C = Complement(B)
 Complement{Float64,BallInf{Float64}}(BallInf{Float64}([0.0, 0.0], 1.0))
 
 julia> Complement(C)

--- a/src/LazyOperations/ConvexHull.jl
+++ b/src/LazyOperations/ConvexHull.jl
@@ -49,6 +49,7 @@ struct ConvexHull{N<:Real, S1<:LazySet{N}, S2<:LazySet{N}} <: LazySet{N}
 end
 
 isoperationtype(::Type{<:ConvexHull}) = true
+isconvextype(::Type{<:ConvexHull}) = true
 
 # convenience constructor without type parameter
 ConvexHull(X::S1, Y::S2) where {N<:Real, S1<:LazySet{N}, S2<:LazySet{N}} =
@@ -215,6 +216,7 @@ struct ConvexHullArray{N<:Real, S<:LazySet{N}} <: LazySet{N}
 end
 
 isoperationtype(::Type{<:ConvexHullArray}) = true
+isconvextype(::Type{<:ConvexHullArray}) = true
 
 # constructor for an empty hull with optional size hint and numeric type
 function ConvexHullArray(n::Int=0, N::Type=Float64)::ConvexHullArray

--- a/src/LazyOperations/Intersection.jl
+++ b/src/LazyOperations/Intersection.jl
@@ -107,6 +107,7 @@ struct Intersection{N<:Real, S1<:LazySet{N}, S2<:LazySet{N}} <: LazySet{N}
 end
 
 isoperationtype(::Type{<:Intersection}) = true
+isconvextype(::Type{Intersection{N, S1, S2}}) where {N, S1, S2} = isconvextype(S1) && isconvextype(S2)
 
 # convenience constructor without type parameter
 Intersection(X::S1, Y::S2) where {N<:Real, S1<:LazySet{N}, S2<:LazySet{N}} =

--- a/src/LazyOperations/LinearMap.jl
+++ b/src/LazyOperations/LinearMap.jl
@@ -108,6 +108,7 @@ struct LinearMap{N<:Real, S<:LazySet{N},
 end
 
 isoperationtype(::Type{<:LinearMap}) = true
+isconvextype(::Type{LinearMap{N, S}}) where {N, S} = isconvextype(S)
 
 """
 ```

--- a/src/LazyOperations/MinkowskiSum.jl
+++ b/src/LazyOperations/MinkowskiSum.jl
@@ -37,6 +37,7 @@ struct MinkowskiSum{N<:Real, S1<:LazySet{N}, S2<:LazySet{N}} <: LazySet{N}
 end
 
 isoperationtype(::Type{<:MinkowskiSum}) = true
+isconvextype(::Type{MinkowskiSum{N, S1, S2}}) where {N, S1, S2} = isconvextype(S1) && isconvextype(S2)
 
 # convenience constructor without type parameter
 MinkowskiSum(X::S1, Y::S2) where {N<:Real, S1<:LazySet{N}, S2<:LazySet{N}} =
@@ -279,6 +280,7 @@ struct MinkowskiSumArray{N<:Real, S<:LazySet{N}} <: LazySet{N}
 end
 
 isoperationtype(::Type{<:MinkowskiSumArray}) = true
+isconvextype(::Type{MinkowskiSumArray{N, S}}) where {N, S} = isconvextype(S)
 
 # constructor for an empty sum with optional size hint and numeric type
 function MinkowskiSumArray(n::Int=0, N::Type=Float64)::MinkowskiSumArray
@@ -480,6 +482,7 @@ struct CacheMinkowskiSum{N<:Real, S<:LazySet{N}} <: LazySet{N}
 end
 
 isoperationtype(::Type{<:CacheMinkowskiSum}) = true
+isconvextype(::Type{CacheMinkowskiSum{N, S}}) where {N, S} = isconvextype(S)
 
 # convenience constructor without type parameter
 CacheMinkowskiSum(arr::Vector{S}) where {N<:Real, S<:LazySet{N}} =

--- a/src/LazyOperations/Rectification.jl
+++ b/src/LazyOperations/Rectification.jl
@@ -111,6 +111,7 @@ struct Rectification{N<:Real, S<:LazySet{N}}
 end
 
 isoperationtype(::Type{<:Rectification}) = true
+isconvextype(::Type{<:Rectification}) = false
 
 # convenience constructor without type parameter
 Rectification(X::S) where {N<:Real, S<:LazySet{N}} = Rectification{N, S}(X)

--- a/src/LazyOperations/ResetMap.jl
+++ b/src/LazyOperations/ResetMap.jl
@@ -83,6 +83,7 @@ struct ResetMap{N<:Real, S<:LazySet{N}} <: LazySet{N}
 end
 
 isoperationtype(::Type{<:ResetMap}) = true
+isconvextype(::Type{ResetMap{N, S}}) where {N, S} = isconvextype(S)
 
 # ZeroSet is "almost absorbing" for the linear map (only the dimension changes)
 # such that only the translation vector remains

--- a/src/LazyOperations/SymmetricIntervalHull.jl
+++ b/src/LazyOperations/SymmetricIntervalHull.jl
@@ -42,6 +42,7 @@ struct SymmetricIntervalHull{N<:Real, S<:LazySet{N}} <: AbstractHyperrectangle{N
 end
 
 isoperationtype(::Type{<:SymmetricIntervalHull}) = true
+isconvextype(::Type{<:SymmetricIntervalHull}) = true
 
 # convenience constructor without type parameter
 SymmetricIntervalHull(X::S) where {N<:Real, S<:LazySet{N}} =

--- a/src/LazyOperations/Translation.jl
+++ b/src/LazyOperations/Translation.jl
@@ -153,6 +153,7 @@ struct Translation{N<:Real, VN<:AbstractVector{N}, S<:LazySet{N}} <: LazySet{N}
 end
 
 isoperationtype(::Type{<:Translation}) = true
+isconvextype(::Type{Translation{N, VN, S}}) where {N, VN, S} = isconvextype(S)
 
 # constructor from a Translation: perform the translation immediately
 Translation(tr::Translation{N}, v::AbstractVector{N}) where {N<:Real} =

--- a/src/LazyOperations/UnionSet.jl
+++ b/src/LazyOperations/UnionSet.jl
@@ -31,6 +31,7 @@ struct UnionSet{N<:Real, S1<:LazySet{N}, S2<:LazySet{N}}
 end
 
 isoperationtype(::Type{<:UnionSet}) = true
+isconvextype(::Type{<:UnionSet}) = false
 
 # convenience constructor without type parameter
 UnionSet(X::S1, Y::S2) where {N<:Real, S1<:LazySet{N}, S2<:LazySet{N}} = UnionSet{N, S1, S2}(X, Y)

--- a/src/LazyOperations/UnionSet.jl
+++ b/src/LazyOperations/UnionSet.jl
@@ -245,6 +245,7 @@ struct UnionSetArray{N<:Real, S<:LazySet{N}}
 end
 
 isoperationtype(::Type{<:UnionSetArray}) = true
+isconvextype(::Type{<:UnionSetArray}) = false
 
 # EmptySet is the neutral element for UnionSetArray
 @neutral(UnionSetArray, EmptySet)

--- a/src/Sets/Ball1.jl
+++ b/src/Sets/Ball1.jl
@@ -54,6 +54,7 @@ struct Ball1{N<:Real} <: AbstractCentrallySymmetricPolytope{N}
 end
 
 isoperationtype(::Type{<:Ball1}) = false
+isconvextype(::Type{<:Ball1}) = true
 
 # convenience constructor without type parameter
 Ball1(center::Vector{N}, radius::N) where {N<:Real} = Ball1{N}(center, radius)

--- a/src/Sets/Ball2.jl
+++ b/src/Sets/Ball2.jl
@@ -63,6 +63,7 @@ struct Ball2{N<:AbstractFloat} <: AbstractCentrallySymmetric{N}
 end
 
 isoperationtype(::Type{<:Ball2}) = false
+isconvextype(::Type{<:Ball2}) = true
 
 # convenience constructor without type parameter
 Ball2(center::Vector{N}, radius::N) where {N<:AbstractFloat} =

--- a/src/Sets/BallInf.jl
+++ b/src/Sets/BallInf.jl
@@ -51,6 +51,7 @@ struct BallInf{N<:Real} <: AbstractHyperrectangle{N}
 end
 
 isoperationtype(::Type{<:BallInf}) = false
+isconvextype(::Type{<:BallInf}) = true
 
 # convenience constructor without type parameter
 BallInf(center::Vector{N}, radius::N) where {N<:Real} =

--- a/src/Sets/Ballp.jl
+++ b/src/Sets/Ballp.jl
@@ -76,6 +76,7 @@ struct Ballp{N<:AbstractFloat} <: AbstractCentrallySymmetric{N}
 end
 
 isoperationtype(::Type{<:Ballp}) = false
+isconvextype(::Type{<:Ballp}) = true
 
 # convenience constructor without type parameter
 function Ballp(p::N, center::Vector{N}, radius::N) where {N<:Real}

--- a/src/Sets/Ellipsoid.jl
+++ b/src/Sets/Ellipsoid.jl
@@ -79,6 +79,7 @@ struct Ellipsoid{N<:AbstractFloat} <: AbstractCentrallySymmetric{N}
 end
 
 isoperationtype(::Type{<:Ellipsoid}) = false
+isconvextype(::Type{<:Ellipsoid}) = true
 
 # convenience constructor without type parameter
 Ellipsoid(c::AbstractVector{N}, Q::AbstractMatrix{N}) where {N<:AbstractFloat} =

--- a/src/Sets/EmptySet.jl
+++ b/src/Sets/EmptySet.jl
@@ -14,6 +14,7 @@ Type that represents the empty set, i.e., the set with no elements.
 struct EmptySet{N<:Real} <: LazySet{N} end
 
 isoperationtype(::Type{<:EmptySet}) = false
+isconvextype(::Type{<:EmptySet}) = true
 
 # default constructor of type Float64
 EmptySet() = EmptySet{Float64}()

--- a/src/Sets/HPolygon.jl
+++ b/src/Sets/HPolygon.jl
@@ -66,6 +66,7 @@ struct HPolygon{N<:Real} <: AbstractHPolygon{N}
 end
 
 isoperationtype(::Type{<:HPolygon}) = false
+isconvextype(::Type{<:HPolygon}) = true
 
 # convenience constructor without type parameter
 HPolygon(constraints::Vector{<:LinearConstraint{N}};

--- a/src/Sets/HPolygonOpt.jl
+++ b/src/Sets/HPolygonOpt.jl
@@ -75,6 +75,7 @@ mutable struct HPolygonOpt{N<:Real} <: AbstractHPolygon{N}
 end
 
 isoperationtype(::Type{<:HPolygonOpt}) = false
+isconvextype(::Type{<:HPolygonOpt}) = true
 
 # convenience constructor without type parameter
 HPolygonOpt(constraints::Vector{<:LinearConstraint{N}},

--- a/src/Sets/HPolyhedron.jl
+++ b/src/Sets/HPolyhedron.jl
@@ -35,6 +35,7 @@ struct HPolyhedron{N<:Real} <: AbstractPolyhedron{N}
 end
 
 isoperationtype(::Type{<:HPolyhedron}) = false
+isconvextype(::Type{<:HPolyhedron}) = true
 
 # convenience constructor without type parameter
 HPolyhedron(constraints::Vector{<:LinearConstraint{N}}) where {N<:Real} =

--- a/src/Sets/HPolytope.jl
+++ b/src/Sets/HPolytope.jl
@@ -35,6 +35,7 @@ struct HPolytope{N<:Real} <: AbstractPolytope{N}
 end
 
 isoperationtype(::Type{<:HPolytope}) = false
+isconvextype(::Type{<:HPolytope}) = true
 
 # convenience constructor without type parameter
 HPolytope(constraints::Vector{<:LinearConstraint{N}};

--- a/src/Sets/HalfSpace.jl
+++ b/src/Sets/HalfSpace.jl
@@ -39,6 +39,7 @@ struct HalfSpace{N<:Real, VN<:AbstractVector{N}} <: AbstractPolyhedron{N}
 end
 
 isoperationtype(::Type{<:HalfSpace}) = false
+isconvextype(::Type{<:HalfSpace}) = true
 
 # convenience constructor without type parameter
 HalfSpace(a::VN, b::N) where {N<:Real, VN<:AbstractVector{N}} =

--- a/src/Sets/Hyperplane.jl
+++ b/src/Sets/Hyperplane.jl
@@ -35,6 +35,7 @@ struct Hyperplane{N<:Real} <: AbstractPolyhedron{N}
 end
 
 isoperationtype(::Type{<:Hyperplane}) = false
+isconvextype(::Type{<:Hyperplane}) = true
 
 # convenience constructor without type parameter
 Hyperplane(a::AbstractVector{N}, b::N) where {N<:Real} = Hyperplane{N}(a, b)

--- a/src/Sets/Hyperrectangle.jl
+++ b/src/Sets/Hyperrectangle.jl
@@ -88,6 +88,7 @@ struct Hyperrectangle{N<:Real, VNC<:AbstractVector{N}, VNR<:AbstractVector{N}
 end
 
 isoperationtype(::Type{<:Hyperrectangle}) = false
+isconvextype(::Type{<:Hyperrectangle}) = true
 
 # constructor from keyword arguments (lower and upper bounds)
 function Hyperrectangle(;

--- a/src/Sets/Interval.jl
+++ b/src/Sets/Interval.jl
@@ -80,6 +80,7 @@ struct Interval{N<:Real, IN<:AbstractInterval{N}} <: AbstractHyperrectangle{N}
 end
 
 isoperationtype(::Type{<:Interval}) = false
+isconvextype(::Type{<:Interval}) = true
 
 # convenience constructor without type parameter for Rational
 Interval(interval::IN) where {N<:Rational, IN<:AbstractInterval{N}} =

--- a/src/Sets/Line.jl
+++ b/src/Sets/Line.jl
@@ -38,6 +38,7 @@ struct Line{N<:Real, VN<:AbstractVector{N}} <: AbstractPolyhedron{N}
 end
 
 isoperationtype(::Type{<:Line}) = false
+isconvextype(::Type{<:Line}) = true
 
 # convenience constructor without type parameter
 Line(a::VN, b::N) where {N<:Real, VN<:AbstractVector{N}} = Line{N, VN}(a, b)

--- a/src/Sets/LineSegment.jl
+++ b/src/Sets/LineSegment.jl
@@ -60,6 +60,7 @@ struct LineSegment{N<:Real} <: AbstractZonotope{N}
 end
 
 isoperationtype(::Type{<:LineSegment}) = false
+isconvextype(::Type{<:LineSegment}) = true
 
 # convenience constructor without type parameter
 LineSegment(p::AbstractVector{N}, q::AbstractVector{N}) where {N<:Real} =

--- a/src/Sets/PolynomialZonotope.jl
+++ b/src/Sets/PolynomialZonotope.jl
@@ -88,7 +88,7 @@ struct PolynomialZonotope{N}
 end
 
 isoperationtype(::Type{<:PolynomialZonotope}) = false
-isconvextype(::Type{<:PolynomialZonotope}) = true
+isconvextype(::Type{<:PolynomialZonotope}) = false
 
 # type-less convenience constructor
 PolynomialZonotope(c::Vector{N},

--- a/src/Sets/PolynomialZonotope.jl
+++ b/src/Sets/PolynomialZonotope.jl
@@ -88,6 +88,7 @@ struct PolynomialZonotope{N}
 end
 
 isoperationtype(::Type{<:PolynomialZonotope}) = false
+isconvextype(::Type{<:PolynomialZonotope}) = true
 
 # type-less convenience constructor
 PolynomialZonotope(c::Vector{N},

--- a/src/Sets/Singleton.jl
+++ b/src/Sets/Singleton.jl
@@ -16,6 +16,7 @@ struct Singleton{N<:Real, VN<:AbstractVector{N}} <: AbstractSingleton{N}
 end
 
 isoperationtype(::Type{<:Singleton}) = false
+isconvextype(::Type{<:Singleton}) = true
 
 # --- AbstractSingleton interface functions ---
 

--- a/src/Sets/Universe.jl
+++ b/src/Sets/Universe.jl
@@ -14,6 +14,7 @@ struct Universe{N<:Real} <: AbstractPolyhedron{N}
 end
 
 isoperationtype(::Type{<:Universe}) = false
+isconvextype(::Type{<:Universe}) = true
 
 # default constructor of type Float64
 Universe(dim::Int) = Universe{Float64}(dim)

--- a/src/Sets/VPolygon.jl
+++ b/src/Sets/VPolygon.jl
@@ -44,6 +44,7 @@ struct VPolygon{N<:Real, VN<:AbstractVector{N}} <: AbstractPolygon{N}
 end
 
 isoperationtype(::Type{<:VPolygon}) = false
+isconvextype(::Type{<:VPolygon}) = true
 
 # convenience constructor without type parameter
 VPolygon(vertices::Vector{VN};

--- a/src/Sets/VPolytope.jl
+++ b/src/Sets/VPolytope.jl
@@ -25,6 +25,7 @@ struct VPolytope{N<:Real} <: AbstractPolytope{N}
 end
 
 isoperationtype(::Type{<:VPolytope}) = false
+isconvextype(::Type{<:VPolytope}) = true
 
 # constructor for a VPolytope with empty vertices list
 VPolytope{N}() where {N<:Real} = VPolytope{N}(Vector{Vector{N}}())

--- a/src/Sets/ZeroSet.jl
+++ b/src/Sets/ZeroSet.jl
@@ -18,6 +18,7 @@ struct ZeroSet{N<:Real} <: AbstractSingleton{N}
 end
 
 isoperationtype(::Type{<:ZeroSet}) = false
+isconvextype(::Type{<:ZeroSet}) = true
 
 # default constructor of type Float64
 ZeroSet(dim::Int) = ZeroSet{Float64}(dim)

--- a/src/Sets/Zonotope.jl
+++ b/src/Sets/Zonotope.jl
@@ -100,6 +100,7 @@ struct Zonotope{N<:Real} <: AbstractZonotope{N}
 end
 
 isoperationtype(::Type{<:Zonotope}) = false
+isconvextype(::Type{<:Zonotope}) = true
 
 # constructor from center and list of generators
 Zonotope(center::AbstractVector{N}, generators_list::AbstractVector{VN};


### PR DESCRIPTION
Closes #1838.
Closes #1844.

--- 

To be added in the "Examples" section of the docstring of `isconvextype` (on a different PR)

````
On the other hand, the complement of a set is not convex, hence the intersection of
the lazy complement of a set with a ball in the infinity norm can no longer be
guaranteed to be convex, and `isconvextype` returns `false` in this case:

```jldoctest convex_types
julia> isconvextype(Intersection{Float64, Complement{Float64,BallInf{Float64}}, BallInf{Float64}})
false
```
````