### PR TITLE
#576 - Plots for unbounded sets

### DIFF
--- a/src/Plotting/plot_recipes.jl
+++ b/src/Plotting/plot_recipes.jl
@@ -82,6 +82,15 @@ julia> plot(Bs, 1e-2)  # faster but less accurate than the previous call
             if Xi isa Intersection
                 res = plot_recipe(Xi, ε, Nφ)
             else
+                if !isbounded(Xi)
+                    # bound unbounded set with the plotting range
+                    p = plot!()
+                    xlim = xlims(p)
+                    ylim = ylims(p)
+                    low = [xlim[1], ylim[1]]
+                    high = [xlim[2], ylim[2]]
+                    Xi = intersection(Xi, Hyperrectangle(low=low, high=high))
+                end
                 # hard-code overapproximation here to avoid individual
                 # compilations for mixed sets
                 Pi = overapproximate(Xi, ε)
@@ -161,6 +170,15 @@ julia> plot(B, 1e-2)  # faster but less accurate than the previous call
         seriesalpha --> DEFAULT_ALPHA
         seriescolor --> DEFAULT_COLOR
 
+        if !isbounded(X)
+            # bound unbounded set with the plotting range
+            pa = plotattributes
+            xlims, ylims = pa[:xlims], pa[:ylims]
+            ε = 1.0
+            low = [xlims[1] - ε, ylims[1] - ε]
+            high = [xlims[2] + ε, ylims[2] + ε]
+            X = intersection(X, Hyperrectangle(low=low, high=high))
+        end
         res = plot_recipe(X, ε)
         if isempty(res)
             res

--- a/src/Plotting/plot_recipes.jl
+++ b/src/Plotting/plot_recipes.jl
@@ -49,15 +49,17 @@ function _update_plot_limits!(lims, X::LazySet)
     box_max = high(box)
     for (idx,symbol) in enumerate([:x, :y])
         if lims[symbol] != :auto
-            # scaling factor for obtaining offset from window width
-            ϵ = 0.05
-            # width of the plotting window in the direction `symbol`
+            # width of the plotting window including the new set in the `symbol` direction
             width = max(lims[symbol][2], box_max[idx]) -
                     min(lims[symbol][1], box_min[idx])
 
+            # scaling factor for beautification
+            ϵ = 0.05
+            offset = width*ϵ
+
             # extend the current plot limits if the new set (plus a small offset) falls outside
-            lims[symbol] = (min(lims[symbol][1], box_min[idx] - width*ϵ),
-                            max(lims[symbol][2], box_max[idx] + width*ϵ))
+            lims[symbol] = (min(lims[symbol][1], box_min[idx] - offset),
+                            max(lims[symbol][2], box_max[idx] + offset))
         end
     end
     nothing

--- a/src/Plotting/plot_recipes.jl
+++ b/src/Plotting/plot_recipes.jl
@@ -83,15 +83,6 @@ julia> plot(Bs, 1e-2)  # faster but less accurate than the previous call
             if Xi isa Intersection
                 res = plot_recipe(Xi, ε, Nφ)
             else
-                if !isbounded(Xi)
-                    # bound unbounded set with the plotting range
-                    p = plot!()
-                    xlim = xlims(p)
-                    ylim = ylims(p)
-                    low = [xlim[1], ylim[1]]
-                    high = [xlim[2], ylim[2]]
-                    Xi = intersection(Xi, Hyperrectangle(low=low, high=high))
-                end
                 # hard-code overapproximation here to avoid individual
                 # compilations for mixed sets
                 Pi = overapproximate(Xi, ε)

--- a/src/Plotting/plot_recipes.jl
+++ b/src/Plotting/plot_recipes.jl
@@ -181,7 +181,7 @@ julia> plot(B, 1e-2)  # faster but less accurate than the previous call
                     emin = extr[symbol].emin
                     emax = extr[symbol].emax
                     # if the extrema are (-Inf,Inf), i.e. an empty plot,
-                    # set it to (0.,1.)
+                    # set it to (-1.,1.)
                     lmin = isinf(emin) ? -1.0 : emin
                     lmax = isinf(emax) ? 1.0 : emax
                     lims[symbol] = (lmin, lmax)
@@ -198,7 +198,7 @@ julia> plot(B, 1e-2)  # faster but less accurate than the previous call
 
         # if there is already a plotted shape and the limits are fixed,
         # automatically adjust the axis limits (e.g. after plotting a unbounded set)
-        elseif  length(p) > 0 && lims[:x] != :auto && lims[:y] != :auto
+        elseif length(p) > 0 && lims[:x] != :auto && lims[:y] != :auto
             # update limits such that the new set is contained in the plot windows
             box = box_approximation(X)
             min_box = low(box)

--- a/src/Plotting/plot_recipes.jl
+++ b/src/Plotting/plot_recipes.jl
@@ -49,29 +49,15 @@ function _update_plot_limits!(lims, X::LazySet)
     box_max = high(box)
     for (idx,symbol) in enumerate([:x, :y])
         if lims[symbol] != :auto
-            # scaling factor for beautification
+            # scaling factor for obtaining offset from window width
             ϵ = 0.05
-            # compute the size of the plotting windows in the direction `symbol`
-            offset = max(lims[symbol][2], box_max[idx]) -
-                     min(lims[symbol][1], box_min[idx])
+            # width of the plotting window in the direction `symbol`
+            width = max(lims[symbol][2], box_max[idx]) -
+                    min(lims[symbol][1], box_min[idx])
 
-            # extend the current upper limit of `symbol`, if the new set plus
-            # beautification offset is outside of the current plotting limits
-            if box_max[idx] + offset*ϵ ≥ lims[symbol][2]
-                lim_max = box_max[idx] + offset*ϵ
-            else
-                lim_max = lims[symbol][2]
-            end
-
-            # extend the current lower limit of `symbol`, if the new set minus
-            # beautification offset is outside of the current plotting limits
-            if box_min[idx] - offset*ϵ ≤ lims[symbol][1]
-                lim_min = box_min[idx] - offset*ϵ
-            else
-                lim_min = lims[symbol][1]
-            end
-
-            lims[symbol] = (lim_min, lim_max)
+            # extend the current plot limits if the new set (plus a small offset) falls outside
+            lims[symbol] = (min(lims[symbol][1], box_min[idx] - width*ϵ),
+                            max(lims[symbol][2], box_max[idx] + width*ϵ))
         end
     end
     nothing

--- a/src/Plotting/plot_recipes.jl
+++ b/src/Plotting/plot_recipes.jl
@@ -21,8 +21,8 @@ function _extract_limits(p::RecipesBase.AbstractPlot)
             lims[symbol] = subplot[Symbol(symbol,:axis)][:lims]
         end
     else
-        lims[:x] = (:auto)
-        lims[:y] = (:auto)
+        lims[:x] = :auto
+        lims[:y] = :auto
     end
     return lims
 end
@@ -75,6 +75,18 @@ function _update_plot_limits!(lims, X::LazySet)
         end
     end
     nothing
+end
+
+macro update_plot_limits!(S)
+    quote
+        p = plotattributes[:plot_object]
+        if length(p) > 0
+            lims = _extract_limits(p)
+            _update_plot_limits!(lims, $esc(S))
+            xlims --> lims[:x]
+            ylims --> lims[:y]
+        end
+    end
 end
 
 function _set_auto_limits_to_extrema!(lims, extr)
@@ -308,7 +320,7 @@ julia> plot(Singleton([0.5, 1.0]))
     seriescolor --> DEFAULT_COLOR
     seriestype := :scatter
 
-    # update fixed plot limits if necessary
+    # update manually set plot limits if necessary
     p = plotattributes[:plot_object]
     if length(p) > 0
         lims = _extract_limits(p)
@@ -375,7 +387,7 @@ julia> plot(L, marker=0)
     markershape --> :circle
     seriestype := :path
 
-    # update fixed plot limits if necessary
+    # update manually set plot limits if necessary
     p = plotattributes[:plot_object]
     if length(p) > 0
         lims = _extract_limits(p)

--- a/src/Plotting/plot_recipes.jl
+++ b/src/Plotting/plot_recipes.jl
@@ -162,7 +162,7 @@ julia> plot(B, 1e-2)  # faster but less accurate than the previous call
         seriesalpha --> DEFAULT_ALPHA
         seriescolor --> DEFAULT_COLOR
 
-        # extract limit and extrema of plotted shapes if existings
+        # extract limits and extrema of already plotted sets
         lims = Dict()
         extr = Dict()
         p = plotattributes[:plot_object]
@@ -180,9 +180,9 @@ julia> plot(B, 1e-2)  # faster but less accurate than the previous call
                 if lims[symbol] == :auto
                     emin = extr[symbol].emin
                     emax = extr[symbol].emax
-                    # if the extrema is (-Inf,Inf), i.e. an empty plot,
+                    # if the extrema are (-Inf,Inf), i.e. an empty plot,
                     # set it to (0.,1.)
-                    lmin = isinf(emin) ? 0.0 : emin
+                    lmin = isinf(emin) ? -1.0 : emin
                     lmax = isinf(emax) ? 1.0 : emax
                     lims[symbol] = (lmin, lmax)
                     # set the limit of the plot
@@ -197,7 +197,7 @@ julia> plot(B, 1e-2)  # faster but less accurate than the previous call
             X = intersection(X, Hyperrectangle(low=low_lim, high=high_lim))
 
         # if there is already a plotted shape and the limits are fixed,
-        # automatically adjust the  axis limits (e.g. after plotting a unbounded set)
+        # automatically adjust the axis limits (e.g. after plotting a unbounded set)
         elseif  length(p) > 0 && lims[:x] != :auto && lims[:y] != :auto
             # update limits such that the new set is contained in the plot windows
             box = box_approximation(X)

--- a/src/Plotting/plot_recipes.jl
+++ b/src/Plotting/plot_recipes.jl
@@ -45,17 +45,33 @@ end
 
 function _update_plot_limits!(lims, X::LazySet)
     box = box_approximation(X)
-    min_box = low(box)
-    max_box = high(box)
+    box_min = low(box)
+    box_max = high(box)
     for (idx,symbol) in enumerate([:x, :y])
         if lims[symbol] != :auto
-            # if the new set is not contained in limits, extend the limit
+            # scaling factor for beautification
             ϵ = 0.05
-            min_offset = abs(min_box[idx])*ϵ
-            max_offset = abs(max_box[idx])*ϵ
-            min_lim = min(lims[symbol][1], min_box[idx] - min_offset)
-            max_lim = max(lims[symbol][2], max_box[idx] + max_offset)
-            lims[symbol] = (min_lim, max_lim)
+            # compute the size of the plotting windows in the direction `symbol`
+            offset = max(lims[symbol][2], box_max[idx]) -
+                     min(lims[symbol][1], box_min[idx])
+
+            # extend the current upper limit of `symbol`, if the new set plus
+            # beautification offset is outside of the current plotting limits
+            if box_max[idx] + offset*ϵ ≥ lims[symbol][2]
+                lim_max = box_max[idx] + offset*ϵ
+            else
+                lim_max = lims[symbol][2]
+            end
+
+            # extend the current lower limit of `symbol`, if the new set minus
+            # beautification offset is outside of the current plotting limits
+            if box_min[idx] - offset*ϵ ≤ lims[symbol][1]
+                lim_min = box_min[idx] - offset*ϵ
+            else
+                lim_min = lims[symbol][1]
+            end
+
+            lims[symbol] = (lim_min, lim_max)
         end
     end
     nothing

--- a/src/Plotting/plot_recipes.jl
+++ b/src/Plotting/plot_recipes.jl
@@ -93,14 +93,11 @@ function _set_auto_limits_to_extrema!(lims, extr)
     nothing
 end
 
-function bounding_hyperrectangle(lims)
+function _bounding_hyperrectangle(lims)
     low_lim = [lims[:x][1] - DEFAULT_PLOT_LIMIT, lims[:y][1] - DEFAULT_PLOT_LIMIT]
     high_lim = [lims[:x][2] + DEFAULT_PLOT_LIMIT, lims[:y][2] + DEFAULT_PLOT_LIMIT]
     return Hyperrectangle(low=low_lim, high=high_lim)
 end
-
-
-
 
 """
     plot_list(list::AbstractVector{VN}, [ε]::N=N(PLOT_PRECISION),
@@ -258,7 +255,7 @@ julia> plot(B, 1e-2)  # faster but less accurate than the previous call
 
         if !isbounded(X)
             _set_auto_limits_to_extrema!(lims, extr)
-            X = intersection(X,  bounding_hyperrectangle(lims))
+            X = intersection(X,  _bounding_hyperrectangle(lims))
 
         # if there is already a plotted set and the limits are fixed,
         # automatically adjust the axis limits (e.g. after plotting a unbounded set)
@@ -475,7 +472,7 @@ julia> plot(X, -1., 100)  # equivalent to the above line
 
     if !isbounded(cap)
         _set_auto_limits_to_extrema!(lims, extr)
-        bounding_box = bounding_hyperrectangle(lims)
+        bounding_box = _bounding_hyperrectangle(lims)
         if !isbounded(cap.X)
             bounded_X = Intersection(bounding_box, cap.X)
             cap = Intersection(bounded_X, cap.Y)

--- a/src/Plotting/plot_recipes.jl
+++ b/src/Plotting/plot_recipes.jl
@@ -105,10 +105,10 @@ function _set_auto_limits_to_extrema!(lims, extr)
     nothing
 end
 
-function _bounding_hyperrectangle(lims)
+function _bounding_hyperrectangle(lims, N)
     low_lim = [lims[:x][1] - DEFAULT_PLOT_LIMIT, lims[:y][1] - DEFAULT_PLOT_LIMIT]
     high_lim = [lims[:x][2] + DEFAULT_PLOT_LIMIT, lims[:y][2] + DEFAULT_PLOT_LIMIT]
-    return Hyperrectangle(low=low_lim, high=high_lim)
+    return Hyperrectangle(low=convert.(N,low_lim), high=convert.(N,high_lim))
 end
 
 """
@@ -267,7 +267,7 @@ julia> plot(B, 1e-2)  # faster but less accurate than the previous call
 
         if !isbounded(X)
             _set_auto_limits_to_extrema!(lims, extr)
-            X = intersection(X,  _bounding_hyperrectangle(lims))
+            X = intersection(X, _bounding_hyperrectangle(lims, eltype(X)))
 
         # if there is already a plotted set and the limits are fixed,
         # automatically adjust the axis limits (e.g. after plotting a unbounded set)
@@ -484,7 +484,7 @@ julia> plot(X, -1., 100)  # equivalent to the above line
 
     if !isbounded(cap)
         _set_auto_limits_to_extrema!(lims, extr)
-        bounding_box = _bounding_hyperrectangle(lims)
+        bounding_box = _bounding_hyperrectangle(lims, eltype(cap))
         if !isbounded(cap.X)
             bounded_X = Intersection(bounding_box, cap.X)
             cap = Intersection(bounded_X, cap.Y)

--- a/src/Plotting/plot_recipes.jl
+++ b/src/Plotting/plot_recipes.jl
@@ -285,6 +285,15 @@ julia> plot(Singleton([0.5, 1.0]))
     seriescolor --> DEFAULT_COLOR
     seriestype := :scatter
 
+    p = plotattributes[:plot_object]
+    lims = _extract_limits(p)
+    if length(p) > 0
+        _update_plot_limits!(lims, S)
+    end
+
+    xlims --> lims[:x]
+    ylims --> lims[:y]
+
     plot_recipe(S, ε)
 end
 

--- a/src/Plotting/plot_recipes.jl
+++ b/src/Plotting/plot_recipes.jl
@@ -234,7 +234,7 @@ julia> plot(B, 1e-2)  # faster but less accurate than the previous call
             high_lim = [lims[:x][2] + DEFAULT_PLOT_LIMIT, lims[:y][2] + DEFAULT_PLOT_LIMIT]
             X = intersection(X, Hyperrectangle(low=low_lim, high=high_lim))
 
-        # if there is already a plotted shape and the limits are fixed,
+        # if there is already a plotted set and the limits are fixed,
         # automatically adjust the axis limits (e.g. after plotting a unbounded set)
         elseif length(p) > 0
             _update_plot_limits!(lims, X)
@@ -285,14 +285,14 @@ julia> plot(Singleton([0.5, 1.0]))
     seriescolor --> DEFAULT_COLOR
     seriestype := :scatter
 
+    # update fixed plot limits if necessary
     p = plotattributes[:plot_object]
-    lims = _extract_limits(p)
     if length(p) > 0
+        lims = _extract_limits(p)
         _update_plot_limits!(lims, S)
+        xlims --> lims[:x]
+        ylims --> lims[:y]
     end
-
-    xlims --> lims[:x]
-    ylims --> lims[:y]
 
     plot_recipe(S, ε)
 end
@@ -351,6 +351,15 @@ julia> plot(L, marker=0)
     markercolor --> DEFAULT_COLOR
     markershape --> :circle
     seriestype := :path
+
+    # update fixed plot limits if necessary
+    p = plotattributes[:plot_object]
+    if length(p) > 0
+        lims = _extract_limits(p)
+        _update_plot_limits!(lims, X)
+        xlims --> lims[:x]
+        ylims --> lims[:y]
+    end
 
     plot_recipe(X, ε)
 end
@@ -432,6 +441,15 @@ julia> plot(X, -1., 100)  # equivalent to the above line
     seriesalpha --> DEFAULT_ALPHA
     seriescolor --> DEFAULT_COLOR
     seriestype := :shape
+
+    # update fixed plot limits if necessary
+    p = plotattributes[:plot_object]
+    if length(p) > 0
+        lims = _extract_limits(p)
+        _update_plot_limits!(lims, cap)
+        xlims --> lims[:x]
+        ylims --> lims[:y]
+    end
 
     plot_recipe(cap, ε)
 end

--- a/src/Plotting/plot_recipes.jl
+++ b/src/Plotting/plot_recipes.jl
@@ -63,18 +63,6 @@ function _update_plot_limits!(lims, X::LazySet)
     nothing
 end
 
-macro update_plot_limits!(S)
-    quote
-        p = plotattributes[:plot_object]
-        if length(p) > 0
-            lims = _extract_limits(p)
-            _update_plot_limits!(lims, $esc(S))
-            xlims --> lims[:x]
-            ylims --> lims[:y]
-        end
-    end
-end
-
 function _set_auto_limits_to_extrema!(lims, extr)
     # if the limit is :auto, set the limits to the current extrema
     for symbol in [:x, :y]

--- a/test/unit_plot.jl
+++ b/test/unit_plot.jl
@@ -95,7 +95,7 @@ for N in [Float64, Float32, Rational{Int}]
     # ------------------------------------------------------------------
     # plot using epsilon-close approximation (default threshold ε value)
     # ------------------------------------------------------------------
-    if N == Float64 # Float32 requires promotion see #1304 
+    if N == Float64 # Float32 requires promotion see #1304
         plot(its)
     end
     plot(hpg)
@@ -105,10 +105,10 @@ for N in [Float64, Float32, Rational{Int}]
     plot(vpg)
     plot(vpt)
     plot(es)
-    @test_throws AssertionError plot(hs) # TODO see #576
-    @test_throws AssertionError plot(hp) # TODO see #576
-    @test_throws AssertionError plot(l) # TODO see #576
-    @test_throws AssertionError plot(uni) # TODO see #576
+    plot(hs)
+    plot(hp)
+    plot(l)
+    plot(uni)
     plot(ch)
     plot(cha)
     plot(sih)


### PR DESCRIPTION
Closes #576.

Things to be addressed in follow-up issues:
* Add a macro for common code in all plot recipes for extending the plot limits (difficult because that code itself is already inside a macro) ([link to discussion](https://github.com/JuliaReach/LazySets.jl/pull/1910#discussion_r365823637), #1917).
* Support plotting of nested `Intersection`s of unbounded sets ([link to comment](https://github.com/JuliaReach/LazySets.jl/pull/1910#issuecomment-574183717), #1913).