### PR TITLE
#1726 - Concrete decomposition using linear_map

### DIFF
--- a/src/Approximations/decompositions.jl
+++ b/src/Approximations/decompositions.jl
@@ -259,7 +259,7 @@ end
 """
     project(S::LazySet{N},
             block::AbstractVector{Int},
-            ::Nothing,
+            [::Nothing=nothing],
             [n]::Int=dim(S)
            ) where {N<:Real}
 
@@ -269,7 +269,7 @@ Project a high-dimensional set to a given block by using a concrete linear map.
 
 - `S`       -- set
 - `block`   -- block structure - a vector with the dimensions of interest
-- `nothing` -- used for dispatch
+- `nothing` -- (default: `nothing`) used for dispatch
 - `n`       -- (optional, default: `dim(S)`) ambient dimension of the set `S`
 
 ### Output
@@ -282,7 +282,7 @@ We apply the function `linear_map`.
 """
 @inline function project(S::LazySet{N},
                          block::AbstractVector{Int},
-                         ::Nothing,
+                         ::Nothing=nothing,
                          n::Int=dim(S)
                         ) where {N<:Real}
     m = length(block)

--- a/src/Approximations/decompositions.jl
+++ b/src/Approximations/decompositions.jl
@@ -237,7 +237,8 @@ function decompose(S::LazySet{N},
                    block_options::Union{Type{<:LazySet},
                                         Pair{<:UnionAll, <:Real},
                                         Real,
-                                        Type{<:AbstractDirections}
+                                        Type{<:AbstractDirections},
+                                        Nothing
                                        }
                   ) where {N<:Real}
     n = dim(S)
@@ -258,6 +259,40 @@ end
 """
     project(S::LazySet{N},
             block::AbstractVector{Int},
+            ::Nothing,
+            [n]::Int=dim(S)
+           ) where {N<:Real}
+
+Project a high-dimensional set to a given block by using a concrete linear map.
+
+### Input
+
+- `S`       -- set
+- `block`   -- block structure - a vector with the dimensions of interest
+- `nothing` -- used for dispatch
+- `n`       -- (optional, default: `dim(S)`) ambient dimension of the set `S`
+
+### Output
+
+A set representing the projection of the set `S` to block `block`.
+
+### Algorithm
+
+We apply the function `linear_map`.
+"""
+@inline function project(S::LazySet{N},
+                         block::AbstractVector{Int},
+                         ::Nothing,
+                         n::Int=dim(S)
+                        ) where {N<:Real}
+    m = length(block)
+    M = sparse(1:m, block, ones(N, m), m, n)
+    return linear_map(M, S)
+end
+
+"""
+    project(S::LazySet{N},
+            block::AbstractVector{Int},
             set_type::Type{<:LinearMap},
             [n]::Int=dim(S)
            ) where {N<:Real}
@@ -273,7 +308,7 @@ Project a high-dimensional set to a given block by using a lazy linear map.
 
 ### Output
 
-A lazy `LinearMap` representing a projection of the set `S` to block `block`.
+A lazy `LinearMap` representing the projection of the set `S` to block `block`.
 """
 @inline function project(S::LazySet{N},
                          block::AbstractVector{Int},

--- a/test/unit_decompose.jl
+++ b/test/unit_decompose.jl
@@ -24,6 +24,9 @@ for N in [Float64, Rational{Int}, Float32]
     @test d.array[1] isa Interval &&
         σ(N[1], d.array[1])[1] == one(N) && σ(N[-1], d.array[1])[1] == -one(N)
 
+    d = decompose(b, partition, nothing)
+    @test d.array[1] isa Zonotope{N} && test_directions(d.array[1])
+
     # ===================
     # 1D/3D decomposition
     # ===================


### PR DESCRIPTION
Closes #1726.

We use dispatch to choose the projection algorithm. I first thought about creating a dummy type for this purpose but I think passing `nothing` is acceptable since the concrete projection should actually be the standard.