### PR TITLE
Add basetype function

### DIFF
--- a/docs/src/lib/interfaces.md
+++ b/docs/src/lib/interfaces.md
@@ -50,6 +50,7 @@ support_function
 ### Other globally defined set functions
 
 ```@docs
+basetype
 norm(::LazySet, ::Real=Inf)
 radius(::LazySet, ::Real=Inf)
 diameter(::LazySet, ::Real=Inf)

--- a/src/Interfaces/LazySet.jl
+++ b/src/Interfaces/LazySet.jl
@@ -2,6 +2,7 @@ import Base: ==, ≈, copy, eltype
 import Random.rand
 
 export LazySet,
+       basetype,
        ρ, support_function,
        σ, support_vector,
        dim,
@@ -161,6 +162,51 @@ Return the numeric type (`N`) of the given set.
 The numeric type of `X`.
 """
 eltype(::LazySet{N}) where {N} = N
+
+"""
+    basetype(T::Type{<:LazySet})
+
+Return the base type of the given set type (i.e., without type parameters).
+
+### Input
+
+- `T` -- set type, used for dispatch
+
+### Output
+
+The base type of `T`.
+"""
+basetype(T::Type{<:LazySet}) = Base.typename(T).wrapper
+
+"""
+    basetype(S::LazySet)
+
+Return the base type of the given set (i.e., without type parameters).
+
+### Input
+
+- `S` -- set instance, used for dispatch
+
+### Output
+
+The base type of `S`.
+
+### Examples
+
+```jldoctest
+julia> z = rand(Zonotope);
+
+julia> basetype(z)
+Zonotope
+
+julia> basetype(z + z)
+MinkowskiSum
+
+julia> basetype(LinearMap(rand(2, 2), z + z))
+LinearMap
+```
+"""
+basetype(S::LazySet) = Base.typename(typeof(S)).wrapper
 
 """
     ρ(d::AbstractVector{N}, S::LazySet{N}) where {N<:Real}

--- a/test/unit_ZeroSet.jl
+++ b/test/unit_ZeroSet.jl
@@ -58,7 +58,7 @@ for N in [Float64, Rational{Int}, Float32]
     # translation
     @test translate(Z, N[1, 2]) == Singleton(N[1, 2])
 
-    # element type
-    @test eltype(Z) == N
-    @test eltype(typeof(Z)) == N
+    # base type and element type
+    @test basetype(Z) == basetype(typeof(Z)) == ZeroSet
+    @test eltype(Z) == eltype(typeof(Z)) == N
 end


### PR DESCRIPTION
This implements the idea(s) from [here](https://discourse.julialang.org/t/extract-type-name-only-from-parametric-type/14188).