### PR TITLE
Fix warning with Optim

### DIFF
--- a/src/Approximations/overapproximate.jl
+++ b/src/Approximations/overapproximate.jl
@@ -817,7 +817,7 @@ end
 
 """
     overapproximate(vTM::Vector{TaylorModel1{T, S}},
-                    ::Type{Zonotope}) where {T, S}
+                    ::Type{<:Zonotope}) where {T, S}
 
 Overapproximate a taylor model in one variable with a zonotope.
 
@@ -960,7 +960,7 @@ This algorithm proceeds in two steps:
    normalization onto the symmetric intervals ``[-1, 1]``.
 """
 function overapproximate(vTM::Vector{TaylorModel1{T, S}},
-                            ::Type{Zonotope}) where {T, S}
+                            ::Type{<:Zonotope}) where {T, S}
     m = length(vTM)
 
     # preallocations
@@ -974,7 +974,7 @@ end
 
 """
     overapproximate(vTM::Vector{TaylorModelN{N, T, S}},
-                    ::Type{Zonotope}) where {N,T, S}
+                    ::Type{<:Zonotope}) where {N,T, S}
 
 
 Overapproximate a multivariate taylor model with a zonotope.
@@ -1047,7 +1047,7 @@ julia> Matrix(genmat(Z))
 We refer to the algorithm description for the univariate case.
 """
 function overapproximate(vTM::Vector{TaylorModelN{N, T, S}},
-                         ::Type{Zonotope}) where {N, T, S}
+                         ::Type{<:Zonotope}) where {N, T, S}
     m = length(vTM)
     n = N # number of variables is get_numvars() in TaylorSeries
 
@@ -1104,7 +1104,7 @@ end
 
 """
     overapproximate(lm::LinearMap{N, <:AbstractZonotope{N}, NM,
-                                  <:AbstractIntervalMatrix{<:NM}},
+                                  <:AbstractIntervalMatrix{NM}},
                     ::Type{<:Zonotope}) where {N<:Real, NM}
 
 Overapproximate an interval-matrix linear map of a zonotopic set by a new
@@ -1138,7 +1138,7 @@ conventional matrix and a symmetric interval matrix) and a zonotope
 uncertain parameters and inputs. CDC 2007.
 """
 function overapproximate(lm::LinearMap{N, <:AbstractZonotope{N}, NM,
-                                       <:AbstractIntervalMatrix{<:NM}},
+                                       <:AbstractIntervalMatrix{NM}},
                          ::Type{<:Zonotope}) where {N<:Real, NM}
     Mc, Ms = split(lm.M)
     Z = lm.X

--- a/src/LazyOperations/Intersection.jl
+++ b/src/LazyOperations/Intersection.jl
@@ -698,7 +698,7 @@ function load_optim_intersection()
 return quote
 
 """
-    _line_search(ℓ, X, H; [kwargs...])
+    _line_search(ℓ, X, H::Union{<:HalfSpace, <:Hyperplane, <:Line}; [kwargs...])
 
 Given a compact and convex set ``X`` and a halfspace ``H = \\{x: a^T x ≤ b \\}``
 or a hyperplane ``H = \\{x: a^T x = b \\}``, calculate:
@@ -758,7 +758,8 @@ julia> _line_search([1.0, 0.0], X, H, upper=1e3, method=GoldenSection())
 (1.0, 381.9660112501051)
 ```
 """
-function _line_search(ℓ, X, H::Union{HalfSpace, Hyperplane, Line}; kwargs...)
+function _line_search(ℓ, X, H::Union{<:HalfSpace, <:Hyperplane, <:Line};
+                      kwargs...)
     options = Dict(kwargs)
 
     # Initialization


### PR DESCRIPTION
Since about two weeks I get these warnings when using optional packages via `Requires` (but only sometimes, so this seems to be nondeterministic):

```julia
julia> using LazySets

julia> using Optim
┌ Warning: Replacing docs for `LazySets._line_search :: Tuple{Any,Any,Union{HalfSpace, Hyperplane, Line}}` in module `LazySets`
└ @ Base.Docs docs/Docs.jl:223

julia> using TaylorModels
┌ Warning: Replacing docs for `LazySets.Approximations.overapproximate :: Union{Tuple{S}, Tuple{T}, Tuple{Array{TaylorModel1{T,S},1},Type{Zonotope}}} where S where T` in module `LazySets.Approximations`
└ @ Base.Docs docs/Docs.jl:223

┌ Warning: Replacing docs for `LazySets.Approximations.overapproximate :: Union{Tuple{S}, Tuple{T}, Tuple{N}, Tuple{Array{TaylorModelN{N,T,S},1},Type{Zonotope}}} where S where T where N` in module `LazySets.Approximations`
└ @ Base.Docs docs/Docs.jl:223

julia> using IntervalMatrices
┌ Warning: Replacing docs for `LazySets.Approximations.overapproximate :: Union{Tuple{NM}, Tuple{N}, Tuple{LinearMap{N,#s579,NM,#s578} where #s578<:(IntervalMatrices.AbstractIntervalMatrix{#s577} where #s577<:NM) where #s579<:AbstractZonotope{N},Type{#s576} where #s576<:Zonotope}} where NM where N<:Real` in module `LazySets.Approximations`
└ @ Base.Docs docs/Docs.jl:223
```

Note that the `Optim` case is actually not ambiguous because there is only a single `_line_search` method. So this might happen when Julia converts to its internal representation. My guess is that there is some problem with nested types and, since this came up only recently without us touching these parts, some update in an external package. It also seems plausible that this came with an update of [`Requires`](https://github.com/JuliaPackaging/Requires.jl/releases/tag/v1.0.1) but downgrading to v1.0.0 did not help.

The `Optim` case seems to be fixed with this PR. I tried all kinds of combinations but could not fix the `TaylorModels` and `IntervalMatrices` cases.

All these cases list the docs only by the function name and not with additional types to disambiguate the methods ([`_line_search`](https://github.com/JuliaReach/LazySets.jl/blob/master/docs/src/lib/lazy_operations/Intersection.md#binary-intersection-intersectionid-def_intersection), [`overapproximate`](https://github.com/JuliaReach/LazySets.jl/blob/master/docs/src/lib/approximations.md#overapproximations)). So I guess an alternative is to list all `overapproximate` methods in the docs explicitly.