### PR TITLE
#1638 - Efficient way to obtain precise Interval bounds in 1D

### DIFF
--- a/src/convert.jl
+++ b/src/convert.jl
@@ -491,8 +491,8 @@ Interval{Float64,IntervalArithmetic.Interval{Float64}}([0, 1])
 ```
 """
 function convert(::Type{Interval}, H::AbstractHyperrectangle)
-    @assert dim(H) == 1 "can only convert a one-dimensional $(typeof(H)) to `Interval`"
-    return Interval([low(H); high(H)])
+    @assert dim(H) == 1 "cannot convert a $(dim(H))-dimensional $(typeof(H)) to `Interval`"
+    return Interval(low(H)[1], high(H)[1])
 end
 
 """
@@ -510,7 +510,7 @@ Converts a convex set to an interval.
 An interval.
 """
 function convert(::Type{Interval}, S::LazySet{N}) where {N<:Real}
-    @assert dim(S) == 1 "can only convert a one-dimensional $(typeof(S)) to `Interval`"
+    @assert dim(S) == 1 "cannot convert a $(dim(H))-dimensional $(typeof(S)) to `Interval`"
     return Interval(-ρ(N[-1], S), ρ(N[1], S))
 end
 

--- a/test/unit_overapproximate.jl
+++ b/test/unit_overapproximate.jl
@@ -36,9 +36,15 @@ for N in [Float64, Rational{Int}, Float32]
 
     # Interval approximation
     b = Ball1(N[0], N(1))
-    p = overapproximate(b, LazySets.Interval)
+    p1 = overapproximate(b, LazySets.Interval)
+    cap = Intersection(b, BallInf(N[1], N(1)))
+    p2 = overapproximate(cap, LazySets.Interval)
+    caparray = IntersectionArray([b, BallInf(N[1], N(1)), BallInf(N[1//2], N(1//4))])
+    p3 = overapproximate(caparray, LazySets.Interval)
     for d in [N[1], N[-1]]
-        @test σ(d, p)[1] ≈ σ(d, b)[1]
+        for (o, p) in [(b, cap, caparray), (p1, p2, p3)]
+            @test σ(d, o)[1] ≈ d[1]
+        end
     end
 
     # approximation with an axis-aligned hyperrectangle


### PR DESCRIPTION
Closes #1638.

The first commit is only related but it makes the `convert` faster.
```julia
julia> @btime convert(Interval, rand(Hyperrectangle, dim=1));  # master
  265.718 ns (7 allocations: 608 bytes)

julia> @btime convert(Interval, rand(Hyperrectangle, dim=1));  # this branch
  225.956 ns (6 allocations: 512 bytes)
```