### PR TITLE
Revision of Ball1.jl

### DIFF
--- a/docs/src/lib/sets/Ball1.md
+++ b/docs/src/lib/sets/Ball1.md
@@ -7,7 +7,7 @@ CurrentModule = LazySets
 ```@docs
 Ball1
 σ(::AbstractVector{N}, ::Ball1{N}) where {N<:Real}
-∈(::AbstractVector{N}, ::Ball1{N}) where {N<:Real}
+∈(::AbstractVector{N}, ::Ball1{N}, ::Bool=false) where {N<:Real}
 vertices_list(::Ball1{N}) where {N<:Real}
 center(::Ball1{N}) where {N<:Real}
 rand(::Type{Ball1})

--- a/docs/src/lib/sets/Ball1.md
+++ b/docs/src/lib/sets/Ball1.md
@@ -8,7 +8,7 @@ CurrentModule = LazySets
 Ball1
 σ(::AbstractVector{N}, ::Ball1{N}) where {N<:Real}
 ∈(::AbstractVector{N}, ::Ball1{N}, ::Bool=false) where {N<:Real}
-vertices_list(::Ball1{N}) where {N<:Real}
+vertices_list(::Ball1{N, VN}) where {N<:Real, VN<:AbstractVector{N}}
 center(::Ball1{N}) where {N<:Real}
 rand(::Type{Ball1})
 constraints_list(::Ball1{N}) where {N<:Real}

--- a/src/Sets/Ball1.jl
+++ b/src/Sets/Ball1.jl
@@ -144,7 +144,7 @@ function σ(d::AbstractVector{N}, B::Ball1{N}) where {N<:Real}
 end
 
 """
-    ∈(x::AbstractVector{N}, B::Ball1{N}) where {N<:Real}
+    ∈(x::AbstractVector{N}, B::Ball1{N}, [failfast]::Bool=false) where {N<:Real}
 
 Check whether a given point is contained in a ball in the 1-norm.
 
@@ -152,6 +152,7 @@ Check whether a given point is contained in a ball in the 1-norm.
 
 - `x` -- point/vector
 - `B` -- ball in the 1-norm
+- `failfast` -- (optional, default: `false`) optimization for negative answer
 
 ### Output
 
@@ -159,10 +160,11 @@ Check whether a given point is contained in a ball in the 1-norm.
 
 ### Notes
 
-This implementation is worst-case optimized, i.e., it is optimistic and first
-computes (see below) the whole sum before comparing to the radius.
-In applications where the point is typically far away from the ball, a fail-fast
-implementation with interleaved comparisons could be more efficient.
+The default behavior (`failfast == false`) is worst-case optimized, i.e., the
+implementation is optimistic and first computes (see below) the whole sum before
+comparing to the radius.
+In applications where the point is typically far away from the ball, the option
+`failfast == true` terminates faster.
 
 ### Algorithm
 
@@ -182,12 +184,15 @@ julia> [.5, 1.5] ∈ B
 true
 ```
 """
-function ∈(x::AbstractVector{N}, B::Ball1{N}) where {N<:Real}
+function ∈(x::AbstractVector{N}, B::Ball1{N}, failfast::Bool=false) where {N<:Real}
     @assert length(x) == dim(B) "a $(length(x))-dimensional vector is " *
         "incompatible with a $(dim(B))-dimensional set"
     sum = zero(N)
     for (i, xi) in enumerate(x)
         sum += abs(B.center[i] - xi)
+        if failfast && sum > B.radius
+            return false
+        end
     end
     return sum <= B.radius
 end

--- a/src/Sets/Ball1.jl
+++ b/src/Sets/Ball1.jl
@@ -4,7 +4,7 @@ import Base: rand,
 export Ball1
 
 """
-    Ball1{N<:Real} <: AbstractCentrallySymmetricPolytope{N}
+    Ball1{N<:Real, VN<:AbstractVector{N}} <: AbstractCentrallySymmetricPolytope{N}
 
 Type that represents a ball in the 1-norm (also known as the Manhattan norm).
 The ball is also known as a
@@ -28,7 +28,7 @@ Unit ball in the 1-norm in the plane:
 
 ```jldoctest ball1_constructor
 julia> B = Ball1(zeros(2), 1.)
-Ball1{Float64}([0.0, 0.0], 1.0)
+Ball1{Float64,Array{Float64,1}}([0.0, 0.0], 1.0)
 julia> dim(B)
 2
 ```
@@ -42,14 +42,14 @@ julia> σ([0.,1], B)
  1.0
 ```
 """
-struct Ball1{N<:Real} <: AbstractCentrallySymmetricPolytope{N}
-    center::Vector{N}
+struct Ball1{N<:Real, VN<:AbstractVector{N}} <: AbstractCentrallySymmetricPolytope{N}
+    center::VN
     radius::N
 
     # default constructor with domain constraint for radius
-    function Ball1(center::Vector{N}, radius::N) where {N<:Real}
+    function Ball1(center::VN, radius::N) where {N<:Real, VN<:AbstractVector{N}}
         @assert radius >= zero(N) "radius must not be negative"
-        return new{N}(center, radius)
+        return new{N, VN}(center, radius)
     end
 end
 
@@ -82,7 +82,7 @@ end
 
 
 """
-    vertices_list(B::Ball1{N}) where {N<:Real}
+    vertices_list(B::Ball1{N, VN}) where {N<:Real, VN<:AbstractVector{N}}
 
 Return the list of vertices of a ball in the 1-norm.
 
@@ -94,12 +94,12 @@ Return the list of vertices of a ball in the 1-norm.
 
 A list containing the vertices of the ball in the 1-norm.
 """
-function vertices_list(B::Ball1{N}) where {N<:Real}
+function vertices_list(B::Ball1{N, VN}) where {N<:Real, VN<:AbstractVector{N}}
     # fast evaluation if B has radius 0
     if iszero(B.radius)
         return [B.center]
     end
-    vertices = Vector{Vector{N}}(undef, 2 * dim(B))
+    vertices = Vector{VN}(undef, 2 * dim(B))
     j = 0
     v = copy(B.center)
     @inbounds for i in 1:dim(B)

--- a/src/Sets/Ball1.jl
+++ b/src/Sets/Ball1.jl
@@ -47,7 +47,7 @@ struct Ball1{N<:Real} <: AbstractCentrallySymmetricPolytope{N}
     radius::N
 
     # default constructor with domain constraint for radius
-    function Ball1{N}(center::Vector{N}, radius::N) where {N<:Real}
+    function Ball1(center::Vector{N}, radius::N) where {N<:Real}
         @assert radius >= zero(N) "radius must not be negative"
         return new{N}(center, radius)
     end
@@ -55,9 +55,6 @@ end
 
 isoperationtype(::Type{<:Ball1}) = false
 isconvextype(::Type{<:Ball1}) = true
-
-# convenience constructor without type parameter
-Ball1(center::Vector{N}, radius::N) where {N<:Real} = Ball1{N}(center, radius)
 
 
 # --- AbstractCentrallySymmetric interface functions ---

--- a/src/Sets/Ball1.jl
+++ b/src/Sets/Ball1.jl
@@ -185,7 +185,7 @@ function ∈(x::AbstractVector{N}, B::Ball1{N}, failfast::Bool=false) where {N<:
     @assert length(x) == dim(B) "a $(length(x))-dimensional vector is " *
         "incompatible with a $(dim(B))-dimensional set"
     sum = zero(N)
-    for (i, xi) in enumerate(x)
+    @inbounds for (i, xi) in enumerate(x)
         sum += abs(B.center[i] - xi)
         if failfast && sum > B.radius
             return false

--- a/test/unit_Ball1.jl
+++ b/test/unit_Ball1.jl
@@ -70,7 +70,12 @@ for N in [Float64, Rational{Int}, Float32]
     @test !isuniversal(b) && !answer && w ∉ b
 
     # an_element & membership function
-    @test an_element(b) ∈ b
+    e = an_element(b)
+    answer = e ∈ b
+    @test answer == ∈(e, b, true) == ∈(e, b, false) == true
+    e += N[2 * b.radius, 1]
+    answer = e ∈ b
+    @test answer == ∈(e, b, true) == ∈(e, b, false) == false
 
     # translation
     @test translate(b, N[1, 2]) == Ball1(N[1, 2], N(2))


### PR DESCRIPTION
This PR may seem a bit strange. I am not particularly interested in `Ball1`. My original plan was to *quickly* go through all files and do some clean-ups. But I got lost in the details and only made it through the first file :disappointed:

Here are the commit descriptions. There is a **breaking change** in the third commit that is debatable.

1. several changes:
   * removed output-type parameters
   * "faster" `vertices_list` implementation by removing `push!`es and look-ups of vector entries (the "faster" is in quotes because the benchmark below shows that there is no dfference for large inputs and even a minor slowdown for 2D inputs...)
   * added assertion message
   * used `enumerate`
   * removed redundant `LazySets.` prefix
2. added fail-fast option to membership test (see small benchmark below; in the best case the implementation takes constant time but in the worst case that option is considerably slower (~30%))
3. removed constructor with type parameter (IMO it has no use case)
4. added type parameter for `center` vector

```julia
julia> using LazySets, BenchmarkTools
julia> d = zeros(2); d2 = 10*ones(2); B = Ball1(zeros(2), 1.);
julia> d3 = zeros(10000); d4 = 10*ones(10000); B2 = Ball1(zeros(10000), 1.);

# --- positive answer ---

julia> @btime ∈($d, $B)  # before change
  8.211 ns (0 allocations: 0 bytes)
true

julia> @btime ∈($d, $B, true)
  8.588 ns (0 allocations: 0 bytes)
true

julia> @btime ∈($d, $B, false)
  8.580 ns (0 allocations: 0 bytes)
true


julia> @btime ∈($d3, $B2)  # before change
  11.188 μs (0 allocations: 0 bytes)
true

julia> @btime ∈($d3, $B2, true)
  14.897 μs (0 allocations: 0 bytes)
true

julia> @btime ∈($d3, $B2, false)
  11.181 μs (0 allocations: 0 bytes)
true

# --- negative answer ---

julia> @btime ∈($d2, $B)  # before change
  8.209 ns (0 allocations: 0 bytes)
false

julia> @btime ∈($d2, $B, true)
  7.464 ns (0 allocations: 0 bytes)
false

julia> @btime ∈($d2, $B, false)
  8.577 ns (0 allocations: 0 bytes)
false


julia> @btime ∈($d4, $B2)  # before change
  11.181 μs (0 allocations: 0 bytes)
false

julia> @btime ∈($d4, $B2, true)
  7.466 ns (0 allocations: 0 bytes)
false

julia> @btime ∈($d4, $B2, false)
  11.187 μs (0 allocations: 0 bytes)
false
```