### PR TITLE
#1840 - Remove output-type annotations

### DIFF
--- a/src/Approximations/box_approximations.jl
+++ b/src/Approximations/box_approximations.jl
@@ -3,8 +3,7 @@
 # ===================================
 
 """
-    box_approximation(S::LazySet{N})::Union{Hyperrectangle{N}, EmptySet{N}}
-        where {N<:Real}
+    box_approximation(S::LazySet{N}) where {N<:Real}
 
 Overapproximate a convex set by a tight hyperrectangle.
 
@@ -16,8 +15,7 @@ Overapproximate a convex set by a tight hyperrectangle.
 
 A tight hyperrectangle.
 """
-function box_approximation(S::LazySet{N}
-                          )::Union{Hyperrectangle{N}, EmptySet{N}} where {N<:Real}
+function box_approximation(S::LazySet{N}) where {N<:Real}
     return overapproximate(S, Hyperrectangle)
 end
 
@@ -29,9 +27,7 @@ Alias for `box_approximation`.
 interval_hull = box_approximation
 
 """
-    box_approximation_symmetric(S::LazySet{N}
-                               )::Union{Hyperrectangle{N}, EmptySet{N}}
-                                where {N<:Real}
+    box_approximation_symmetric(S::LazySet{N}) where {N<:Real}
 
 Overapproximate a convex set by a tight hyperrectangle centered in the origin.
 
@@ -48,9 +44,7 @@ A tight hyperrectangle centered in the origin.
 The center of the box is the origin, and the radius is obtained by computing the
 maximum value of the support function evaluated at the canonical directions.
 """
-function box_approximation_symmetric(S::LazySet{N};
-                                    )::Union{Hyperrectangle{N},
-                                             EmptySet{N}} where {N<:Real}
+function box_approximation_symmetric(S::LazySet{N}) where {N<:Real}
     (c, r) = box_approximation_helper(S)
     if r[1] < 0
         return EmptySet{N}()
@@ -118,8 +112,7 @@ functions in the same directions.
 end
 
 """
-    ballinf_approximation(S::LazySet{N}
-                         )::Union{BallInf{N}, EmptySet{N}} where {N<:Real}
+    ballinf_approximation(S::LazySet{N}) where {N<:Real}
 
 Overapproximate a convex set by a tight ball in the infinity norm.
 
@@ -131,8 +124,7 @@ Overapproximate a convex set by a tight ball in the infinity norm.
 
 A tight ball in the infinity norm.
 """
-function ballinf_approximation(S::LazySet{N}
-                              )::Union{BallInf{N}, EmptySet{N}} where {N<:Real}
+function ballinf_approximation(S::LazySet{N}) where {N<:Real}
     return overapproximate(S, BallInf)
 end
 

--- a/src/Approximations/decompositions.jl
+++ b/src/Approximations/decompositions.jl
@@ -70,7 +70,7 @@ end
     decompose(S::LazySet{N},
               partition::AbstractVector{<:AbstractVector{Int}},
               block_options
-             )::CartesianProductArray{N} where {N<:Real}
+             ) where {N<:Real}
 
 Decompose a high-dimensional set into a Cartesian product of overapproximations
 of the projections over the specified subspaces.
@@ -221,7 +221,7 @@ julia> typeof(res[1]), typeof(res[2])
 function decompose(S::LazySet{N},
                    partition::AbstractVector{<:AbstractVector{Int}},
                    block_options
-                  )::CartesianProductArray{N} where {N<:Real}
+                  ) where {N<:Real}
     n = dim(S)
     result = Vector{LazySet{N}}(undef, length(partition))
 
@@ -239,7 +239,7 @@ function decompose(S::LazySet{N},
                                         Real,
                                         Type{<:AbstractDirections}
                                        }
-                  )::CartesianProductArray{N} where {N<:Real}
+                  ) where {N<:Real}
     n = dim(S)
     result = Vector{LazySet{N}}(undef, length(partition))
 
@@ -260,7 +260,7 @@ end
             block::AbstractVector{Int},
             set_type::Type{<:LinearMap},
             [n]::Int=dim(S)
-           )::LinearMap{N} where {N<:Real}
+           ) where {N<:Real}
 
 Project a high-dimensional set to a given block by using a lazy linear map.
 
@@ -279,7 +279,7 @@ A lazy `LinearMap` representing a projection of the set `S` to block `block`.
                          block::AbstractVector{Int},
                          set_type::Type{<:LinearMap},
                          n::Int=dim(S)
-                        )::LinearMap{N} where {N<:Real}
+                        ) where {N<:Real}
     m = length(block)
     M = sparse(1:m, block, ones(N, m), m, n)
     return M * S

--- a/src/Approximations/iterative_refinement.jl
+++ b/src/Approximations/iterative_refinement.jl
@@ -120,7 +120,7 @@ the new approximation is returned by this function.
 """
 function addapproximation!(Ω::PolygonalOverapproximation,
                            p1::Vector{N}, d1::Vector{N}, p2::Vector{N},
-                           d2::Vector{N})::LocalApproximation{N} where {N<:Real}
+                           d2::Vector{N}) where {N<:Real}
 
     approx = new_approx(Ω.S, p1, d1, p2, d2)
     push!(Ω.approx_stack, approx)
@@ -128,8 +128,7 @@ function addapproximation!(Ω::PolygonalOverapproximation,
 end
 
 """
-    refine(approx::LocalApproximation, S::LazySet
-          )::Tuple{LocalApproximation, LocalApproximation}
+    refine(approx::LocalApproximation, S::LazySet)
 
 Refine a given local approximation of the polygonal approximation of a convex
 set by splitting along the normal direction of the approximation.
@@ -143,9 +142,7 @@ set by splitting along the normal direction of the approximation.
 
 The tuple consisting of the refined right and left local approximations.
 """
-function refine(approx::LocalApproximation,
-                S::LazySet
-               )::Tuple{LocalApproximation, LocalApproximation}
+function refine(approx::LocalApproximation, S::LazySet)
     @assert approx.refinable
 
     ndir = normalize([approx.p2[2]-approx.p1[2], approx.p1[1]-approx.p2[1]])
@@ -156,7 +153,7 @@ function refine(approx::LocalApproximation,
 end
 
 """
-    tohrep(Ω::PolygonalOverapproximation{N})::AbstractHPolygon{N}
+    tohrep(Ω::PolygonalOverapproximation{N})
         where {N<:Real}
 
 Convert a polygonal overapproximation into a concrete polygon.
@@ -174,8 +171,7 @@ A polygon in constraint representation.
 Internally we keep the constraints sorted.
 Hence we do not need to use `addconstraint!` when creating the `HPolygon`.
 """
-function tohrep(Ω::PolygonalOverapproximation{N}
-               )::AbstractHPolygon{N} where {N<:Real}
+function tohrep(Ω::PolygonalOverapproximation{N}) where {N<:Real}
     # already finalized
     if isempty(Ω.approx_stack)
         return HPolygon(Ω.constraints, sort_constraints=false)
@@ -189,8 +185,7 @@ function tohrep(Ω::PolygonalOverapproximation{N}
 end
 
 """
-    approximate(S::LazySet{N},
-                ε::N)::PolygonalOverapproximation{N} where {N<:AbstractFloat}
+    approximate(S::LazySet{N}, ε::N) where {N<:AbstractFloat}
 
 Return an ε-close approximation of the given 2D convex set (in terms of
 Hausdorff distance) as an inner and an outer approximation composed by sorted
@@ -205,8 +200,7 @@ local `Approximation2D`.
 
 An ε-close approximation of the given 2D convex set.
 """
-function approximate(S::LazySet{N}, ε::N
-                    )::PolygonalOverapproximation{N} where {N<:AbstractFloat}
+function approximate(S::LazySet{N}, ε::N) where {N<:AbstractFloat}
     # initialize box directions
     pe = σ(DIR_EAST(N), S)
     pn = σ(DIR_NORTH(N), S)

--- a/src/Approximations/overapproximate.jl
+++ b/src/Approximations/overapproximate.jl
@@ -79,19 +79,16 @@ function overapproximate(X::S, ::Type{<:HPolytope}) where {S<:LazySet}
 end
 
 """
-    overapproximate(S::LazySet, ε::Real)::HPolygon
+    overapproximate(S::LazySet, ε::Real)
 
 Alias for `overapproximate(S, HPolygon, ε)`.
 """
-function overapproximate(S::LazySet,
-                         ε::Real;
-                        )::HPolygon
+function overapproximate(S::LazySet, ε::Real)
     return overapproximate(S, HPolygon, ε)
 end
 
 """
-    overapproximate(S::LazySet,
-                    Type{<:Hyperrectangle})::Union{Hyperrectangle, EmptySet}
+    overapproximate(S::LazySet, Type{<:Hyperrectangle})
 
 Return an approximation of a given set as a hyperrectangle.
 
@@ -111,8 +108,7 @@ of the given set in the canonical directions, and the lengths of the sides can
 be recovered from the distance among support functions in the same directions.
 """
 function overapproximate(S::LazySet{N},
-                         ::Type{<:Hyperrectangle};
-                        )::Union{Hyperrectangle, EmptySet} where {N<:Real}
+                         ::Type{<:Hyperrectangle}) where {N<:Real}
     c, r = box_approximation_helper(S)
     if r[1] < 0
         return EmptySet{N}()
@@ -250,13 +246,11 @@ overapproximate(∅::EmptySet, ::Type{<:Hyperrectangle}) = ∅
 overapproximate(∅::EmptySet, ::Type{<:EmptySet}) = ∅
 
 """
-    overapproximate(S::LazySet)::Union{Hyperrectangle, EmptySet}
+    overapproximate(S::LazySet)
 
 Alias for `overapproximate(S, Hyperrectangle)`.
 """
-overapproximate(S::LazySet;
-               )::Union{Hyperrectangle, EmptySet} =
-    overapproximate(S, Hyperrectangle)
+overapproximate(S::LazySet) = overapproximate(S, Hyperrectangle)
 
 """
     overapproximate(S::LazySet{N}, ::Type{<:BallInf}) where {N<:Real}

--- a/src/Approximations/template_directions.jl
+++ b/src/Approximations/template_directions.jl
@@ -9,12 +9,12 @@ Abstract type for template direction representations.
 ### Notes
 
 All subtypes should implement the standard iterator methods from `Base` and the
-function `dim(d<:AbstractDirections)::Int`.
+function `dim(d<:AbstractDirections)`.
 """
 abstract type AbstractDirections{N} end
 
 """
-    dim(ad::AbstractDirections)::Int
+    dim(ad::AbstractDirections)
 
 Returns the dimension of the generated directions.
 
@@ -26,12 +26,12 @@ Returns the dimension of the generated directions.
 
 The dimension of the generated directions.
 """
-function dim(ad::AbstractDirections)::Int
+function dim(ad::AbstractDirections)
     return ad.n
 end
 
 """
-    isbounding(ad::AbstractDirections)::Bool
+    isbounding(ad::AbstractDirections)
 
 Checks if an overapproximation with a list of template directions results in a
 bounded set, given a bounded input set.
@@ -55,7 +55,7 @@ By default, this function returns `false` in order to be conservative.
 Custom subtypes of `AbstractDirections` should hence add a method for this
 function.
 """
-function isbounding(ad::AbstractDirections)::Bool
+function isbounding(ad::AbstractDirections)
     return false
 end
 

--- a/src/Arrays/matrix_operations.jl
+++ b/src/Arrays/matrix_operations.jl
@@ -25,7 +25,7 @@ end
 LinearAlgebra.rank(M::SubArray{N, 2, <:SparseMatrixCSC}) where {N} = rank(sparse(M))
 
 """
-    issquare(M::AbstractMatrix)::Bool
+    issquare(M::AbstractMatrix)
 
 Check whether a matrix is square.
 
@@ -37,7 +37,7 @@ Check whether a matrix is square.
 
 `true` iff the matrix is square.
 """
-function issquare(M::AbstractMatrix)::Bool
+function issquare(M::AbstractMatrix)
     m, n = size(M)
     return m == n
 end
@@ -120,7 +120,7 @@ where ``M^{[i]}`` is defined as ``M`` with the ``i``-th row removed.
 See *Althoff, Stursberg, Buss: Computing Reachable Sets of Hybrid Systems Using
 a Combination of Zonotopes and Polytopes. 2009.*
 """
-function cross_product(M::AbstractMatrix{N})::Vector{N} where {N<:Real}
+function cross_product(M::AbstractMatrix{N}) where {N<:Real}
     n = size(M, 1)
     @assert 1 < n == size(M, 2) + 1 "the matrix must be n x (n-1) dimensional"
 

--- a/src/Arrays/vector_operations.jl
+++ b/src/Arrays/vector_operations.jl
@@ -59,8 +59,7 @@ function remove_duplicates_sorted!(v::AbstractVector)
 end
 
 """
-    samedir(u::AbstractVector{N},
-            v::AbstractVector{N})::Tuple{Bool, Real} where {N<:Real}
+    samedir(u::AbstractVector{N}, v::AbstractVector{N}) where {N<:Real}
 
 Check whether two vectors point in the same direction.
 
@@ -92,8 +91,7 @@ julia> samedir([1, 2, 3], [-1, -2, -3])
 ```
 """
 function samedir(u::AbstractVector{N},
-                 v::AbstractVector{N}
-                )::Tuple{Bool, Real} where {N<:Real}
+                 v::AbstractVector{N}) where {N<:Real}
     @assert length(u) == length(v) "wrong dimension"
     no_factor = true
     factor = 0
@@ -124,7 +122,7 @@ function samedir(u::AbstractVector{N},
 end
 
 """
-    nonzero_indices(v::AbstractVector{N})::Vector{Int} where {N<:Real}
+    nonzero_indices(v::AbstractVector{N}) where {N<:Real}
 
 Return the indices in which a vector is non-zero.
 
@@ -137,7 +135,7 @@ Return the indices in which a vector is non-zero.
 A vector of ascending indices `i` such that the vector is non-zero in dimension
 `i`.
 """
-function nonzero_indices(v::AbstractVector{N})::Vector{Int} where {N<:Real}
+function nonzero_indices(v::AbstractVector{N}) where {N<:Real}
     n = length(v)
     res = Vector{Int}()
     sizehint!(res, n)
@@ -149,7 +147,7 @@ function nonzero_indices(v::AbstractVector{N})::Vector{Int} where {N<:Real}
     return res
 end
 
-function nonzero_indices(v::SparseVector{N})::Vector{Int} where {N<:Real}
+function nonzero_indices(v::SparseVector{N}) where {N<:Real}
     return v.nzind
 end
 
@@ -288,7 +286,7 @@ end
 
 """
     right_turn([O::AbstractVector{N}=[0, 0]], u::AbstractVector{N},
-               v::AbstractVector{N})::N where {N<:Real}
+               v::AbstractVector{N}) where {N<:Real}
 
 Compute a scalar that determines whether the acute angle defined by three 2D
 points `O`, `u`, `v` in the plane is a right turn (< 180° counter-clockwise)
@@ -314,19 +312,19 @@ determine the sense of rotation.
 """
 @inline function right_turn(O::AbstractVector{N},
                             u::AbstractVector{N},
-                            v::AbstractVector{N})::N where {N<:Real}
+                            v::AbstractVector{N}) where {N<:Real}
     return (u[1] - O[1]) * (v[2] - O[2]) - (u[2] - O[2]) * (v[1] - O[1])
 end
 
 # version for O = origin
 @inline function right_turn(u::AbstractVector{N},
-                            v::AbstractVector{N})::N where {N<:Real}
+                            v::AbstractVector{N}) where {N<:Real}
     return u[1] * v[2] - u[2] * v[1]
 end
 
 """
     is_right_turn([O::AbstractVector{N}=[0, 0]], u::AbstractVector{N},
-                  v::AbstractVector{N})::Bool where {N<:Real}
+                  v::AbstractVector{N}) where {N<:Real}
 
 Determine whether the acute angle defined by three 2D points `O`, `u`, `v`
 in the plane is a right turn (< 180° counter-clockwise) with
@@ -346,12 +344,12 @@ counter-clockwise) with respect to the center `O`.
 """
 @inline function is_right_turn(O::AbstractVector{N},
                                u::AbstractVector{N},
-                               v::AbstractVector{N})::Bool where {N<:Real}
+                               v::AbstractVector{N}) where {N<:Real}
     return right_turn(O, u, v) >= zero(N)
 end
 
 # version for O = origin
 @inline function is_right_turn(u::AbstractVector{N},
-                               v::AbstractVector{N})::Bool where {N<:Real}
+                               v::AbstractVector{N}) where {N<:Real}
     return right_turn(u, v) >= zero(N)
 end

--- a/src/ConcreteOperations/convex_hull.jl
+++ b/src/ConcreteOperations/convex_hull.jl
@@ -72,7 +72,7 @@ end
                 [algorithm]=nothing,
                 [backend]=nothing,
                 [solver]=nothing
-                )::Vector{VN} where {N<:Real, VN<:AbstractVector{N}}
+                ) where {N<:Real, VN<:AbstractVector{N}}
 
 Compute the convex hull of the given points.
 
@@ -144,14 +144,14 @@ function convex_hull(points::Vector{VN};
                      algorithm=nothing,
                      backend=nothing,
                      solver=nothing
-                     )::Vector{VN} where {N<:Real, VN<:AbstractVector{N}}
+                     ) where {N<:Real, VN<:AbstractVector{N}}
     return convex_hull!(copy(points), algorithm=algorithm, backend=backend, solver=solver)
 end
 
 function convex_hull!(points::Vector{VN};
                       algorithm=nothing,
                       backend=nothing,
-                      solver=nothing)::Vector{VN} where {N<:Real, VN<:AbstractVector{N}}
+                      solver=nothing) where {N<:Real, VN<:AbstractVector{N}}
 
     m = length(points)
 
@@ -372,7 +372,7 @@ function _four_points_2d!(points::AbstractVector{<:AbstractVector{N}}) where {N<
     return points
 end
 
-function _convex_hull_1d!(points::Vector{VN})::Vector{VN} where {N<:Real, VN<:AbstractVector{N}}
+function _convex_hull_1d!(points::Vector{VN}) where {N<:Real, VN<:AbstractVector{N}}
     points[1:2] = [minimum(points), maximum(points)]
     return resize!(points, 2)
 end
@@ -380,7 +380,7 @@ end
 function _convex_hull_nd!(points::Vector{VN};
                           backend=nothing,
                           solver=nothing
-                          )::Vector{VN} where {N<:Real, VN<:AbstractVector{N}}
+                          ) where {N<:Real, VN<:AbstractVector{N}}
     V = VPolytope(points)
     Vch = remove_redundant_vertices(V, backend=backend, solver=solver)
     m = length(Vch.vertices)
@@ -390,7 +390,7 @@ end
 
 function _convex_hull_2d!(points::Vector{VN};
                           algorithm="monotone_chain"
-                         )::Vector{VN} where {N<:Real, VN<:AbstractVector{N}}
+                         ) where {N<:Real, VN<:AbstractVector{N}}
     if algorithm == nothing
         algorithm = default_convex_hull_algorithm(points)
     end
@@ -405,7 +405,7 @@ end
 
 """
     monotone_chain!(points::Vector{VN}; sort::Bool=true
-                   )::Vector{VN} where {N<:Real, VN<:AbstractVector{N}}
+                   ) where {N<:Real, VN<:AbstractVector{N}}
 
 Compute the convex hull of points in the plane using Andrew's monotone chain
 method.
@@ -438,7 +438,7 @@ For further details see
 [Monotone chain](https://en.wikibooks.org/wiki/Algorithm_Implementation/Geometry/Convex_hull/Monotone_chain)
 """
 function monotone_chain!(points::Vector{VN}; sort::Bool=true
-                        )::Vector{VN} where {N<:Real, VN<:AbstractVector{N}}
+                        ) where {N<:Real, VN<:AbstractVector{N}}
 
     @inline function build_hull!(semihull, iterator, points)
         @inbounds for i in iterator

--- a/src/ConcreteOperations/difference.jl
+++ b/src/ConcreteOperations/difference.jl
@@ -42,7 +42,7 @@ julia> X.dat \\ Y.dat  # computing the left division
 # =================================
 
 """
-    difference(I1::IN, I2::IN)::Union{EmptySet{N}, IN, UnionSet{N, IN, IN}} where {N, IN<:Interval{N}}
+    difference(I1::IN, I2::IN) where {N, IN<:Interval{N}}
 
 Return the set difference between the given intervals.
 
@@ -91,7 +91,7 @@ are flat or not. Three cases may arise:
 - Finally, if none of the intervals is flat, then `I₂` is strictly contained in
   `I₁` and the set union of `Ileft` and `Iright` is returned.
 """
-function difference(I1::IN, I2::IN)::Union{EmptySet{N}, IN, UnionSet{N, IN, IN}} where {N, IN<:Interval{N}}
+function difference(I1::IN, I2::IN) where {N, IN<:Interval{N}}
     I12 = intersection(I1, I2)
     if isempty(I12)
         return I1

--- a/src/ConcreteOperations/intersection.jl
+++ b/src/ConcreteOperations/intersection.jl
@@ -5,7 +5,7 @@ export intersection
 """
     intersection(S::AbstractSingleton{N},
                  X::LazySet{N}
-                )::Union{Singleton{N}, EmptySet{N}} where {N<:Real}
+                ) where {N<:Real}
 
 Return the intersection of a singleton with another set.
 
@@ -21,27 +21,27 @@ Otherwise, the result is the empty set.
 """
 function intersection(S::AbstractSingleton{N},
                       X::LazySet{N}
-                     )::Union{Singleton{N}, EmptySet{N}} where {N<:Real}
+                     ) where {N<:Real}
     return element(S) ∈ X ? S : EmptySet{N}()
 end
 
 # symmetric method
 function intersection(X::LazySet{N},
                       S::AbstractSingleton{N}
-                     )::Union{Singleton{N}, EmptySet{N}} where {N<:Real}
+                     ) where {N<:Real}
     return intersection(S, X)
 end
 
 # disambiguation
 function intersection(S1::AbstractSingleton{N},
                       S2::AbstractSingleton{N}
-                     )::Union{Singleton{N}, EmptySet{N}} where {N<:Real}
+                     ) where {N<:Real}
     return element(S1) == element(S2) ? S1 : EmptySet{N}()
 end
 
 """
     intersection(L1::Line{N}, L2::Line{N}
-                )::Union{Singleton{N}, Line{N}, EmptySet{N}} where {N<:Real}
+                ) where {N<:Real}
 
 Return the intersection of two 2D lines.
 
@@ -69,7 +69,7 @@ Line{Float64,Array{Float64,1}}([1.0, 1.0], 1.0)
 ```
 """
 function intersection(L1::Line{N}, L2::Line{N}
-                     )::Union{Singleton{N}, Line{N}, EmptySet{N}} where {N<:Real}
+                     ) where {N<:Real}
     b = [L1.b, L2.b]
     a = [transpose(L1.a); transpose(L2.a)]
     try
@@ -92,7 +92,7 @@ end
 """
     intersection(H1::AbstractHyperrectangle{N},
                  H2::AbstractHyperrectangle{N}
-                )::Union{<:Hyperrectangle{N}, EmptySet{N}} where {N<:Real}
+                ) where {N<:Real}
 
 Return the intersection of two hyperrectangles.
 
@@ -115,7 +115,7 @@ Otherwise the result uses these borders in each dimension.
 """
 function intersection(H1::AbstractHyperrectangle{N},
                       H2::AbstractHyperrectangle{N}
-                     )::Union{Hyperrectangle{N}, EmptySet{N}} where {N<:Real}
+                     ) where {N<:Real}
     n = dim(H1)
     c1 = center(H1)
     c2 = center(H2)
@@ -140,18 +140,18 @@ end
 # disambiguation
 function intersection(S::AbstractSingleton{N},
                       H::AbstractHyperrectangle{N}
-                     )::Union{Singleton{N}, EmptySet{N}} where {N<:Real}
+                     ) where {N<:Real}
     return invoke(intersection, Tuple{typeof(S), LazySet{N}}, S, H)
 end
 function intersection(H::AbstractHyperrectangle{N},
                       S::AbstractSingleton{N}
-                     )::Union{Singleton{N}, EmptySet{N}} where {N<:Real}
+                     ) where {N<:Real}
     return invoke(intersection, Tuple{typeof(S), LazySet{N}}, S, H)
 end
 
 """
     intersection(x::Interval{N}, y::Interval{N}
-                )::Union{Interval{N}, EmptySet{N}} where {N<:Real}
+                ) where {N<:Real}
 
 Return the intersection of two intervals.
 
@@ -166,7 +166,7 @@ If the intervals do not intersect, the result is the empty set.
 Otherwise the result is the interval that describes the intersection.
 """
 function intersection(x::Interval{N}, y::Interval{N}
-                     )::Union{Interval{N}, EmptySet{N}} where {N<:Real}
+                     ) where {N<:Real}
     if min(y) > max(x) || min(x) > max(y)
         return EmptySet{N}()
     else
@@ -176,7 +176,7 @@ end
 
 """
     intersection(X::Interval{N}, hs::HalfSpace{N}
-                )::Union{Interval{N}, EmptySet{N}} where {N<:Real}
+                ) where {N<:Real}
 
 Compute the intersection of an interval and a half-space.
 
@@ -199,7 +199,7 @@ zero.
 Then we distinguish the cases that `hs` is a lower or an upper bound.
 """
 function intersection(X::Interval{N}, hs::HalfSpace{N}
-                     )::Union{Interval{N}, EmptySet{N}} where {N<:Real}
+                     ) where {N<:Real}
     @assert dim(hs) == 1 "cannot take the intersection between an interval " *
                          "and a $(dim(hs))-dimensional half-space"
 
@@ -253,13 +253,13 @@ end
 
 # symmetric method
 function intersection(hs::HalfSpace{N}, X::Interval{N}
-                     )::Union{Interval{N}, EmptySet{N}} where {N<:Real}
+                     ) where {N<:Real}
     return intersection(X, hs)
 end
 
 """
     intersection(X::Interval{N}, hp::Hyperplane{N}
-                )::Union{Singleton{N}, EmptySet{N}} where {N<:Real}
+                ) where {N<:Real}
 
 Compute the intersection of an interval and a hyperplane.
 
@@ -274,7 +274,7 @@ If the sets do not intersect, the result is the empty set.
 Otherwise the result is the singleton that describes the intersection.
 """
 function intersection(X::Interval{N}, hp::Hyperplane{N}
-                     )::Union{Singleton{N}, EmptySet{N}} where {N<:Real}
+                     ) where {N<:Real}
     @assert dim(hp) == 1 "cannot take the intersection between an interval " *
                          "and a $(dim(hp))-dimensional hyperplane"
 
@@ -289,13 +289,13 @@ end
 
 # symmetric method
 function intersection(hp::Hyperplane{N}, X::Interval{N}
-                     )::Union{Singleton{N}, EmptySet{N}} where {N<:Real}
+                     ) where {N<:Real}
     return intersection(X, hp)
 end
 
 """
     intersection(X::Interval{N}, Y::LazySet{N}
-                )::Union{Interval{N}, Singleton{N}, EmptySet{N}} where {N<:Real}
+                ) where {N<:Real}
 
 Compute the intersection of an interval and a convex set.
 
@@ -311,7 +311,7 @@ Otherwise the result is the interval that describes the intersection, which may
 be of type `Singleton` if the intersection is very small.
 """
 function intersection(X::Interval{N}, Y::LazySet{N}
-                     )::Union{Interval{N}, Singleton{N}, EmptySet{N}} where {N<:Real}
+                     ) where {N<:Real}
     lower = max(min(X), -ρ(N[-1], Y))
     upper = min(max(X), ρ(N[1], Y))
     if _isapprox(lower, upper)
@@ -325,25 +325,25 @@ end
 
 # symmetric method
 function intersection(Y::LazySet{N}, X::Interval{N}
-                     )::Union{Singleton{N}, EmptySet{N}} where {N<:Real}
+                     ) where {N<:Real}
     return intersection(X, Y)
 end
 
 # disambiguation
 function intersection(X::Interval{N}, H::AbstractHyperrectangle{N}
-                     )::Union{Interval{N}, Singleton{N}, EmptySet{N}} where {N<:Real}
+                     ) where {N<:Real}
     return invoke(intersection, Tuple{Interval{N}, LazySet{N}}, X, H)
 end
 function intersection(H::AbstractHyperrectangle{N}, X::Interval{N}
-                     )::Union{Interval{N}, Singleton{N}, EmptySet{N}} where {N<:Real}
+                     ) where {N<:Real}
     return invoke(intersection, Tuple{Interval{N}, LazySet{N}}, X, H)
 end
 function intersection(X::Interval{N}, S::AbstractSingleton{N}
-                     )::Union{Singleton{N}, EmptySet{N}} where {N<:Real}
+                     ) where {N<:Real}
     return invoke(intersection, Tuple{typeof(S), LazySet{N}}, S, X)
 end
 function intersection(S::AbstractSingleton{N}, X::Interval{N}
-                     )::Union{Singleton{N}, EmptySet{N}} where {N<:Real}
+                     ) where {N<:Real}
     return invoke(intersection, Tuple{typeof(S), LazySet{N}}, S, X)
 end
 
@@ -351,7 +351,7 @@ end
     intersection(P1::AbstractHPolygon{N},
                  P2::AbstractHPolygon{N},
                  [prune]::Bool=true
-                )::Union{HPolygon{N}, EmptySet{N}} where {N<:Real}
+                ) where {N<:Real}
 
 Return the intersection of two polygons in constraint representation.
 
@@ -379,7 +379,7 @@ Redundancy of constraints is checked with
 function intersection(P1::AbstractHPolygon{N},
                       P2::AbstractHPolygon{N},
                       prune::Bool=true
-                     )::Union{HPolygon{N}, EmptySet{N}} where {N<:Real}
+                     ) where {N<:Real}
     # all constraints of one polygon are processed; now add the other polygon's
     # constraints
     @inline function add_remaining_constraints!(c, i, c1, i1, duplicates)
@@ -554,20 +554,20 @@ end
 # disambiguation
 function intersection(S::AbstractSingleton{N},
                       P::AbstractPolyhedron{N}
-                     )::Union{Singleton{N}, EmptySet{N}} where {N<:Real}
+                     ) where {N<:Real}
     return invoke(intersection, Tuple{typeof(S), LazySet{N}}, S, P)
 end
 function intersection(P::AbstractPolyhedron{N},
                       S::AbstractSingleton{N}
-                     )::Union{Singleton{N}, EmptySet{N}} where {N<:Real}
+                     ) where {N<:Real}
     return invoke(intersection, Tuple{typeof(S), LazySet{N}}, S, P)
 end
 function intersection(X::Interval{N}, P::AbstractPolyhedron{N}
-                     )::Union{Interval{N}, Singleton{N}, EmptySet{N}} where {N<:Real}
+                     ) where {N<:Real}
     return invoke(intersection, Tuple{Interval{N}, LazySet{N}}, X, P)
 end
 function intersection(P::AbstractPolyhedron{N}, X::Interval{N}
-                     )::Union{Interval{N}, Singleton{N}, EmptySet{N}} where {N<:Real}
+                     ) where {N<:Real}
     return invoke(intersection, Tuple{Interval{N}, LazySet{N}}, X, P)
 end
 

--- a/src/ConcreteOperations/isdisjoint.jl
+++ b/src/ConcreteOperations/isdisjoint.jl
@@ -7,7 +7,7 @@ export is_intersection_empty,
     is_intersection_empty(X::LazySet{N},
                           Y::LazySet{N},
                           witness::Bool=false
-                          )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+                          ) where {N<:Real}
 
 Check whether two sets do not intersect, and otherwise optionally compute a
 witness.
@@ -35,7 +35,7 @@ A witness is constructed using the `an_element` implementation of the result.
 function is_intersection_empty(X::LazySet{N},
                                Y::LazySet{N},
                                witness::Bool=false
-                              )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+                              ) where {N<:Real}
     cap = intersection(X, Y)
     empty_intersection = isempty(cap)
     if witness
@@ -63,7 +63,7 @@ const isdisjoint = is_intersection_empty
     is_intersection_empty(H1::AbstractHyperrectangle{N},
                           H2::AbstractHyperrectangle{N},
                           witness::Bool=false
-                         )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+                         ) where {N<:Real}
 
 Check whether two hyperrectangles do not intersect, and otherwise optionally
 compute a witness.
@@ -94,7 +94,7 @@ of `H2`.
 function is_intersection_empty(H1::AbstractHyperrectangle{N},
                                H2::AbstractHyperrectangle{N},
                                witness::Bool=false
-                              )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+                              ) where {N<:Real}
     empty_intersection = false
     center_diff = center(H2) - center(H1)
     @inbounds for i in eachindex(center_diff)
@@ -171,7 +171,7 @@ end
 # common code for singletons
 @inline function is_intersection_empty_helper_singleton(
         S::AbstractSingleton{N}, X::LazySet{N}, witness::Bool=false
-       )::Union{Bool, Tuple{Bool, Vector{N}} } where {N<:Real}
+       ) where {N<:Real}
     empty_intersection = element(S) ∉ X
     if witness
         return (empty_intersection, empty_intersection ? N[] : element(S))
@@ -184,7 +184,7 @@ end
     is_intersection_empty(X::LazySet{N},
                           S::AbstractSingleton{N},
                           witness::Bool=false
-                         )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+                         ) where {N<:Real}
 
 Check whether a convex set and a singleton do not intersect, and otherwise
 optionally compute a witness.
@@ -210,7 +210,7 @@ optionally compute a witness.
 function is_intersection_empty(X::LazySet{N},
                                S::AbstractSingleton{N},
                                witness::Bool=false
-                              )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+                              ) where {N<:Real}
     return is_intersection_empty_helper_singleton(S, X, witness)
 end
 
@@ -218,7 +218,7 @@ end
 function is_intersection_empty(S::AbstractSingleton{N},
                                X::LazySet{N},
                                witness::Bool=false
-                              )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+                              ) where {N<:Real}
     return is_intersection_empty_helper_singleton(S, X, witness)
 end
 
@@ -226,7 +226,7 @@ end
     is_intersection_empty(S1::AbstractSingleton{N},
                           S2::AbstractSingleton{N},
                           witness::Bool=false
-                         )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+                         ) where {N<:Real}
 
 Check whether two singletons do not intersect, and otherwise optionally compute
 a witness.
@@ -251,7 +251,7 @@ a witness.
 function is_intersection_empty(S1::AbstractSingleton{N},
                                S2::AbstractSingleton{N},
                                witness::Bool=false
-                              )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+                              ) where {N<:Real}
     empty_intersection = element(S1) != element(S2)
     if witness
         return (empty_intersection, empty_intersection ? N[] : element(S1))
@@ -264,7 +264,7 @@ end
     is_intersection_empty(H::AbstractHyperrectangle{N},
                           S::AbstractSingleton{N},
                           witness::Bool=false
-                         )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+                         ) where {N<:Real}
 
 Check whether a hyperrectangle and a singleton do not intersect, and otherwise
 optionally compute a witness.
@@ -289,7 +289,7 @@ optionally compute a witness.
 function is_intersection_empty(H::AbstractHyperrectangle{N},
                                S::AbstractSingleton{N},
                                witness::Bool=false
-                              )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+                              ) where {N<:Real}
     return is_intersection_empty_helper_singleton(S, H, witness)
 end
 
@@ -297,7 +297,7 @@ end
 function is_intersection_empty(S::AbstractSingleton{N},
                                H::AbstractHyperrectangle{N},
                                witness::Bool=false
-                              )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+                              ) where {N<:Real}
     return is_intersection_empty_helper_singleton(S, H, witness)
 end
 
@@ -309,7 +309,7 @@ end
     is_intersection_empty(B1::Ball2{N},
                           B2::Ball2{N},
                           witness::Bool=false
-                         )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:AbstractFloat}
+                         ) where {N<:AbstractFloat}
 
 Check whether two balls in the 2-norm do not intersect, and otherwise optionally
 compute a witness.
@@ -342,7 +342,7 @@ choose `B1` for the smaller ball) as follows.
 function is_intersection_empty(B1::Ball2{N},
                                B2::Ball2{N},
                                witness::Bool=false
-                              )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:AbstractFloat}
+                              ) where {N<:AbstractFloat}
     center_diff_normed = norm(center(B2) - center(B1), 2)
     empty_intersection = center_diff_normed > B1.radius + B2.radius
 
@@ -377,7 +377,7 @@ end
 
 """
     is_intersection_empty(Z::Zonotope{N}, H::Hyperplane{N}, witness::Bool=false
-                         )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+                         ) where {N<:Real}
 
 Check whether a zonotope and a hyperplane do not intersect, and otherwise
 optionally compute a witness.
@@ -407,7 +407,7 @@ general sets as the first argument.
 function is_intersection_empty(Z::Zonotope{N},
                                H::Hyperplane{N},
                                witness::Bool=false
-                              )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+                              ) where {N<:Real}
     if witness
         # use less efficient implementation that supports witness production
         return invoke(is_intersection_empty,
@@ -424,7 +424,7 @@ end
 function is_intersection_empty(H::Hyperplane{N},
                                Z::Zonotope{N},
                                witness::Bool=false
-                              )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+                              ) where {N<:Real}
     return is_intersection_empty(Z, H, witness)
 end
 
@@ -473,7 +473,7 @@ end
     is_intersection_empty(ls1::LineSegment{N},
                           ls2::LineSegment{N},
                           witness::Bool=false
-                         )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+                         ) where {N<:Real}
 
 Check whether two line segments do not intersect, and otherwise optionally
 compute a witness.
@@ -507,8 +507,8 @@ intersection point, if it exists.
 function is_intersection_empty(ls1::LineSegment{N},
                                ls2::LineSegment{N},
                                witness::Bool=false
-                              )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
-    function cross(ls1::Vector{N}, ls2::Vector{N})::N where {N<:Real}
+                              ) where {N<:Real}
+    function cross(ls1::Vector{N}, ls2::Vector{N}) where {N<:Real}
         return ls1[1] * ls2[2] - ls1[2] * ls2[1]
     end
 
@@ -588,7 +588,7 @@ end
         hp::Union{Hyperplane{N}, Line{N}},
         X::LazySet{N},
         witness::Bool=false
-       )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+       ) where {N<:Real}
     normal_hp = hp.a
     sv_left = σ(-normal_hp, X)
     if -dot(sv_left, -normal_hp) <= hp.b
@@ -619,7 +619,7 @@ end
     is_intersection_empty(X::LazySet{N},
                           hp::Union{Hyperplane{N}, Line{N}},
                           [witness]::Bool=false
-                         )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+                         ) where {N<:Real}
 
 Check whether a compact set an a hyperplane do not intersect, and otherwise
 optionally compute a witness.
@@ -661,7 +661,7 @@ for the line-hyperplane intersection.
 function is_intersection_empty(X::LazySet{N},
                                hp::Union{Hyperplane{N}, Line{N}},
                                witness::Bool=false
-                              )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+                              ) where {N<:Real}
     return is_intersection_empty_helper_hyperplane(hp, X, witness)
 end
 
@@ -669,7 +669,7 @@ end
 function is_intersection_empty(hp::Union{Hyperplane{N}, Line{N}},
                                X::LazySet{N},
                                witness::Bool=false
-                              )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+                              ) where {N<:Real}
     return is_intersection_empty_helper_hyperplane(hp, X, witness)
 end
 
@@ -677,7 +677,7 @@ end
 function is_intersection_empty(hp1::Union{Hyperplane{N}, Line{N}},
                                hp2::Union{Hyperplane{N}, Line{N}},
                                witness::Bool=false
-                              )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+                              ) where {N<:Real}
     return is_intersection_empty_helper_hyperplane(hp1, hp2, witness)
 end
 
@@ -685,7 +685,7 @@ end
 function is_intersection_empty(hp::Union{Hyperplane{N}, Line{N}},
                                S::AbstractSingleton{N},
                                witness::Bool=false
-                              )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+                              ) where {N<:Real}
     return is_intersection_empty_helper_singleton(S, hp, witness)
 end
 
@@ -693,7 +693,7 @@ end
 function is_intersection_empty(S::AbstractSingleton{N},
                                hp::Union{Hyperplane{N}, Line{N}},
                                witness::Bool=false
-                              )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+                              ) where {N<:Real}
     return is_intersection_empty_helper_singleton(S, hp, witness)
 end
 
@@ -705,7 +705,7 @@ end
         hs::HalfSpace{N},
         X::LazySet{N},
         witness::Bool=false
-       )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+       ) where {N<:Real}
     if !witness
         return -ρ(-hs.a, X) > hs.b
     end
@@ -721,7 +721,7 @@ end
     is_intersection_empty(X::LazySet{N},
                           hs::HalfSpace{N},
                           [witness]::Bool=false
-                         )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+                         ) where {N<:Real}
 
 Check whether a compact set an a half-space do not intersect, and otherwise
 optionally compute a witness.
@@ -757,7 +757,7 @@ Optional keyword arguments can be passed to the `ρ` function. In particular, if
 function is_intersection_empty(X::LazySet{N},
                                hs::HalfSpace{N},
                                witness::Bool=false
-                               )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+                               ) where {N<:Real}
     return is_intersection_empty_helper_halfspace(hs, X, witness)
 end
 
@@ -765,7 +765,7 @@ end
 function is_intersection_empty(hs::HalfSpace{N},
                                X::LazySet{N},
                                witness::Bool=false
-                              )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+                              ) where {N<:Real}
     return is_intersection_empty_helper_halfspace(hs, X, witness)
 end
 
@@ -773,7 +773,7 @@ end
     is_intersection_empty(hs1::HalfSpace{N},
                           hs2::HalfSpace{N},
                           [witness]::Bool=false
-                         )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+                         ) where {N<:Real}
 
 Check whether two half-spaces do not intersect, and otherwise optionally compute
 a witness.
@@ -819,7 +819,7 @@ Such a dimension ``i`` always exists.
 function is_intersection_empty(hs1::HalfSpace{N},
                                hs2::HalfSpace{N},
                                witness::Bool=false
-                              )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+                              ) where {N<:Real}
     a1 = hs1.a
     a2 = hs2.a
     issamedir, k = samedir(a1, -a2)
@@ -861,7 +861,7 @@ end
 function is_intersection_empty(H::HalfSpace{N},
                                S::AbstractSingleton{N},
                                witness::Bool=false
-                              )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+                              ) where {N<:Real}
     return is_intersection_empty_helper_singleton(S, H, witness)
 end
 
@@ -869,7 +869,7 @@ end
 function is_intersection_empty(S::AbstractSingleton{N},
                                H::HalfSpace{N},
                                witness::Bool=false
-                              )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+                              ) where {N<:Real}
     return is_intersection_empty_helper_singleton(S, H, witness)
 end
 
@@ -877,7 +877,7 @@ end
 function is_intersection_empty(hp::Union{Hyperplane{N}, Line{N}},
                                hs::HalfSpace{N},
                                witness::Bool=false
-                              )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+                              ) where {N<:Real}
     return is_intersection_empty_helper_halfspace(hs, hp, witness)
 end
 
@@ -885,7 +885,7 @@ end
 function is_intersection_empty(hs::HalfSpace{N},
                                hp::Union{Hyperplane{N}, Line{N}},
                                witness::Bool=false
-                              )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+                              ) where {N<:Real}
     return is_intersection_empty_helper_halfspace(hs, hp, witness)
 end
 
@@ -898,7 +898,7 @@ end
                           X::LazySet{N},
                           witness::Bool=false;
                           solver=default_lp_solver(N)
-                         )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+                         ) where {N<:Real}
 
 Check whether two polyhedra do not intersect.
 
@@ -941,7 +941,7 @@ function is_intersection_empty(P::AbstractPolyhedron{N},
                                witness::Bool=false;
                                solver=default_lp_solver(N),
                                algorithm="exact"
-                              )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+                              ) where {N<:Real}
     if algorithm == "sufficient"
         # sufficient check for empty intersection using half-space checks
         for Hi in constraints_list(P)
@@ -971,7 +971,7 @@ function is_intersection_empty(X::LazySet{N},
                                witness::Bool=false;
                                solver=default_lp_solver(N),
                                algorithm="exact"
-                              )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+                              ) where {N<:Real}
     return is_intersection_empty(P, X, witness;
                                  solver=solver, algorithm=algorithm)
 end
@@ -982,7 +982,7 @@ function is_intersection_empty(P::AbstractPolyhedron{N},
                                witness::Bool=false;
                                solver=default_lp_solver(N),
                                algorithm="exact"
-                              )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+                              ) where {N<:Real}
     return invoke(is_intersection_empty,
                   Tuple{typeof(P), LazySet{N}, Bool},
                   P, Q, witness; solver=solver, algorithm=algorithm)
@@ -992,7 +992,7 @@ end
 function is_intersection_empty(P::AbstractPolyhedron{N},
                                hs::HalfSpace{N},
                                witness::Bool=false
-                              )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+                              ) where {N<:Real}
     return is_intersection_empty_helper_halfspace(hs, P, witness)
 end
 
@@ -1000,7 +1000,7 @@ end
 function is_intersection_empty(hs::HalfSpace{N},
                                P::AbstractPolyhedron{N},
                                witness::Bool=false
-                              )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+                              ) where {N<:Real}
     return is_intersection_empty_helper_halfspace(hs, P, witness)
 end
 
@@ -1008,7 +1008,7 @@ end
 function is_intersection_empty(P::AbstractPolyhedron{N},
                                S::AbstractSingleton{N},
                                witness::Bool=false
-                              )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+                              ) where {N<:Real}
     return is_intersection_empty_helper_singleton(S, P, witness)
 end
 
@@ -1016,7 +1016,7 @@ end
 function is_intersection_empty(S::AbstractSingleton{N},
                                P::AbstractPolyhedron{N},
                                witness::Bool=false
-                              )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+                              ) where {N<:Real}
     return is_intersection_empty_helper_singleton(S, P, witness)
 end
 
@@ -1026,7 +1026,7 @@ function is_intersection_empty(P::AbstractPolyhedron{N},
                                witness::Bool=false;
                                solver=default_lp_solver(N),
                                algorithm="exact"
-                              )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+                              ) where {N<:Real}
     return invoke(is_intersection_empty,
                   Tuple{typeof(P), LazySet{N}, Bool},
                   P, hp, witness, solver=solver, algorithm=algorithm)
@@ -1038,7 +1038,7 @@ function is_intersection_empty(hp::Union{Hyperplane{N}, Line{N}},
                                witness::Bool=false;
                                solver=default_lp_solver(N),
                                algorithm="exact"
-                              )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+                              ) where {N<:Real}
     return invoke(is_intersection_empty,
                   Tuple{typeof(P), LazySet{N}, Bool},
                   P, hp, witness, solver=solver, algorithm=algorithm)
@@ -1049,8 +1049,8 @@ end
 
 
 """
-    is_intersection_empty(cup::UnionSet{N}, X::LazySet{N}, [witness]::Bool=false
-                         )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+    is_intersection_empty(cup::UnionSet{N}, X::LazySet{N},
+                          [witness]::Bool=false) where {N<:Real}
 
 Check whether a union of two convex sets and another set do not intersect.
 
@@ -1063,38 +1063,27 @@ Check whether a union of two convex sets and another set do not intersect.
 
 `true` iff ``\\text{cup} ∩ X = ∅``.
 """
-function is_intersection_empty(cup::UnionSet{N},
-                               X::LazySet{N},
-                               witness::Bool=false
-                              )::Union{Bool, Tuple{Bool, Vector{N}}} where
-                                  {N<:Real}
+function is_intersection_empty(cup::UnionSet{N}, X::LazySet{N},
+                               witness::Bool=false) where {N<:Real}
     return is_intersection_empty(UnionSetArray([cup.X, cup.Y]), X, witness)
 end
 
 # symmetric method
-function is_intersection_empty(X::LazySet{N},
-                               cup::UnionSet{N},
-                               witness::Bool=false
-                              )::Union{Bool, Tuple{Bool, Vector{N}}} where
-                                  {N<:Real}
+function is_intersection_empty(X::LazySet{N}, cup::UnionSet{N},
+                               witness::Bool=false) where {N<:Real}
     return is_intersection_empty(cup, X, witness)
 end
 
 # disambiguation
-function is_intersection_empty(cup1::UnionSet{N},
-                               cup2::UnionSet{N},
-                               witness::Bool=false
-                              )::Union{Bool, Tuple{Bool, Vector{N}}} where
-                                  {N<:Real}
+function is_intersection_empty(cup1::UnionSet{N}, cup2::UnionSet{N},
+                               witness::Bool=false) where {N<:Real}
     return is_intersection_empty(UnionSetArray([cup1.X, cup1.Y]),
                                  UnionSetArray([cup2.X, cup2.Y]), witness)
 end
 
 """
-    is_intersection_empty(cup::UnionSetArray{N},
-                          X::LazySet{N},
-                          [witness]::Bool=false
-                         )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+    is_intersection_empty(cup::UnionSetArray{N}, X::LazySet{N},
+                          [witness]::Bool=false) where {N<:Real}
 
 Check whether a union of a finite number of convex sets and another set do not
 intersect.
@@ -1108,11 +1097,8 @@ intersect.
 
 `true` iff ``\\text{cup} ∩ X = ∅``.
 """
-function is_intersection_empty(cup::UnionSetArray{N},
-                               X::LazySet{N},
-                               witness::Bool=false
-                              )::Union{Bool, Tuple{Bool, Vector{N}}} where
-                                  {N<:Real}
+function is_intersection_empty(cup::UnionSetArray{N}, X::LazySet{N},
+                               witness::Bool=false) where {N<:Real}
     result = true
     w = N[]
     for Y in array(cup)
@@ -1129,38 +1115,27 @@ function is_intersection_empty(cup::UnionSetArray{N},
 end
 
 # symmetric method
-function is_intersection_empty(X::LazySet{N},
-                               cup::UnionSetArray{N},
-                               witness::Bool=false
-                              )::Union{Bool, Tuple{Bool, Vector{N}}} where
-                                  {N<:Real}
+function is_intersection_empty(X::LazySet{N}, cup::UnionSetArray{N},
+                               witness::Bool=false) where {N<:Real}
     return is_intersection_empty(cup, X, witness)
 end
 
 # disambiguation
-function is_intersection_empty(cup1::UnionSet{N},
-                               cup2::UnionSetArray{N},
-                               witness::Bool=false
-                              )::Union{Bool, Tuple{Bool, Vector{N}}} where
-                                  {N<:Real}
+function is_intersection_empty(cup1::UnionSet{N}, cup2::UnionSetArray{N},
+                               witness::Bool=false) where {N<:Real}
     return is_intersection_empty(UnionSetArray([cup1.X, cup1.Y]), cup2, witness)
 end
 
 # disambiguation
-function is_intersection_empty(cup1::UnionSetArray{N},
-                               cup2::UnionSet{N},
-                               witness::Bool=false
-                              )::Union{Bool, Tuple{Bool, Vector{N}}} where
-                                  {N<:Real}
+function is_intersection_empty(cup1::UnionSetArray{N}, cup2::UnionSet{N},
+                               witness::Bool=false) where {N<:Real}
     return is_intersection_empty(cup1, UnionSetArray([cup2.X, cup2.Y]), witness)
 end
 
 # disambiguation
 function is_intersection_empty(cup1::UnionSetArray{N},
                                cup2::UnionSetArray{N},
-                               witness::Bool=false
-                              )::Union{Bool, Tuple{Bool, Vector{N}}} where
-                                  {N<:Real}
+                               witness::Bool=false) where {N<:Real}
     result = true
     w = N[]
     for X in array(cup1)
@@ -1183,10 +1158,8 @@ end
 
 
 """
-    is_intersection_empty(U::Universe{N},
-                          X::LazySet{N},
-                          [witness]::Bool=false
-                         )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+    is_intersection_empty(U::Universe{N}, X::LazySet{N},
+                          [witness]::Bool=false) where {N<:Real}
 
 Check whether a universe and another set do not intersect.
 
@@ -1199,11 +1172,8 @@ Check whether a universe and another set do not intersect.
 
 `true` iff ``X ≠ ∅``.
 """
-function is_intersection_empty(U::Universe{N},
-                               X::LazySet{N},
-                               witness::Bool=false
-                              )::Union{Bool, Tuple{Bool, Vector{N}}} where
-                                  {N<:Real}
+function is_intersection_empty(U::Universe{N}, X::LazySet{N},
+                               witness::Bool=false) where {N<:Real}
     result = isempty(X)
     if result
         return witness ? (result, N[]) : result
@@ -1213,90 +1183,62 @@ function is_intersection_empty(U::Universe{N},
 end
 
 # symmetric method
-function is_intersection_empty(X::LazySet{N},
-                               U::Universe{N},
-                               witness::Bool=false
-                              )::Union{Bool, Tuple{Bool, Vector{N}}} where
-                                  {N<:Real}
+function is_intersection_empty(X::LazySet{N}, U::Universe{N},
+                               witness::Bool=false) where {N<:Real}
     return is_intersection_empty(U, X, witness)
 end
 
 # disambiguation
-function is_intersection_empty(U::Universe{N},
-                               ::Universe{N},
-                               witness::Bool=false
-                              )::Union{Bool, Tuple{Bool, Vector{N}}} where
-                                  {N<:Real}
+function is_intersection_empty(U::Universe{N}, ::Universe{N},
+                               witness::Bool=false) where {N<:Real}
     return witness ? (false, an_element(U)) : false
 end
-function is_intersection_empty(P::AbstractPolyhedron{N},
-                               U::Universe{N},
-                               witness::Bool=false
-                              )::Union{Bool, Tuple{Bool, Vector{N}}} where
-                                  {N<:Real}
+function is_intersection_empty(P::AbstractPolyhedron{N}, U::Universe{N},
+                               witness::Bool=false) where {N<:Real}
     return invoke(is_intersection_empty,
                   Tuple{Universe{N}, LazySet{N}, Bool},
                   U, P, witness)
 end
-function is_intersection_empty(U::Universe{N},
-                               P::AbstractPolyhedron{N},
-                               witness::Bool=false
-                              )::Union{Bool, Tuple{Bool, Vector{N}}} where
-                                  {N<:Real}
+function is_intersection_empty(U::Universe{N}, P::AbstractPolyhedron{N},
+                               witness::Bool=false) where {N<:Real}
     return invoke(is_intersection_empty,
                   Tuple{Universe{N}, LazySet{N}, Bool},
                   U, P, witness)
 end
-function is_intersection_empty(S::AbstractSingleton{N},
-                               U::Universe{N},
-                               witness::Bool=false
-                              )::Union{Bool, Tuple{Bool, Vector{N}}} where
-                                  {N<:Real}
+function is_intersection_empty(S::AbstractSingleton{N}, U::Universe{N},
+                               witness::Bool=false) where {N<:Real}
     return invoke(is_intersection_empty,
                   Tuple{Universe{N}, LazySet{N}, Bool},
                   U, S, witness)
 end
-function is_intersection_empty(U::Universe{N},
-                               S::AbstractSingleton{N},
-                               witness::Bool=false
-                              )::Union{Bool, Tuple{Bool, Vector{N}}} where
-                                  {N<:Real}
+function is_intersection_empty(U::Universe{N}, S::AbstractSingleton{N},
+                               witness::Bool=false) where {N<:Real}
     return invoke(is_intersection_empty,
                   Tuple{Universe{N}, LazySet{N}, Bool},
                   U, S, witness)
 end
-function is_intersection_empty(hs::HalfSpace{N},
-                               U::Universe{N},
-                               witness::Bool=false
-                              )::Union{Bool, Tuple{Bool, Vector{N}}} where
-                                  {N<:Real}
+function is_intersection_empty(hs::HalfSpace{N}, U::Universe{N},
+                               witness::Bool=false) where {N<:Real}
     return invoke(is_intersection_empty,
                   Tuple{Universe{N}, LazySet{N}, Bool},
                   U, hs, witness)
 end
 function is_intersection_empty(U::Universe{N},
                                hp::Union{Hyperplane{N}, Line{N}},
-                               witness::Bool=false
-                              )::Union{Bool, Tuple{Bool, Vector{N}}} where
-                                  {N<:Real}
+                               witness::Bool=false) where {N<:Real}
     return invoke(is_intersection_empty,
                   Tuple{Universe{N}, LazySet{N}, Bool},
                   U, hp, witness)
 end
 function is_intersection_empty(hp::Union{Hyperplane{N}, Line{N}},
                                U::Universe{N},
-                               witness::Bool=false
-                              )::Union{Bool, Tuple{Bool, Vector{N}}} where
-                                  {N<:Real}
+                               witness::Bool=false) where {N<:Real}
     return invoke(is_intersection_empty,
                   Tuple{Universe{N}, LazySet{N}, Bool},
                   U, hp, witness)
 end
-function is_intersection_empty(U::Universe{N},
-                               hs::HalfSpace{N},
-                               witness::Bool=false
-                              )::Union{Bool, Tuple{Bool, Vector{N}}} where
-                                  {N<:Real}
+function is_intersection_empty(U::Universe{N}, hs::HalfSpace{N},
+                               witness::Bool=false) where {N<:Real}
     return invoke(is_intersection_empty,
                   Tuple{Universe{N}, LazySet{N}, Bool},
                   U, hs, witness)
@@ -1310,7 +1252,7 @@ end
     is_intersection_empty(C::Complement{N},
                           X::LazySet{N},
                           [witness]::Bool=false
-                         )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+                         ) where {N<:Real}
 
 Check whether the complement of a convex set and another set do not intersect.
 
@@ -1334,20 +1276,14 @@ We fall back to `X ⊆ C.X`, which can be justified as follows:
     X ∩ Y^C = ∅ ⟺ X ⊆ Y
 ```
 """
-function is_intersection_empty(C::Complement{N},
-                               X::LazySet{N},
-                               witness::Bool=false
-                              )::Union{Bool, Tuple{Bool, Vector{N}}} where
-                                  {N<:Real}
+function is_intersection_empty(C::Complement{N}, X::LazySet{N},
+                               witness::Bool=false) where {N<:Real}
     return ⊆(X, C.X, witness)
 end
 
 # symmetric method
-function is_intersection_empty(X::LazySet{N},
-                               C::Complement{N},
-                               witness::Bool=false
-                              )::Union{Bool, Tuple{Bool, Vector{N}}} where
-                                  {N<:Real}
+function is_intersection_empty(X::LazySet{N}, C::Complement{N},
+                               witness::Bool=false) where {N<:Real}
     return is_intersection_empty(C, X, witness)
 end
 

--- a/src/ConcreteOperations/issubset.jl
+++ b/src/ConcreteOperations/issubset.jl
@@ -1,7 +1,7 @@
 import Base.issubset
 
 # this operation is forbidden, but it is a common error so we give a detailed error message
-function ⊆(::AbstractVector{N}, ::LazySet{N})::Bool where {N<:Real}
+function ⊆(::AbstractVector{N}, ::LazySet{N}) where {N<:Real}
     error("cannot make an inclusion check if the left-hand side " *
           "is a vector; either wrap it as a set with one element, as in " *
           "`Singleton(v) ⊆ X`, or check for set membership, as in `v ∈ X` " *
@@ -53,7 +53,7 @@ end
 
 """
     ⊆(S::LazySet{N}, H::AbstractHyperrectangle{N}, [witness]::Bool=false
-     )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+     ) where {N<:Real}
 
 Check whether a convex set is contained in a hyperrectangular set, and if not,
 optionally compute a witness.
@@ -77,13 +77,13 @@ optionally compute a witness.
 is the interval hull operator.
 """
 function ⊆(S::LazySet{N}, H::AbstractHyperrectangle{N}, witness::Bool=false
-          )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+          ) where {N<:Real}
     return ⊆(Approximations.interval_hull(S), H, witness)
 end
 
 """
     ⊆(P::AbstractPolytope{N}, H::AbstractHyperrectangle, [witness]::Bool=false
-     )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+     ) where {N<:Real}
 
 Check whether a polytope is contained in a hyperrectangular set, and if not,
 optionally compute a witness.
@@ -113,7 +113,7 @@ Since ``H`` is convex, ``P ⊆ H`` iff ``v_i ∈ H`` for all vertices ``v_i`` of
 function ⊆(P::AbstractPolytope{N},
            H::AbstractHyperrectangle,
            witness::Bool=false
-          )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+          ) where {N<:Real}
     @assert dim(P) == dim(H)
 
     return _issubset_vertices_list(P, H, witness)
@@ -124,7 +124,7 @@ end
     ⊆(H1::AbstractHyperrectangle{N},
       H2::AbstractHyperrectangle{N},
       [witness]::Bool=false
-     )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+     ) where {N<:Real}
 
 Check whether a given hyperrectangular set is contained in another
 hyperrectangular set, and if not, optionally compute a witness.
@@ -150,7 +150,7 @@ hyperrectangular set, and if not, optionally compute a witness.
 function ⊆(H1::AbstractHyperrectangle{N},
            H2::AbstractHyperrectangle{N},
            witness::Bool=false
-          )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+          ) where {N<:Real}
     @assert dim(H1) == dim(H2)
     c1 = center(H1)
     c2 = center(H2)
@@ -315,31 +315,31 @@ end
 function ⊆(P1::AbstractPolytope{N},
            P2::AbstractPolyhedron{N},
            witness::Bool=false
-          )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+          ) where {N<:Real}
     return invoke(⊆, Tuple{LazySet{N}, typeof(P2), Bool}, P1, P2, witness)
 end
 function ⊆(H::AbstractHyperrectangle{N},
            P::AbstractPolyhedron{N},
            witness::Bool=false
-          )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+          ) where {N<:Real}
     return invoke(⊆, Tuple{LazySet{N}, typeof(P), Bool}, H, P, witness)
 end
 function ⊆(S::AbstractSingleton{N},
            P::AbstractPolyhedron{N},
            witness::Bool=false
-          )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+          ) where {N<:Real}
     return invoke(⊆, Tuple{LazySet{N}, typeof(P), Bool}, S, P, witness)
 end
 function ⊆(L::LineSegment{N},
            P::AbstractPolyhedron{N},
            witness::Bool=false
-          )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+          ) where {N<:Real}
     return invoke(⊆, Tuple{LazySet{N}, typeof(P), Bool}, L, P, witness)
 end
 function ⊆(P::AbstractPolytope{N},
            H::AbstractHyperrectangle{N},
            witness::Bool=false
-          )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+          ) where {N<:Real}
     return invoke(⊆,
                   Tuple{LazySet{N}, AbstractHyperrectangle{N}, Bool},
                   P, H, witness)
@@ -351,7 +351,7 @@ end
 
 """
     ⊆(S::AbstractSingleton{N}, set::LazySet{N}, [witness]::Bool=false
-     )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+     ) where {N<:Real}
 
 Check whether a given set with a single value is contained in a convex set, and
 if not, optionally compute a witness.
@@ -371,7 +371,7 @@ if not, optionally compute a witness.
     ``v ∈ S \\setminus \\text{set}``
 """
 function ⊆(S::AbstractSingleton{N}, set::LazySet{N}, witness::Bool=false
-          )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+          ) where {N<:Real}
     result = element(S) ∈ set
     if witness
         return (result, result ? N[] : element(S))
@@ -385,7 +385,7 @@ end
     ⊆(S::AbstractSingleton{N},
       H::AbstractHyperrectangle{N},
       [witness]::Bool=false
-     )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+     ) where {N<:Real}
 
 Check whether a given set with a single value is contained in a hyperrectangular
 set, and if not, optionally compute a witness.
@@ -410,7 +410,7 @@ This copy-pasted method just exists to avoid method ambiguities.
 function ⊆(S::AbstractSingleton{N},
            H::AbstractHyperrectangle{N},
            witness::Bool=false
-          )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+          ) where {N<:Real}
     result = element(S) ∈ H
     if witness
         return (result, result ? N[] : element(S))
@@ -424,7 +424,7 @@ end
     ⊆(S1::AbstractSingleton{N},
       S2::AbstractSingleton{N},
       [witness]::Bool=false
-     )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+     ) where {N<:Real}
 
 Check whether a given set with a single value is contained in another set with a
 single value, and if not, optionally compute a witness.
@@ -445,7 +445,7 @@ single value, and if not, optionally compute a witness.
 function ⊆(S1::AbstractSingleton{N},
            S2::AbstractSingleton{N},
            witness::Bool=false
-          )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+          ) where {N<:Real}
     result = element(S1) == element(S2)
     if witness
         return (result, result ? N[] : element(S1))
@@ -460,7 +460,7 @@ end
 
 """
     ⊆(B1::Ball2{N}, B2::Ball2{N}, [witness]::Bool=false
-     )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:AbstractFloat}
+     ) where {N<:AbstractFloat}
 
 Check whether a ball in the 2-norm is contained in another ball in the 2-norm,
 and if not, optionally compute a witness.
@@ -483,7 +483,7 @@ and if not, optionally compute a witness.
 ``B1 ⊆ B2`` iff ``‖ c_1 - c_2 ‖_2 + r_1 ≤ r_2``
 """
 function ⊆(B1::Ball2{N}, B2::Ball2{N}, witness::Bool=false
-          )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:AbstractFloat}
+          ) where {N<:AbstractFloat}
     result = norm(B1.center - B2.center, 2) + B1.radius <= B2.radius
     if witness
         if result
@@ -506,7 +506,7 @@ end
     ⊆(B::Union{Ball2{N}, Ballp{N}},
       S::AbstractSingleton{N},
       [witness]::Bool=false
-     )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:AbstractFloat}
+     ) where {N<:AbstractFloat}
 
 Check whether a ball in the 2-norm or p-norm is contained in a set with a single
 value, and if not, optionally compute a witness.
@@ -527,7 +527,7 @@ value, and if not, optionally compute a witness.
 function ⊆(B::Union{Ball2{N}, Ballp{N}},
            S::AbstractSingleton{N},
            witness::Bool=false
-          )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:AbstractFloat}
+          ) where {N<:AbstractFloat}
     result = B.center == element(S) && B.radius == 0
     if witness
         if result
@@ -553,7 +553,7 @@ end
 
 """
     ⊆(L::LineSegment{N}, S::LazySet{N}, [witness]::Bool=false
-     )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+     ) where {N<:Real}
 
 Check whether a line segment is contained in a convex set, and if not,
 optionally compute a witness.
@@ -577,7 +577,7 @@ Since ``S`` is convex, ``L ⊆ S`` iff ``p ∈ S`` and ``q ∈ S``, where ``p, q
 the end points of ``L``.
 """
 function ⊆(L::LineSegment{N}, S::LazySet{N}, witness::Bool=false
-          )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+          ) where {N<:Real}
     p_in_S = L.p ∈ S
     result = p_in_S && L.q ∈ S
     if !witness
@@ -592,7 +592,7 @@ end
 
 """
     ⊆(L::LineSegment{N}, H::AbstractHyperrectangle{N}, [witness]::Bool=false
-     )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+     ) where {N<:Real}
 
 Check whether a line segment is contained in a hyperrectangular set, and if not,
 optionally compute a witness.
@@ -620,7 +620,7 @@ Since ``H`` is convex, ``L ⊆ H`` iff ``p ∈ H`` and ``q ∈ H``, where ``p, q
 the end points of ``L``.
 """
 function ⊆(L::LineSegment{N}, H::AbstractHyperrectangle{N}, witness::Bool=false
-          )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+          ) where {N<:Real}
     p_in_H = L.p ∈ H
     result = p_in_H && L.q ∈ H
     if !witness
@@ -660,7 +660,7 @@ end
 
 """
     ⊆(∅::EmptySet{N}, X::LazySet{N}, [witness]::Bool=false
-     )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+     ) where {N<:Real}
 
 Check whether an empty set is contained in another set.
 
@@ -676,7 +676,7 @@ Check whether an empty set is contained in another set.
 `true`.
 """
 function ⊆(∅::EmptySet{N}, X::LazySet{N}, witness::Bool=false
-          )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+          ) where {N<:Real}
     return witness ? (true, N[]) : true
 end
 
@@ -684,19 +684,19 @@ end
 function ⊆(∅::EmptySet{N},
            ::AbstractPolyhedron{N},
            witness::Bool=false
-          )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+          ) where {N<:Real}
     return witness ? (true, N[]) : true
 end
 function ⊆(∅::EmptySet{N},
            ::AbstractHyperrectangle{N},
            witness::Bool=false
-          )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+          ) where {N<:Real}
     return witness ? (true, N[]) : true
 end
 
 """
     ⊆(X::LazySet{N}, ∅::EmptySet{N}, [witness]::Bool=false
-     )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+     ) where {N<:Real}
 
 Check whether a set is contained in an empty set.
 
@@ -716,7 +716,7 @@ We rely on `isempty(X)` for the emptiness check and on `an_element(X)` for
 witness production.
 """
 function ⊆(X::LazySet{N}, ∅::EmptySet{N}, witness::Bool=false
-          )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+          ) where {N<:Real}
     if isempty(X)
         return witness ? (true, N[]) : true
     else
@@ -726,7 +726,7 @@ end
 
 # disambiguation
 function ⊆(X::AbstractPolytope{N}, ::EmptySet{N}, witness::Bool=false
-          )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+          ) where {N<:Real}
     if isempty(X)
         return witness ? (true, N[]) : true
     else
@@ -734,15 +734,15 @@ function ⊆(X::AbstractPolytope{N}, ::EmptySet{N}, witness::Bool=false
     end
 end
 function ⊆(X::AbstractSingleton{N}, ::EmptySet{N}, witness::Bool=false
-          )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+          ) where {N<:Real}
     return witness ? (false, an_element(X)) : false
 end
 function ⊆(X::LineSegment{N}, ::EmptySet{N}, witness::Bool=false
-          )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+          ) where {N<:Real}
     return witness ? (false, an_element(X)) : false
 end
 function ⊆(::EmptySet{N}, ::EmptySet{N}, witness::Bool=false
-          )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+          ) where {N<:Real}
     return witness ? (true, N[]) : true
 end
 
@@ -752,7 +752,7 @@ end
 
 """
     ⊆(cup::UnionSet{N}, X::LazySet{N}, [witness]::Bool=false
-     )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+     ) where {N<:Real}
 
 Check whether a union of two convex sets is contained in another set.
 
@@ -771,13 +771,13 @@ Check whether a union of two convex sets is contained in another set.
     ``v ∈ \\text{cup} \\setminus X``
 """
 function ⊆(cup::UnionSet{N}, X::LazySet{N}, witness::Bool=false
-          )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+          ) where {N<:Real}
     return ⊆(UnionSetArray([cup.X, cup.Y]), X, witness)
 end
 
 """
     ⊆(cup::UnionSetArray{N}, X::LazySet{N}, [witness]::Bool=false
-     )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+     ) where {N<:Real}
 
 Check whether a union of a finite number of convex sets is contained in another
 set.
@@ -797,7 +797,7 @@ set.
     ``v ∈ \\text{cup} \\setminus X``
 """
 function ⊆(cup::UnionSetArray{N}, X::LazySet{N}, witness::Bool=false
-          )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+          ) where {N<:Real}
     result = true
     w = N[]
     for Y in array(cup)
@@ -819,7 +819,7 @@ end
 
 """
     ⊆(X::LazySet{N}, U::Universe{N}, [witness]::Bool=false
-     )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+     ) where {N<:Real}
 
 Check whether a convex set is contained in a universe.
 
@@ -835,35 +835,35 @@ Check whether a convex set is contained in a universe.
 * If `witness` option is activated: `(true, [])`
 """
 function ⊆(X::LazySet{N}, U::Universe{N}, witness::Bool=false
-          )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+          ) where {N<:Real}
     return witness ? (true, N[]) : true
 end
 
 # disambiguation
 function ⊆(P::AbstractPolytope{N}, ::Universe{N}, witness::Bool=false
-          )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+          ) where {N<:Real}
     return witness ? (true, N[]) : true
 end
 function ⊆(P::AbstractHyperrectangle{N}, ::Universe{N}, witness::Bool=false
-          )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+          ) where {N<:Real}
     return witness ? (true, N[]) : true
 end
 function ⊆(S::AbstractSingleton{N}, ::Universe{N}, witness::Bool=false
-          )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+          ) where {N<:Real}
     return witness ? (true, N[]) : true
 end
 function ⊆(::LineSegment{N}, ::Universe{N}, witness::Bool=false
-          )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+          ) where {N<:Real}
     return witness ? (true, N[]) : true
 end
 function ⊆(::EmptySet{N}, ::Universe{N}, witness::Bool=false
-          )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+          ) where {N<:Real}
     return witness ? (true, N[]) : true
 end
 
 """
     ⊆(U::Universe{N}, X::LazySet{N}, [witness]::Bool=false
-     )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+     ) where {N<:Real}
 
 Check whether a universe is contained in another convex set, and otherwise
 optionally compute a witness.
@@ -887,33 +887,33 @@ optionally compute a witness.
 We fall back to `isuniversal(X)`.
 """
 function ⊆(U::Universe{N}, X::LazySet{N}, witness::Bool=false
-          )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+          ) where {N<:Real}
     return isuniversal(X, witness)
 end
 
 # disambiguation
 function ⊆(::Universe{N}, ::Universe{N}, witness::Bool=false
-          )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+          ) where {N<:Real}
     return witness ? (true, N[]) : true
 end
 function ⊆(::Universe{N}, P::AbstractPolyhedron{N}, witness::Bool=false
-          )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+          ) where {N<:Real}
     return isuniversal(P, witness)
 end
 function ⊆(::Universe{N}, P::AbstractPolytope{N}, witness::Bool=false
-          )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+          ) where {N<:Real}
     return isuniversal(P, witness)
 end
 function ⊆(::Universe{N}, H::AbstractHyperrectangle{N}, witness::Bool=false
-          )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+          ) where {N<:Real}
     return isuniversal(H, witness)
 end
 function ⊆(::Universe{N}, S::AbstractSingleton{N}, witness::Bool=false
-          )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+          ) where {N<:Real}
     return isuniversal(S, witness)
 end
 function ⊆(::Universe{N}, ::EmptySet{N}, witness::Bool=false
-          )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+          ) where {N<:Real}
     return isuniversal(P, witness)
 end
 
@@ -923,7 +923,7 @@ end
 
 """
     ⊆(X::LazySet{N}, C::Complement{N}, [witness]::Bool=false
-     )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+     ) where {N<:Real}
 
 Check whether a convex set is contained in the complement of another convex set,
 and otherwise optionally compute a witness.
@@ -951,7 +951,7 @@ We fall back to `isdisjoint(X, C.X)`, which can be justified as follows.
 ```
 """
 function ⊆(X::LazySet{N}, C::Complement{N}, witness::Bool=false
-          )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+          ) where {N<:Real}
     return isdisjoint(X, C.X, witness)
 end
 
@@ -962,7 +962,7 @@ end
 """
     ⊆(X::CartesianProductArray{N}, Y::CartesianProductArray{N},
       witness::Bool=false; check_block_equality::Bool=true
-     )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+     ) where {N<:Real}
 
 Check whether a Cartesian product of finitely many convex sets is contained in
 another Cartesian product of finitely many convex sets, and otherwise optionally
@@ -1002,7 +1002,7 @@ function ⊆(X::CartesianProductArray{N},
            Y::CartesianProductArray{N},
            witness::Bool=false;
            check_block_equality::Bool=true
-          )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+          ) where {N<:Real}
     aX = array(X)
     aY = array(Y)
     if check_block_equality && !same_block_structure(aX, aY)

--- a/src/Interfaces/AbstractCentrallySymmetric.jl
+++ b/src/Interfaces/AbstractCentrallySymmetric.jl
@@ -13,7 +13,7 @@ Abstract type for centrally symmetric sets.
 
 Every concrete `AbstractCentrallySymmetric` must define the following functions:
 
-- `center(::AbstractCentrallySymmetric{N})::Vector{N}` -- return the center
+- `center(::AbstractCentrallySymmetric{N})` -- return the center
     point
 
 ```jldoctest; setup = :(using LazySets: subtypes)
@@ -29,7 +29,7 @@ abstract type AbstractCentrallySymmetric{N<:Real} <: LazySet{N} end
 isconvextype(::Type{<:AbstractCentrallySymmetric}) = false
 
 """
-    dim(S::AbstractCentrallySymmetric)::Int
+    dim(S::AbstractCentrallySymmetric)
 
 Return the ambient dimension of a centrally symmetric set.
 
@@ -41,12 +41,12 @@ Return the ambient dimension of a centrally symmetric set.
 
 The ambient dimension of the set.
 """
-@inline function dim(S::AbstractCentrallySymmetric)::Int
+@inline function dim(S::AbstractCentrallySymmetric)
     return length(center(S))
 end
 
 """
-    isbounded(S::AbstractCentrallySymmetric)::Bool
+    isbounded(S::AbstractCentrallySymmetric)
 
 Determine whether a centrally symmetric set is bounded.
 
@@ -58,12 +58,12 @@ Determine whether a centrally symmetric set is bounded.
 
 `true` (since a set with a unique center must be bounded).
 """
-function isbounded(::AbstractCentrallySymmetric)::Bool
+function isbounded(::AbstractCentrallySymmetric)
     return true
 end
 
 """
-    an_element(S::AbstractCentrallySymmetric{N})::Vector{N} where {N<:Real}
+    an_element(S::AbstractCentrallySymmetric{N}) where {N<:Real}
 
 Return some element of a centrally symmetric set.
 
@@ -75,12 +75,12 @@ Return some element of a centrally symmetric set.
 
 The center of the centrally symmetric set.
 """
-function an_element(S::AbstractCentrallySymmetric{N})::Vector{N} where {N<:Real}
+function an_element(S::AbstractCentrallySymmetric{N}) where {N<:Real}
     return center(S)
 end
 
 """
-    isempty(S::AbstractCentrallySymmetric)::Bool
+    isempty(S::AbstractCentrallySymmetric)
 
 Return if a centrally symmetric set is empty or not.
 
@@ -92,13 +92,13 @@ Return if a centrally symmetric set is empty or not.
 
 `false`.
 """
-function isempty(::AbstractCentrallySymmetric)::Bool
+function isempty(::AbstractCentrallySymmetric)
     return false
 end
 
 """
     isuniversal(S::AbstractCentrallySymmetric{N}, [witness]::Bool=false
-               )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+               ) where {N<:Real}
 
 Check whether a centrally symmetric set is universal.
 
@@ -118,7 +118,7 @@ A witness is obtained by computing the support vector in direction
 `d = [1, 0, …, 0]` and adding `d` on top.
 """
 function isuniversal(S::AbstractCentrallySymmetric{N}, witness::Bool=false
-                    )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+                    ) where {N<:Real}
     if witness
         d = SingleEntryVector{N}(1, dim(S))
         w = σ(d, S) + d

--- a/src/Interfaces/AbstractCentrallySymmetricPolytope.jl
+++ b/src/Interfaces/AbstractCentrallySymmetricPolytope.jl
@@ -19,10 +19,10 @@ Such a type combination is necessary as long as Julia does not support
 Every concrete `AbstractCentrallySymmetricPolytope` must define the following
 functions:
 - from `AbstractCentrallySymmetric`:
-  - `center(::AbstractCentrallySymmetricPolytope{N})::Vector{N}` -- return the
+  - `center(::AbstractCentrallySymmetricPolytope{N})` -- return the
      center point
 - from `AbstractPolytope`:
-  - `vertices_list(::AbstractCentrallySymmetricPolytope{N})::Vector{Vector{N}}`
+  - `vertices_list(::AbstractCentrallySymmetricPolytope{N})`
      -- return a list of all vertices
 
 ```jldoctest; setup = :(using LazySets: subtypes)
@@ -40,7 +40,7 @@ isconvextype(::Type{<:AbstractCentrallySymmetricPolytope}) = true
 
 
 """
-    dim(P::AbstractCentrallySymmetricPolytope)::Int
+    dim(P::AbstractCentrallySymmetricPolytope)
 
 Return the ambient dimension of a centrally symmetric, polytopic set.
 
@@ -52,14 +52,13 @@ Return the ambient dimension of a centrally symmetric, polytopic set.
 
 The ambient dimension of the polytopic set.
 """
-@inline function dim(P::AbstractCentrallySymmetricPolytope)::Int
+@inline function dim(P::AbstractCentrallySymmetricPolytope)
     return length(center(P))
 end
 
 
 """
-    an_element(P::AbstractCentrallySymmetricPolytope{N})::Vector{N}
-        where {N<:Real}
+    an_element(P::AbstractCentrallySymmetricPolytope{N}) where {N<:Real}
 
 Return some element of a centrally symmetric polytope.
 
@@ -71,13 +70,12 @@ Return some element of a centrally symmetric polytope.
 
 The center of the centrally symmetric polytope.
 """
-function an_element(P::AbstractCentrallySymmetricPolytope{N}
-                   )::Vector{N} where {N<:Real}
+function an_element(P::AbstractCentrallySymmetricPolytope{N}) where {N<:Real}
     return center(P)
 end
 
 """
-    isempty(P::AbstractCentrallySymmetricPolytope)::Bool
+    isempty(P::AbstractCentrallySymmetricPolytope)
 
 Return if a centrally symmetric, polytopic set is empty or not.
 
@@ -89,6 +87,6 @@ Return if a centrally symmetric, polytopic set is empty or not.
 
 `false`.
 """
-function isempty(P::AbstractCentrallySymmetricPolytope)::Bool
+function isempty(P::AbstractCentrallySymmetricPolytope)
     return false
 end

--- a/src/Interfaces/AbstractHPolygon.jl
+++ b/src/Interfaces/AbstractHPolygon.jl
@@ -47,7 +47,7 @@ isconvextype(::Type{<:AbstractHPolygon}) = true
 
 
 """
-    tovrep(P::AbstractHPolygon{N})::VPolygon{N} where {N<:Real}
+    tovrep(P::AbstractHPolygon{N}) where {N<:Real}
 
 Build a vertex representation of the given polygon.
 
@@ -59,13 +59,13 @@ Build a vertex representation of the given polygon.
 
 The same polygon but in vertex representation, a `VPolygon`.
 """
-function tovrep(P::AbstractHPolygon{N})::VPolygon{N} where {N<:Real}
+function tovrep(P::AbstractHPolygon{N}) where {N<:Real}
     return VPolygon(vertices_list(P; apply_convex_hull=false))
 end
 
 
 """
-    tohrep(P::HPOLYGON)::HPOLYGON where {HPOLYGON<:AbstractHPolygon}
+    tohrep(P::HPOLYGON) where {HPOLYGON<:AbstractHPolygon}
 
 Build a contraint representation of the given polygon.
 
@@ -77,7 +77,7 @@ Build a contraint representation of the given polygon.
 
 The identity, i.e., the same polygon instance.
 """
-function tohrep(P::HPOLYGON)::HPOLYGON where {HPOLYGON<:AbstractHPolygon}
+function tohrep(P::HPOLYGON) where {HPOLYGON<:AbstractHPolygon}
     return P
 end
 
@@ -88,8 +88,7 @@ end
 """
     vertices_list(P::AbstractHPolygon{N};
                   apply_convex_hull::Bool=true,
-                  check_feasibility::Bool=true
-                 )::Vector{Vector{N}} where {N<:Real}
+                  check_feasibility::Bool=true) where {N<:Real}
 
 Return the list of vertices of a polygon in constraint representation.
 
@@ -117,8 +116,7 @@ constraint.
 """
 function vertices_list(P::AbstractHPolygon{N};
                        apply_convex_hull::Bool=true,
-                       check_feasibility::Bool=true
-                      )::Vector{Vector{N}} where {N<:Real}
+                       check_feasibility::Bool=true) where {N<:Real}
     n = length(P.constraints)
     points = Vector{Vector{N}}(undef, n)
     if n == 0
@@ -165,7 +163,7 @@ end
 
 
 """
-    an_element(P::AbstractHPolygon{N})::Vector{N} where {N<:Real}
+    an_element(P::AbstractHPolygon{N}) where {N<:Real}
 
 Return some element of a polygon in constraint representation.
 
@@ -178,14 +176,14 @@ Return some element of a polygon in constraint representation.
 A vertex of the polygon in constraint representation (the first one in the order
 of the constraints).
 """
-function an_element(P::AbstractHPolygon{N})::Vector{N} where {N<:Real}
+function an_element(P::AbstractHPolygon{N}) where {N<:Real}
     @assert length(P.constraints) >= 2 "polygon has less than two constraints"
     return element(intersection(Line(P.constraints[1]),
                                 Line(P.constraints[2])))
 end
 
 """
-    ∈(x::AbstractVector{N}, P::AbstractHPolygon{N})::Bool where {N<:Real}
+    ∈(x::AbstractVector{N}, P::AbstractHPolygon{N}) where {N<:Real}
 
 Check whether a given 2D point is contained in a polygon in constraint
 representation.
@@ -203,7 +201,7 @@ representation.
 
 This implementation checks if the point lies on the outside of each edge.
 """
-function ∈(x::AbstractVector{N}, P::AbstractHPolygon{N})::Bool where {N<:Real}
+function ∈(x::AbstractVector{N}, P::AbstractHPolygon{N}) where {N<:Real}
     @assert length(x) == 2
 
     for c in P.constraints
@@ -217,8 +215,7 @@ end
 """
     rand(::Type{HPOLYGON}; [N]::Type{<:Real}=Float64, [dim]::Int=2,
          [rng]::AbstractRNG=GLOBAL_RNG, [seed]::Union{Int, Nothing}=nothing,
-         [num_constraints]::Int=-1
-        )::HPOLYGON{N} where {HPOLYGON<:AbstractHPolygon}
+         [num_constraints]::Int=-1) where {HPOLYGON<:AbstractHPolygon}
 
 Create a random polygon in constraint representation.
 
@@ -249,8 +246,7 @@ function rand(::Type{HPOLYGON};
               dim::Int=2,
               rng::AbstractRNG=GLOBAL_RNG,
               seed::Union{Int, Nothing}=nothing,
-              num_constraints::Int=-1
-             )::HPOLYGON{N} where {HPOLYGON<:AbstractHPolygon}
+              num_constraints::Int=-1) where {HPOLYGON<:AbstractHPolygon}
     @assert dim == 2 "cannot create a random $HPOLYGON of dimension $dim"
     @assert num_constraints < 0 || num_constraints >= 3 "cannot construct a " *
         "random $HPOLYGON with only $num_constraints constraints"
@@ -265,7 +261,7 @@ end
 
 """
     isredundant(cmid::LinearConstraint{N}, cright::LinearConstraint{N},
-                cleft::LinearConstraint{N})::Bool where {N<:Real}
+                cleft::LinearConstraint{N}) where {N<:Real}
 
 Check whether a linear constraint is redundant wrt. two surrounding constraints.
 
@@ -292,7 +288,7 @@ set defined by `cmid`.
 """
 function isredundant(cmid::LinearConstraint{N},
                      cright::LinearConstraint{N},
-                     cleft::LinearConstraint{N})::Bool where {N<:Real}
+                     cleft::LinearConstraint{N}) where {N<:Real}
     samedir_check = false
     # determine angle between surrounding constraints
     if !is_right_turn(cright.a, cleft.a)
@@ -379,8 +375,7 @@ end
                    constraint::LinearConstraint{N};
                    [linear_search]::Bool=(length(P.constraints) <
                                           BINARY_SEARCH_THRESHOLD),
-                   [prune]::Bool=true
-                  )::Nothing where {N<:Real}
+                   [prune]::Bool=true) where {N<:Real}
 
 Add a linear constraint to a polygon in constraint representation, keeping the
 constraints sorted by their normal directions.
@@ -394,17 +389,12 @@ constraints sorted by their normal directions.
                      and binary search
 - `prune`         -- (optional, default: `true`) flag for removing redundant
                      constraints in the end
-
-### Output
-
-Nothing.
 """
 function addconstraint!(P::AbstractHPolygon{N},
                         constraint::LinearConstraint{N};
                         linear_search::Bool=(length(P.constraints) <
                                              BINARY_SEARCH_THRESHOLD),
-                        prune::Bool=true
-                       )::Nothing where {N<:Real}
+                        prune::Bool=true) where {N<:Real}
     return addconstraint!(P.constraints, constraint,
                           linear_search=linear_search, prune=prune)
 end
@@ -415,7 +405,7 @@ end
                    [linear_search]::Bool=(length(P.constraints) <
                                           BINARY_SEARCH_THRESHOLD),
                    [prune]::Bool=true
-                  )::Nothing where {N<:Real, LC<:LinearConstraint{N}}
+                  ) where {N<:Real, LC<:LinearConstraint{N}}
 
 Add a linear constraint to a sorted vector of constrains, keeping the
 constraints sorted by their normal directions.
@@ -431,10 +421,6 @@ constraints sorted by their normal directions.
 - `prune`          -- (optional, default: `true`) flag for removing redundant
                       constraints in the end
 
-### Output
-
-Nothing.
-
 ### Algorithm
 
 If `prune` is active, we check if the new constraint is redundant.
@@ -446,7 +432,7 @@ function addconstraint!(constraints::Vector{LC},
                         linear_search::Bool=(length(constraints) <
                                              BINARY_SEARCH_THRESHOLD),
                         prune::Bool=true
-                       )::Nothing where {N<:Real, LC<:LinearConstraint{N}}
+                       ) where {N<:Real, LC<:LinearConstraint{N}}
     m = length(constraints)
     k = m
     if k > 0
@@ -518,8 +504,7 @@ end
                               constraints::Vector{<:LinearConstraint{N}},
                               n::Int,
                               k::Int;
-                              [choose_lower]::Bool=false
-                             )::Int where {N<:Real}
+                              [choose_lower]::Bool=false) where {N}
 
 Performs a binary search in the constraints.
 
@@ -544,8 +529,7 @@ function binary_search_constraints(d::AbstractVector{N},
                                    constraints::Vector{<:LinearConstraint{N}},
                                    n::Int,
                                    k::Int;
-                                   choose_lower::Bool=false
-                                  )::Int where {N}
+                                   choose_lower::Bool=false) where {N}
     lower = 1
     upper = n+1
     while lower + 1 < upper
@@ -568,7 +552,7 @@ function binary_search_constraints(d::AbstractVector{N},
 end
 
 """
-    isbounded(P::AbstractHPolygon, [use_type_assumption]::Bool=true)::Bool
+    isbounded(P::AbstractHPolygon, [use_type_assumption]::Bool=true)
 
 Determine whether a polygon in constraint representation is bounded.
 
@@ -588,7 +572,7 @@ Otherwise, `true` iff `P` is bounded.
 If `!use_type_assumption`, we convert `P` to an `HPolyhedron` `P2` and then use
 `isbounded(P2)`.
 """
-function isbounded(P::AbstractHPolygon, use_type_assumption::Bool=true)::Bool
+function isbounded(P::AbstractHPolygon, use_type_assumption::Bool=true)
     if use_type_assumption
         return true
     end

--- a/src/Interfaces/AbstractHyperrectangle.jl
+++ b/src/Interfaces/AbstractHyperrectangle.jl
@@ -19,11 +19,11 @@ Abstract type for hyperrectangular sets.
 See [`Hyperrectangle`](@ref) for a standard implementation of this interface.
 
 Every concrete `AbstractHyperrectangle` must define the following functions:
-- `radius_hyperrectangle(::AbstractHyperrectangle{N})::Vector{N}` -- return the
+- `radius_hyperrectangle(::AbstractHyperrectangle{N})` -- return the
     hyperrectangle's radius, which is a full-dimensional vector
-- `radius_hyperrectangle(::AbstractHyperrectangle{N}, i::Int)::N` -- return the
+- `radius_hyperrectangle(::AbstractHyperrectangle{N}, i::Int)` -- return the
     hyperrectangle's radius in the `i`-th dimension
-- `isflat(::AbstractHyperrectangle{N})::Bool` -- determine whether the
+- `isflat(::AbstractHyperrectangle{N})` -- determine whether the
     hyperrectangle's radius is zero in some dimension
 
 ```jldoctest; setup = :(using LazySets: subtypes)
@@ -140,8 +140,7 @@ end
 
 
 """
-    vertices_list(H::AbstractHyperrectangle{N}
-                 )::Vector{Vector{N}} where {N<:Real}
+    vertices_list(H::AbstractHyperrectangle{N}) where {N<:Real}
 
 Return the list of vertices of a hyperrectangular set.
 
@@ -180,8 +179,7 @@ entry `1` (but changing it to `-1`).
 This way we only need to change the vertex in those dimensions where `v` has
 changed, which usually is a smaller number than `n`.
 """
-function vertices_list(H::AbstractHyperrectangle{N}
-                      )::Vector{Vector{N}} where {N<:Real}
+function vertices_list(H::AbstractHyperrectangle{N}) where {N<:Real}
     n = dim(H)
 
     # identify flat dimensions and store them in a binary vector whose entry in
@@ -326,7 +324,7 @@ function _ρ_sev_hyperrectangle(d::SingleEntryVector{N}, H::AbstractHyperrectang
 end
 
 """
-    norm(H::AbstractHyperrectangle, [p]::Real=Inf)::Real
+    norm(H::AbstractHyperrectangle, [p]::Real=Inf)
 
 Return the norm of a hyperrectangular set.
 
@@ -371,13 +369,13 @@ maximum of each term ``|c_i + α_i r_i|^p`` is given by ``|c_i + \\text{sign}(c_
 for each ``i``. Hence, ``x^* := \\text{argmax}_{x ∈ X} ‖ x ‖_p`` is the vertex
 ``c + \\text{diag}(\\text{sign}(c)) r``.
 """
-function norm(H::AbstractHyperrectangle, p::Real=Inf)::Real
+function norm(H::AbstractHyperrectangle, p::Real=Inf)
     c, r = center(H), radius_hyperrectangle(H)
     return norm((@. c + sign_cadlag(c) * r), p)
 end
 
 """
-    radius(H::AbstractHyperrectangle, [p]::Real=Inf)::Real
+    radius(H::AbstractHyperrectangle, [p]::Real=Inf)
 
 Return the radius of a hyperrectangular set.
 
@@ -396,12 +394,12 @@ The radius is defined as the radius of the enclosing ball of the given
 ``p``-norm of minimal volume with the same center.
 It is the same for all corners of a hyperrectangular set.
 """
-function radius(H::AbstractHyperrectangle, p::Real=Inf)::Real
+function radius(H::AbstractHyperrectangle, p::Real=Inf)
     return norm(radius_hyperrectangle(H), p)
 end
 
 """
-    ∈(x::AbstractVector{N}, H::AbstractHyperrectangle{N})::Bool where {N<:Real}
+    ∈(x::AbstractVector{N}, H::AbstractHyperrectangle{N}) where {N<:Real}
 
 Check whether a given point is contained in a hyperrectangular set.
 
@@ -422,7 +420,7 @@ respectively.
 Then ``x ∈ H`` iff ``|c_i - x_i| ≤ r_i`` for all ``i=1,…,n``.
 """
 function ∈(x::AbstractVector{N},
-           H::AbstractHyperrectangle{N})::Bool where {N<:Real}
+           H::AbstractHyperrectangle{N}) where {N<:Real}
     @assert length(x) == dim(H)
     c = center(H)
     @inbounds for i in eachindex(x)
@@ -437,7 +435,7 @@ end
 # --- common AbstractHyperrectangle functions ---
 
 """
-    high(H::AbstractHyperrectangle{N})::Vector{N} where {N<:Real}
+    high(H::AbstractHyperrectangle{N}) where {N<:Real}
 
 Return the higher coordinates of a hyperrectangular set.
 
@@ -449,12 +447,12 @@ Return the higher coordinates of a hyperrectangular set.
 
 A vector with the higher coordinates of the hyperrectangular set.
 """
-function high(H::AbstractHyperrectangle{N})::Vector{N} where {N<:Real}
+function high(H::AbstractHyperrectangle{N}) where {N<:Real}
     return center(H) .+ radius_hyperrectangle(H)
 end
 
 """
-    high(H::AbstractHyperrectangle{N}, i::Int)::N where {N<:Real}
+    high(H::AbstractHyperrectangle{N}, i::Int) where {N<:Real}
 
 Return the higher coordinate of a hyperrectangular set in a given dimension.
 
@@ -467,12 +465,12 @@ Return the higher coordinate of a hyperrectangular set in a given dimension.
 
 The higher coordinate of the hyperrectangular set in the given dimension.
 """
-function high(H::AbstractHyperrectangle{N}, i::Int)::N where {N<:Real}
+function high(H::AbstractHyperrectangle{N}, i::Int) where {N<:Real}
     return center(H)[i] + radius_hyperrectangle(H, i)
 end
 
 """
-    low(H::AbstractHyperrectangle{N})::Vector{N} where {N<:Real}
+    low(H::AbstractHyperrectangle{N}) where {N<:Real}
 
 Return the lower coordinates of a hyperrectangular set.
 
@@ -484,12 +482,12 @@ Return the lower coordinates of a hyperrectangular set.
 
 A vector with the lower coordinates of the hyperrectangular set.
 """
-function low(H::AbstractHyperrectangle{N})::Vector{N} where {N<:Real}
+function low(H::AbstractHyperrectangle{N}) where {N<:Real}
     return center(H) .- radius_hyperrectangle(H)
 end
 
 """
-    low(H::AbstractHyperrectangle{N}, i::Int)::N where {N<:Real}
+    low(H::AbstractHyperrectangle{N}, i::Int) where {N<:Real}
 
 Return the lower coordinate of a hyperrectangular set in a given dimension.
 
@@ -502,12 +500,12 @@ Return the lower coordinate of a hyperrectangular set in a given dimension.
 
 The lower coordinate of the hyperrectangular set in the given dimension.
 """
-function low(H::AbstractHyperrectangle{N}, i::Int)::N where {N<:Real}
+function low(H::AbstractHyperrectangle{N}, i::Int) where {N<:Real}
     return center(H)[i] - radius_hyperrectangle(H, i)
 end
 
 """
-    isflat(H::AbstractHyperrectangle)::Bool
+    isflat(H::AbstractHyperrectangle)
 
 Determine whether a hyperrectangular set is flat, i.e. whether its radius
 is zero in some dimension.
@@ -526,7 +524,7 @@ For robustness with respect to floating-point inputs, this function relies on
 the result of `isapproxzero` when applied to the radius in some dimension.
 Hence, this function depends on the absolute zero tolerance `ABSZTOL`.
 """
-function isflat(H::AbstractHyperrectangle)::Bool
+function isflat(H::AbstractHyperrectangle)
     return any(i -> isapproxzero(radius_hyperrectangle(H, i)), 1:dim(H))
 end
 
@@ -546,7 +544,7 @@ Partition a hyperrectangular set into uniform sub-hyperrectangles.
 A list of `Hyperrectangle`s.
 """
 function split(H::AbstractHyperrectangle{N}, num_blocks::AbstractVector{Int}
-              )::Vector{Hyperrectangle{N}} where {N<:Real}
+              ) where {N<:Real}
     @assert length(num_blocks) == dim(H) "need number of blocks in each dimension"
     radius = copy(radius_hyperrectangle(H))
     total_number = 1

--- a/src/Interfaces/AbstractPolygon.jl
+++ b/src/Interfaces/AbstractPolygon.jl
@@ -12,9 +12,9 @@ Abstract type for polygons (i.e., 2D polytopes).
 ### Notes
 
 Every concrete `AbstractPolygon` must define the following functions:
-- `tovrep(::AbstractPolygon{N})::VPolygon{N}`         -- transform into
+- `tovrep(::AbstractPolygon{N})`         -- transform into
     V-representation
-- `tohrep(::AbstractPolygon{N})::S where {S<:AbstractHPolygon{N}}` -- transform
+- `tohrep(::AbstractPolygon{N}) where {S<:AbstractHPolygon{N}}` -- transform
     into H-representation
 
 ```jldoctest; setup = :(using LazySets: subtypes)
@@ -32,7 +32,7 @@ isconvextype(::Type{<:AbstractPolygon}) = true
 
 
 """
-    dim(P::AbstractPolygon)::Int
+    dim(P::AbstractPolygon)
 
 Return the ambient dimension of a polygon.
 
@@ -44,12 +44,12 @@ Return the ambient dimension of a polygon.
 
 The ambient dimension of the polygon, which is 2.
 """
-@inline function dim(P::AbstractPolygon)::Int
+@inline function dim(P::AbstractPolygon)
     return 2
 end
 
 """
-    jump2pi(x::N)::N where {N<:AbstractFloat}
+    jump2pi(x::N) where {N<:AbstractFloat}
 
 Return ``x + 2π`` if ``x`` is negative, otherwise return ``x``.
 
@@ -76,12 +76,12 @@ julia> jump2pi(0.5)
 0.5
 ```
 """
-@inline function jump2pi(x::N)::N where {N<:AbstractFloat}
+@inline function jump2pi(x::N) where {N<:AbstractFloat}
     x < zero(N) ? 2 * pi + x : x
 end
 
 """
-    quadrant(w::AbstractVector{N})::Int where {N<:Real}
+    quadrant(w::AbstractVector{N}) where {N<:Real}
 
 Compute the quadrant where the direction `w` belongs.
 
@@ -108,14 +108,14 @@ The idea is to encode the following logic function:
 This function is inspired from AGPX's answer in:
 [Sort points in clockwise order?](https://stackoverflow.com/a/46635372)
 """
-@inline function quadrant(w::AbstractVector{N})::Int where {N<:Real}
+@inline function quadrant(w::AbstractVector{N}) where {N<:Real}
     dwx = w[1] >= zero(N) ? 1 : 0
     dwy = w[2] >= zero(N) ? 1 : 0
     return (1 - dwx) + (1 - dwy) + ((dwx & (1 - dwy)) << 1)
 end
 
 """
-    <=(u::AbstractVector{N}, v::AbstractVector{N})::Bool where {N<:Real}
+    <=(u::AbstractVector{N}, v::AbstractVector{N}) where {N<:Real}
 
 Compare two 2D vectors by their direction.
 
@@ -139,7 +139,7 @@ The implementation checks the quadrant of each direction, and compares
 directions using the right-hand rule (see [`is_right_turn`](@ref)).
 In particular, this method does not use the arctangent.
 """
-function <=(u::AbstractVector{N}, v::AbstractVector{N})::Bool where {N<:Real}
+function <=(u::AbstractVector{N}, v::AbstractVector{N}) where {N<:Real}
     qu, qv = quadrant(u), quadrant(v)
     if qu == qv
         # same quadrant, check right-turn with center 0
@@ -150,7 +150,7 @@ function <=(u::AbstractVector{N}, v::AbstractVector{N})::Bool where {N<:Real}
 end
 
 """
-    <=(u::AbstractVector{N}, v::AbstractVector{N})::Bool where {N<:AbstractFloat}
+    <=(u::AbstractVector{N}, v::AbstractVector{N}) where {N<:AbstractFloat}
 
 Compares two 2D vectors by their direction.
 
@@ -175,6 +175,6 @@ arguments implements the
 [`atan2` function](https://en.wikipedia.org/wiki/Atan2).
 """
 function <=(u::AbstractVector{N},
-            v::AbstractVector{N})::Bool where {N<:AbstractFloat}
+            v::AbstractVector{N}) where {N<:AbstractFloat}
     return jump2pi(atan(u[2], u[1])) <= jump2pi(atan(v[2], v[1]))
 end

--- a/src/Interfaces/AbstractPolyhedron_functions.jl
+++ b/src/Interfaces/AbstractPolyhedron_functions.jl
@@ -25,7 +25,7 @@ function default_polyhedra_backend(P, N)
 end
 
 """
-    ∈(x::AbstractVector{N}, P::AbstractPolyhedron{N})::Bool where {N<:Real}
+    ∈(x::AbstractVector{N}, P::AbstractPolyhedron{N}) where {N<:Real}
 
 Check whether a given point is contained in a polyhedron.
 
@@ -42,7 +42,7 @@ Check whether a given point is contained in a polyhedron.
 
 This implementation checks if the point lies inside each defining half-space.
 """
-function ∈(x::AbstractVector{N}, P::AbstractPolyhedron{N})::Bool where {N<:Real}
+function ∈(x::AbstractVector{N}, P::AbstractPolyhedron{N}) where {N<:Real}
     @assert length(x) == dim(P) "a $(length(x))-dimensional point cannot be " *
         "an element of a $(dim(P))-dimensional set"
 
@@ -56,7 +56,7 @@ end
 
 """
     isuniversal(P::AbstractPolyhedron{N}, [witness]::Bool=false
-               )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+               ) where {N<:Real}
 
 Check whether a polyhedron is universal.
 
@@ -80,7 +80,7 @@ A witness is produced using `isuniversal(H)` where `H` is the first linear
 constraint of `P`.
 """
 function isuniversal(P::AbstractPolyhedron{N}, witness::Bool=false
-                    )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+                    ) where {N<:Real}
     constraints = constraints_list(P)
     if isempty(constraints)
         return witness ? (true, N[]) : true
@@ -90,7 +90,7 @@ function isuniversal(P::AbstractPolyhedron{N}, witness::Bool=false
 end
 
 """
-    constrained_dimensions(P::AbstractPolyhedron)::Vector{Int} where {N<:Real}
+    constrained_dimensions(P::AbstractPolyhedron) where {N<:Real}
 
 Return the indices in which a polyhedron is constrained.
 
@@ -107,7 +107,7 @@ dimension `i`.
 
 A 2D polyhedron with constraint ``x1 ≥ 0`` is constrained in dimension 1 only.
 """
-function constrained_dimensions(P::AbstractPolyhedron)::Vector{Int}
+function constrained_dimensions(P::AbstractPolyhedron)
     constraints = constraints_list(P)
     if isempty(constraints)
         return Int[]
@@ -158,7 +158,7 @@ end
 """
      remove_redundant_constraints!(
          constraints::AbstractVector{<:LinearConstraint{N}};
-         [backend]=default_lp_solver(N))::Bool where {N<:Real}
+         [backend]=default_lp_solver(N)) where {N<:Real}
 
 Remove the redundant constraints of a given list of linear constraints; the list
 is updated in-place.
@@ -198,7 +198,7 @@ FAQ](https://www.cs.mcgill.ca/~fukuda/soft/polyfaq/node24.html).
 """
 function remove_redundant_constraints!(
         constraints::AbstractVector{<:LinearConstraint{N}};
-        backend=default_lp_solver(N))::Bool where {N<:Real}
+        backend=default_lp_solver(N)) where {N<:Real}
 
     A, b = tosimplehrep(constraints)
     m, n = size(A)

--- a/src/Interfaces/AbstractPolytope.jl
+++ b/src/Interfaces/AbstractPolytope.jl
@@ -14,8 +14,7 @@ Abstract type for compact convex polytopic sets.
 ### Notes
 
 Every concrete `AbstractPolytope` must define the following functions:
-- `vertices_list(::AbstractPolytope{N})::Vector{Vector{N}}` -- return a list of
-    all vertices
+- `vertices_list(::AbstractPolytope{N})` -- return a list of all vertices
 
 ```jldoctest; setup = :(using LazySets: subtypes)
 julia> subtypes(AbstractPolytope)
@@ -41,7 +40,7 @@ isconvextype(::Type{<:AbstractPolytope}) = true
 # =============================================
 
 """
-    isbounded(P::AbstractPolytope)::Bool
+    isbounded(P::AbstractPolytope)
 
 Determine whether a polytopic set is bounded.
 
@@ -53,12 +52,12 @@ Determine whether a polytopic set is bounded.
 
 `true` (since a polytope must be bounded).
 """
-function isbounded(::AbstractPolytope)::Bool
+function isbounded(::AbstractPolytope)
     return true
 end
 
 """
-    singleton_list(P::AbstractPolytope{N})::Vector{Singleton{N}} where {N<:Real}
+    singleton_list(P::AbstractPolytope{N}) where {N<:Real}
 
 Return the vertices of a polytopic set as a list of singletons.
 
@@ -70,13 +69,12 @@ Return the vertices of a polytopic set as a list of singletons.
 
 List containing a singleton for each vertex.
 """
-function singleton_list(P::AbstractPolytope{N}
-                       )::Vector{Singleton{N}} where {N<:Real}
+function singleton_list(P::AbstractPolytope{N}) where {N<:Real}
     return [Singleton(vi) for vi in vertices_list(P)]
 end
 
 """
-    isempty(P::AbstractPolytope)::Bool
+    isempty(P::AbstractPolytope)
 
 Determine whether a polytope is empty.
 
@@ -93,13 +91,13 @@ Determine whether a polytope is empty.
 This algorithm checks whether the `vertices_list` of the given polytope is empty
 or not.
 """
-function isempty(P::AbstractPolytope)::Bool
+function isempty(P::AbstractPolytope)
     return isempty(vertices_list(P))
 end
 
 """
     isuniversal(P::AbstractPolytope{N}, [witness]::Bool=false
-               )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+               ) where {N<:Real}
 
 Check whether a polyhedron is universal.
 
@@ -119,7 +117,7 @@ A witness is produced using `isuniversal(H)` where `H` is the first linear
 constraint of `P`.
 """
 function isuniversal(P::AbstractPolytope{N}, witness::Bool=false
-                    )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+                    ) where {N<:Real}
     if witness
         constraints = constraints_list(P)
         if isempty(constraints)

--- a/src/Interfaces/AbstractSingleton.jl
+++ b/src/Interfaces/AbstractSingleton.jl
@@ -13,8 +13,8 @@ Abstract type for sets with a single value.
 ### Notes
 
 Every concrete `AbstractSingleton` must define the following functions:
-- `element(::AbstractSingleton{N})::Vector{N}` -- return the single element
-- `element(::AbstractSingleton{N}, i::Int)::N` -- return the single element's
+- `element(::AbstractSingleton{N})` -- return the single element
+- `element(::AbstractSingleton{N}, i::Int)` -- return the single element's
     entry in the `i`-th dimension
 
 ```jldoctest; setup = :(using LazySets: subtypes)
@@ -32,7 +32,7 @@ isconvextype(::Type{<:AbstractSingleton}) = true
 
 
 """
-    radius_hyperrectangle(S::AbstractSingleton{N}, i::Int)::N where {N<:Real}
+    radius_hyperrectangle(S::AbstractSingleton{N}, i::Int) where {N<:Real}
 
 Return the box radius of a set with a single value in a given dimension.
 
@@ -46,13 +46,13 @@ Return the box radius of a set with a single value in a given dimension.
 Zero.
 """
 function radius_hyperrectangle(S::AbstractSingleton{N}, i::Int
-                              )::N where {N<:Real}
+                              ) where {N<:Real}
     return zero(N)
 end
 
 
 """
-    radius_hyperrectangle(S::AbstractSingleton{N})::Vector{N} where {N<:Real}
+    radius_hyperrectangle(S::AbstractSingleton{N}) where {N<:Real}
 
 Return the box radius of a set with a single value in every dimension.
 
@@ -64,14 +64,13 @@ Return the box radius of a set with a single value in every dimension.
 
 The zero vector.
 """
-function radius_hyperrectangle(S::AbstractSingleton{N}
-                              )::Vector{N} where {N<:Real}
+function radius_hyperrectangle(S::AbstractSingleton{N}) where {N<:Real}
     return zeros(N, dim(S))
 end
 
 
 """
-    high(S::AbstractSingleton{N})::Vector{N} where {N<:Real}
+    high(S::AbstractSingleton{N}) where {N<:Real}
 
 Return the higher coordinates of a set with a single value.
 
@@ -83,12 +82,12 @@ Return the higher coordinates of a set with a single value.
 
 A vector with the higher coordinates of the set with a single value.
 """
-function high(S::AbstractSingleton{N})::Vector{N} where {N<:Real}
+function high(S::AbstractSingleton{N}) where {N<:Real}
     return element(S)
 end
 
 """
-    high(S::AbstractSingleton{N}, i::Int)::N where {N<:Real}
+    high(S::AbstractSingleton{N}, i::Int) where {N<:Real}
 
 Return the higher coordinate of a set with a single value in the given
 dimension.
@@ -102,12 +101,12 @@ dimension.
 
 The higher coordinate of the set with a single value in the given dimension.
 """
-function high(S::AbstractSingleton{N}, i::Int)::N where {N<:Real}
+function high(S::AbstractSingleton{N}, i::Int) where {N<:Real}
     return element(S)[i]
 end
 
 """
-    low(S::AbstractSingleton{N})::Vector{N} where {N<:Real}
+    low(S::AbstractSingleton{N}) where {N<:Real}
 
 Return the lower coordinates of a set with a single value.
 
@@ -119,12 +118,12 @@ Return the lower coordinates of a set with a single value.
 
 A vector with the lower coordinates of the set with a single value.
 """
-function low(S::AbstractSingleton{N})::Vector{N} where {N<:Real}
+function low(S::AbstractSingleton{N}) where {N<:Real}
     return element(S)
 end
 
 """
-    low(S::AbstractSingleton{N}, i::Int)::N where {N<:Real}
+    low(S::AbstractSingleton{N}, i::Int) where {N<:Real}
 
 Return the lower coordinate of a set with a single value in the given
 dimension.
@@ -138,7 +137,7 @@ dimension.
 
 The lower coordinate of the set with a single value in the given dimension.
 """
-function low(S::AbstractSingleton{N}, i::Int)::N where {N<:Real}
+function low(S::AbstractSingleton{N}, i::Int) where {N<:Real}
     return element(S)[i]
 end
 
@@ -218,7 +217,7 @@ end
 
 
 """
-    center(S::AbstractSingleton{N})::Vector{N} where {N<:Real}
+    center(S::AbstractSingleton{N}) where {N<:Real}
 
 Return the center of a set with a single value.
 
@@ -230,7 +229,7 @@ Return the center of a set with a single value.
 
 The only element of the set.
 """
-function center(S::AbstractSingleton{N})::Vector{N} where {N<:Real}
+function center(S::AbstractSingleton{N}) where {N<:Real}
     return element(S)
 end
 
@@ -239,7 +238,7 @@ end
 
 
 """
-    vertices_list(S::AbstractSingleton{N})::Vector{Vector{N}} where {N<:Real}
+    vertices_list(S::AbstractSingleton{N}) where {N<:Real}
 
 Return the list of vertices of a set with a single value.
 
@@ -251,8 +250,7 @@ Return the list of vertices of a set with a single value.
 
 A list containing only a single vertex.
 """
-function vertices_list(S::AbstractSingleton{N}
-                      )::Vector{Vector{N}} where {N<:Real}
+function vertices_list(S::AbstractSingleton{N}) where {N<:Real}
     return [element(S)]
 end
 
@@ -321,7 +319,7 @@ function ρ(d::AbstractVector{N}, S::AbstractSingleton{N}) where {N<:Real}
 end
 
 """
-    ∈(x::AbstractVector{N}, S::AbstractSingleton{N})::Bool where {N<:Real}
+    ∈(x::AbstractVector{N}, S::AbstractSingleton{N}) where {N<:Real}
 
 Check whether a given point is contained in a set with a single value.
 
@@ -339,12 +337,12 @@ Check whether a given point is contained in a set with a single value.
 This implementation performs an exact comparison, which may be insufficient with
 floating point computations.
 """
-function ∈(x::AbstractVector{N}, S::AbstractSingleton{N})::Bool where {N<:Real}
+function ∈(x::AbstractVector{N}, S::AbstractSingleton{N}) where {N<:Real}
     return x == element(S)
 end
 
 # this operation is forbidden, but it is a common error
-function ∈(S::AbstractSingleton{N}, X::LazySet{N})::Bool where {N<:Real}
+function ∈(S::AbstractSingleton{N}, X::LazySet{N}) where {N<:Real}
     error("cannot make a point-in-set check if the left-hand side is " *
           "a set; either check for set inclusion, as in `S ⊆ X`, or check for " *
           "membership, as in `element(S) ∈ X` (the results are equivalent but " *

--- a/src/Interfaces/AbstractZonotope.jl
+++ b/src/Interfaces/AbstractZonotope.jl
@@ -28,8 +28,7 @@ ball in ``\\mathbb{R}^n`` by an affine transformation.
 See [`Zonotope`](@ref) for a standard implementation of this interface.
 
 Every concrete `AbstractZonotope` must define the following functions:
-- `genmat(::AbstractZonotope{N})::AbstractMatrix{N}` -- return the generator
-    matrix
+- `genmat(::AbstractZonotope{N})` -- return the generator matrix
 - `generators(::AbstractZonotope{N})` -- return an iterator over the generators
 
 Since the functions `genmat` and `generators` can be defined in terms of each
@@ -124,7 +123,7 @@ end
 
 
 """
-    ngens(Z::AbstractZonotope)::Int
+    ngens(Z::AbstractZonotope)
 
 Return the number of generators of a zonotopic set.
 
@@ -136,12 +135,12 @@ Return the number of generators of a zonotopic set.
 
 An integer representing the number of generators.
 """
-function ngens(Z::AbstractZonotope)::Int
+function ngens(Z::AbstractZonotope)
     return length(generators(Z))
 end
 
 """
-    order(Z::AbstractZonotope)::Rational
+    order(Z::AbstractZonotope)
 
 Return the order of a zonotope.
 
@@ -158,7 +157,7 @@ A rational number representing the order of the zonotope.
 The order of a zonotope is defined as the quotient of its number of generators
 and its dimension.
 """
-function order(Z::AbstractZonotope)::Rational
+function order(Z::AbstractZonotope)
     return ngens(Z) // dim(Z)
 end
 

--- a/src/Interfaces/LazySet.jl
+++ b/src/Interfaces/LazySet.jl
@@ -40,7 +40,7 @@ Every concrete `LazySet` must define the following functions:
     of `S` in a given direction `d`; note that the numeric type `N` of `d` and
     `S` must be identical; for some set types `N` may be more restrictive than
     `Real`
-- `dim(S::LazySet)::Int` -- the ambient dimension of `S`
+- `dim(S::LazySet)` -- the ambient dimension of `S`
 
 The function
 - `ρ(d::AbstractVector{N}, S::LazySet{N}) where {N<:Real}` -- the support
@@ -163,7 +163,7 @@ The numeric type of `X`.
 eltype(::LazySet{N}) where {N} = N
 
 """
-    ρ(d::AbstractVector{N}, S::LazySet{N})::N where {N<:Real}
+    ρ(d::AbstractVector{N}, S::LazySet{N}) where {N<:Real}
 
 Evaluate the support function of a set in a given direction.
 
@@ -180,7 +180,7 @@ The support function of the set `S` for the direction `d`.
 
 The numeric type of the direction and the set must be identical.
 """
-function ρ(d::AbstractVector{N}, S::LazySet{N})::N where {N<:Real}
+function ρ(d::AbstractVector{N}, S::LazySet{N}) where {N<:Real}
     return dot(d, σ(d, S))
 end
 
@@ -206,7 +206,7 @@ Alias for the support vector σ.
 const support_vector = σ
 
 """
-    isbounded(S::LazySet)::Bool
+    isbounded(S::LazySet)
 
 Determine whether a set is bounded.
 
@@ -222,12 +222,12 @@ Determine whether a set is bounded.
 
 We check boundedness via [`isbounded_unit_dimensions`](@ref).
 """
-function isbounded(S::LazySet)::Bool
+function isbounded(S::LazySet)
     return isbounded_unit_dimensions(S)
 end
 
 """
-    isbounded_unit_dimensions(S::LazySet{N})::Bool where {N<:Real}
+    isbounded_unit_dimensions(S::LazySet{N}) where {N<:Real}
 
 Determine whether a set is bounded in each unit dimension.
 
@@ -244,7 +244,7 @@ Determine whether a set is bounded in each unit dimension.
 This function performs ``2n`` support function checks, where ``n`` is the
 ambient dimension of `S`.
 """
-function isbounded_unit_dimensions(S::LazySet{N})::Bool where {N<:Real}
+function isbounded_unit_dimensions(S::LazySet{N}) where {N<:Real}
     n = dim(S)
     @inbounds for i in 1:n
         for o in [one(N), -one(N)]
@@ -299,7 +299,7 @@ A real number representing the radius.
 """
 function radius(S::LazySet, p::Real=Inf)
     if p == Inf
-        return radius(Approximations.ballinf_approximation(S)::BallInf, p)
+        return radius(Approximations.ballinf_approximation(S), p)
     else
         error("the radius for this value of p=$p is not implemented")
     end
@@ -558,8 +558,7 @@ function reflect(P::LazySet)
 end
 
 """
-    isuniversal(X::LazySet{N}, [witness]::Bool=false
-               )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+    isuniversal(X::LazySet{N}, [witness]::Bool=false) where {N<:Real}
 
 Check whether a given convex set is universal, and otherwise optionally compute
 a witness.
@@ -580,8 +579,7 @@ a witness.
 
 This is a naive fallback implementation.
 """
-function isuniversal(X::LazySet{N}, witness::Bool=false
-                    )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+function isuniversal(X::LazySet{N}, witness::Bool=false) where {N<:Real}
     if isbounded(X)
         result = false
     else

--- a/src/LazyOperations/AffineMap.jl
+++ b/src/LazyOperations/AffineMap.jl
@@ -154,7 +154,7 @@ end
 # ============================
 
 """
-    dim(am::AffineMap)::Int
+    dim(am::AffineMap)
 
 Return the dimension of an affine map.
 
@@ -166,7 +166,7 @@ Return the dimension of an affine map.
 
 The dimension of an affine map.
 """
-function dim(am::AffineMap)::Int
+function dim(am::AffineMap)
     return length(am.v)
 end
 
@@ -225,7 +225,7 @@ function an_element(am::AffineMap)
 end
 
 """
-    isempty(am::AffineMap)::Bool
+    isempty(am::AffineMap)
 
 Return whether an affine map is empty or not.
 
@@ -237,12 +237,12 @@ Return whether an affine map is empty or not.
 
 `true` iff the wrapped set is empty and the affine vector is empty.
 """
-function isempty(am::AffineMap)::Bool
+function isempty(am::AffineMap)
     return isempty(am.X)
 end
 
 """
-    isbounded(am::AffineMap; cond_tol::Number=DEFAULT_COND_TOL)::Bool
+    isbounded(am::AffineMap; cond_tol::Number=DEFAULT_COND_TOL)
 
 Determine whether an affine map is bounded.
 
@@ -264,7 +264,7 @@ If the matrix is invertible, then the map being bounded is equivalent to the
 wrapped set being bounded, and hence the map is unbounded.
 Otherwise, we check boundedness via [`isbounded_unit_dimensions`](@ref).
 """
-function isbounded(am::AffineMap; cond_tol::Number=DEFAULT_COND_TOL)::Bool
+function isbounded(am::AffineMap; cond_tol::Number=DEFAULT_COND_TOL)
     if iszero(am.M) || isbounded(am.X)
         return true
     end
@@ -275,7 +275,7 @@ function isbounded(am::AffineMap; cond_tol::Number=DEFAULT_COND_TOL)::Bool
 end
 
 """
-    ∈(x::AbstractVector{N}, am::AffineMap{N})::Bool where {N<:Real}
+    ∈(x::AbstractVector{N}, am::AffineMap{N}) where {N<:Real}
 
 Check whether a given point is contained in the affine map of a convex set.
 
@@ -317,13 +317,12 @@ julia> [0.5, 0.5] ∈ M*B
 true
 ```
 """
-function ∈(x::AbstractVector{N}, am::AffineMap{N})::Bool where {N<:Real}
+function ∈(x::AbstractVector{N}, am::AffineMap{N}) where {N<:Real}
     return ∈(am.M \ (x - am.v), am.X)
 end
 
 """
-    vertices_list(am::AffineMap{N};
-                  [apply_convex_hull]::Bool)::Vector{Vector{N}} where {N<:Real}
+    vertices_list(am::AffineMap{N}; [apply_convex_hull]::Bool) where {N<:Real}
 
 Return the list of vertices of a (polyhedral) affine map.
 
@@ -353,7 +352,7 @@ Note that we assume that the underlying set `X` is polyhedral, either concretely
 or lazily, i.e. there the function `vertices_list` should be applicable.
 """
 function vertices_list(am::AffineMap{N};
-                       apply_convex_hull::Bool=true)::Vector{Vector{N}} where {N<:Real}
+                       apply_convex_hull::Bool=true) where {N<:Real}
 
     # collect vertices list of the wrapped set
     vlist_X = vertices_list(am.X)

--- a/src/LazyOperations/CachedMinkowskiSumArray.jl
+++ b/src/LazyOperations/CachedMinkowskiSumArray.jl
@@ -78,7 +78,7 @@ CachedMinkowskiSumArray(arr::Vector{S}) where {N<:Real, S<:LazySet{N}} =
     CachedMinkowskiSumArray{N, S}(arr)
 
 # constructor for an empty sum with optional size hint and numeric type
-function CachedMinkowskiSumArray(n::Int=0, N::Type=Float64)::CachedMinkowskiSumArray
+function CachedMinkowskiSumArray(n::Int=0, N::Type=Float64)
     arr = Vector{LazySet{N}}()
     sizehint!(arr, n)
     return CachedMinkowskiSumArray(arr)
@@ -92,7 +92,7 @@ end
 # @absorbing(CachedMinkowskiSumArray, Universe)  # TODO problematic
 
 """
-    array(cms::CachedMinkowskiSumArray{N, S})::Vector{S} where {N<:Real, S<:LazySet{N}}
+    array(cms::CachedMinkowskiSumArray{N, S}) where {N<:Real, S<:LazySet{N}}
 
 Return the array of a caching Minkowski sum.
 
@@ -105,12 +105,12 @@ Return the array of a caching Minkowski sum.
 The array of a caching Minkowski sum.
 """
 function array(cms::CachedMinkowskiSumArray{N, S}
-              )::Vector{S} where {N<:Real, S<:LazySet{N}}
+              ) where {N<:Real, S<:LazySet{N}}
     return cms.array
 end
 
 """
-    dim(cms::CachedMinkowskiSumArray)::Int
+    dim(cms::CachedMinkowskiSumArray)
 
 Return the dimension of a caching Minkowski sum.
 
@@ -122,7 +122,7 @@ Return the dimension of a caching Minkowski sum.
 
 The ambient dimension of the caching Minkowski sum.
 """
-function dim(cms::CachedMinkowskiSumArray)::Int
+function dim(cms::CachedMinkowskiSumArray)
     return length(cms.array) == 0 ? 0 : dim(cms.array[1])
 end
 
@@ -174,7 +174,7 @@ function σ(d::AbstractVector{N}, cms::CachedMinkowskiSumArray{N}) where {N<:Rea
 end
 
 """
-	isbounded(cms::CachedMinkowskiSumArray)::Bool
+	isbounded(cms::CachedMinkowskiSumArray)
 
 Determine whether a caching Minkowski sum is bounded.
 
@@ -186,12 +186,12 @@ Determine whether a caching Minkowski sum is bounded.
 
 `true` iff all wrapped sets are bounded.
 """
-function isbounded(cms::CachedMinkowskiSumArray)::Bool
+function isbounded(cms::CachedMinkowskiSumArray)
     return all(x -> isbounded(x), cms.array)
 end
 
 """
-    isempty(cms::CachedMinkowskiSumArray)::Bool
+    isempty(cms::CachedMinkowskiSumArray)
 
 Return if a caching Minkowski sum array is empty or not.
 
@@ -210,12 +210,12 @@ Usually they have been empty because otherwise the support vector query should
 have crashed before.
 In that case, the caching Minkowski sum should not be used further.
 """
-function isempty(cms::CachedMinkowskiSumArray)::Bool
+function isempty(cms::CachedMinkowskiSumArray)
     return any(X -> isempty(X), array(cms))
 end
 
 """
-    forget_sets!(cms::CachedMinkowskiSumArray)::Int
+    forget_sets!(cms::CachedMinkowskiSumArray)
 
 Tell a caching Minkowski sum to forget the stored sets (but not the support
 vectors).
@@ -269,7 +269,7 @@ julia> idx1 = forget_sets!(cms2) # support vector was only computed for first se
 1
 ```
 """
-function forget_sets!(cms::CachedMinkowskiSumArray)::Int
+function forget_sets!(cms::CachedMinkowskiSumArray)
     len = length(cms.array)
     sets_to_remove = len
     for pair in values(cms.cache)

--- a/src/LazyOperations/CartesianProduct.jl
+++ b/src/LazyOperations/CartesianProduct.jl
@@ -90,7 +90,7 @@ function swap(cp::CartesianProduct)
 end
 
 """
-    dim(cp::CartesianProduct)::Int
+    dim(cp::CartesianProduct)
 
 Return the dimension of a Cartesian product.
 
@@ -102,7 +102,7 @@ Return the dimension of a Cartesian product.
 
 The ambient dimension of the Cartesian product.
 """
-function dim(cp::CartesianProduct)::Int
+function dim(cp::CartesianProduct)
     return dim(cp.X) + dim(cp.Y)
 end
 
@@ -147,7 +147,7 @@ function ρ(d::AbstractVector{N}, cp::CartesianProduct{N}) where {N<:Real}
 end
 
 """
-    isbounded(cp::CartesianProduct)::Bool
+    isbounded(cp::CartesianProduct)
 
 Determine whether a Cartesian product is bounded.
 
@@ -159,12 +159,12 @@ Determine whether a Cartesian product is bounded.
 
 `true` iff both wrapped sets are bounded.
 """
-function isbounded(cp::CartesianProduct)::Bool
+function isbounded(cp::CartesianProduct)
     return isbounded(cp.X) && isbounded(cp.Y)
 end
 
 """
-    ∈(x::AbstractVector{N}, cp::CartesianProduct{N})::Bool where {N<:Real}
+    ∈(x::AbstractVector{N}, cp::CartesianProduct{N}) where {N<:Real}
 
 Check whether a given point is contained in a Cartesian product.
 
@@ -177,7 +177,7 @@ Check whether a given point is contained in a Cartesian product.
 
 `true` iff ``x ∈ cp``.
 """
-function ∈(x::AbstractVector{N}, cp::CartesianProduct{N})::Bool where {N<:Real}
+function ∈(x::AbstractVector{N}, cp::CartesianProduct{N}) where {N<:Real}
     @assert length(x) == dim(cp)
 
     n1 = dim(cp.X)
@@ -186,7 +186,7 @@ function ∈(x::AbstractVector{N}, cp::CartesianProduct{N})::Bool where {N<:Real
 end
 
 """
-    isempty(cp::CartesianProduct)::Bool
+    isempty(cp::CartesianProduct)
 
 Return if a Cartesian product is empty or not.
 
@@ -198,7 +198,7 @@ Return if a Cartesian product is empty or not.
 
 `true` iff any of the sub-blocks is empty.
 """
-function isempty(cp::CartesianProduct)::Bool
+function isempty(cp::CartesianProduct)
     return isempty(cp.X) || isempty(cp.Y)
 end
 
@@ -220,7 +220,7 @@ function constraints_list(cp::CartesianProduct{N}) where {N<:Real}
 end
 
 """
-    vertices_list(cp::CartesianProduct{N})::Vector{Vector{N}} where {N<:Real}
+    vertices_list(cp::CartesianProduct{N}) where {N<:Real}
 
 Return the list of vertices of a (polytopic) Cartesian product.
 
@@ -238,8 +238,7 @@ We assume that the underlying sets are polytopic.
 Then the high-dimensional set of vertices is just the Cartesian product of the
 low-dimensional sets of vertices.
 """
-function vertices_list(cp::CartesianProduct{N}
-                      )::Vector{Vector{N}} where {N<:Real}
+function vertices_list(cp::CartesianProduct{N}) where {N<:Real}
     # collect low-dimensional vertices lists
     vlist_low = (vertices_list(cp.X), vertices_list(cp.Y))
 

--- a/src/LazyOperations/CartesianProductArray.jl
+++ b/src/LazyOperations/CartesianProductArray.jl
@@ -33,7 +33,7 @@ struct CartesianProductArray{N<:Real, S<:LazySet{N}} <: LazySet{N}
 end
 
 # constructor for an empty product with optional size hint and numeric type
-function CartesianProductArray(n::Int=0, N::Type=Float64)::CartesianProductArray
+function CartesianProductArray(n::Int=0, N::Type=Float64)
    arr = Vector{LazySet{N}}()
    sizehint!(arr, n)
    return CartesianProductArray(arr)
@@ -49,8 +49,7 @@ isconvextype(::Type{CartesianProductArray{N, S}}) where {N, S} = isconvextype(S)
 @declare_array_version(CartesianProduct, CartesianProductArray)
 
 """
-   array(cpa::CartesianProductArray{N, S}
-        )::Vector{S} where {N<:Real, S<:LazySet{N}}
+   array(cpa::CartesianProductArray{N, S}) where {N<:Real, S<:LazySet{N}}
 
 Return the array of a Cartesian product of a finite number of convex sets.
 
@@ -63,12 +62,12 @@ Return the array of a Cartesian product of a finite number of convex sets.
 The array of a Cartesian product of a finite number of convex sets.
 """
 function array(cpa::CartesianProductArray{N, S}
-             )::Vector{S} where {N<:Real, S<:LazySet{N}}
+             ) where {N<:Real, S<:LazySet{N}}
    return cpa.array
 end
 
 """
-   dim(cpa::CartesianProductArray)::Int
+   dim(cpa::CartesianProductArray)
 
 Return the dimension of a Cartesian product of a finite number of convex sets.
 
@@ -81,7 +80,7 @@ Return the dimension of a Cartesian product of a finite number of convex sets.
 The ambient dimension of the Cartesian product of a finite number of convex
 sets.
 """
-function dim(cpa::CartesianProductArray)::Int
+function dim(cpa::CartesianProductArray)
    return length(cpa.array) == 0 ? 0 : sum([dim(Xi) for Xi in cpa.array])
 end
 
@@ -214,7 +213,7 @@ function ρ(d::AbstractSparseVector{N}, cpa::CartesianProductArray{N}
 end
 
 """
-   isbounded(cpa::CartesianProductArray)::Bool
+   isbounded(cpa::CartesianProductArray)
 
 Determine whether a Cartesian product of a finite number of convex sets is
 bounded.
@@ -227,13 +226,12 @@ bounded.
 
 `true` iff all wrapped sets are bounded.
 """
-function isbounded(cpa::CartesianProductArray)::Bool
+function isbounded(cpa::CartesianProductArray)
    return all(x -> isbounded(x), cpa.array)
 end
 
 """
-   ∈(x::AbstractVector{N}, cpa::CartesianProductArray{N}
-    )::Bool where {N<:Real}
+   ∈(x::AbstractVector{N}, cpa::CartesianProductArray{N}) where {N<:Real}
 
 Check whether a given point is contained in a Cartesian product of a finite
 number of sets.
@@ -248,7 +246,7 @@ number of sets.
 `true` iff ``x ∈ \\text{cpa}``.
 """
 function ∈(x::AbstractVector{N}, cpa::CartesianProductArray{N}
-         )::Bool where {N<:Real}
+         ) where {N<:Real}
    @assert length(x) == dim(cpa)
 
    i0 = 1
@@ -263,7 +261,7 @@ function ∈(x::AbstractVector{N}, cpa::CartesianProductArray{N}
 end
 
 """
-   isempty(cpa::CartesianProductArray)::Bool
+   isempty(cpa::CartesianProductArray)
 
 Return if a Cartesian product is empty or not.
 
@@ -275,7 +273,7 @@ Return if a Cartesian product is empty or not.
 
 `true` iff any of the sub-blocks is empty.
 """
-function isempty(cpa::CartesianProductArray)::Bool
+function isempty(cpa::CartesianProductArray)
    return any(X -> isempty(X), array(cpa))
 end
 
@@ -315,8 +313,7 @@ function constraints_list(cpa::CartesianProductArray{N}) where {N<:Real}
 end
 
 """
-   vertices_list(cpa::CartesianProductArray{N}
-                )::Vector{Vector{N}} where {N<:Real}
+   vertices_list(cpa::CartesianProductArray{N}) where {N<:Real}
 
 Return the list of vertices of a (polytopic) Cartesian product of a finite
 number of sets.
@@ -335,8 +332,7 @@ We assume that the underlying sets are polytopic.
 Then the high-dimensional set of vertices is just the Cartesian product of the
 low-dimensional sets of vertices.
 """
-function vertices_list(cpa::CartesianProductArray{N}
-                     )::Vector{Vector{N}} where {N<:Real}
+function vertices_list(cpa::CartesianProductArray{N}) where {N<:Real}
    # collect low-dimensional vertices lists
    vlist_low = [vertices_list(X) for X in array(cpa)]
 
@@ -386,7 +382,7 @@ end
 
 """
    same_block_structure(x::AbstractVector{S1}, y::AbstractVector{S2}
-                       )::Bool where {S1<:LazySet, S2<:LazySet}
+                       ) where {S1<:LazySet, S2<:LazySet}
 
 Check whether two vectors of sets have the same block structure, i.e., the
 ``i``-th entry in the vectors have the same dimension.
@@ -401,7 +397,7 @@ Check whether two vectors of sets have the same block structure, i.e., the
 `true` iff the vectors have the same block structure.
 """
 function same_block_structure(x::AbstractVector{S1}, y::AbstractVector{S2}
-                            )::Bool where {S1<:LazySet, S2<:LazySet}
+                            ) where {S1<:LazySet, S2<:LazySet}
    if length(x) != length(y)
        return false
    end

--- a/src/LazyOperations/Complement.jl
+++ b/src/LazyOperations/Complement.jl
@@ -63,12 +63,12 @@ Return the dimension of the complement of a convex set.
 
 The dimension of the complement of a convex set.
 """
-function dim(C::Complement)::Int
+function dim(C::Complement)
     return dim(C.X)
 end
 
 """
-    ∈(x::AbstractVector{N}, C::Complement{N})::Bool where {N<:Real}
+    ∈(x::AbstractVector{N}, C::Complement{N}) where {N<:Real}
 
 Check whether a given point is contained in the complement of a convex set.
 
@@ -87,13 +87,13 @@ Check whether a given point is contained in the complement of a convex set.
     x ∈ X^C ⟺ x ∉ X
 ```
 """
-function ∈(x::AbstractVector{N}, C::Complement{N})::Bool where {N<:Real}
+function ∈(x::AbstractVector{N}, C::Complement{N}) where {N<:Real}
     @assert length(x) == dim(C)
     return x ∉ C.X
 end
 
 """
-    isempty(C::Complement)::Bool
+    isempty(C::Complement)
 
 Return if the complement of a convex set is empty or not.
 
@@ -109,6 +109,6 @@ Return if the complement of a convex set is empty or not.
 
 We use the `isuniversal` method.
 """
-function isempty(C::Complement)::Bool
+function isempty(C::Complement)
     return isuniversal(C.X)
 end

--- a/src/LazyOperations/ConvexHull.jl
+++ b/src/LazyOperations/ConvexHull.jl
@@ -84,7 +84,7 @@ function swap(ch::ConvexHull)
 end
 
 """
-    dim(ch::ConvexHull)::Int
+    dim(ch::ConvexHull)
 
 Return the dimension of a convex hull of two convex sets.
 
@@ -96,7 +96,7 @@ Return the dimension of a convex hull of two convex sets.
 
 The ambient dimension of the convex hull of two convex sets.
 """
-function dim(ch::ConvexHull)::Int
+function dim(ch::ConvexHull)
     return dim(ch.X)
 end
 
@@ -143,7 +143,7 @@ function ρ(d::AbstractVector{N}, ch::ConvexHull{N}) where {N<:Real}
 end
 
 """
-    isbounded(ch::ConvexHull)::Bool
+    isbounded(ch::ConvexHull)
 
 Determine whether a convex hull of two convex sets is bounded.
 
@@ -155,12 +155,12 @@ Determine whether a convex hull of two convex sets is bounded.
 
 `true` iff both wrapped sets are bounded.
 """
-function isbounded(ch::ConvexHull)::Bool
+function isbounded(ch::ConvexHull)
     return isbounded(ch.X) && isbounded(ch.Y)
 end
 
 """
-    isempty(ch::ConvexHull)::Bool
+    isempty(ch::ConvexHull)
 
 Return if a convex hull of two convex sets is empty or not.
 
@@ -172,6 +172,6 @@ Return if a convex hull of two convex sets is empty or not.
 
 `true` iff both wrapped sets are empty.
 """
-function isempty(ch::ConvexHull)::Bool
+function isempty(ch::ConvexHull)
     return isempty(ch.X) && isempty(ch.Y)
 end

--- a/src/LazyOperations/ConvexHullArray.jl
+++ b/src/LazyOperations/ConvexHullArray.jl
@@ -45,7 +45,7 @@ isoperationtype(::Type{<:ConvexHullArray}) = true
 isconvextype(::Type{<:ConvexHullArray}) = true
 
 # constructor for an empty hull with optional size hint and numeric type
-function ConvexHullArray(n::Int=0, N::Type=Float64)::ConvexHullArray
+function ConvexHullArray(n::Int=0, N::Type=Float64)
     a = Vector{LazySet{N}}()
     sizehint!(a, n)
     return ConvexHullArray(a)
@@ -68,7 +68,7 @@ Alias for `ConvexHullArray`.
 const CHArray = ConvexHullArray
 
 """
-    array(cha::ConvexHullArray{N, S})::Vector{S} where {N<:Real, S<:LazySet{N}}
+    array(cha::ConvexHullArray{N, S}) where {N<:Real, S<:LazySet{N}}
 
 Return the array of a convex hull of a finite number of convex sets.
 
@@ -80,12 +80,12 @@ Return the array of a convex hull of a finite number of convex sets.
 
 The array of a convex hull of a finite number of convex sets.
 """
-function array(cha::ConvexHullArray{N, S})::Vector{S} where {N<:Real, S<:LazySet{N}}
+function array(cha::ConvexHullArray{N, S}) where {N<:Real, S<:LazySet{N}}
     return cha.array
 end
 
 """
-    dim(cha::ConvexHullArray)::Int
+    dim(cha::ConvexHullArray)
 
 Return the dimension of the convex hull of a finite number of convex sets.
 
@@ -97,7 +97,7 @@ Return the dimension of the convex hull of a finite number of convex sets.
 
 The ambient dimension of the convex hull of a finite number of convex sets.
 """
-function dim(cha::ConvexHullArray)::Int
+function dim(cha::ConvexHullArray)
     @assert !isempty(cha.array)
     return dim(cha.array[1])
 end
@@ -151,7 +151,7 @@ function ρ(d::AbstractVector{N}, cha::ConvexHullArray{N}) where {N<:Real}
 end
 
 """
-    isbounded(cha::ConvexHullArray)::Bool
+    isbounded(cha::ConvexHullArray)
 
 Determine whether a convex hull of a finite number of convex sets is
 bounded.
@@ -164,12 +164,12 @@ bounded.
 
 `true` iff all wrapped sets are bounded.
 """
-function isbounded(cha::ConvexHullArray)::Bool
+function isbounded(cha::ConvexHullArray)
     return all(x -> isbounded(x), cha.array)
 end
 
 """
-    isempty(cha::ConvexHullArray)::Bool
+    isempty(cha::ConvexHullArray)
 
 Return if a convex hull array is empty or not.
 
@@ -181,7 +181,7 @@ Return if a convex hull array is empty or not.
 
 `true` iff all wrapped sets are empty.
 """
-function isempty(cha::ConvexHullArray)::Bool
+function isempty(cha::ConvexHullArray)
     return all(X -> isempty(X), array(cha))
 end
 

--- a/src/LazyOperations/ExponentialMap.jl
+++ b/src/LazyOperations/ExponentialMap.jl
@@ -84,15 +84,15 @@ SparseMatrixExp(M::Matrix) =
 Base.IndexStyle(::Type{<:SparseMatrixExp}) = IndexCartesian()
 Base.getindex(spmexp::SparseMatrixExp, I::Vararg{Int, 2}) = get_column(spmexp, I[2])[I[1]]
 
-function size(spmexp::SparseMatrixExp)::Tuple{Int, Int}
+function size(spmexp::SparseMatrixExp)
     return size(spmexp.M)
 end
 
-function size(spmexp::SparseMatrixExp, ax::Int)::Int
+function size(spmexp::SparseMatrixExp, ax::Int)
     return size(spmexp.M, ax)
 end
 
-function get_column(spmexp::SparseMatrixExp{N}, j::Int)::Vector{N} where {N}
+function get_column(spmexp::SparseMatrixExp{N}, j::Int) where {N}
     require(:Expokit; fun_name="get_column")
 
     n = size(spmexp, 1)
@@ -101,8 +101,7 @@ function get_column(spmexp::SparseMatrixExp{N}, j::Int)::Vector{N} where {N}
     return expmv(one(N), spmexp.M, aux)
 end
 
-function get_columns(spmexp::SparseMatrixExp{N},
-                     J::AbstractArray)::Matrix{N} where {N}
+function get_columns(spmexp::SparseMatrixExp{N}, J::AbstractArray) where {N}
     require(:Expokit; fun_name="get_columns")
 
     n = size(spmexp, 1)
@@ -149,8 +148,7 @@ function get_row(spmexp::SparseMatrixExp{N}, i::Int) where {N}
     return transpose(expmv(one(N), transpose(spmexp.M), aux))
 end
 
-function get_rows(spmexp::SparseMatrixExp{N},
-                  I::AbstractArray{Int})::Matrix{N} where {N}
+function get_rows(spmexp::SparseMatrixExp{N}, I::AbstractArray{Int}) where {N}
     require(:Expokit; fun_name="get_rows")
 
     n = size(spmexp, 1)
@@ -256,7 +254,7 @@ function *(spmexp::SparseMatrixExp{N}, X::LazySet{N}) where {N<:Real}
 end
 
 """
-    dim(em::ExponentialMap)::Int
+    dim(em::ExponentialMap)
 
 Return the dimension of an exponential map.
 
@@ -268,7 +266,7 @@ Return the dimension of an exponential map.
 
 The ambient dimension of the exponential map.
 """
-function dim(em::ExponentialMap)::Int
+function dim(em::ExponentialMap)
     return size(em.spmexp.M, 1)
 end
 
@@ -334,7 +332,7 @@ function ρ(d::AbstractVector{N}, em::ExponentialMap{N}) where {N<:Real}
 end
 
 """
-    ∈(x::AbstractVector{N}, em::ExponentialMap{N})::Bool where {N<:Real}
+    ∈(x::AbstractVector{N}, em::ExponentialMap{N}) where {N<:Real}
 
 Check whether a given point is contained in an exponential map of a convex set.
 
@@ -367,7 +365,7 @@ julia> [1.0, 1.0] ∈ em
 true
 ```
 """
-function ∈(x::AbstractVector{N}, em::ExponentialMap{N})::Bool where {N<:Real}
+function ∈(x::AbstractVector{N}, em::ExponentialMap{N}) where {N<:Real}
     require(:Expokit; fun_name="∈")
 
     @assert length(x) == dim(em)
@@ -375,7 +373,7 @@ function ∈(x::AbstractVector{N}, em::ExponentialMap{N})::Bool where {N<:Real}
 end
 
 """
-    vertices_list(em::ExponentialMap{N})::Vector{Vector{N}} where {N<:Real}
+    vertices_list(em::ExponentialMap{N}) where {N<:Real}
 
 Return the list of vertices of a (polytopic) exponential map.
 
@@ -392,7 +390,7 @@ A list of vertices.
 We assume that the underlying set `X` is polytopic.
 Then the result is just the exponential map applied to the vertices of `X`.
 """
-function vertices_list(em::ExponentialMap{N})::Vector{Vector{N}} where {N<:Real}
+function vertices_list(em::ExponentialMap{N}) where {N<:Real}
     require(:Expokit; fun_name="vertices_list")
 
     # collect low-dimensional vertices lists
@@ -409,7 +407,7 @@ function vertices_list(em::ExponentialMap{N})::Vector{Vector{N}} where {N<:Real}
 end
 
 """
-    isbounded(em::ExponentialMap)::Bool
+    isbounded(em::ExponentialMap)
 
 Determine whether an exponential map is bounded.
 
@@ -421,12 +419,12 @@ Determine whether an exponential map is bounded.
 
 `true` iff the exponential map is bounded.
 """
-function isbounded(em::ExponentialMap)::Bool
+function isbounded(em::ExponentialMap)
     return isbounded(em.X)
 end
 
 """
-    isempty(em::ExponentialMap)::Bool
+    isempty(em::ExponentialMap)
 
 Return if an exponential map is empty or not.
 
@@ -438,7 +436,7 @@ Return if an exponential map is empty or not.
 
 `true` iff the wrapped set is empty.
 """
-function isempty(em::ExponentialMap)::Bool
+function isempty(em::ExponentialMap)
     return isempty(em.X)
 end
 
@@ -506,7 +504,7 @@ function *(projspmexp::ProjectionSparseMatrixExp, X::LazySet)
 end
 
 """
-    dim(eprojmap::ExponentialProjectionMap)::Int
+    dim(eprojmap::ExponentialProjectionMap)
 
 Return the dimension of a projection of an exponential map.
 
@@ -518,7 +516,7 @@ Return the dimension of a projection of an exponential map.
 
 The ambient dimension of the projection of an exponential map.
 """
-function dim(eprojmap::ExponentialProjectionMap)::Int
+function dim(eprojmap::ExponentialProjectionMap)
     return size(eprojmap.projspmexp.L, 1)
 end
 
@@ -563,7 +561,7 @@ function σ(d::AbstractVector{N},
 end
 
 """
-    isbounded(eprojmap::ExponentialProjectionMap)::Bool
+    isbounded(eprojmap::ExponentialProjectionMap)
 
 Determine whether an exponential projection map is bounded.
 
@@ -581,7 +579,7 @@ We first check if the left or right projection matrix is zero or the wrapped set
 is bounded.
 Otherwise, we check boundedness via [`isbounded_unit_dimensions`](@ref).
 """
-function isbounded(eprojmap::ExponentialProjectionMap)::Bool
+function isbounded(eprojmap::ExponentialProjectionMap)
     if iszero(eprojmap.projspmexp.L) || iszero(eprojmap.projspmexp.R) ||
             isbounded(eprojmap.X)
         return true
@@ -590,7 +588,7 @@ function isbounded(eprojmap::ExponentialProjectionMap)::Bool
 end
 
 """
-    isempty(eprojmap::ExponentialProjectionMap)::Bool
+    isempty(eprojmap::ExponentialProjectionMap)
 
 Return if an exponential projection map is empty or not.
 
@@ -602,6 +600,6 @@ Return if an exponential projection map is empty or not.
 
 `true` iff the wrapped set is empty.
 """
-function isempty(eprojmap::ExponentialProjectionMap)::Bool
+function isempty(eprojmap::ExponentialProjectionMap)
     return isempty(eprojmap.X)
 end

--- a/src/LazyOperations/Intersection.jl
+++ b/src/LazyOperations/Intersection.jl
@@ -29,11 +29,11 @@ mutable struct IntersectionCache
     IntersectionCache() = new(Int8(-1))
 end
 
-function isempty_known(c::IntersectionCache)::Bool
+function isempty_known(c::IntersectionCache)
     return c.isempty != Int8(-1)
 end
 
-function isempty(c::IntersectionCache)::Bool
+function isempty(c::IntersectionCache)
     @assert isempty_known(c) "'isempty_known' only works if 'isempty' " *
         "returns 'true'"
     return c.isempty == Int8(1)
@@ -188,7 +188,7 @@ end
 
 
 """
-    dim(cap::Intersection)::Int
+    dim(cap::Intersection)
 
 Return the dimension of an intersection of two convex sets.
 
@@ -200,7 +200,7 @@ Return the dimension of an intersection of two convex sets.
 
 The ambient dimension of the intersection of two convex sets.
 """
-function dim(cap::Intersection)::Int
+function dim(cap::Intersection)
     return dim(cap.X)
 end
 
@@ -278,7 +278,7 @@ function ρ_helper(d::AbstractVector{N},
 end
 
 """
-    use_precise_ρ(cap::Intersection{N})::Bool where {N<:Real}
+    use_precise_ρ(cap::Intersection{N}) where {N<:Real}
 
 Determine whether a precise algorithm for computing ``ρ`` shall be applied.
 
@@ -299,7 +299,7 @@ returned.
 
 This function can be overwritten by the user to control the policy.
 """
-function use_precise_ρ(cap::Intersection{N})::Bool where {N<:Real}
+function use_precise_ρ(cap::Intersection{N}) where {N<:Real}
     return true
 end
 
@@ -522,7 +522,7 @@ function ρ(d::AbstractVector{N}, cap::Intersection{N, S1, S2}
 end
 
 """
-    isbounded(cap::Intersection)::Bool
+    isbounded(cap::Intersection)
 
 Determine whether an intersection of two convex sets is bounded.
 
@@ -539,7 +539,7 @@ Determine whether an intersection of two convex sets is bounded.
 We first check if any of the wrapped sets is bounded.
 Otherwise, we check boundedness via [`isbounded_unit_dimensions`](@ref).
 """
-function isbounded(cap::Intersection)::Bool
+function isbounded(cap::Intersection)
     if isbounded(cap.X) || isbounded(cap.Y)
         return true
     end
@@ -547,7 +547,7 @@ function isbounded(cap::Intersection)::Bool
 end
 
 """
-    ∈(x::AbstractVector{N}, cap::Intersection{N})::Bool where {N<:Real}
+    ∈(x::AbstractVector{N}, cap::Intersection{N}) where {N<:Real}
 
 Check whether a given point is contained in an intersection of two convex sets.
 
@@ -560,7 +560,7 @@ Check whether a given point is contained in an intersection of two convex sets.
 
 `true` iff ``x ∈ cap``.
 """
-function ∈(x::AbstractVector{N}, cap::Intersection{N})::Bool where {N<:Real}
+function ∈(x::AbstractVector{N}, cap::Intersection{N}) where {N<:Real}
     return (x ∈ cap.X) && (x ∈ cap.Y)
 end
 
@@ -602,7 +602,7 @@ end
 
 
 """
-    isempty(cap::Intersection)::Bool
+    isempty(cap::Intersection)
 
 Return if the intersection is empty or not.
 
@@ -618,7 +618,7 @@ Return if the intersection is empty or not.
 
 The result will be cached, so a second query will be fast.
 """
-function isempty(cap::Intersection)::Bool
+function isempty(cap::Intersection)
     if isempty_known(cap)
         # use cached result
         return isempty(cap.cache)

--- a/src/LazyOperations/IntersectionArray.jl
+++ b/src/LazyOperations/IntersectionArray.jl
@@ -35,7 +35,7 @@ isoperationtype(::Type{<:IntersectionArray}) = true
 isconvextype(::Type{IntersectionArray{N, S}}) where {N, S} = isconvextype(S)
 
 # constructor for an empty sum with optional size hint and numeric type
-function IntersectionArray(n::Int=0, N::Type=Float64)::IntersectionArray
+function IntersectionArray(n::Int=0, N::Type=Float64)
    arr = Vector{LazySet{N}}()
    sizehint!(arr, n)
    return IntersectionArray(arr)
@@ -51,7 +51,7 @@ end
 @declare_array_version(Intersection, IntersectionArray)
 
 """
-   array(ia::IntersectionArray{N, S})::Vector{S} where {N<:Real, S<:LazySet{N}}
+   array(ia::IntersectionArray{N, S}) where {N<:Real, S<:LazySet{N}}
 
 Return the array of an intersection of a finite number of convex sets.
 
@@ -63,7 +63,7 @@ Return the array of an intersection of a finite number of convex sets.
 
 The array of an intersection of a finite number of convex sets.
 """
-function array(ia::IntersectionArray{N, S})::Vector{S} where {N<:Real, S<:LazySet{N}}
+function array(ia::IntersectionArray{N, S}) where {N<:Real, S<:LazySet{N}}
    return ia.array
 end
 
@@ -72,7 +72,7 @@ end
 
 
 """
-   dim(ia::IntersectionArray)::Int
+   dim(ia::IntersectionArray)
 
 Return the dimension of an intersection of a finite number of sets.
 
@@ -84,12 +84,12 @@ Return the dimension of an intersection of a finite number of sets.
 
 The ambient dimension of the intersection of a finite number of sets.
 """
-function dim(ia::IntersectionArray)::Int
+function dim(ia::IntersectionArray)
    return length(ia.array) == 0 ? 0 : dim(ia.array[1])
 end
 
 """
-   σ(d::AbstractVector{N}, ia::IntersectionArray{N})::Vector{N} where {N<:Real}
+   σ(d::AbstractVector{N}, ia::IntersectionArray{N}) where {N<:Real}
 
 Return the support vector of an intersection of a finite number of sets in a
 given direction.
@@ -104,14 +104,13 @@ given direction.
 The support vector in the given direction.
 If the direction has norm zero, the result depends on the individual sets.
 """
-function σ(d::AbstractVector{N},
-          ia::IntersectionArray{N})::Vector{N} where {N<:Real}
+function σ(d::AbstractVector{N}, ia::IntersectionArray{N}) where {N<:Real}
    # TODO implement
    error("not implemented yet")
 end
 
 """
-   isbounded(ia::IntersectionArray)::Bool
+   isbounded(ia::IntersectionArray)
 
 Determine whether an intersection of a finite number of convex sets is bounded.
 
@@ -128,7 +127,7 @@ Determine whether an intersection of a finite number of convex sets is bounded.
 We first check if any of the wrapped sets is bounded.
 Otherwise, we check boundedness via [`isbounded_unit_dimensions`](@ref).
 """
-function isbounded(ia::IntersectionArray)::Bool
+function isbounded(ia::IntersectionArray)
    if any(x -> isbounded(x), ia.array)
        return true
    end
@@ -136,7 +135,7 @@ function isbounded(ia::IntersectionArray)::Bool
 end
 
 """
-   ∈(x::AbstractVector{N}, ia::IntersectionArray{N})::Bool where {N<:Real}
+   ∈(x::AbstractVector{N}, ia::IntersectionArray{N}) where {N<:Real}
 
 Check whether a given point is contained in an intersection of a finite number
 of convex sets.
@@ -150,7 +149,7 @@ of convex sets.
 
 `true` iff ``x ∈ ia``.
 """
-function ∈(x::AbstractVector{N}, ia::IntersectionArray{N})::Bool where {N<:Real}
+function ∈(x::AbstractVector{N}, ia::IntersectionArray{N}) where {N<:Real}
    for S in ia.array
        if x ∉ S
            return false

--- a/src/LazyOperations/LinearMap.jl
+++ b/src/LazyOperations/LinearMap.jl
@@ -191,7 +191,7 @@ function LinearMap(M::AbstractMatrix{N}, ∅::EmptySet{N}) where {N<:Real}
 end
 
 """
-    dim(lm::LinearMap)::Int
+    dim(lm::LinearMap)
 
 Return the dimension of a linear map.
 
@@ -203,7 +203,7 @@ Return the dimension of a linear map.
 
 The ambient dimension of the linear map.
 """
-function dim(lm::LinearMap)::Int
+function dim(lm::LinearMap)
     return size(lm.M, 1)
 end
 
@@ -258,7 +258,7 @@ function ρ(d::AbstractVector{N}, lm::LinearMap{N}; kwargs...) where {N<:Real}
 end
 
 """
-    isbounded(lm::LinearMap; cond_tol::Number=DEFAULT_COND_TOL)::Bool
+    isbounded(lm::LinearMap; cond_tol::Number=DEFAULT_COND_TOL)
 
 Determine whether a linear map is bounded.
 
@@ -280,7 +280,7 @@ If the matrix is invertible, then the map being bounded is equivalent to the
 wrapped set being bounded, and hence the map is unbounded.
 Otherwise, we check boundedness via [`isbounded_unit_dimensions`](@ref).
 """
-function isbounded(lm::LinearMap; cond_tol::Number=DEFAULT_COND_TOL)::Bool
+function isbounded(lm::LinearMap; cond_tol::Number=DEFAULT_COND_TOL)
     if iszero(lm.M) || isbounded(lm.X)
         return true
     end
@@ -291,7 +291,7 @@ function isbounded(lm::LinearMap; cond_tol::Number=DEFAULT_COND_TOL)::Bool
 end
 
 """
-    ∈(x::AbstractVector{N}, lm::LinearMap{N})::Bool where {N<:Real}
+    ∈(x::AbstractVector{N}, lm::LinearMap{N}) where {N<:Real}
 
 Check whether a given point is contained in a linear map of a convex set.
 
@@ -331,7 +331,7 @@ julia> [0.5, 0.5] ∈ M*B
 true
 ```
 """
-function ∈(x::AbstractVector{N}, lm::LinearMap{N})::Bool where {N<:Real}
+function ∈(x::AbstractVector{N}, lm::LinearMap{N}) where {N<:Real}
     return lm.M \ x ∈ lm.X
 end
 
@@ -354,7 +354,7 @@ function an_element(lm::LinearMap{N})::Vector{N} where {N<:Real}
 end
 
 """
-    isempty(lm::LinearMap)::Bool
+    isempty(lm::LinearMap)
 
 Return if a linear map is empty or not.
 
@@ -366,7 +366,7 @@ Return if a linear map is empty or not.
 
 `true` iff the wrapped set is empty.
 """
-function isempty(lm::LinearMap)::Bool
+function isempty(lm::LinearMap)
     return isempty(lm.X)
 end
 

--- a/src/LazyOperations/MinkowskiSum.jl
+++ b/src/LazyOperations/MinkowskiSum.jl
@@ -87,7 +87,7 @@ function swap(ms::MinkowskiSum)
 end
 
 """
-    dim(ms::MinkowskiSum)::Int
+    dim(ms::MinkowskiSum)
 
 Return the dimension of a Minkowski sum.
 
@@ -99,7 +99,7 @@ Return the dimension of a Minkowski sum.
 
 The ambient dimension of the Minkowski sum.
 """
-function dim(ms::MinkowskiSum)::Int
+function dim(ms::MinkowskiSum)
     return dim(ms.X)
 end
 
@@ -153,7 +153,7 @@ function ρ(d::AbstractVector{N}, ms::MinkowskiSum{N}) where {N<:Real}
 end
 
 """
-    isbounded(ms::MinkowskiSum)::Bool
+    isbounded(ms::MinkowskiSum)
 
 Determine whether a Minkowski sum is bounded.
 
@@ -165,12 +165,12 @@ Determine whether a Minkowski sum is bounded.
 
 `true` iff both wrapped sets are bounded.
 """
-function isbounded(ms::MinkowskiSum)::Bool
+function isbounded(ms::MinkowskiSum)
     return isbounded(ms.X) && isbounded(ms.Y)
 end
 
 """
-    isempty(ms::MinkowskiSum)::Bool
+    isempty(ms::MinkowskiSum)
 
 Return if a Minkowski sum is empty or not.
 
@@ -182,7 +182,7 @@ Return if a Minkowski sum is empty or not.
 
 `true` iff any of the wrapped sets are empty.
 """
-function isempty(ms::MinkowskiSum)::Bool
+function isempty(ms::MinkowskiSum)
     return isempty(ms.X) || isempty(ms.Y)
 end
 
@@ -249,8 +249,7 @@ end
 # ================
 
 @inline function σ_helper(d::AbstractVector{N},
-                          array::AbstractVector{<:LazySet}
-                         )::Vector{N} where {N<:Real}
+                          array::AbstractVector{<:LazySet}) where {N<:Real}
     svec = zeros(N, length(d))
     for sj in array
         svec += σ(d, sj)

--- a/src/LazyOperations/MinkowskiSumArray.jl
+++ b/src/LazyOperations/MinkowskiSumArray.jl
@@ -36,7 +36,7 @@ isoperationtype(::Type{<:MinkowskiSumArray}) = true
 isconvextype(::Type{MinkowskiSumArray{N, S}}) where {N, S} = isconvextype(S)
 
 # constructor for an empty sum with optional size hint and numeric type
-function MinkowskiSumArray(n::Int=0, N::Type=Float64)::MinkowskiSumArray
+function MinkowskiSumArray(n::Int=0, N::Type=Float64)
    arr = Vector{LazySet{N}}()
    sizehint!(arr, n)
    return MinkowskiSumArray(arr)
@@ -53,7 +53,7 @@ end
 @declare_array_version(MinkowskiSum, MinkowskiSumArray)
 
 """
-   array(msa::MinkowskiSumArray{N, S})::Vector{S} where {N<:Real, S<:LazySet{N}}
+   array(msa::MinkowskiSumArray{N, S}) where {N<:Real, S<:LazySet{N}}
 
 Return the array of a Minkowski sum of a finite number of convex sets.
 
@@ -65,12 +65,12 @@ Return the array of a Minkowski sum of a finite number of convex sets.
 
 The array of a Minkowski sum of a finite number of convex sets.
 """
-function array(msa::MinkowskiSumArray{N, S})::Vector{S} where {N<:Real, S<:LazySet{N}}
+function array(msa::MinkowskiSumArray{N, S}) where {N<:Real, S<:LazySet{N}}
    return msa.array
 end
 
 """
-   dim(msa::MinkowskiSumArray)::Int
+   dim(msa::MinkowskiSumArray)
 
 Return the dimension of a Minkowski sum of a finite number of sets.
 
@@ -82,7 +82,7 @@ Return the dimension of a Minkowski sum of a finite number of sets.
 
 The ambient dimension of the Minkowski sum of a finite number of sets.
 """
-function dim(msa::MinkowskiSumArray)::Int
+function dim(msa::MinkowskiSumArray)
    return length(msa.array) == 0 ? 0 : dim(msa.array[1])
 end
 
@@ -131,7 +131,7 @@ function ρ(d::AbstractVector{N}, msa::MinkowskiSumArray{N}) where {N<:Real}
 end
 
 """
-	isbounded(msa::MinkowskiSumArray)::Bool
+	isbounded(msa::MinkowskiSumArray)
 
 Determine whether a Minkowski sum of a finite number of convex sets is bounded.
 
@@ -143,12 +143,12 @@ Determine whether a Minkowski sum of a finite number of convex sets is bounded.
 
 `true` iff all wrapped sets are bounded.
 """
-function isbounded(msa::MinkowskiSumArray)::Bool
+function isbounded(msa::MinkowskiSumArray)
    return all(x -> isbounded(x), msa.array)
 end
 
 """
-   isempty(msa::MinkowskiSumArray)::Bool
+   isempty(msa::MinkowskiSumArray)
 
 Return if a Minkowski sum array is empty or not.
 
@@ -160,6 +160,6 @@ Return if a Minkowski sum array is empty or not.
 
 `true` iff any of the wrapped sets are empty.
 """
-function isempty(msa::MinkowskiSumArray)::Bool
+function isempty(msa::MinkowskiSumArray)
    return any(X -> isempty(X), array(msa))
 end

--- a/src/LazyOperations/Rectification.jl
+++ b/src/LazyOperations/Rectification.jl
@@ -117,7 +117,7 @@ isconvextype(::Type{<:Rectification}) = false
 Rectification(X::S) where {N<:Real, S<:LazySet{N}} = Rectification{N, S}(X)
 
 """
-    dim(r::Rectification)::Int
+    dim(r::Rectification)
 
 Return the dimension of a rectification.
 
@@ -129,7 +129,7 @@ Return the dimension of a rectification.
 
 The ambient dimension of the rectification.
 """
-function dim(r::Rectification)::Int
+function dim(r::Rectification)
     return dim(r.X)
 end
 
@@ -286,7 +286,7 @@ function ρ(d::AbstractVector{N}, r::Rectification{N}) where {N<:Real}
 end
 
 """
-    an_element(r::Rectification{N})::Vector{N} where {N<:Real}
+    an_element(r::Rectification{N}) where {N<:Real}
 
 Return some element of a rectification.
 
@@ -299,12 +299,12 @@ Return some element of a rectification.
 An element in the rectification.
 The implementation relies on the `an_element` function of the wrapped set.
 """
-function an_element(r::Rectification{N})::Vector{N} where {N<:Real}
+function an_element(r::Rectification{N}) where {N<:Real}
     return rectify(an_element(r.X))
 end
 
 """
-    ∈(x::AbstractVector{N}, r::Rectification{N})::Bool where {N<:Real}
+    ∈(x::AbstractVector{N}, r::Rectification{N}) where {N<:Real}
 
 Check whether a given point is contained in a rectification.
 
@@ -332,7 +332,7 @@ the answer is negative.
 Finally, if there are zero entries in the vector and the vector is not contained
 in the wrapped set, we give up and throw an error.
 """
-function ∈(x::AbstractVector{N}, r::Rectification{N})::Bool where {N<:Real}
+function ∈(x::AbstractVector{N}, r::Rectification{N}) where {N<:Real}
     # scan for negative entries
     if any(xi -> xi < zero(N), x)
         return false
@@ -354,7 +354,7 @@ function ∈(x::AbstractVector{N}, r::Rectification{N})::Bool where {N<:Real}
 end
 
 """
-    isempty(r::Rectification)::Bool
+    isempty(r::Rectification)
 
 Check whether a rectification is empty or not.
 
@@ -366,12 +366,12 @@ Check whether a rectification is empty or not.
 
 `true` iff the wrapped set is empty.
 """
-function isempty(r::Rectification)::Bool
+function isempty(r::Rectification)
     return isempty(r.X)
 end
 
 """
-    isbounded(r::Rectification)::Bool
+    isbounded(r::Rectification)
 
 Determine whether a rectification is bounded.
 
@@ -393,7 +393,7 @@ a heuristics.
 Otherwise, we check boundedness of ``X`` in every positive unit direction, which
 is sufficient and necessary for boundedness of ``r``.
 """
-function isbounded(r::Rectification{N})::Bool where {N<:Real}
+function isbounded(r::Rectification{N}) where {N<:Real}
     # check boundedness of the wrapped set
     if isbounded(r.X)
         return true

--- a/src/LazyOperations/ResetMap.jl
+++ b/src/LazyOperations/ResetMap.jl
@@ -171,7 +171,7 @@ Return the dimension of a reset map.
 
 The dimension of a reset map.
 """
-function dim(rm::ResetMap)::Int
+function dim(rm::ResetMap)
     return dim(rm.X)
 end
 
@@ -248,7 +248,7 @@ function an_element(rm::ResetMap)
 end
 
 """
-    isempty(rm::ResetMap)::Bool
+    isempty(rm::ResetMap)
 
 Return if a reset map is empty or not.
 
@@ -260,7 +260,7 @@ Return if a reset map is empty or not.
 
 `true` iff the wrapped set is empty.
 """
-function isempty(rm::ResetMap)::Bool
+function isempty(rm::ResetMap)
     return isempty(rm.X)
 end
 

--- a/src/LazyOperations/SymmetricIntervalHull.jl
+++ b/src/LazyOperations/SymmetricIntervalHull.jl
@@ -49,7 +49,7 @@ SymmetricIntervalHull(X::S) where {N<:Real, S<:LazySet{N}} =
     SymmetricIntervalHull{N, S}(X)
 
 """
-    SymmetricIntervalHull(∅::EmptySet)::EmptySet
+    SymmetricIntervalHull(∅::EmptySet)
 
 The symmetric interval hull of an empty set.
 
@@ -61,7 +61,7 @@ The symmetric interval hull of an empty set.
 
 The empty set because it is absorbing for the symmetric interval hull.
 """
-SymmetricIntervalHull(∅::EmptySet)::EmptySet = ∅
+SymmetricIntervalHull(∅::EmptySet) = ∅
 
 
 # --- AbstractHyperrectangle interface functions ---
@@ -69,7 +69,7 @@ SymmetricIntervalHull(∅::EmptySet)::EmptySet = ∅
 
 """
     radius_hyperrectangle(sih::SymmetricIntervalHull{N},
-                          i::Int)::N where {N<:Real}
+                          i::Int) where {N<:Real}
 
 Return the box radius of a symmetric interval hull of a convex set in a given
 dimension.
@@ -86,13 +86,12 @@ If it was computed before, this is just a look-up, otherwise it requires two
 support vector computations.
 """
 function radius_hyperrectangle(sih::SymmetricIntervalHull{N},
-                               i::Int)::N where {N<:Real}
+                               i::Int) where {N<:Real}
     return get_radius!(sih, i)
 end
 
 """
-    radius_hyperrectangle(sih::SymmetricIntervalHull{N}
-                         )::Vector{N} where {N<:Real}
+    radius_hyperrectangle(sih::SymmetricIntervalHull{N}) where {N<:Real}
 
 Return the box radius of a symmetric interval hull of a convex set in every
 dimension.
@@ -109,8 +108,7 @@ The box radius of the symmetric interval hull of a convex set.
 
 This function computes the symmetric interval hull explicitly.
 """
-function radius_hyperrectangle(sih::SymmetricIntervalHull{N}
-                              )::Vector{N} where {N<:Real}
+function radius_hyperrectangle(sih::SymmetricIntervalHull{N}) where {N<:Real}
     n = dim(sih)
     for i in 1:n
         get_radius!(sih, i, n)
@@ -123,7 +121,7 @@ end
 
 
 """
-    center(sih::SymmetricIntervalHull{N})::Vector{N} where {N<:Real}
+    center(sih::SymmetricIntervalHull{N}) where {N<:Real}
 
 Return the center of a symmetric interval hull of a convex set.
 
@@ -135,7 +133,7 @@ Return the center of a symmetric interval hull of a convex set.
 
 The origin.
 """
-function center(sih::SymmetricIntervalHull{N})::Vector{N} where {N<:Real}
+function center(sih::SymmetricIntervalHull{N}) where {N<:Real}
     return zeros(N, dim(sih))
 end
 
@@ -144,7 +142,7 @@ end
 
 
 """
-    dim(sih::SymmetricIntervalHull)::Int
+    dim(sih::SymmetricIntervalHull)
 
 Return the dimension of a symmetric interval hull of a convex set.
 
@@ -156,7 +154,7 @@ Return the dimension of a symmetric interval hull of a convex set.
 
 The ambient dimension of the symmetric interval hull of a convex set.
 """
-function dim(sih::SymmetricIntervalHull)::Int
+function dim(sih::SymmetricIntervalHull)
     return dim(sih.X)
 end
 
@@ -208,7 +206,7 @@ end
 """
     get_radius!(sih::SymmetricIntervalHull{N},
                 i::Int,
-                n::Int=dim(sih))::N where {N<:Real}
+                n::Int=dim(sih)) where {N<:Real}
 
 Compute the radius of a symmetric interval hull of a convex set in a given
 dimension.
@@ -230,7 +228,7 @@ negative unit vector in the dimension `i`.
 """
 function get_radius!(sih::SymmetricIntervalHull{N},
                      i::Int,
-                     n::Int=dim(sih))::N where {N<:Real}
+                     n::Int=dim(sih)) where {N<:Real}
     if sih.cache[i] == -one(N)
         right_bound = σ(sparsevec([i], [one(N)], n), sih.X)
         left_bound = σ(sparsevec([i], [-one(N)], n), sih.X)

--- a/src/LazyOperations/Translation.jl
+++ b/src/LazyOperations/Translation.jl
@@ -201,7 +201,7 @@ LinearMap(M::AbstractMatrix, tr::Translation) = AffineMap(M, tr.X, M * tr.v)
 # ============================
 
 """
-    dim(tr::Translation)::Int
+    dim(tr::Translation)
 
 Return the dimension of a translation.
 
@@ -213,7 +213,7 @@ Return the dimension of a translation.
 
 The dimension of a translation.
 """
-function dim(tr::Translation)::Int
+function dim(tr::Translation)
     return length(tr.v)
 end
 
@@ -277,7 +277,7 @@ function an_element(tr::Translation)
 end
 
 """
-    isempty(tr::Translation)::Bool
+    isempty(tr::Translation)
 
 Return if a translation is empty or not.
 
@@ -289,7 +289,7 @@ Return if a translation is empty or not.
 
 `true` iff the wrapped set is empty.
 """
-function isempty(tr::Translation)::Bool
+function isempty(tr::Translation)
     return isempty(tr.X)
 end
 
@@ -334,7 +334,7 @@ function _constraints_list_translation(X::LazySet, v::AbstractVector)
 end
 
 """
-    ∈(x::AbstractVector{N}, tr::Translation{N})::Bool where {N<:Real}
+    ∈(x::AbstractVector{N}, tr::Translation{N}) where {N<:Real}
 
 Check whether a given point is contained in the translation of a convex set.
 
@@ -352,7 +352,7 @@ Check whether a given point is contained in the translation of a convex set.
 This implementation relies on the set membership function for the wrapped set
 `tr.X`, since ``x ∈ X ⊕ v`` iff ``x - v ∈ X``.
 """
-function ∈(x::AbstractVector{N}, tr::Translation{N})::Bool where {N<:Real}
+function ∈(x::AbstractVector{N}, tr::Translation{N}) where {N<:Real}
     return x - tr.v ∈ tr.X
 end
 

--- a/src/LazyOperations/UnionSet.jl
+++ b/src/LazyOperations/UnionSet.jl
@@ -65,7 +65,7 @@ function swap(cup::UnionSet)
 end
 
 """
-    dim(cup::UnionSet)::Int
+    dim(cup::UnionSet)
 
 Return the dimension of the set union of two convex sets.
 
@@ -77,7 +77,7 @@ Return the dimension of the set union of two convex sets.
 
 The ambient dimension of the union of two convex sets.
 """
-function dim(cup::UnionSet)::Int
+function dim(cup::UnionSet)
     return dim(cup.X)
 end
 
@@ -153,7 +153,7 @@ function ρ(d::AbstractVector{N}, cup::UnionSet{N}) where {N<:Real}
 end
 
 """
-    an_element(cup::UnionSet{N})::Vector{N} where {N<:Real}
+    an_element(cup::UnionSet{N}) where {N<:Real}
 
 Return some element of a union of two convex sets.
 
@@ -169,12 +169,12 @@ An element in the union of two convex sets.
 
 We use `an_element` on the first wrapped set.
 """
-function an_element(cup::UnionSet{N})::Vector{N} where {N<:Real}
+function an_element(cup::UnionSet{N}) where {N<:Real}
     return an_element(cup.X)
 end
 
 """
-    ∈(x::AbstractVector{N}, cup::UnionSet{N})::Bool where {N<:Real}
+    ∈(x::AbstractVector{N}, cup::UnionSet{N}) where {N<:Real}
 
 Check whether a given point is contained in a union of two convex sets.
 
@@ -187,12 +187,12 @@ Check whether a given point is contained in a union of two convex sets.
 
 `true` iff ``x ∈ cup``.
 """
-function ∈(x::AbstractVector{N}, cup::UnionSet{N})::Bool where {N<:Real}
+function ∈(x::AbstractVector{N}, cup::UnionSet{N}) where {N<:Real}
     return x ∈ cup.X || x ∈ cup.Y
 end
 
 """
-    isempty(cup::UnionSet)::Bool
+    isempty(cup::UnionSet)
 
 Check whether a union of two convex sets is empty.
 
@@ -204,12 +204,12 @@ Check whether a union of two convex sets is empty.
 
 `true` iff the union is empty.
 """
-function isempty(cup::UnionSet)::Bool
+function isempty(cup::UnionSet)
     return isempty(cup.X) && isempty(cup.Y)
 end
 
 """
-    isbounded(cup::UnionSet)::Bool
+    isbounded(cup::UnionSet)
 
 Determine whether a union of two convex sets is bounded.
 
@@ -221,6 +221,6 @@ Determine whether a union of two convex sets is bounded.
 
 `true` iff the union is bounded.
 """
-function isbounded(cup::UnionSet)::Bool
+function isbounded(cup::UnionSet)
     return isbounded(cup.X) && isbounded(cup.Y)
 end

--- a/src/LazyOperations/UnionSetArray.jl
+++ b/src/LazyOperations/UnionSetArray.jl
@@ -31,7 +31,7 @@ isconvextype(::Type{<:UnionSetArray}) = false
 @declare_array_version(UnionSet, UnionSetArray)
 
 """
-   dim(cup::UnionSetArray)::Int
+   dim(cup::UnionSetArray)
 
 Return the dimension of the set union of a finite number of convex sets.
 
@@ -43,12 +43,12 @@ Return the dimension of the set union of a finite number of convex sets.
 
 The ambient dimension of the union of a finite number of convex sets.
 """
-function dim(cup::UnionSetArray)::Int
+function dim(cup::UnionSetArray)
    return dim(cup.array[1])
 end
 
 """
-   array(cup::UnionSetArray{N, S})::Vector{S} where {N<:Real, S<:LazySet{N}}
+   array(cup::UnionSetArray{N, S}) where {N<:Real, S<:LazySet{N}}
 
 Return the array of a union of a finite number of convex sets.
 
@@ -60,7 +60,7 @@ Return the array of a union of a finite number of convex sets.
 
 The array that holds the union of a finite number of convex sets.
 """
-function array(cup::UnionSetArray{N, S})::Vector{S} where {N<:Real, S<:LazySet{N}}
+function array(cup::UnionSetArray{N, S}) where {N<:Real, S<:LazySet{N}}
    return cup.array
 end
 
@@ -141,7 +141,7 @@ function ρ(d::AbstractVector{N}, cup::UnionSetArray{N}) where {N<:Real}
 end
 
 """
-   an_element(cup::UnionSetArray{N})::Vector{N} where {N<:Real}
+   an_element(cup::UnionSetArray{N}) where {N<:Real}
 
 Return some element of a union of a finite number of convex sets.
 
@@ -157,12 +157,12 @@ An element in the union of a finite number of convex sets.
 
 We use `an_element` on the first wrapped set.
 """
-function an_element(cup::UnionSetArray{N})::Vector{N} where {N<:Real}
+function an_element(cup::UnionSetArray{N}) where {N<:Real}
    return an_element(array(cup)[1])
 end
 
 """
-   ∈(x::AbstractVector{N}, cup::UnionSetArray{N})::Bool where {N<:Real}
+   ∈(x::AbstractVector{N}, cup::UnionSetArray{N}) where {N<:Real}
 
 Check whether a given point is contained in a union of a finite number of convex
 sets.
@@ -176,12 +176,12 @@ sets.
 
 `true` iff ``x ∈ cup``.
 """
-function ∈(x::AbstractVector{N}, cup::UnionSetArray{N})::Bool where {N<:Real}
+function ∈(x::AbstractVector{N}, cup::UnionSetArray{N}) where {N<:Real}
    return any(X -> x ∈ X, array(cup))
 end
 
 """
-   isempty(cup::UnionSetArray)::Bool
+   isempty(cup::UnionSetArray)
 
 Check whether a union of a finite number of convex sets is empty.
 
@@ -193,12 +193,12 @@ Check whether a union of a finite number of convex sets is empty.
 
 `true` iff the union is empty.
 """
-function isempty(cup::UnionSetArray)::Bool
+function isempty(cup::UnionSetArray)
    return all(isempty, array(cup))
 end
 
 """
-   isbounded(cup::UnionSetArray)::Bool
+   isbounded(cup::UnionSetArray)
 
 Determine whether a union of a finite number of convex sets is bounded.
 
@@ -210,6 +210,6 @@ Determine whether a union of a finite number of convex sets is bounded.
 
 `true` iff the union is bounded.
 """
-function isbounded(cup::UnionSetArray)::Bool
+function isbounded(cup::UnionSetArray)
    return all(isbounded, array(cup))
 end

--- a/src/Parallel/box_approximations.jl
+++ b/src/Parallel/box_approximations.jl
@@ -3,7 +3,7 @@ export box_approximation,
        symmetric_interval_hull
 
 """
-    box_approximation(S::LazySet)::Hyperrectangle
+    box_approximation(S::LazySet{N}) where {N<:Real}
 
 Overapproximation a convex set by a tight hyperrectangle using a parallel
 algorithm.
@@ -22,8 +22,7 @@ The center of the hyperrectangle is obtained by averaging the support function
 of the given set in the canonical directions, and the lengths of the sides can
 be recovered from the distance among support functions in the same directions.
 """
-function box_approximation(S::LazySet{N};
-                          )::Union{Hyperrectangle{N}, EmptySet{N}} where N<:Real
+function box_approximation(S::LazySet{N}) where {N<:Real}
     (c, r) = box_approximation_helper_parallel(S)
     if r[1] < 0
         return EmptySet{N}()
@@ -32,8 +31,7 @@ function box_approximation(S::LazySet{N};
 end
 
 """
-    box_approximation_symmetric(S::LazySet{N}
-                               )::Union{Hyperrectangle{N}, EmptySet{N}} where {N<:Real}
+    box_approximation_symmetric(S::LazySet{N}) where {N<:Real}
 
 Overapproximate a convex set by a tight hyperrectangle centered in the origin,
 using a parallel algorithm.
@@ -51,8 +49,7 @@ A tight hyperrectangle centered in the origin.
 The center of the box is the origin, and the radius is obtained by computing the
 maximum value of the support function evaluated at the canonical directions.
 """
-function box_approximation_symmetric(S::LazySet{N}
-                                    )::Union{Hyperrectangle{N}, EmptySet{N}} where {N<:Real}
+function box_approximation_symmetric(S::LazySet{N}) where {N<:Real}
     (c, r) = box_approximation_helper_parallel(S)
     return Hyperrectangle(zeros(N, length(c)), abs.(c) .+ r)
 end

--- a/src/Sets/Ball2.jl
+++ b/src/Sets/Ball2.jl
@@ -73,7 +73,7 @@ Ball2(center::Vector{N}, radius::N) where {N<:AbstractFloat} =
 
 
 """
-    center(B::Ball2{N})::Vector{N} where {N<:AbstractFloat}
+    center(B::Ball2{N}) where {N<:AbstractFloat}
 
 Return the center of a ball in the 2-norm.
 
@@ -85,7 +85,7 @@ Return the center of a ball in the 2-norm.
 
 The center of the ball in the 2-norm.
 """
-function center(B::Ball2{N})::Vector{N} where {N<:AbstractFloat}
+function center(B::Ball2{N}) where {N<:AbstractFloat}
     return B.center
 end
 
@@ -133,7 +133,7 @@ function σ(d::AbstractVector{N}, B::Ball2{N}) where {N<:AbstractFloat}
 end
 
 """
-    ∈(x::AbstractVector{N}, B::Ball2{N})::Bool where {N<:AbstractFloat}
+    ∈(x::AbstractVector{N}, B::Ball2{N}) where {N<:AbstractFloat}
 
 Check whether a given point is contained in a ball in the 2-norm.
 
@@ -171,7 +171,7 @@ julia> [.5, 1.5] ∈ B
 true
 ```
 """
-function ∈(x::AbstractVector{N}, B::Ball2{N})::Bool where {N<:AbstractFloat}
+function ∈(x::AbstractVector{N}, B::Ball2{N}) where {N<:AbstractFloat}
     @assert length(x) == dim(B)
     sum = zero(N)
     @inbounds for i in eachindex(x)
@@ -182,8 +182,7 @@ end
 
 """
     rand(::Type{Ball2}; [N]::Type{<:Real}=Float64, [dim]::Int=2,
-         [rng]::AbstractRNG=GLOBAL_RNG, [seed]::Union{Int, Nothing}=nothing
-        )::Ball2{N}
+         [rng]::AbstractRNG=GLOBAL_RNG, [seed]::Union{Int, Nothing}=nothing)
 
 Create a random ball in the 2-norm.
 
@@ -208,8 +207,7 @@ function rand(::Type{Ball2};
               N::Type{<:Real}=Float64,
               dim::Int=2,
               rng::AbstractRNG=GLOBAL_RNG,
-              seed::Union{Int, Nothing}=nothing
-             )::Ball2{N}
+              seed::Union{Int, Nothing}=nothing)
     rng = reseed(rng, seed)
     center = randn(rng, N, dim)
     radius = abs(randn(rng, N))

--- a/src/Sets/BallInf.jl
+++ b/src/Sets/BallInf.jl
@@ -62,7 +62,7 @@ BallInf(center::Vector{N}, radius::N) where {N<:Real} =
 
 
 """
-    radius_hyperrectangle(B::BallInf{N}, i::Int)::N where {N<:Real}
+    radius_hyperrectangle(B::BallInf{N}, i::Int) where {N<:Real}
 
 Return the box radius of a ball in the infinity norm in a given dimension.
 
@@ -75,12 +75,12 @@ Return the box radius of a ball in the infinity norm in a given dimension.
 
 The box radius of the ball in the infinity norm in the given dimension.
 """
-function radius_hyperrectangle(B::BallInf{N}, i::Int)::N where {N<:Real}
+function radius_hyperrectangle(B::BallInf{N}, i::Int) where {N<:Real}
     return B.radius
 end
 
 """
-    radius_hyperrectangle(B::BallInf{N})::Vector{N} where {N<:Real}
+    radius_hyperrectangle(B::BallInf{N}) where {N<:Real}
 
 Return the box radius of a ball in the infinity norm, which is the same in every
 dimension.
@@ -93,12 +93,12 @@ dimension.
 
 The box radius of the ball in the infinity norm.
 """
-function radius_hyperrectangle(B::BallInf{N})::Vector{N} where {N<:Real}
+function radius_hyperrectangle(B::BallInf{N}) where {N<:Real}
     return fill(B.radius, dim(B))
 end
 
 """
-    isflat(B::BallInf)::Bool
+    isflat(B::BallInf)
 
 Determine whether a ball in the infinity norm is flat, i.e. whether its radius
 is zero.
@@ -117,7 +117,7 @@ For robustness with respect to floating-point inputs, this function relies on
 the result of `isapproxzero` when applied to the radius of the ball.
 Hence, this function depends on the absolute zero tolerance `ABSZTOL`.
 """
-function isflat(B::BallInf)::Bool
+function isflat(B::BallInf)
     return isapproxzero(B.radius)
 end
 
@@ -126,7 +126,7 @@ end
 
 
 """
-    center(B::BallInf{N})::Vector{N} where {N<:Real}
+    center(B::BallInf{N}) where {N<:Real}
 
 Return the center of a ball in the infinity norm.
 
@@ -138,7 +138,7 @@ Return the center of a ball in the infinity norm.
 
 The center of the ball in the infinity norm.
 """
-function center(B::BallInf{N})::Vector{N} where {N<:Real}
+function center(B::BallInf{N}) where {N<:Real}
     return B.center
 end
 
@@ -234,7 +234,7 @@ function ρ(d::SingleEntryVector{N}, B::BallInf{N}) where {N<:Real}
 end
 
 """
-    radius(B::BallInf, [p]::Real=Inf)::Real
+    radius(B::BallInf, [p]::Real=Inf)
 
 Return the radius of a ball in the infinity norm.
 
@@ -252,14 +252,13 @@ A real number representing the radius.
 The radius is defined as the radius of the enclosing ball of the given
 ``p``-norm of minimal volume with the same center.
 """
-function radius(B::BallInf, p::Real=Inf)::Real
+function radius(B::BallInf, p::Real=Inf)
     return (p == Inf) ? B.radius : norm(fill(B.radius, dim(B)), p)
 end
 
 """
     rand(::Type{BallInf}; [N]::Type{<:Real}=Float64, [dim]::Int=2,
-         [rng]::AbstractRNG=GLOBAL_RNG, [seed]::Union{Int, Nothing}=nothing
-        )::BallInf{N}
+         [rng]::AbstractRNG=GLOBAL_RNG, [seed]::Union{Int, Nothing}=nothing)
 
 Create a random ball in the infinity norm.
 
@@ -284,8 +283,7 @@ function rand(::Type{BallInf};
               N::Type{<:Real}=Float64,
               dim::Int=2,
               rng::AbstractRNG=GLOBAL_RNG,
-              seed::Union{Int, Nothing}=nothing
-             )::BallInf{N}
+              seed::Union{Int, Nothing}=nothing)
     rng = reseed(rng, seed)
     center = randn(rng, N, dim)
     radius = abs(randn(rng, N))

--- a/src/Sets/Ballp.jl
+++ b/src/Sets/Ballp.jl
@@ -96,7 +96,7 @@ end
 
 
 """
-    center(B::Ballp{N})::Vector{N} where {N<:AbstractFloat}
+    center(B::Ballp{N}) where {N<:AbstractFloat}
 
 Return the center of a ball in the p-norm.
 
@@ -108,7 +108,7 @@ Return the center of a ball in the p-norm.
 
 The center of the ball in the p-norm.
 """
-function center(B::Ballp{N})::Vector{N} where {N<:AbstractFloat}
+function center(B::Ballp{N}) where {N<:AbstractFloat}
     return B.center
 end
 
@@ -163,7 +163,7 @@ function σ(d::AbstractVector{N}, B::Ballp{N}) where {N<:AbstractFloat}
 end
 
 """
-    ∈(x::AbstractVector{N}, B::Ballp{N})::Bool where {N<:AbstractFloat}
+    ∈(x::AbstractVector{N}, B::Ballp{N}) where {N<:AbstractFloat}
 
 Check whether a given point is contained in a ball in the p-norm.
 
@@ -201,7 +201,7 @@ julia> [.5, 1.5] ∈ B
 true
 ```
 """
-function ∈(x::AbstractVector{N}, B::Ballp{N})::Bool where {N<:AbstractFloat}
+function ∈(x::AbstractVector{N}, B::Ballp{N}) where {N<:AbstractFloat}
     @assert length(x) == dim(B)
     sum = zero(N)
     for i in eachindex(x)
@@ -212,8 +212,7 @@ end
 
 """
     rand(::Type{Ballp}; [N]::Type{<:Real}=Float64, [dim]::Int=2,
-         [rng]::AbstractRNG=GLOBAL_RNG, [seed]::Union{Int, Nothing}=nothing
-        )::Ballp{N}
+         [rng]::AbstractRNG=GLOBAL_RNG, [seed]::Union{Int, Nothing}=nothing)
 
 Create a random ball in the p-norm.
 
@@ -241,8 +240,7 @@ function rand(::Type{Ballp};
               N::Type{<:Real}=Float64,
               dim::Int=2,
               rng::AbstractRNG=GLOBAL_RNG,
-              seed::Union{Int, Nothing}=nothing
-             )::Ballp{N}
+              seed::Union{Int, Nothing}=nothing)
     rng = reseed(rng, seed)
     p = one(N) + abs(randn(rng, N))
     center = randn(rng, N, dim)

--- a/src/Sets/Ellipsoid.jl
+++ b/src/Sets/Ellipsoid.jl
@@ -94,7 +94,7 @@ Ellipsoid(Q::AbstractMatrix{N}) where {N<:AbstractFloat} =
 
 
 """
-    center(E::Ellipsoid{N})::Vector{N} where {N<:AbstractFloat}
+    center(E::Ellipsoid{N}) where {N<:AbstractFloat}
 
 Return the center of the ellipsoid.
 
@@ -106,7 +106,7 @@ Return the center of the ellipsoid.
 
 The center of the ellipsoid.
 """
-function center(E::Ellipsoid{N})::Vector{N} where {N<:AbstractFloat}
+function center(E::Ellipsoid{N}) where {N<:AbstractFloat}
     return E.center
 end
 
@@ -172,7 +172,7 @@ function ρ(d::AbstractVector{N}, E::Ellipsoid{N}) where {N<:AbstractFloat}
 end
 
 """
-    ∈(x::AbstractVector{N}, E::Ellipsoid{N})::Bool where {N<:AbstractFloat}
+    ∈(x::AbstractVector{N}, E::Ellipsoid{N}) where {N<:AbstractFloat}
 
 Check whether a given point is contained in an ellipsoid.
 
@@ -194,7 +194,7 @@ if and only if
 (x-c)^\\mathrm{T} Q^{-1} (x-c) ≤ 1.
 ```
 """
-function ∈(x::AbstractVector{N}, E::Ellipsoid{N})::Bool where {N<:AbstractFloat}
+function ∈(x::AbstractVector{N}, E::Ellipsoid{N}) where {N<:AbstractFloat}
     @assert length(x) == dim(E)
     w, Q = x-E.center, E.shape_matrix
     return dot(w, Q \ w) ≤ 1
@@ -202,8 +202,7 @@ end
 
 """
     rand(::Type{Ellipsoid}; [N]::Type{<:AbstractFloat}=Float64, [dim]::Int=2,
-         [rng]::AbstractRNG=GLOBAL_RNG, [seed]::Union{Int, Nothing}=nothing
-        )::Ellipsoid{N}
+         [rng]::AbstractRNG=GLOBAL_RNG, [seed]::Union{Int, Nothing}=nothing)
 
 Create a random ellipsoid.
 
@@ -238,8 +237,7 @@ function rand(::Type{Ellipsoid};
               N::Type{<:AbstractFloat}=Float64,
               dim::Int=2,
               rng::AbstractRNG=GLOBAL_RNG,
-              seed::Union{Int, Nothing}=nothing
-             )::Ellipsoid{N}
+              seed::Union{Int, Nothing}=nothing)
     rng = reseed(rng, seed)
     center = randn(rng, N, dim)
     # random entries in [-1, 1]

--- a/src/Sets/EmptySet.jl
+++ b/src/Sets/EmptySet.jl
@@ -43,7 +43,7 @@ Return the dimension of the empty set, which is -1 by convention.
 
 `-1` by convention.
 """
-function dim(∅::EmptySet)::Int
+function dim(∅::EmptySet)
     return -1
 end
 
@@ -84,7 +84,7 @@ function ρ(d::AbstractVector{N}, ∅::EmptySet{N}) where {N<:Real}
 end
 
 """
-    isbounded(∅::EmptySet)::Bool
+    isbounded(∅::EmptySet)
 
 Determine whether an empty set is bounded.
 
@@ -96,13 +96,12 @@ Determine whether an empty set is bounded.
 
 `true`.
 """
-function isbounded(::EmptySet)::Bool
+function isbounded(::EmptySet)
     return true
 end
 
 """
-    isuniversal(∅::EmptySet{N}, [witness]::Bool=false
-               )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+    isuniversal(∅::EmptySet{N}, [witness]::Bool=false) where {N<:Real}
 
 Check whether an empty is universal.
 
@@ -117,8 +116,7 @@ Check whether an empty is universal.
 * If `witness` option is activated: `(false, v)` where ``v ∉ S``, although
   we currently throw an error
 """
-function isuniversal(∅::EmptySet{N}, witness::Bool=false
-                    )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+function isuniversal(∅::EmptySet{N}, witness::Bool=false) where {N<:Real}
     if witness
         error("witness production is currently not supported")
         # return (false, zeros(N, dim(∅)))  # deactivated, see #1201
@@ -128,7 +126,7 @@ function isuniversal(∅::EmptySet{N}, witness::Bool=false
 end
 
 """
-    ∈(x::AbstractVector{N}, ∅::EmptySet{N})::Bool where {N<:Real}
+    ∈(x::AbstractVector{N}, ∅::EmptySet{N}) where {N<:Real}
 
 Check whether a given point is contained in an empty set.
 
@@ -148,7 +146,7 @@ julia> [1.0, 0.0] ∈ ∅
 false
 ```
 """
-function ∈(x::AbstractVector{N}, ∅::EmptySet{N})::Bool where {N<:Real}
+function ∈(x::AbstractVector{N}, ∅::EmptySet{N}) where {N<:Real}
     return false
 end
 
@@ -171,8 +169,7 @@ end
 
 """
     rand(::Type{EmptySet}; [N]::Type{<:Real}=Float64, [dim]::Int=0,
-         [rng]::AbstractRNG=GLOBAL_RNG, [seed]::Union{Int, Nothing}=nothing
-        )::EmptySet{N}
+         [rng]::AbstractRNG=GLOBAL_RNG, [seed]::Union{Int, Nothing}=nothing)
 
 Create an empty set (note that there is nothing to randomize).
 
@@ -192,14 +189,13 @@ function rand(::Type{EmptySet};
               N::Type{<:Real}=Float64,
               dim::Int=0,
               rng::AbstractRNG=GLOBAL_RNG,
-              seed::Union{Int, Nothing}=nothing
-             )::EmptySet{N}
+              seed::Union{Int, Nothing}=nothing)
     rng = reseed(rng, seed)
     return EmptySet{N}()
 end
 
 """
-    isempty(∅::EmptySet)::Bool
+    isempty(∅::EmptySet)
 
 Return if the empty set is empty or not.
 
@@ -211,7 +207,7 @@ Return if the empty set is empty or not.
 
 `true`.
 """
-function isempty(∅::EmptySet)::Bool
+function isempty(∅::EmptySet)
     return true
 end
 

--- a/src/Sets/HPolyhedron.jl
+++ b/src/Sets/HPolyhedron.jl
@@ -64,7 +64,7 @@ const HPoly{N} = Union{HPolytope{N}, HPolyhedron{N}}
 
 
 """
-    dim(P::HPoly{N})::Int where {N<:Real}
+    dim(P::HPoly{N}) where {N<:Real}
 
 Return the dimension of a polyhedron in H-representation.
 
@@ -77,13 +77,13 @@ Return the dimension of a polyhedron in H-representation.
 The ambient dimension of the polyhedron in H-representation.
 If it has no constraints, the result is ``-1``.
 """
-function dim(P::HPoly{N})::Int where {N<:Real}
+function dim(P::HPoly{N}) where {N<:Real}
     return length(P.constraints) == 0 ? -1 : length(P.constraints[1].a)
 end
 
 """
-    ρ(d::AbstractVector{N}, P::HPoly{N}; solver=default_lp_solver(N)
-     )::N where {N<:Real}
+    ρ(d::AbstractVector{N}, P::HPoly{N};
+      solver=default_lp_solver(N)) where {N<:Real}
 
 Evaluate the support function of a polyhedron (in H-representation) in a given
 direction.
@@ -101,8 +101,8 @@ The support function of the polyhedron.
 If a polytope is unbounded in the given direction, we throw an error.
 If a polyhedron is unbounded in the given direction, the result is `Inf`.
 """
-function ρ(d::AbstractVector{N}, P::HPoly{N}; solver=default_lp_solver(N)
-          )::N where {N<:Real}
+function ρ(d::AbstractVector{N}, P::HPoly{N};
+           solver=default_lp_solver(N)) where {N<:Real}
     lp, unbounded = σ_helper(d, P, solver)
     if unbounded
         if P isa HPolytope
@@ -191,7 +191,7 @@ function σ_helper(d::AbstractVector{N}, P::HPoly{N}, solver) where {N<:Real}
 end
 
 """
-    isbounded(P::HPolyhedron)::Bool
+    isbounded(P::HPolyhedron)
 
 Determine whether a polyhedron in constraint representation is bounded.
 
@@ -209,7 +209,7 @@ We first check if the polyhedron has more than `max(dim(P), 1)` constraints,
 which is a necessary condition for boundedness.
 If so, we check boundedness via [`isbounded_unit_dimensions`](@ref).
 """
-function isbounded(P::HPolyhedron)::Bool
+function isbounded(P::HPolyhedron)
     if length(P.constraints) <= max(dim(P), 1)
         return false
     end
@@ -218,8 +218,7 @@ end
 
 """
     rand(::Type{HPolyhedron}; [N]::Type{<:Real}=Float64, [dim]::Int=2,
-         [rng]::AbstractRNG=GLOBAL_RNG, [seed]::Union{Int, Nothing}=nothing
-        )::HPolyhedron{N}
+         [rng]::AbstractRNG=GLOBAL_RNG, [seed]::Union{Int, Nothing}=nothing)
 
 Create a polyhedron.
 
@@ -244,8 +243,7 @@ function rand(::Type{HPolyhedron};
               N::Type{<:Real}=Float64,
               dim::Int=2,
               rng::AbstractRNG=GLOBAL_RNG,
-              seed::Union{Int, Nothing}=nothing
-             )::HPolyhedron{N}
+              seed::Union{Int, Nothing}=nothing)
     rng = reseed(rng, seed)
     P = rand(HPolytope; N=N, dim=dim, rng=rng)
     constraints_P = constraints_list(P)
@@ -265,8 +263,7 @@ end
 
 
 """
-    addconstraint!(P::HPoly{N},
-                   constraint::LinearConstraint{N})::Nothing where {N<:Real}
+    addconstraint!(P::HPoly{N}, constraint::LinearConstraint{N}) where {N<:Real}
 
 Add a linear constraint to a polyhedron in H-representation.
 
@@ -275,18 +272,13 @@ Add a linear constraint to a polyhedron in H-representation.
 - `P`          -- polyhedron in H-representation
 - `constraint` -- linear constraint to add
 
-### Output
-
-Nothing.
-
 ### Notes
 
 It is left to the user to guarantee that the dimension of all linear constraints
 is the same.
 """
 function addconstraint!(P::HPoly{N},
-                        constraint::LinearConstraint{N}
-                       )::Nothing where {N<:Real}
+                        constraint::LinearConstraint{N}) where {N<:Real}
     push!(P.constraints, constraint)
     return nothing
 end
@@ -363,7 +355,7 @@ end
 
 """
     remove_redundant_constraints!(P::HPoly{N};
-                                  backend=default_lp_solver(N))::Bool where {N<:Real}
+                                  backend=default_lp_solver(N)) where {N<:Real}
 
 Remove the redundant constraints in a polyhedron in H-representation; the
 polyhedron is updated in-place.
@@ -387,7 +379,7 @@ details.
 """
 function remove_redundant_constraints!(P::HPoly{N};
                                        backend=default_lp_solver(N)
-                                      )::Bool where {N<:Real}
+                                      ) where {N<:Real}
     remove_redundant_constraints!(P.constraints, backend=backend)
 end
 
@@ -560,7 +552,7 @@ function vertices_list(P::HPolyhedron{N}) where {N<:Real}
 end
 
 """
-    singleton_list(P::HPolyhedron{N})::Vector{Singleton{N}} where {N<:Real}
+    singleton_list(P::HPolyhedron{N}) where {N<:Real}
 
 Return the vertices of a polyhedron in H-representation as a list of singletons.
 
@@ -582,8 +574,7 @@ end
 """
    isempty(P::HPoly{N}, witness::Bool=false;
            [use_polyhedra_interface]::Bool=false, [solver]=default_lp_solver(N),
-           [backend]=nothing
-          )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+           [backend]=nothing) where {N<:Real}
 
 Determine whether a polyhedron is empty.
 
@@ -623,8 +614,7 @@ function isempty(P::HPoly{N},
                  witness::Bool=false;
                  use_polyhedra_interface::Bool=false,
                  solver=default_lp_solver(N),
-                 backend=nothing
-                )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+                 backend=nothing) where {N<:Real}
     if length(constraints_list(P)) < 2
         # catch corner case because of problems in LP solver for Rationals
         return witness ? (false, an_element(P)) : false

--- a/src/Sets/HPolytope.jl
+++ b/src/Sets/HPolytope.jl
@@ -64,8 +64,7 @@ HPolytope{N}(A::AbstractMatrix{N}, b::AbstractVector{N};
 
 """
     rand(::Type{HPolytope}; [N]::Type{<:Real}=Float64, [dim]::Int=2,
-         [rng]::AbstractRNG=GLOBAL_RNG, [seed]::Union{Int, Nothing}=nothing
-        )::HPolytope{N}
+         [rng]::AbstractRNG=GLOBAL_RNG, [seed]::Union{Int, Nothing}=nothing)
 
 Create a random polytope in constraint representation.
 
@@ -94,8 +93,7 @@ function rand(::Type{HPolytope};
               dim::Int=2,
               rng::AbstractRNG=GLOBAL_RNG,
               seed::Union{Int, Nothing}=nothing,
-              num_vertices::Int=-1
-             )::HPolytope{N}
+              num_vertices::Int=-1)
     require(:Polyhedra; fun_name="rand")
     rng = reseed(rng, seed)
     vpolytope = rand(VPolytope; N=N, dim=dim, rng=rng, seed=seed,
@@ -104,7 +102,7 @@ function rand(::Type{HPolytope};
 end
 
 """
-    isbounded(P::HPolytope, [use_type_assumption]::Bool=true)::Bool
+    isbounded(P::HPolytope, [use_type_assumption]::Bool=true)
 
 Determine whether a polytope in constraint representation is bounded.
 
@@ -124,7 +122,7 @@ Otherwise, `true` iff `P` is bounded.
 If `!use_type_assumption`, we convert `P` to an `HPolyhedron` `P2` and then use
 `isbounded(P2)`.
 """
-function isbounded(P::HPolytope, use_type_assumption::Bool=true)::Bool
+function isbounded(P::HPolytope, use_type_assumption::Bool=true)
     if use_type_assumption
         return true
     end
@@ -189,8 +187,7 @@ end # function load_polyhedra_hpolytope()
 
 """
     vertices_list(P::HPolytope{N};
-                  [backend]=nothing,
-                  [prune]::Bool=true)::Vector{Vector{N}} where {N<:Real}
+                  [backend]=nothing, [prune]::Bool=true) where {N<:Real}
 
 Return the list of vertices of a polytope in constraint representation.
 
@@ -220,8 +217,7 @@ For further information on the supported backends see
 [Polyhedra's documentation](https://juliapolyhedra.github.io/Polyhedra.jl/).
 """
 function vertices_list(P::HPolytope{N};
-                       backend=nothing,
-                       prune::Bool=true)::Vector{Vector{N}} where {N<:Real}
+                       backend=nothing, prune::Bool=true) where {N<:Real}
     if length(P.constraints) == 0
         return Vector{N}(Vector{N}(undef, 0))
     end

--- a/src/Sets/HalfSpace.jl
+++ b/src/Sets/HalfSpace.jl
@@ -56,7 +56,7 @@ const LinearConstraint = HalfSpace
 
 
 """
-    dim(hs::HalfSpace)::Int
+    dim(hs::HalfSpace)
 
 Return the dimension of a half-space.
 
@@ -68,12 +68,12 @@ Return the dimension of a half-space.
 
 The ambient dimension of the half-space.
 """
-function dim(hs::HalfSpace)::Int
+function dim(hs::HalfSpace)
     return length(hs.a)
 end
 
 """
-    ρ(d::AbstractVector{N}, hs::HalfSpace{N})::N where {N<:Real}
+    ρ(d::AbstractVector{N}, hs::HalfSpace{N}) where {N<:Real}
 
 Evaluate the support function of a half-space in a given direction.
 
@@ -87,7 +87,7 @@ Evaluate the support function of a half-space in a given direction.
 The support function of the half-space.
 If the set is unbounded in the given direction, the result is `Inf`.
 """
-function ρ(d::AbstractVector{N}, hs::HalfSpace{N})::N where {N<:Real}
+function ρ(d::AbstractVector{N}, hs::HalfSpace{N}) where {N<:Real}
     v, unbounded = σ_helper(d, Hyperplane(hs.a, hs.b); error_unbounded=false,
                             halfspace=true)
     if unbounded
@@ -122,7 +122,7 @@ function σ(d::AbstractVector{N}, hs::HalfSpace{N}) where {N<:Real}
 end
 
 """
-    isbounded(hs::HalfSpace)::Bool
+    isbounded(hs::HalfSpace)
 
 Determine whether a half-space is bounded.
 
@@ -134,13 +134,12 @@ Determine whether a half-space is bounded.
 
 `false`.
 """
-function isbounded(::HalfSpace)::Bool
+function isbounded(::HalfSpace)
     return false
 end
 
 """
-    isuniversal(hs::HalfSpace{N}, [witness]::Bool=false
-               )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+    isuniversal(hs::HalfSpace{N}, [witness]::Bool=false) where {N<:Real}
 
 Check whether a half-space is universal.
 
@@ -158,8 +157,7 @@ Check whether a half-space is universal.
 
 Witness production falls back to `isuniversal(::Hyperplane)`.
 """
-function isuniversal(hs::HalfSpace{N}, witness::Bool=false
-                    )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+function isuniversal(hs::HalfSpace{N}, witness::Bool=false) where {N<:Real}
     if witness
         return isuniversal(Hyperplane(hs.a, hs.b), true)
     else
@@ -168,7 +166,7 @@ function isuniversal(hs::HalfSpace{N}, witness::Bool=false
 end
 
 """
-    an_element(hs::HalfSpace{N})::Vector{N} where {N<:Real}
+    an_element(hs::HalfSpace{N}) where {N<:Real}
 
 Return some element of a half-space.
 
@@ -180,12 +178,12 @@ Return some element of a half-space.
 
 An element on the defining hyperplane.
 """
-function an_element(hs::HalfSpace{N})::Vector{N} where {N<:Real}
+function an_element(hs::HalfSpace{N}) where {N<:Real}
     return an_element_helper(Hyperplane(hs.a, hs.b))
 end
 
 """
-    ∈(x::AbstractVector{N}, hs::HalfSpace{N})::Bool where {N<:Real}
+    ∈(x::AbstractVector{N}, hs::HalfSpace{N}) where {N<:Real}
 
 Check whether a given point is contained in a half-space.
 
@@ -202,14 +200,13 @@ Check whether a given point is contained in a half-space.
 
 We just check if ``x`` satisfies ``a⋅x ≤ b``.
 """
-function ∈(x::AbstractVector{N}, hs::HalfSpace{N})::Bool where {N<:Real}
+function ∈(x::AbstractVector{N}, hs::HalfSpace{N}) where {N<:Real}
     return dot(x, hs.a) <= hs.b
 end
 
 """
     rand(::Type{HalfSpace}; [N]::Type{<:Real}=Float64, [dim]::Int=2,
-         [rng]::AbstractRNG=GLOBAL_RNG, [seed]::Union{Int, Nothing}=nothing
-        )::HalfSpace{N}
+         [rng]::AbstractRNG=GLOBAL_RNG, [seed]::Union{Int, Nothing}=nothing)
 
 Create a random half-space.
 
@@ -234,8 +231,7 @@ function rand(::Type{HalfSpace};
               N::Type{<:Real}=Float64,
               dim::Int=2,
               rng::AbstractRNG=GLOBAL_RNG,
-              seed::Union{Int, Nothing}=nothing
-             )::HalfSpace{N}
+              seed::Union{Int, Nothing}=nothing)
     rng = reseed(rng, seed)
     a = randn(rng, N, dim)
     while iszero(a)
@@ -246,7 +242,7 @@ function rand(::Type{HalfSpace};
 end
 
 """
-    isempty(hs::HalfSpace)::Bool
+    isempty(hs::HalfSpace)
 
 Return if a half-space is empty or not.
 
@@ -258,7 +254,7 @@ Return if a half-space is empty or not.
 
 `false`.
 """
-function isempty(hs::HalfSpace)::Bool
+function isempty(hs::HalfSpace)
     return false
 end
 
@@ -303,7 +299,7 @@ function constraints_list(A::AbstractMatrix{N}, b::AbstractVector{N}
 end
 
 """
-    constrained_dimensions(hs::HalfSpace{N})::Vector{Int} where {N<:Real}
+    constrained_dimensions(hs::HalfSpace{N}) where {N<:Real}
 
 Return the indices in which a half-space is constrained.
 
@@ -320,13 +316,12 @@ dimension `i`.
 
 A 2D half-space with constraint ``x1 ≥ 0`` is constrained in dimension 1 only.
 """
-function constrained_dimensions(hs::HalfSpace{N})::Vector{Int} where {N<:Real}
+function constrained_dimensions(hs::HalfSpace{N}) where {N<:Real}
     return nonzero_indices(hs.a)
 end
 
 """
-    halfspace_left(p::AbstractVector{N},
-                   q::AbstractVector{N})::HalfSpace{N} where {N<:Real}
+    halfspace_left(p::AbstractVector{N}, q::AbstractVector{N}) where {N<:Real}
 
 Return a half-space describing the 'left' of a two-dimensional line segment
 through two points.
@@ -382,7 +377,7 @@ true
 ```
 """
 function halfspace_left(p::AbstractVector{N},
-                        q::AbstractVector{N})::HalfSpace{N} where {N<:Real}
+                        q::AbstractVector{N}) where {N<:Real}
     @assert length(p) == length(q) == 2 "the points must be two-dimensional"
     @assert p != q "the points must not be equal"
     a = [q[2] - p[2], p[1] - q[1]]
@@ -390,8 +385,7 @@ function halfspace_left(p::AbstractVector{N},
 end
 
 """
-    halfspace_right(p::AbstractVector{N},
-                    q::AbstractVector{N})::HalfSpace{N} where {N<:Real}
+    halfspace_right(p::AbstractVector{N}, q::AbstractVector{N}) where {N<:Real}
 
 Return a half-space describing the 'right' of a two-dimensional line segment
 through two points.
@@ -411,7 +405,7 @@ describes the right-hand side of the directed line segment `pq`.
 See the documentation of `halfspace_left`.
 """
 function halfspace_right(p::AbstractVector{N},
-                         q::AbstractVector{N})::HalfSpace{N} where {N<:Real}
+                         q::AbstractVector{N}) where {N<:Real}
     return halfspace_left(q, p)
 end
 

--- a/src/Sets/Hyperplane.jl
+++ b/src/Sets/Hyperplane.jl
@@ -66,7 +66,7 @@ end
 
 
 """
-    dim(hp::Hyperplane)::Int
+    dim(hp::Hyperplane)
 
 Return the dimension of a hyperplane.
 
@@ -78,12 +78,12 @@ Return the dimension of a hyperplane.
 
 The ambient dimension of the hyperplane.
 """
-function dim(hp::Hyperplane)::Int
+function dim(hp::Hyperplane)
     return length(hp.a)
 end
 
 """
-    ρ(d::AbstractVector{N}, hp::Hyperplane{N})::N where {N<:Real}
+    ρ(d::AbstractVector{N}, hp::Hyperplane{N}) where {N<:Real}
 
 Evaluate the support function of a hyperplane in a given direction.
 
@@ -97,7 +97,7 @@ Evaluate the support function of a hyperplane in a given direction.
 The support function of the hyperplane.
 If the set is unbounded in the given direction, the result is `Inf`.
 """
-function ρ(d::AbstractVector{N}, hp::Hyperplane{N})::N where {N<:Real}
+function ρ(d::AbstractVector{N}, hp::Hyperplane{N}) where {N<:Real}
     v, unbounded = σ_helper(d, hp, error_unbounded=false)
     if unbounded
         return N(Inf)
@@ -130,7 +130,7 @@ function σ(d::AbstractVector{N}, hp::Hyperplane{N}) where {N<:Real}
 end
 
 """
-    isbounded(hp::Hyperplane)::Bool
+    isbounded(hp::Hyperplane)
 
 Determine whether a hyperplane is bounded.
 
@@ -142,13 +142,12 @@ Determine whether a hyperplane is bounded.
 
 `false`.
 """
-function isbounded(::Hyperplane)::Bool
+function isbounded(::Hyperplane)
     return false
 end
 
 """
-    isuniversal(hp::Hyperplane{N}, [witness]::Bool=false
-               )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+    isuniversal(hp::Hyperplane{N}, [witness]::Bool=false) where {N<:Real}
 
 Check whether a hyperplane is universal.
 
@@ -167,8 +166,7 @@ Check whether a hyperplane is universal.
 A witness is produced by adding the normal vector to an element on the
 hyperplane.
 """
-function isuniversal(hp::Hyperplane{N}, witness::Bool=false
-                    )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+function isuniversal(hp::Hyperplane{N}, witness::Bool=false) where {N<:Real}
     if witness
         v = an_element(hp) + hp.a
         return (false, v)
@@ -178,7 +176,7 @@ function isuniversal(hp::Hyperplane{N}, witness::Bool=false
 end
 
 """
-    an_element(hp::Hyperplane{N})::Vector{N} where {N<:Real}
+    an_element(hp::Hyperplane{N}) where {N<:Real}
 
 Return some element of a hyperplane.
 
@@ -190,12 +188,12 @@ Return some element of a hyperplane.
 
 An element on the hyperplane.
 """
-function an_element(hp::Hyperplane{N})::Vector{N} where {N<:Real}
+function an_element(hp::Hyperplane{N}) where {N<:Real}
     return an_element_helper(hp)
 end
 
 """
-    ∈(x::AbstractVector{N}, hp::Hyperplane{N})::Bool where {N<:Real}
+    ∈(x::AbstractVector{N}, hp::Hyperplane{N}) where {N<:Real}
 
 Check whether a given point is contained in a hyperplane.
 
@@ -212,14 +210,13 @@ Check whether a given point is contained in a hyperplane.
 
 We just check if ``x`` satisfies ``a⋅x = b``.
 """
-function ∈(x::AbstractVector{N}, hp::Hyperplane{N})::Bool where {N<:Real}
+function ∈(x::AbstractVector{N}, hp::Hyperplane{N}) where {N<:Real}
     return dot(x, hp.a) == hp.b
 end
 
 """
     rand(::Type{Hyperplane}; [N]::Type{<:Real}=Float64, [dim]::Int=2,
-         [rng]::AbstractRNG=GLOBAL_RNG, [seed]::Union{Int, Nothing}=nothing
-        )::Hyperplane{N}
+         [rng]::AbstractRNG=GLOBAL_RNG, [seed]::Union{Int, Nothing}=nothing)
 
 Create a random hyperplane.
 
@@ -244,8 +241,7 @@ function rand(::Type{Hyperplane};
               N::Type{<:Real}=Float64,
               dim::Int=2,
               rng::AbstractRNG=GLOBAL_RNG,
-              seed::Union{Int, Nothing}=nothing
-             )::Hyperplane{N}
+              seed::Union{Int, Nothing}=nothing)
     rng = reseed(rng, seed)
     a = randn(rng, N, dim)
     while iszero(a)
@@ -256,7 +252,7 @@ function rand(::Type{Hyperplane};
 end
 
 """
-    isempty(hp::Hyperplane)::Bool
+    isempty(hp::Hyperplane)
 
 Return if a hyperplane is empty or not.
 
@@ -268,12 +264,12 @@ Return if a hyperplane is empty or not.
 
 `false`.
 """
-function isempty(hp::Hyperplane)::Bool
+function isempty(hp::Hyperplane)
     return false
 end
 
 """
-    constrained_dimensions(hp::Hyperplane{N})::Vector{Int} where {N<:Real}
+    constrained_dimensions(hp::Hyperplane{N}) where {N<:Real}
 
 Return the indices in which a hyperplane is constrained.
 
@@ -290,7 +286,7 @@ dimension `i`.
 
 A 2D hyperplane with constraint ``x1 = 0`` is constrained in dimension 1 only.
 """
-function constrained_dimensions(hp::Hyperplane{N})::Vector{Int} where {N<:Real}
+function constrained_dimensions(hp::Hyperplane{N}) where {N<:Real}
     return nonzero_indices(hp.a)
 end
 
@@ -399,7 +395,7 @@ end
 
 """
     an_element_helper(hp::Hyperplane{N},
-                      [nonzero_entry_a]::Int)::Vector{N} where {N<:Real}
+                      [nonzero_entry_a]::Int) where {N<:Real}
 
 Helper function that computes an element on a hyperplane's hyperplane.
 
@@ -422,7 +418,7 @@ We compute the point on the hyperplane as follows:
 """
 @inline function an_element_helper(hp::Hyperplane{N},
                                    nonzero_entry_a::Int=findnext(x -> x!=zero(N), hp.a, 1)
-                                  )::Vector{N} where {N<:Real}
+                                  ) where {N<:Real}
     @assert nonzero_entry_a in 1:length(hp.a) "invalid index " *
         "$nonzero_entry_a for hyperplane"
     x = zeros(N, dim(hp))

--- a/src/Sets/Hyperrectangle.jl
+++ b/src/Sets/Hyperrectangle.jl
@@ -106,7 +106,7 @@ end
 
 
 """
-    radius_hyperrectangle(H::Hyperrectangle{N}, i::Int)::N where {N<:Real}
+    radius_hyperrectangle(H::Hyperrectangle{N}, i::Int) where {N<:Real}
 
 Return the box radius of a hyperrectangle in a given dimension.
 
@@ -119,12 +119,12 @@ Return the box radius of a hyperrectangle in a given dimension.
 
 The radius in the given dimension.
 """
-function radius_hyperrectangle(H::Hyperrectangle{N}, i::Int)::N where {N<:Real}
+function radius_hyperrectangle(H::Hyperrectangle{N}, i::Int) where {N<:Real}
     return H.radius[i]
 end
 
 """
-    radius_hyperrectangle(H::Hyperrectangle{N})::Vector{N} where {N<:Real}
+    radius_hyperrectangle(H::Hyperrectangle{N}) where {N<:Real}
 
 Return the box radius of a hyperrectangle in every dimension.
 
@@ -136,7 +136,7 @@ Return the box radius of a hyperrectangle in every dimension.
 
 The box radius of the hyperrectangle.
 """
-function radius_hyperrectangle(H::Hyperrectangle{N})::Vector{N} where {N<:Real}
+function radius_hyperrectangle(H::Hyperrectangle{N}) where {N<:Real}
     return H.radius
 end
 
@@ -145,7 +145,7 @@ end
 
 
 """
-    center(H::Hyperrectangle{N})::Vector{N} where {N<:Real}
+    center(H::Hyperrectangle{N}) where {N<:Real}
 
 Return the center of a hyperrectangle.
 
@@ -157,7 +157,7 @@ Return the center of a hyperrectangle.
 
 The center of the hyperrectangle.
 """
-function center(H::Hyperrectangle{N})::Vector{N} where {N<:Real}
+function center(H::Hyperrectangle{N}) where {N<:Real}
     return H.center
 end
 
@@ -167,8 +167,7 @@ end
 
 """
     rand(::Type{Hyperrectangle}; [N]::Type{<:Real}=Float64, [dim]::Int=2,
-         [rng]::AbstractRNG=GLOBAL_RNG, [seed]::Union{Int, Nothing}=nothing
-        )::Hyperrectangle{N}
+         [rng]::AbstractRNG=GLOBAL_RNG, [seed]::Union{Int, Nothing}=nothing)
 
 Create a random hyperrectangle.
 
@@ -193,8 +192,7 @@ function rand(::Type{Hyperrectangle};
               N::Type{<:Real}=Float64,
               dim::Int=2,
               rng::AbstractRNG=GLOBAL_RNG,
-              seed::Union{Int, Nothing}=nothing
-             )::Hyperrectangle{N}
+              seed::Union{Int, Nothing}=nothing)
     rng = reseed(rng, seed)
     center = randn(rng, N, dim)
     radius = abs.(randn(rng, N, dim))

--- a/src/Sets/Interval.jl
+++ b/src/Sets/Interval.jl
@@ -109,7 +109,7 @@ function Interval(x::AbstractVector{N}) where {N<:Rational}
 end
 
 """
-    dim(x::Interval)::Int
+    dim(x::Interval)
 
 Return the ambient dimension of an interval.
 
@@ -121,7 +121,7 @@ Return the ambient dimension of an interval.
 
 The integer 1.
 """
-dim(x::Interval)::Int = 1
+dim(x::Interval) = 1
 
 """
     σ(d::AbstractVector{N}, x::Interval{N}) where {N<:Real}
@@ -162,7 +162,7 @@ function ρ(d::AbstractVector{N}, x::Interval{N}) where {N<:Real}
 end
 
 """
-    center(x::Interval{N})::Vector{N} where {N<:Real}
+    center(x::Interval{N}) where {N<:Real}
 
 Return the interval's center.
 
@@ -174,7 +174,7 @@ Return the interval's center.
 
 The center, or midpoint, of ``x``.
 """
-function center(x::Interval{N})::Vector{N} where {N<:Real}
+function center(x::Interval{N}) where {N<:Real}
     return [IntervalArithmetic.mid(x.dat)]
 end
 
@@ -271,7 +271,7 @@ function ∈(v::N, x::Interval{N}) where {N<:Real}
 end
 
 """
-    min(x::Interval{N})::N where {N<:Real}
+    min(x::Interval{N}) where {N<:Real}
 
 Return the lower component of an interval.
 
@@ -283,12 +283,12 @@ Return the lower component of an interval.
 
 The lower (`lo`) component of the interval.
 """
-function min(x::Interval{N})::N where {N<:Real}
+function min(x::Interval{N}) where {N<:Real}
     return x.dat.lo
 end
 
 """
-    max(x::Interval{N})::N where {N<:Real}
+    max(x::Interval{N}) where {N<:Real}
 
 Return the higher or upper component of an interval.
 
@@ -300,12 +300,12 @@ Return the higher or upper component of an interval.
 
 The higher (`hi`) component of the interval.
 """
-function max(x::Interval{N})::N where {N<:Real}
+function max(x::Interval{N}) where {N<:Real}
     return x.dat.hi
 end
 
 """
-    low(x::Interval{N})::Vector{N} where {N<:Real}
+    low(x::Interval{N}) where {N<:Real}
 
 Return the lower coordinate of an interval set.
 
@@ -317,12 +317,12 @@ Return the lower coordinate of an interval set.
 
 A vector with the lower coordinate of the interval.
 """
-function low(x::Interval{N})::Vector{N} where {N<:Real}
+function low(x::Interval{N}) where {N<:Real}
     return N[x.dat.lo]
 end
 
 """
-    high(x::Interval{N})::Vector{N} where {N<:Real}
+    high(x::Interval{N}) where {N<:Real}
 
 Return the higher coordinate of an interval set.
 
@@ -334,12 +334,12 @@ Return the higher coordinate of an interval set.
 
 A vector with the higher coordinate of the interval.
 """
-function high(x::Interval{N})::Vector{N} where {N<:Real}
+function high(x::Interval{N}) where {N<:Real}
     return N[x.dat.hi]
 end
 
 """
-    an_element(x::Interval{N})::Vector{N} where {N<:Real}
+    an_element(x::Interval{N}) where {N<:Real}
 
 Return some element of an interval.
 
@@ -351,14 +351,13 @@ Return some element of an interval.
 
 The left border (`min(x)`) of the interval.
 """
-function an_element(x::Interval{N})::Vector{N} where {N<:Real}
+function an_element(x::Interval{N}) where {N<:Real}
     return [min(x)]
 end
 
 """
     rand(::Type{Interval}; [N]::Type{<:Real}=Float64, [dim]::Int=2,
-         [rng]::AbstractRNG=GLOBAL_RNG, [seed]::Union{Int, Nothing}=nothing
-        )::Interval{N}
+         [rng]::AbstractRNG=GLOBAL_RNG, [seed]::Union{Int, Nothing}=nothing)
 
 Create a random interval.
 
@@ -382,8 +381,7 @@ function rand(::Type{Interval};
               N::Type{<:Real}=Float64,
               dim::Int=1,
               rng::AbstractRNG=GLOBAL_RNG,
-              seed::Union{Int, Nothing}=nothing
-             )::Interval{N}
+              seed::Union{Int, Nothing}=nothing)
     @assert dim == 1 "cannot create a random Interval of dimension $dim"
     rng = reseed(rng, seed)
     x = randn(rng, N)
@@ -392,7 +390,7 @@ function rand(::Type{Interval};
 end
 
 """
-    vertices_list(x::Interval{N})::Vector{Vector{N}} where {N<:Real}
+    vertices_list(x::Interval{N}) where {N<:Real}
 
 Return the list of vertices of this interval.
 
@@ -404,7 +402,7 @@ Return the list of vertices of this interval.
 
 The list of vertices of the interval represented as two one-dimensional vectors.
 """
-function vertices_list(x::Interval{N})::Vector{Vector{N}} where {N<:Real}
+function vertices_list(x::Interval{N}) where {N<:Real}
     return [[min(x)], [max(x)]]
 end
 
@@ -437,7 +435,7 @@ end
 
 
 """
-    radius_hyperrectangle(x::Interval{N}, i::Int)::N where {N<:Real}
+    radius_hyperrectangle(x::Interval{N}, i::Int) where {N<:Real}
 
 Return the box radius of an interval in a given dimension.
 
@@ -450,13 +448,13 @@ Return the box radius of an interval in a given dimension.
 
 The box radius in the given dimension.
 """
-function radius_hyperrectangle(x::Interval{N}, i::Int)::N where {N<:Real}
+function radius_hyperrectangle(x::Interval{N}, i::Int) where {N<:Real}
     @assert i == 1 "an interval is one-dimensional"
     return (max(x) - min(x)) / N(2)
 end
 
 """
-    radius_hyperrectangle(x::Interval{N})::Vector{N} where {N<:Real}
+    radius_hyperrectangle(x::Interval{N}) where {N<:Real}
 
 Return the box radius of an interval in every dimension.
 
@@ -468,12 +466,12 @@ Return the box radius of an interval in every dimension.
 
 The box radius of the interval (a one-dimensional vector).
 """
-function radius_hyperrectangle(x::Interval{N})::Vector{N} where {N<:Real}
+function radius_hyperrectangle(x::Interval{N}) where {N<:Real}
     return [radius_hyperrectangle(x, 1)]
 end
 
 """
-    isflat(I::Interval)::Bool
+    isflat(I::Interval)
 
 Determine whether an interval is flat, i.e. whether its extreme values coincide.
 
@@ -491,7 +489,7 @@ For robustness with respect to floating-point inputs, this function relies on
 the result of `isapproxzero` when applied to the diameter of the interval.
 Hence, this function depends on the absolute zero tolerance `ABSZTOL`.
 """
-function isflat(I::Interval)::Bool
+function isflat(I::Interval)
     return isapproxzero(IntervalArithmetic.diam(I.dat))
 end
 

--- a/src/Sets/Line.jl
+++ b/src/Sets/Line.jl
@@ -113,7 +113,7 @@ end
 
 
 """
-    dim(L::Line)::Int
+    dim(L::Line)
 
 Return the ambient dimension of a line.
 
@@ -125,7 +125,7 @@ Return the ambient dimension of a line.
 
 The ambient dimension of the line, which is 2.
 """
-function dim(L::Line)::Int
+function dim(L::Line)
     return 2
 end
 
@@ -149,7 +149,7 @@ function σ(d::AbstractVector{N}, L::Line{N}) where {N<:Real}
 end
 
 """
-    isbounded(L::Line)::Bool
+    isbounded(L::Line)
 
 Determine whether a line is bounded.
 
@@ -161,13 +161,12 @@ Determine whether a line is bounded.
 
 `false`.
 """
-function isbounded(::Line)::Bool
+function isbounded(::Line)
     return false
 end
 
 """
-    isuniversal(L::Line{N}, [witness]::Bool=false
-               )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+    isuniversal(L::Line{N}, [witness]::Bool=false) where {N<:Real}
 
 Check whether a line is universal.
 
@@ -185,8 +184,7 @@ Check whether a line is universal.
 
 Witness production falls back to `isuniversal(::Hyperplane)`.
 """
-function isuniversal(L::Line{N}, witness::Bool=false
-                    )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+function isuniversal(L::Line{N}, witness::Bool=false) where {N<:Real}
     if witness
         return isuniversal(Hyperplane(L.a, L.b), true)
     else
@@ -195,7 +193,7 @@ function isuniversal(L::Line{N}, witness::Bool=false
 end
 
 """
-    an_element(L::Line{N})::Vector{N} where {N<:Real}
+    an_element(L::Line{N}) where {N<:Real}
 
 Return some element of a line.
 
@@ -214,7 +212,7 @@ Otherwise the result is some ``x = [x1, x2]`` such that ``a·[x1, x2] = b``.
 We first find out in which dimension ``a`` is nonzero, say, dimension 1, and
 then choose ``x1 = 1`` and accordingly ``x2 = \\frac{b - a1}{a2}``.
 """
-function an_element(L::Line{N})::Vector{N} where {N<:Real}
+function an_element(L::Line{N}) where {N<:Real}
     if L.b == zero(N)
         return zeros(N, 2)
     end
@@ -226,7 +224,7 @@ function an_element(L::Line{N})::Vector{N} where {N<:Real}
 end
 
 """
-    ∈(x::AbstractVector{N}, L::Line{N})::Bool where {N<:Real}
+    ∈(x::AbstractVector{N}, L::Line{N}) where {N<:Real}
 
 Check whether a given point is contained in a line.
 
@@ -243,15 +241,14 @@ Check whether a given point is contained in a line.
 
 The point ``x`` belongs to the line if and only if ``a⋅x = b`` holds.
 """
-function ∈(x::AbstractVector{N}, L::Line{N})::Bool where {N<:Real}
+function ∈(x::AbstractVector{N}, L::Line{N}) where {N<:Real}
     @assert length(x) == dim(L)
     return dot(L.a, x) == L.b
 end
 
 """
     rand(::Type{Line}; [N]::Type{<:Real}=Float64, [dim]::Int=2,
-         [rng]::AbstractRNG=GLOBAL_RNG, [seed]::Union{Int, Nothing}=nothing
-        )::Line{N}
+         [rng]::AbstractRNG=GLOBAL_RNG, [seed]::Union{Int, Nothing}=nothing)
 
 Create a random line.
 
@@ -276,8 +273,7 @@ function rand(::Type{Line};
               N::Type{<:Real}=Float64,
               dim::Int=2,
               rng::AbstractRNG=GLOBAL_RNG,
-              seed::Union{Int, Nothing}=nothing
-             )::Line{N}
+              seed::Union{Int, Nothing}=nothing)
     @assert dim == 2 "cannot create a random Line of dimension $dim"
     rng = reseed(rng, seed)
     a = randn(rng, N, dim)
@@ -289,7 +285,7 @@ function rand(::Type{Line};
 end
 
 """
-    isempty(L::Line)::Bool
+    isempty(L::Line)
 
 Return if a line is empty or not.
 
@@ -301,12 +297,12 @@ Return if a line is empty or not.
 
 `false`.
 """
-function isempty(L::Line)::Bool
+function isempty(L::Line)
     return false
 end
 
 """
-    constrained_dimensions(L::Line{N})::Vector{Int} where {N<:Real}
+    constrained_dimensions(L::Line{N}) where {N<:Real}
 
 Return the indices in which a line is constrained.
 
@@ -323,7 +319,7 @@ A vector of ascending indices `i` such that the line is constrained in dimension
 
 A line with constraint ``x1 = 0`` is constrained in dimension 1 only.
 """
-function constrained_dimensions(L::Line{N})::Vector{Int} where {N<:Real}
+function constrained_dimensions(L::Line{N}) where {N<:Real}
     return nonzero_indices(L.a)
 end
 

--- a/src/Sets/LineSegment.jl
+++ b/src/Sets/LineSegment.jl
@@ -71,7 +71,7 @@ LineSegment(p::AbstractVector{N}, q::AbstractVector{N}) where {N<:Real} =
 
 
 """
-    dim(L::LineSegment)::Int
+    dim(L::LineSegment)
 
 Return the ambient dimension of a line segment.
 
@@ -83,7 +83,7 @@ Return the ambient dimension of a line segment.
 
 The ambient dimension of the line segment, which is 2.
 """
-function dim(L::LineSegment)::Int
+function dim(L::LineSegment)
     return 2
 end
 
@@ -131,7 +131,7 @@ function an_element(L::LineSegment{N}) where {N<:Real}
 end
 
 """
-    ∈(x::AbstractVector{N}, L::LineSegment{N})::Bool where {N<:Real}
+    ∈(x::AbstractVector{N}, L::LineSegment{N}) where {N<:Real}
 
 Check whether a given point is contained in a line segment.
 
@@ -159,7 +159,7 @@ Let ``L = (p, q)`` be the line segment with extremes ``p`` and ``q``, and let
 
 The algorithm is inspired from [here](https://stackoverflow.com/a/328110).
 """
-function ∈(x::AbstractVector{N}, L::LineSegment{N})::Bool where {N<:Real}
+function ∈(x::AbstractVector{N}, L::LineSegment{N}) where {N<:Real}
     @assert length(x) == dim(L)
     # check if the point is on the line through the line segment
     if (x[2] - L.p[2]) * (L.q[1] - L.p[1]) -
@@ -176,7 +176,7 @@ end
 
 
 """
-    center(L::LineSegment{N})::Vector{N} where {N<:Real}
+    center(L::LineSegment{N}) where {N<:Real}
 
 Return the center of a line segment.
 
@@ -188,7 +188,7 @@ Return the center of a line segment.
 
 The center of the line segment.
 """
-function center(L::LineSegment{N})::Vector{N} where {N<:Real}
+function center(L::LineSegment{N}) where {N<:Real}
     return L.p + (L.q - L.p) / 2
 end
 
@@ -239,8 +239,7 @@ end
 
 
 """
-    vertices_list(L::LineSegment{N}
-                 )::Vector{<:AbstractVector{N}} where {N<:Real}
+    vertices_list(L::LineSegment{N}) where {N<:Real}
 
 Return the list of vertices of a line segment.
 
@@ -252,8 +251,7 @@ Return the list of vertices of a line segment.
 
 The list of end points of the line segment.
 """
-function vertices_list(L::LineSegment{N}
-                      )::Vector{<:AbstractVector{N}} where {N<:Real}
+function vertices_list(L::LineSegment{N}) where {N<:Real}
     return [L.p, L.q]
 end
 
@@ -263,8 +261,7 @@ end
 
 """
     rand(::Type{LineSegment}; [N]::Type{<:Real}=Float64, [dim]::Int=2,
-         [rng]::AbstractRNG=GLOBAL_RNG, [seed]::Union{Int, Nothing}=nothing
-        )::LineSegment{N}
+         [rng]::AbstractRNG=GLOBAL_RNG, [seed]::Union{Int, Nothing}=nothing)
 
 Create a random line segment.
 
@@ -288,8 +285,7 @@ function rand(::Type{LineSegment};
               N::Type{<:Real}=Float64,
               dim::Int=2,
               rng::AbstractRNG=GLOBAL_RNG,
-              seed::Union{Int, Nothing}=nothing
-             )::LineSegment{N}
+              seed::Union{Int, Nothing}=nothing)
     @assert dim == 2 "cannot create a random LineSegment of dimension $dim"
     rng = reseed(rng, seed)
     p = randn(rng, N, dim)

--- a/src/Sets/PolynomialZonotope.jl
+++ b/src/Sets/PolynomialZonotope.jl
@@ -97,7 +97,7 @@ PolynomialZonotope(c::Vector{N},
                    G::Matrix{N}) where {N} = PolynomialZonotope{N}(c, E, F, G)
 
 """
-    dim(pz::PolynomialZonotope)::Int
+    dim(pz::PolynomialZonotope)
 
 Return the ambient dimension of a polynomial zonotope.
 
@@ -109,10 +109,10 @@ Return the ambient dimension of a polynomial zonotope.
 
 An integer representing the ambient dimension of the polynomial zonotope.
 """
-dim(pz::PolynomialZonotope)::Int = length(pz.c)
+dim(pz::PolynomialZonotope) = length(pz.c)
 
 """
-    σ(d::AbstractVector{N}, pz::PolynomialZonotope{N})::AbstractVector{N} where {N}
+    σ(d::AbstractVector{N}, pz::PolynomialZonotope{N}) where {N}
 
 Return the support vector of a polynomial zonotope along direction `d`.
 
@@ -125,12 +125,12 @@ Return the support vector of a polynomial zonotope along direction `d`.
 
 Vector representing the support vector.
 """
-function σ(d::AbstractVector{N}, pz::PolynomialZonotope{N})::AbstractVector{N} where {N}
+function σ(d::AbstractVector{N}, pz::PolynomialZonotope{N}) where {N}
     error("this function is not yet implemented")
 end
 
 """
-    ρ(d::AbstractVector{N}, pz::PolynomialZonotope{N})::AbstractVector{N} where {N}
+    ρ(d::AbstractVector{N}, pz::PolynomialZonotope{N}) where {N}
 
 Return the support function of a polynomial zonotope along direction `d`.
 
@@ -143,12 +143,12 @@ Return the support function of a polynomial zonotope along direction `d`.
 
 Value of the support function.
 """
-function ρ(d::AbstractVector{N}, pz::PolynomialZonotope{N})::N where {N}
+function ρ(d::AbstractVector{N}, pz::PolynomialZonotope{N}) where {N}
     error("this function is not yet implemented")
 end
 
 """
-    polynomial_order(pz::PolynomialZonotope)::Int
+    polynomial_order(pz::PolynomialZonotope)
 
 Polynomial order of a polynomial zonotope.
 
@@ -161,10 +161,10 @@ Polynomial order of a polynomial zonotope.
 The polynomial order, defined as the maximal power of the scale factors ``β_i``.
 Usually denoted ``η``.
 """
-polynomial_order(pz::PolynomialZonotope)::Int = length(pz.E)
+polynomial_order(pz::PolynomialZonotope) = length(pz.E)
 
 """
-    order(pz::PolynomialZonotope)::Rational{Int}
+    order(pz::PolynomialZonotope)
 
 Order of a polynomial zonotope.
 
@@ -177,7 +177,7 @@ Order of a polynomial zonotope.
 The order, a rational number defined as the total number of generators divided
 by the ambient dimension.
 """
-function order(pz::PolynomialZonotope)::Rational{Int}
+function order(pz::PolynomialZonotope)
     η = polynomial_order(pz)  # polynomial order
     p = size(pz.E[1], 2)  # number of dependent factors
     q = size(pz.G, 2)  # number of independent factors

--- a/src/Sets/Singleton.jl
+++ b/src/Sets/Singleton.jl
@@ -39,7 +39,7 @@ function element(S::Singleton{N}) where {N<:Real}
 end
 
 """
-    element(S::Singleton{N}, i::Int)::N where {N<:Real}
+    element(S::Singleton{N}, i::Int) where {N<:Real}
 
 Return the i-th entry of the element of a singleton.
 
@@ -52,7 +52,7 @@ Return the i-th entry of the element of a singleton.
 
 The i-th entry of the element of the singleton.
 """
-function element(S::Singleton{N}, i::Int)::N where {N<:Real}
+function element(S::Singleton{N}, i::Int) where {N<:Real}
     return S.element[i]
 end
 
@@ -62,8 +62,7 @@ end
 
 """
     rand(::Type{Singleton}; [N]::Type{<:Real}=Float64, [dim]::Int=2,
-         [rng]::AbstractRNG=GLOBAL_RNG, [seed]::Union{Int, Nothing}=nothing
-        )::Singleton{N}
+         [rng]::AbstractRNG=GLOBAL_RNG, [seed]::Union{Int, Nothing}=nothing)
 
 Create a random singleton.
 
@@ -88,8 +87,7 @@ function rand(::Type{Singleton};
               N::Type{<:Real}=Float64,
               dim::Int=2,
               rng::AbstractRNG=GLOBAL_RNG,
-              seed::Union{Int, Nothing}=nothing
-             )::Singleton{N}
+              seed::Union{Int, Nothing}=nothing)
     rng = reseed(rng, seed)
     element = randn(rng, N, dim)
     return Singleton(element)

--- a/src/Sets/Universe.jl
+++ b/src/Sets/Universe.jl
@@ -41,7 +41,7 @@ function constraints_list(U::Universe{N}) where {N<:Real}
 end
 
 """
-    constrained_dimensions(U::Universe)::Vector{Int}
+    constrained_dimensions(U::Universe)
 
 Return the indices in which a universe is constrained.
 
@@ -53,7 +53,7 @@ Return the indices in which a universe is constrained.
 
 The empty vector, as the universe is unconstrained in every dimension.
 """
-function constrained_dimensions(U::Universe)::Vector{Int}
+function constrained_dimensions(U::Universe)
     return Int[]
 end
 
@@ -74,7 +74,7 @@ Return the dimension of a universe.
 
 The dimension of a universe.
 """
-function dim(U::Universe)::Int
+function dim(U::Universe)
     return U.dim
 end
 
@@ -120,7 +120,7 @@ function σ(d::AbstractVector{N}, U::Universe{N}) where {N<:Real}
 end
 
 """
-    ∈(x::AbstractVector{N}, U::Universe{N})::Bool where {N<:Real}
+    ∈(x::AbstractVector{N}, U::Universe{N}) where {N<:Real}
 
 Check whether a given point is contained in a universe.
 
@@ -140,7 +140,7 @@ julia> [1.0, 0.0] ∈ Universe(2)
 true
 ```
 """
-function ∈(x::AbstractVector{N}, U::Universe{N})::Bool where {N<:Real}
+function ∈(x::AbstractVector{N}, U::Universe{N}) where {N<:Real}
     @assert length(x) == dim(U)
     return true
 end
@@ -164,8 +164,7 @@ end
 
 """
     rand(::Type{Universe}; [N]::Type{<:Real}=Float64, [dim]::Int=2,
-         [rng]::AbstractRNG=GLOBAL_RNG, [seed]::Union{Int, Nothing}=nothing
-        )::Universe{N}
+         [rng]::AbstractRNG=GLOBAL_RNG, [seed]::Union{Int, Nothing}=nothing)
 
 Create a universe (note that there is nothing to randomize).
 
@@ -185,14 +184,13 @@ function rand(::Type{Universe};
               N::Type{<:Real}=Float64,
               dim::Int=2,
               rng::AbstractRNG=GLOBAL_RNG,
-              seed::Union{Int, Nothing}=nothing
-             )::Universe{N}
+              seed::Union{Int, Nothing}=nothing)
     rng = reseed(rng, seed)
     return Universe{N}(dim)
 end
 
 """
-    isempty(U::Universe)::Bool
+    isempty(U::Universe)
 
 Return if a universe is empty or not.
 
@@ -204,12 +202,12 @@ Return if a universe is empty or not.
 
 `false`.
 """
-function isempty(U::Universe)::Bool
+function isempty(U::Universe)
     return false
 end
 
 """
-    isbounded(U::Universe)::Bool
+    isbounded(U::Universe)
 
 Determine whether a universe is bounded.
 
@@ -221,13 +219,12 @@ Determine whether a universe is bounded.
 
 `false` as the universe is unbounded.
 """
-function isbounded(U::Universe)::Bool
+function isbounded(U::Universe)
     return false
 end
 
 """
-    isuniversal(U::Universe{N}, [witness]::Bool=false
-               )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+    isuniversal(U::Universe{N}, [witness]::Bool=false) where {N<:Real}
 
 Check whether a universe is universal.
 
@@ -241,8 +238,7 @@ Check whether a universe is universal.
 * If `witness` option is deactivated: `true`
 * If `witness` option is activated: `(true, [])`
 """
-function isuniversal(U::Universe{N}, witness::Bool=false
-                    )::Union{Bool, Tuple{Bool, Vector{N}}} where {N<:Real}
+function isuniversal(U::Universe{N}, witness::Bool=false) where {N<:Real}
     return witness ? (true, N[]) : true
 end
 

--- a/src/Sets/VPolygon.jl
+++ b/src/Sets/VPolygon.jl
@@ -62,7 +62,7 @@ VPolygon() = VPolygon{Float64}()
 
 """
     remove_redundant_vertices!(P::VPolygon{N};
-                               [algorithm]::String="monotone_chain")::VPolygon{N} where {N<:Real}
+                               [algorithm]::String="monotone_chain") where {N<:Real}
 
 Remove the redundant vertices of the given polygon.
 
@@ -83,13 +83,13 @@ given input polygon `P`; see `?convex_hull` for details on the available algorit
 The vertices of the output polygon are sorted in counter-clockwise fashion.
 """
 function remove_redundant_vertices!(P::VPolygon{N};
-                                    algorithm::String="monotone_chain")::VPolygon{N} where {N<:Real}
+                                    algorithm::String="monotone_chain") where {N<:Real}
     convex_hull!(P.vertices; algorithm=algorithm)
 end
 
 """
     remove_redundant_vertices(P::VPolygon{N};
-                              [algorithm]::String="monotone_chain")::VPolygon{N} where {N<:Real}
+                              [algorithm]::String="monotone_chain") where {N<:Real}
 
 Return the polygon obtained by removing the redundant vertices of the given polygon.
 
@@ -110,7 +110,7 @@ given input polygon `P`; see `?convex_hull` for details on the available algorit
 The vertices of the output polygon are sorted in counter-clockwise fashion.
 """
 function remove_redundant_vertices(P::VPolygon{N};
-                                   algorithm::String="monotone_chain")::VPolygon{N} where {N<:Real}
+                                   algorithm::String="monotone_chain") where {N<:Real}
     return remove_redundant_vertices!(copy(P), algorithm=algorithm)
 end
 
@@ -127,7 +127,7 @@ end
 
 
 """
-    tovrep(P::VPolygon{N})::VPolygon{N} where {N<:Real}
+    tovrep(P::VPolygon{N}) where {N<:Real}
 
 Build a vertex representation of the given polygon.
 
@@ -139,7 +139,7 @@ Build a vertex representation of the given polygon.
 
 The identity, i.e., the same polygon instance.
 """
-function tovrep(P::VPolygon{N})::VPolygon{N} where {N<:Real}
+function tovrep(P::VPolygon{N}) where {N<:Real}
     return P
 end
 
@@ -207,7 +207,7 @@ end
 
 
 """
-    vertices_list(P::VPolygon{N})::Vector{Vector{N}} where {N<:Real}
+    vertices_list(P::VPolygon{N}) where {N<:Real}
 
 Return the list of vertices of a convex polygon in vertex representation.
 
@@ -219,7 +219,7 @@ Return the list of vertices of a convex polygon in vertex representation.
 
 List of vertices.
 """
-function vertices_list(P::VPolygon{N})::Vector{Vector{N}} where {N<:Real}
+function vertices_list(P::VPolygon{N}) where {N<:Real}
     return P.vertices
 end
 
@@ -323,7 +323,7 @@ function _binary_support_vector(d::AbstractVector{N}, P::VPolygon{N}) where {N <
 end
 
 """
-    an_element(P::VPolygon{N})::Vector{N} where {N<:Real}
+    an_element(P::VPolygon{N}) where {N<:Real}
 
 Return some element of a polygon in vertex representation.
 
@@ -335,13 +335,13 @@ Return some element of a polygon in vertex representation.
 
 The first vertex of the polygon in vertex representation.
 """
-function an_element(P::VPolygon{N})::Vector{N} where {N<:Real}
+function an_element(P::VPolygon{N}) where {N<:Real}
     @assert !isempty(P.vertices) "the polygon has no vertices"
     return P.vertices[1]
 end
 
 """
-    ∈(x::AbstractVector{N}, P::VPolygon{N})::Bool where {N<:Real}
+    ∈(x::AbstractVector{N}, P::VPolygon{N}) where {N<:Real}
 
 Check whether a given point is contained in a polygon in vertex representation.
 
@@ -380,7 +380,7 @@ julia> [44//10, 34//10] ∈ P  #  with rational numbers the answer is correct
 true
 ```
 """
-function ∈(x::AbstractVector{N}, P::VPolygon{N})::Bool where {N<:Real}
+function ∈(x::AbstractVector{N}, P::VPolygon{N}) where {N<:Real}
     @assert length(x) == 2
 
     # special cases: 0 or 1 vertex
@@ -457,8 +457,7 @@ end
 
 """
     rand(::Type{VPolygon}; [N]::Type{<:Real}=Float64, [dim]::Int=2,
-         [rng]::AbstractRNG=GLOBAL_RNG, [seed]::Union{Int, Nothing}=nothing
-        )::VPolygon{N}
+         [rng]::AbstractRNG=GLOBAL_RNG, [seed]::Union{Int, Nothing}=nothing)
 
 Create a random polygon in vertex representation.
 
@@ -492,8 +491,7 @@ function rand(::Type{VPolygon};
               dim::Int=2,
               rng::AbstractRNG=GLOBAL_RNG,
               seed::Union{Int, Nothing}=nothing,
-              num_vertices::Int=-1
-             )::VPolygon{N}
+              num_vertices::Int=-1)
     @assert dim == 2 "cannot create a random VPolygon of dimension $dim"
     rng = reseed(rng, seed)
     if num_vertices < 0
@@ -559,7 +557,7 @@ end
 
 """
     convex_hull(P::VPolygon{N}, Q::VPolygon{N};
-                [algorithm]::String="monotone_chain")::VPolygon{N} where {N<:Real}
+                [algorithm]::String="monotone_chain") where {N<:Real}
 
 Return the convex hull of two polygons in vertex representation.
 
@@ -582,7 +580,7 @@ algorithms. The vertices of the output polygon are sorted in counter-clockwise
 fashion.
 """
 function convex_hull(P::VPolygon{N}, Q::VPolygon{N};
-                     algorithm::String="monotone_chain")::VPolygon{N} where {N<:Real}
+                     algorithm::String="monotone_chain") where {N<:Real}
     vunion = [P.vertices; Q.vertices]
     convex_hull!(vunion; algorithm=algorithm)
     return VPolygon(vunion, apply_convex_hull=false)

--- a/src/Sets/VPolytope.jl
+++ b/src/Sets/VPolytope.jl
@@ -45,7 +45,7 @@ end
 # --- LazySet interface functions ---
 
 """
-    dim(P::VPolytope)::Int
+    dim(P::VPolytope)
 
 Return the dimension of a polytope in V-representation.
 
@@ -74,7 +74,7 @@ true
 
 ```
 """
-function dim(P::VPolytope)::Int
+function dim(P::VPolytope)
     return length(P.vertices) == 0 ? -1 : length(P.vertices[1])
 end
 
@@ -123,7 +123,7 @@ end
 
 """
     ∈(x::AbstractVector{N}, P::VPolytope{N};
-      solver=default_lp_solver(N))::Bool where {N<:Real}
+      solver=default_lp_solver(N)) where {N<:Real}
 
 Check whether a given point is contained in a polytope in vertex representation.
 
@@ -154,7 +154,7 @@ Then we solve the following ``m``-dimensional linear program.
 ```
 """
 function ∈(x::AbstractVector{N}, P::VPolytope{N};
-           solver=default_lp_solver(N))::Bool where {N<:Real}
+           solver=default_lp_solver(N)) where {N<:Real}
     vertices = P.vertices
     m = length(vertices)
 
@@ -198,7 +198,7 @@ end
 """
     rand(::Type{VPolytope}; [N]::Type{<:Real}=Float64, [dim]::Int=2,
          [rng]::AbstractRNG=GLOBAL_RNG, [seed]::Union{Int, Nothing}=nothing,
-         [num_vertices]::Int=-1)::VPolytope{N}
+         [num_vertices]::Int=-1)
 
 Create a random polytope in vertex representation.
 
@@ -230,8 +230,7 @@ function rand(::Type{VPolytope};
               dim::Int=2,
               rng::AbstractRNG=GLOBAL_RNG,
               seed::Union{Int, Nothing}=nothing,
-              num_vertices::Int=-1
-             )::VPolytope{N}
+              num_vertices::Int=-1)
     rng = reseed(rng, seed)
     if num_vertices < 0
         num_vertices = (dim == 1) ? rand(1:2) : rand(dim:5*dim)
@@ -295,7 +294,7 @@ end
 # --- AbstractPolytope interface functions ---
 
 """
-    vertices_list(P::VPolytope{N})::Vector{Vector{N}} where {N<:Real}
+    vertices_list(P::VPolytope{N}) where {N<:Real}
 
 Return the list of vertices of a polytope in V-representation.
 
@@ -307,7 +306,7 @@ Return the list of vertices of a polytope in V-representation.
 
 List of vertices.
 """
-function vertices_list(P::VPolytope{N})::Vector{Vector{N}} where {N<:Real}
+function vertices_list(P::VPolytope{N}) where {N<:Real}
     return P.vertices
 end
 
@@ -397,7 +396,7 @@ end
 """
     remove_redundant_vertices(P::VPolytope{N};
                               [backend]=nothing,
-                              [solver]=nothing)::VPolytope{N} where {N<:Real}
+                              [solver]=nothing) where {N<:Real}
 
 Return the polytope obtained by removing the redundant vertices of the given polytope.
 
@@ -426,7 +425,7 @@ Otherwise, the redundancy removal function of the polyhedral backend is used.
 """
 function remove_redundant_vertices(P::VPolytope{N};
                                    backend=nothing,
-                                   solver=nothing)::VPolytope{N} where {N<:Real}
+                                   solver=nothing) where {N<:Real}
     require(:Polyhedra; fun_name="remove_redundant_vertices")
     if backend == nothing
         backend = default_polyhedra_backend(P, N)

--- a/src/Sets/ZeroSet.jl
+++ b/src/Sets/ZeroSet.jl
@@ -28,7 +28,7 @@ ZeroSet(dim::Int) = ZeroSet{Float64}(dim)
 
 
 """
-    element(S::ZeroSet{N})::Vector{N} where {N<:Real}
+    element(S::ZeroSet{N}) where {N<:Real}
 
 Return the element of a zero set.
 
@@ -40,12 +40,12 @@ Return the element of a zero set.
 
 The element of the zero set, i.e., a zero vector.
 """
-function element(S::ZeroSet{N})::Vector{N} where {N<:Real}
+function element(S::ZeroSet{N}) where {N<:Real}
     return zeros(N, S.dim)
 end
 
 """
-    element(S::ZeroSet{N}, ::Int)::N where {N<:Real}
+    element(S::ZeroSet{N}, ::Int) where {N<:Real}
 
 Return the i-th entry of the element of a zero set.
 
@@ -58,7 +58,7 @@ Return the i-th entry of the element of a zero set.
 
 The i-th entry of the element of the zero set, i.e., 0.
 """
-function element(S::ZeroSet{N}, ::Int)::N where {N<:Real}
+function element(S::ZeroSet{N}, ::Int) where {N<:Real}
     return zero(N)
 end
 
@@ -67,7 +67,7 @@ end
 
 
 """
-    dim(Z::ZeroSet)::Int
+    dim(Z::ZeroSet)
 
 Return the ambient dimension of this zero set.
 
@@ -79,7 +79,7 @@ Return the ambient dimension of this zero set.
 
 The ambient dimension of the zero set.
 """
-function dim(Z::ZeroSet)::Int
+function dim(Z::ZeroSet)
     return Z.dim
 end
 
@@ -123,7 +123,7 @@ function ρ(d::AbstractVector{N}, Z::ZeroSet{N}) where {N<:Real}
 end
 
 """
-    ∈(x::AbstractVector{N}, Z::ZeroSet{N})::Bool where {N<:Real}
+    ∈(x::AbstractVector{N}, Z::ZeroSet{N}) where {N<:Real}
 
 Check whether a given point is contained in a zero set.
 
@@ -147,7 +147,7 @@ julia> [0.0, 0.0] ∈ Z
 true
 ```
 """
-function ∈(x::AbstractVector{N}, Z::ZeroSet{N})::Bool where {N<:Real}
+function ∈(x::AbstractVector{N}, Z::ZeroSet{N}) where {N<:Real}
     @assert length(x) == dim(Z)
 
     zero_N = zero(N)
@@ -156,8 +156,7 @@ end
 
 """
     rand(::Type{ZeroSet}; [N]::Type{<:Real}=Float64, [dim]::Int=2,
-         [rng]::AbstractRNG=GLOBAL_RNG, [seed]::Union{Int, Nothing}=nothing
-        )::ZeroSet{N}
+         [rng]::AbstractRNG=GLOBAL_RNG, [seed]::Union{Int, Nothing}=nothing)
 
 Create a zero set (note that there is nothing to randomize).
 
@@ -177,8 +176,7 @@ function rand(::Type{ZeroSet};
               N::Type{<:Real}=Float64,
               dim::Int=2,
               rng::AbstractRNG=GLOBAL_RNG,
-              seed::Union{Int, Nothing}=nothing
-             )::ZeroSet{N}
+              seed::Union{Int, Nothing}=nothing)
     rng = reseed(rng, seed)
     return ZeroSet{N}(dim)
 end

--- a/src/Sets/Zonotope.jl
+++ b/src/Sets/Zonotope.jl
@@ -169,7 +169,7 @@ function generators(Z::Zonotope)
 end
 
 """
-    ngens(Z::Zonotope)::Int
+    ngens(Z::Zonotope)
 
 Return the number of generators of a zonotope.
 
@@ -181,7 +181,7 @@ Return the number of generators of a zonotope.
 
 Integer representing the number of generators.
 """
-ngens(Z::Zonotope)::Int = size(Z.generators, 2)
+ngens(Z::Zonotope) = size(Z.generators, 2)
 
 
 # --- LazySet interface functions ---
@@ -189,8 +189,7 @@ ngens(Z::Zonotope)::Int = size(Z.generators, 2)
 
 """
     rand(::Type{Zonotope}; [N]::Type{<:Real}=Float64, [dim]::Int=2,
-         [rng]::AbstractRNG=GLOBAL_RNG, [seed]::Union{Int, Nothing}=nothing
-        )::Zonotope{N}
+         [rng]::AbstractRNG=GLOBAL_RNG, [seed]::Union{Int, Nothing}=nothing)
 
 Create a random zonotope.
 
@@ -221,8 +220,7 @@ function rand(::Type{Zonotope};
               dim::Int=2,
               rng::AbstractRNG=GLOBAL_RNG,
               seed::Union{Int, Nothing}=nothing,
-              num_generators::Int=-1
-             )::Zonotope{N}
+              num_generators::Int=-1)
     rng = reseed(rng, seed)
     center = randn(rng, N, dim)
     if num_generators < 0

--- a/src/Utils/comparisons.jl
+++ b/src/Utils/comparisons.jl
@@ -283,7 +283,7 @@ function _isapprox(x::AbstractVector{N}, y::AbstractVector{M};
 end
 
 """
-    ispermutation(u::AbstractVector{T}, v::AbstractVector)::Bool where {T}
+    ispermutation(u::AbstractVector{T}, v::AbstractVector) where {T}
 
 Check that two vectors contain the same elements up to reordering.
 
@@ -312,7 +312,7 @@ Containment check is performed using `LazySets._in(e, v)`, so in the case of
 floating point numbers, the precision to which the check is made is determined
 by the type of elements in `v`. See `_in` and `_isapprox` for more information.
 """
-function ispermutation(u::AbstractVector{T}, v::AbstractVector)::Bool where {T}
+function ispermutation(u::AbstractVector{T}, v::AbstractVector) where {T}
     if length(u) != length(v)
         return false
     end

--- a/src/Utils/helper_functions.jl
+++ b/src/Utils/helper_functions.jl
@@ -1,5 +1,5 @@
 """
-    sign_cadlag(x::N)::N where {N<:Real}
+    sign_cadlag(x::N) where {N<:Real}
 
 This function works like the sign function but is ``1`` for input ``0``.
 
@@ -27,7 +27,7 @@ julia> LazySets.sign_cadlag.([-0.6, 1.3, 0.0])
   1.0
 ```
 """
-function sign_cadlag(x::N)::N where {N<:Real}
+function sign_cadlag(x::N) where {N<:Real}
     return x < zero(x) ? -one(x) : one(x)
 end
 
@@ -82,7 +82,7 @@ function substitute!(substitution::Dict{Int, T},
 end
 
 """
-    reseed(rng::AbstractRNG, seed::Union{Int, Nothing})::AbstractRNG
+    reseed(rng::AbstractRNG, seed::Union{Int, Nothing})
 
 Reset the RNG seed if the seed argument is a number.
 
@@ -95,7 +95,7 @@ Reset the RNG seed if the seed argument is a number.
 
 The input RNG if the seed is `nothing`, and a reseeded RNG otherwise.
 """
-function reseed(rng::AbstractRNG, seed::Union{Int, Nothing})::AbstractRNG
+function reseed(rng::AbstractRNG, seed::Union{Int, Nothing})
     if seed != nothing
         return Random.seed!(rng, seed)
     end

--- a/test/unit_Hyperrectangle.jl
+++ b/test/unit_Hyperrectangle.jl
@@ -219,9 +219,14 @@ for N in [Float64, Rational{Int}, Float32]
     @test convert(IntervalBox, H) == B
 
     # conversion from other hyperrectangular sets
-    @test convert(Hyperrectangle, BallInf(N[1], N(1))) ==
-          convert(Hyperrectangle, Interval(N(0), N(2))) ==
-          Hyperrectangle(N[1], N[1])
+    H = Hyperrectangle(N[1], N[1])
+    @test convert(Hyperrectangle, BallInf(N[1], N(1))) == H
+    if VERSION >= v"1.1" || N == Float64
+        # in pre-v1.1 versions, IntervalArithmetic always returned a Float64
+        # vector in the `center(·)` implementation, leading to an error
+        @test convert(Hyperrectangle, Interval(N(0), N(2))) == H
+    end
+
     @test convert(Hyperrectangle, SymmetricIntervalHull(Singleton(N[1, 1]))) ==
           Hyperrectangle(N[0, 0], N[1, 1])
 

--- a/test/unit_Interval.jl
+++ b/test/unit_Interval.jl
@@ -1,4 +1,11 @@
-for N in [Float64, Float32, Rational{Int}]
+if VERSION >= v"1.1"
+    Ns = [Float64, Float32, Rational{Int}]
+else
+    # in pre-v1.1 versions, IntervalArithmetic always operated with Float64
+    Ns = [Float64]
+end
+
+for N in Ns
     # random interval
     rand(Interval)
 

--- a/test/unit_Interval.jl
+++ b/test/unit_Interval.jl
@@ -1,4 +1,4 @@
-if VERSION >= v"1.1"
+@static if VERSION >= v"1.1"
     Ns = [Float64, Float32, Rational{Int}]
 else
     # in pre-v1.1 versions, IntervalArithmetic always operated with Float64


### PR DESCRIPTION
Closes #1840.

* `Ball1` was revised in #1894 already.
* The second commit adds version checks to the unit tests. The reason is that `IntervalArithmetic` operated with `Float64` before Julia v1.1. This was hidden by the automatic conversions enforced by the output types.