### PR TITLE
#1855 - Restrict epsilon-close approx to convex sets

### DIFF
--- a/src/Approximations/overapproximate.jl
+++ b/src/Approximations/overapproximate.jl
@@ -28,19 +28,25 @@ end
                     ::Type{<:HPolygon},
                     [ε]::Real=Inf) where {N<:Real}
 
-Return an approximation of a given 2D convex set.
-If no error tolerance is given, or is `Inf`, the result is a box-shaped polygon.
-Otherwise the result is an ε-close approximation as a polygon.
+Return an approximation of a given 2D convex set using iterative refinement.
 
 ### Input
 
 - `S`        -- convex set, assumed to be two-dimensional
 - `HPolygon` -- type for dispatch
-- `ε`        -- (optional, default: `Inf`) error bound
+- `ε`        -- (optional, default: `Inf`) error tolerance
 
 ### Output
 
 A polygon in constraint representation.
+
+### Notes
+
+The result is always a convex overapproximation of the input set.
+
+If no error tolerance ε is given, or is `Inf`, the result is a box-shaped polygon.
+For convex input sets, the result is an ε-close approximation as a polygon,
+with respect to the Hausdorff distance.
 """
 function overapproximate(S::ST,
                          ::Type{<:HPolygon},
@@ -55,10 +61,6 @@ function overapproximate(S::ST,
         constraints[4] = LinearConstraint(DIR_SOUTH(N), ρ(DIR_SOUTH(N), S))
         return HPolygon(constraints, sort_constraints=false)
     else
-        if !isconvextype(ST)
-            throw(ArgumentError("this function requires the set type to be convex, but " *
-                    "it is not the case for a $ST"))
-        end
         return tohrep(approximate(S, ε))
     end
 end

--- a/src/Approximations/overapproximate.jl
+++ b/src/Approximations/overapproximate.jl
@@ -26,7 +26,7 @@ end
 """
     overapproximate(S::LazySet{N},
                     ::Type{<:HPolygon},
-                    [ε]::Real=Inf)::HPolygon where {N<:Real}
+                    [ε]::Real=Inf) where {N<:Real}
 
 Return an approximation of a given 2D convex set.
 If no error tolerance is given, or is `Inf`, the result is a box-shaped polygon.
@@ -42,10 +42,9 @@ Otherwise the result is an ε-close approximation as a polygon.
 
 A polygon in constraint representation.
 """
-function overapproximate(S::LazySet{N},
+function overapproximate(S::ST,
                          ::Type{<:HPolygon},
-                         ε::Real=Inf
-                        )::HPolygon where {N<:Real}
+                         ε::Real=Inf) where {N<:Real, ST<:LazySet{N}}
     @assert dim(S) == 2 "epsilon-close approximation is only available for " *
                         "two-dimensional sets"
     if ε == Inf
@@ -56,6 +55,10 @@ function overapproximate(S::LazySet{N},
         constraints[4] = LinearConstraint(DIR_SOUTH(N), ρ(DIR_SOUTH(N), S))
         return HPolygon(constraints, sort_constraints=false)
     else
+        if !isconvextype(ST)
+            throw(ArgumentError("this function requires the set type to be convex, but " *
+                    "it is not the case for a $ST"))
+        end
         return tohrep(approximate(S, ε))
     end
 end

--- a/src/Approximations/overapproximate.jl
+++ b/src/Approximations/overapproximate.jl
@@ -28,7 +28,7 @@ end
                     ::Type{<:HPolygon},
                     [ε]::Real=Inf) where {N<:Real}
 
-Return an approximation of a given 2D convex set using iterative refinement.
+Return an approximation of a given 2D set using iterative refinement.
 
 ### Input
 


### PR DESCRIPTION
Closes #1855.


This PR implements a restriction on the argument type such that epsilon-close overapproximation of a set which is not guaranteed to be convex by its type is forbidden.  