### PR TITLE
convert/overapproximate for zonotopic LinearMap

### DIFF
--- a/docs/src/lib/conversion.md
+++ b/docs/src/lib/conversion.md
@@ -40,7 +40,7 @@ convert(::Type{Zonotope}, ::CartesianProduct{N, Zonotope{N}, Zonotope{N}}) where
 convert(::Type{Hyperrectangle}, ::CartesianProduct{N, HN1, HN2}) where {N<:Real, HN1<:AbstractHyperrectangle{N}, HN2<:AbstractHyperrectangle{N}}
 convert(::Type{Zonotope}, ::CartesianProduct{N, HN1, HN2}) where {N<:Real, HN1<:AbstractHyperrectangle{N}, HN2<:AbstractHyperrectangle{N}}
 convert(::Type{Zonotope}, ::CartesianProductArray{N, HN}) where {N<:Real, HN<:AbstractHyperrectangle{N}}
-convert(::Type{Zonotope}, ::LinearMap{N, SN}) where {N, SN<:AbstractHyperrectangle{N}}
+convert(::Type{Zonotope}, ::LinearMap{N, ZN}) where {N, ZN<:AbstractZonotope{N}}
 convert(::Type{Zonotope}, ::LinearMap{N, CartesianProduct{N, HN1, HN2}}) where {N, HN1<:AbstractHyperrectangle{N}, HN2<:AbstractHyperrectangle{N}}
 convert(::Type{Zonotope}, ::LinearMap{N, CartesianProductArray{N, HN}}) where {N, HN<:AbstractHyperrectangle{N}}
 convert(::Type{CartesianProduct{N, Interval{N}, Interval{N}}}, ::AbstractHyperrectangle{N}) where {N<:Real}

--- a/src/Approximations/overapproximate.jl
+++ b/src/Approximations/overapproximate.jl
@@ -482,6 +482,26 @@ function _overapproximate_convex_hull_zonotope_GGP09(
 end
 
 """
+    overapproximate(lm::LinearMap{N, <:AbstractZonotope{N}},
+                    ::Type{<:Zonotope}) where {N<:Real}
+
+Overapproximate a lazy linear map of a zonotopic set with a zonotope.
+
+### Input
+
+- `lm`       -- lazy linear map of a zonotopic set
+- `Zonotope` -- type for dispatch
+
+### Output
+
+The tight zonotope corresponding to `lm`.
+"""
+function overapproximate(lm::LinearMap{N, <:AbstractZonotope{N}},
+                         ::Type{<:Zonotope}) where {N<:Real}
+    return convert(Zonotope, lm)
+end
+
+"""
     overapproximate(Z::AbstractZonotope, ::Type{<:Hyperrectangle})
 
 Return a tight overapproximation of a zonotope with an axis-aligned box.

--- a/src/convert.jl
+++ b/src/convert.jl
@@ -307,16 +307,15 @@ function convert(::Type{Zonotope}, cpa::CartesianProductArray{N, HN}
 end
 
 """
-    convert(::Type{Zonotope},
-            S::LinearMap{N, SN}
-            ) where {N, SN<:AbstractHyperrectangle{N}}
+    convert(::Type{Zonotope}, S::LinearMap{N, ZN}
+           ) where {N, ZN<:AbstractZonotope{N}}
 
-Converts the lazy linear map of a hyperrectangular set to a zonotope.
+Converts the lazy linear map of a zonotopic set to a zonotope.
 
 ### Input
 
 - `Zonotope` -- type, used for dispatch
-- `S`        -- linear map of a hyperrectangular set
+- `S`        -- linear map of a zonotopic set
 
 ### Output
 
@@ -324,12 +323,12 @@ A zonotope.
 
 ### Algorithm
 
-This method first converts the hyperrectangular set to a zonotope, and then
-applies the (concrete) linear map to the zonotope.
+This method first applies the (concrete) linear map to the zonotopic set and
+then converts the result to a `Zonotope` type.
 """
-function convert(::Type{Zonotope}, S::LinearMap{N, SN}
-                ) where {N, SN<:AbstractHyperrectangle{N}}
-    return linear_map(S.M, convert(Zonotope, S.X))
+function convert(::Type{Zonotope}, S::LinearMap{N, ZN}
+                ) where {N, ZN<:AbstractZonotope{N}}
+    return convert(Zonotope, linear_map(S.M, S.X))
 end
 
 """


### PR DESCRIPTION
The first commit generalizes a `convert` method from `AbstractHyperrectangle` to `AbstractZonotope` (which presumably we did not have when we originally wrote the method).

The second commit makes this `convert` method available in `overapproximate`. This would be redundant if we had #1229 already.