### PR TITLE
#1926 - Add isboundedtype

### DIFF
--- a/docs/src/lib/interfaces.md
+++ b/docs/src/lib/interfaces.md
@@ -58,7 +58,7 @@ basetype
 norm(::LazySet, ::Real=Inf)
 radius(::LazySet, ::Real=Inf)
 diameter(::LazySet, ::Real=Inf)
-isboundedtype(::Type{<:LazySet})
+isboundedtype(::Type{T}) where {T<:LazySet}
 isboundedtype(::LazySet)
 isbounded(::LazySet)
 _isbounded_unit_dimensions(::LazySet{N}) where {N<:Real}

--- a/docs/src/lib/interfaces.md
+++ b/docs/src/lib/interfaces.md
@@ -58,6 +58,7 @@ basetype
 norm(::LazySet, ::Real=Inf)
 radius(::LazySet, ::Real=Inf)
 diameter(::LazySet, ::Real=Inf)
+isboundedtype(::Type{<:LazySet})
 isboundedtype(::LazySet)
 isbounded(::LazySet)
 _isbounded_unit_dimensions(::LazySet{N}) where {N<:Real}

--- a/docs/src/lib/interfaces.md
+++ b/docs/src/lib/interfaces.md
@@ -58,6 +58,7 @@ basetype
 norm(::LazySet, ::Real=Inf)
 radius(::LazySet, ::Real=Inf)
 diameter(::LazySet, ::Real=Inf)
+isboundedtype(::LazySet)
 isbounded(::LazySet)
 _isbounded_unit_dimensions(::LazySet{N}) where {N<:Real}
 _isbounded_stiemke(::HPolyhedron{N}) where {N<:Real}

--- a/src/Interfaces/AbstractCentrallySymmetric.jl
+++ b/src/Interfaces/AbstractCentrallySymmetric.jl
@@ -46,7 +46,7 @@ The ambient dimension of the set.
     return length(center(S))
 end
 
-function isboundedtype(::AbstractCentrallySymmetric)
+function isboundedtype(::Type{<:AbstractCentrallySymmetric})
     return true
 end
 

--- a/src/Interfaces/AbstractCentrallySymmetric.jl
+++ b/src/Interfaces/AbstractCentrallySymmetric.jl
@@ -46,6 +46,10 @@ The ambient dimension of the set.
     return length(center(S))
 end
 
+function isboundedtype(::AbstractCentrallySymmetric)
+    return true
+end
+
 """
     isbounded(S::AbstractCentrallySymmetric)
 

--- a/src/Interfaces/AbstractPolytope.jl
+++ b/src/Interfaces/AbstractPolytope.jl
@@ -38,6 +38,10 @@ isconvextype(::Type{<:AbstractPolytope}) = true
 # Common AbstractPolytope functions
 # =============================================
 
+function isboundedtype(::AbstractPolytope)
+    return true
+end
+
 """
     isbounded(P::AbstractPolytope)
 

--- a/src/Interfaces/AbstractPolytope.jl
+++ b/src/Interfaces/AbstractPolytope.jl
@@ -38,7 +38,7 @@ isconvextype(::Type{<:AbstractPolytope}) = true
 # Common AbstractPolytope functions
 # =============================================
 
-function isboundedtype(::AbstractPolytope)
+function isboundedtype(::Type{<:AbstractPolytope})
     return true
 end
 

--- a/src/Interfaces/LazySet.jl
+++ b/src/Interfaces/LazySet.jl
@@ -268,7 +268,7 @@ Determine whether a set is bounded only based on type information.
 
 `true` if the set is bounded based on type information.
 Note that some sets may still represent an unbounded set even though their type
-actually (example: [`HPolytope`](@ref)).
+actually does not (example: [`HPolytope`](@ref)).
 
 ### Notes
 

--- a/src/Interfaces/LazySet.jl
+++ b/src/Interfaces/LazySet.jl
@@ -256,6 +256,30 @@ Alias for the support vector σ.
 const support_vector = σ
 
 """
+    isboundedtype(::Type{<:LazySet})
+
+Determine whether a set type only represents bounded sets.
+
+### Input
+
+- `LazySet` -- set type for dispatch
+
+### Output
+
+`true` if the set type only represents bounded sets.
+Note that some sets may still represent an unbounded set even though their type
+actually does not (example: [`HPolytope`](@ref)).
+
+### Notes
+
+By default this function returns `false`.
+All set types that can determine boundedness should override this behavior.
+"""
+function isboundedtype(::Type{<:LazySet})
+    return false
+end
+
+"""
     isboundedtype(S::LazySet)
 
 Determine whether a set is bounded only based on type information.
@@ -270,13 +294,12 @@ Determine whether a set is bounded only based on type information.
 Note that some sets may still represent an unbounded set even though their type
 actually does not (example: [`HPolytope`](@ref)).
 
-### Notes
+### Algorithm
 
-By default this function returns `false`.
-All set types that can determine boundedness should override this behavior.
+See `isboundedtype(typeof(X))`.
 """
-function isboundedtype(S::LazySet)
-    return false
+function isboundedtype(X::LazySet)
+    return isboundedtype(typeof(X))
 end
 
 """

--- a/src/Interfaces/LazySet.jl
+++ b/src/Interfaces/LazySet.jl
@@ -11,6 +11,7 @@ export LazySet,
        diameter,
        an_element,
        isbounded,
+       isboundedtype,
        neutral,
        absorbing,
        tosimplehrep,
@@ -253,6 +254,30 @@ function σ end
 Alias for the support vector σ.
 """
 const support_vector = σ
+
+"""
+    isboundedtype(S::LazySet)
+
+Determine whether a set is bounded only based on type information.
+
+### Input
+
+- `S` -- set
+
+### Output
+
+`true` if the set is bounded based on type information.
+Note that some sets may still represent an unbounded set even though their type
+actually (example: [`HPolytope`](@ref)).
+
+### Notes
+
+By default this function returns `false`.
+All set types that can determine boundedness should override this behavior.
+"""
+function isboundedtype(S::LazySet)
+    return false
+end
 
 """
     isbounded(S::LazySet)

--- a/src/Interfaces/LazySet.jl
+++ b/src/Interfaces/LazySet.jl
@@ -275,18 +275,18 @@ actually does not (example: [`HPolytope`](@ref)).
 By default this function returns `false`.
 All set types that can determine boundedness should override this behavior.
 """
-function isboundedtype(::Type{<:LazySet})
+function isboundedtype(::Type{T}) where {T<:LazySet}
     return false
 end
 
 """
-    isboundedtype(S::LazySet)
+    isboundedtype(X::LazySet)
 
 Determine whether a set is bounded only based on type information.
 
 ### Input
 
-- `S` -- set
+- `X` -- set
 
 ### Output
 

--- a/src/LazyOperations/Complement.jl
+++ b/src/LazyOperations/Complement.jl
@@ -113,10 +113,10 @@ function isempty(C::Complement)
     return isuniversal(C.X)
 end
 
-function isboundedtype(::Complement{<:Real, <:Universe})
+function isboundedtype(::Type{<:Complement{<:Real, <:Universe}})
     return true
 end
 
-function isboundedtype(::Complement{<:Real, <:LazySet})
+function isboundedtype(::Type{<:Complement{<:Real, <:LazySet}})
     return false
 end

--- a/src/LazyOperations/Complement.jl
+++ b/src/LazyOperations/Complement.jl
@@ -117,6 +117,10 @@ function isboundedtype(::Type{<:Complement{<:Real, <:Universe}})
     return true
 end
 
-function isboundedtype(::Type{<:Complement{<:Real, <:LazySet}})
+function isboundedtype(::Type{<:Complement})
     return false
+end
+
+function isboundedtype(X::Complement)
+    return isboundedtype(typeof(X))
 end

--- a/src/LazyOperations/Complement.jl
+++ b/src/LazyOperations/Complement.jl
@@ -112,3 +112,11 @@ We use the `isuniversal` method.
 function isempty(C::Complement)
     return isuniversal(C.X)
 end
+
+function isboundedtype(::Complement{<:Real, <:Universe})
+    return true
+end
+
+function isboundedtype(::Complement{<:Real, <:LazySet})
+    return false
+end

--- a/src/Sets/EmptySet.jl
+++ b/src/Sets/EmptySet.jl
@@ -85,6 +85,10 @@ function ρ(d::AbstractVector{N}, ∅::EmptySet{N}) where {N<:Real}
     error("the support function of an empty set does not exist")
 end
 
+function isboundedtype(::EmptySet)
+    return true
+end
+
 """
     isbounded(∅::EmptySet)
 

--- a/src/Sets/EmptySet.jl
+++ b/src/Sets/EmptySet.jl
@@ -85,7 +85,7 @@ function ρ(d::AbstractVector{N}, ∅::EmptySet{N}) where {N<:Real}
     error("the support function of an empty set does not exist")
 end
 
-function isboundedtype(::EmptySet)
+function isboundedtype(::Type{<:EmptySet})
     return true
 end
 

--- a/test/unit_Ball2.jl
+++ b/test/unit_Ball2.jl
@@ -57,7 +57,7 @@ for N in [Float64, Float32]
     @test σ(d, b) == N[0, -2]
 
     # boundedness
-    @test isbounded(b)
+    @test isbounded(b) && isboundedtype(b)
 
     # isempty
     @test !isempty(b)

--- a/test/unit_Complement.jl
+++ b/test/unit_Complement.jl
@@ -40,4 +40,8 @@ for N in [Float64, Rational{Int}, Float32]
     @test isconvextype(typeof(Complement(Universe{N}(2))))
     @test isconvextype(typeof(Complement(EmptySet{N}(2))))
     @test isconvextype(typeof(Complement(HalfSpace(N[1], N(0)))))
+
+    # test boundedness
+    @test isboundedtype(Complement(Universe{N}(2)))
+    @test !isboundedtype(Complement(EmptySet{N}(2)))
 end

--- a/test/unit_EmptySet.jl
+++ b/test/unit_EmptySet.jl
@@ -43,7 +43,7 @@ for N in [Float64, Rational{Int}, Float32]
     @test_throws ErrorException σ(N[0], E)
 
     # boundedness
-    @test isbounded(E)
+    @test isbounded(E) && isboundedtype(E)
 
     # isuniversal
     res, w = isuniversal(E, true)

--- a/test/unit_Polyhedron.jl
+++ b/test/unit_Polyhedron.jl
@@ -141,7 +141,7 @@ for N in [Float64, Float32]
     p_univ = HPolyhedron{N}()
 
     # boundedness
-    @test !isbounded(p_univ)
+    @test !isbounded(p_univ) && !isboundedtype(p_univ)
     @test isbounded(p)
     @test !isbounded(HPolyhedron([HalfSpace(N[1, 0], N(1))]))
 
@@ -185,7 +185,7 @@ for N in [Float64]
     @test_broken an_element(P) ∈ P # see LazySets.jl/pull/2197
 
     # boundedness
-    @test isbounded(p)
+    @test isbounded(p) && !isboundedtype(p)
 
     if test_suite_polyhedra
         p_unbounded = HPolyhedron([LinearConstraint(N[-1, 0], N(0))])

--- a/test/unit_Polytope.jl
+++ b/test/unit_Polytope.jl
@@ -45,9 +45,9 @@ for N in [Float64, Rational{Int}, Float32]
     @test_throws ErrorException σ(N[0], HPolytope{N}())
 
     # boundedness
-    @test isbounded(p) && isbounded(p, false)
+    @test isbounded(p) && isbounded(p, false) && isboundedtype(p)
     p2 = HPolytope{N}()
-    @test isbounded(p2) && !isbounded(p2, false)
+    @test isbounded(p2) && !isbounded(p2, false) && isboundedtype(p2)
 
     # isuniversal
     answer, w = isuniversal(p, true)


### PR DESCRIPTION
Closes #1926.

This version returns `false` for lazy set types. A more sophisticated approach (to be added later) would require to define a function `isboundedtype(::Type{<:LazySet})` based on set types that can then be applied to type parameters like so:

```julia
function isboundedtype(cp::CartesianProduct{N, S1, S2}) where {N, S1, S2}
    return isboundedtype(S1) && isboundedtype(S2)
end
```