### PR TITLE
Concrete projection of polyhedral sets

### DIFF
--- a/src/Approximations/decompositions.jl
+++ b/src/Approximations/decompositions.jl
@@ -457,10 +457,24 @@ Concrete projection of a half-space.
 A set representing the projection of the half-space `H` on the dimensions
 specified by `block`.
 
-### Notes
+### Algorithm
 
-Currently only the case where the unconstrained dimensions of `H` are a subset
-of the `block` variables is implemented.
+If the unconstrained dimensions of `H` are a subset of the `block` variables,
+the projection is applied to the normal direction of `H`.
+Otherwise, the projection results in the universal set.
+
+The latter can be seen as follows.
+Without loss of generality consider a projection onto a single and constrained
+dimension ``xₖ`` (projections in multiple dimensions can be modeled as repeated
+one-dimensional projections).
+We can write the projection as an existentially quantified linear constraint:
+
+```math
+    ∃xₖ: a₁x₁ + … + aₖxₖ + … + aₙxₙ ≤ b
+```
+
+Since ``aₖ ≠ 0``, there is always a value for ``xₖ`` that satisfies the
+constraint for any valuation of the other variables.
 
 ### Examples
 
@@ -471,8 +485,6 @@ of variables to be `[1, 2, 3]`:
 ```jldoctest project_halfspace
 julia> H = HalfSpace([1.0, 1.0, 0.0], 1.0)
 HalfSpace{Float64,Array{Float64,1}}([1.0, 1.0, 0.0], 1.0)
-
-julia> using LazySets.Approximations: project
 
 julia> project(H, [1, 2, 3])
 HalfSpace{Float64,Array{Float64,1}}([1.0, 1.0, 0.0], 1.0)
@@ -492,13 +504,23 @@ the half-space projected on the dimensions where it is constrained only:
 julia> project(H, constrained_dimensions(H))
 HalfSpace{Float64,Array{Float64,1}}([1.0, 1.0], 1.0)
 ```
+
+If a constrained dimension is projected, we get the universal set of the
+dimension corresponding to the projection.
+
+```jldoctest project_halfspace
+julia> project(H, [1, 3])
+Universe{Float64}(2)
+
+julia> project(H, [1])
+Universe{Float64}(1)
+```
 """
 function project(H::HalfSpace{N}, block::AbstractVector{Int}) where {N}
     if constrained_dimensions(H) ⊆ block
         return HalfSpace(H.a[block], H.b)
     else
-        error("the concrete projection of a half-space " *
-              "for a general block structure is not implemented yet")
+        return Universe(length(block))
     end
 end
 

--- a/src/Approximations/decompositions.jl
+++ b/src/Approximations/decompositions.jl
@@ -525,9 +525,9 @@ function project(H::HalfSpace{N}, block::AbstractVector{Int}) where {N}
 end
 
 """
-    project(P::HPolyhedron{N}, block::AbstractVector{Int}) where {N}
+    project(P::AbstractPolyhedron{N}, block::AbstractVector{Int}) where {N}
 
-Concrete projection of a polyhedron in half-space representation.
+Concrete projection of a polyhedral set.
 
 ### Input
 
@@ -536,7 +536,8 @@ Concrete projection of a polyhedron in half-space representation.
 
 ### Output
 
-A set representing the projection of `P` on the dimensions specified by `block`.
+An `HPolyhedron` representing the projection of `P` on the dimensions specified
+by `block`.
 
 ### Notes
 
@@ -547,16 +548,14 @@ of the `block` variables is implemented.
 
 Consider the four-dimensional cross-polytope (unit ball in the 1-norm):
 
-```jldoctest project_hpolyhedron
-julia> using LazySets.Approximations: project
-
-julia> P = convert(HPolyhedron, Ball1(zeros(4), 1.0));
+```jldoctest project_polyhedron
+julia> P = Ball1(zeros(4), 1.0);
 ```
 
 All dimensions are constrained, and computing the (trivial) projection on the whole
 space behaves as expected:
 
-```jldoctest project_hpolyhedron
+```jldoctest project_polyhedron
 julia> constrained_dimensions(P)
 4-element Array{Int64,1}:
  1
@@ -566,14 +565,14 @@ julia> constrained_dimensions(P)
 
 julia> P_1234 = project(P, [1, 2, 3, 4]);
 
-julia> P_1234 == P
+julia> P_1234 == convert(HPolyhedron, P)
 true
 ```
 Each constraint of the cross polytope is constrained in all dimensions.
 
 Now let's take a ball in the infinity norm and remove some constraints:
 
-```jldoctest project_hpolyhedron
+```jldoctest project_polyhedron
 julia> B = BallInf(zeros(4), 1.0);
 
 julia> c = constraints_list(B)[1:2]
@@ -591,14 +590,14 @@ julia> constrained_dimensions(P)
 
 Finally we take the concrete projection onto variables `1` and `2`:
 
-```jldoctest project_hpolyhedron
+```jldoctest project_polyhedron
 julia> project(P, [1, 2]) |> constraints_list
 2-element Array{HalfSpace{Float64,VN} where VN<:AbstractArray{Float64,1},1}:
  HalfSpace{Float64,Array{Float64,1}}([1.0, 0.0], 1.0)
  HalfSpace{Float64,Array{Float64,1}}([0.0, 1.0], 1.0)
 ```
 """
-function project(P::HPolyhedron{N}, block::AbstractVector{Int}) where {N}
+function project(P::AbstractPolyhedron{N}, block::AbstractVector{Int}) where {N}
     if constrained_dimensions(P) ⊆ block
         return HPolyhedron([HalfSpace(c.a[block], c.b) for c in constraints_list(P)])
     else


### PR DESCRIPTION
See #1209 and #1207.

The projection of a half-space is simple and I added a proof idea in the documentation.
For the projection of a polyhedron I was too fast here: it is more complicated than the projection of each half-space individually. So I reverted those changes. Nevertheless, we can take the generalization of the code to arbitrary polyhedra. This gives us a naive but free projection algorithm.