### PR TITLE
#1318 - Plot recipe for set union

### DIFF
--- a/src/Plotting/plot_recipes.jl
+++ b/src/Plotting/plot_recipes.jl
@@ -344,3 +344,13 @@ julia> plot(X, -1., 100)  # equivalent to the above line
 
     plot_recipe(cap, ε)
 end
+
+# non-convex sets
+
+@recipe function plot_union(cup::UnionSet{N}, ε::N=zero(N)) where {N<:Real}
+    @series [cup.X, cup.Y], ε
+end
+
+@recipe function plot_union(cup::UnionSetArray{N}, ε::N=zero(N)) where {N<:Real}
+    @series array(cup), ε
+end


### PR DESCRIPTION
Closes #1318.

This is a simple solution. I could not find out how to draw the convex parts in the same color without fixing a global color. The parts will have the same color when passed explicitly, though:
```julia
julia> using LazySets, Plots
julia> cup = UnionSet(rand(BallInf), rand(Ball2));
julia> cup2 = UnionSetArray([rand(Ball1), rand(LineSegment), rand(Singleton)]);

# each part of the unions in different colors
julia> plot(cup)
julia> plot!(cup2)

# all parts of one union in the same color (as specified)
julia> plot(cup, color=:red)
julia> plot!(cup2, color=:blue)
```