### PR TITLE
#1779 - Support function for empty sets

### DIFF
--- a/src/Sets/EmptySet.jl
+++ b/src/Sets/EmptySet.jl
@@ -79,10 +79,10 @@ Evaluate the support function of an empty set in a given direction.
 
 ### Output
 
-An error.
+`-Inf`.
 """
 function ρ(d::AbstractVector{N}, ∅::EmptySet{N}) where {N<:Real}
-    error("the support function of an empty set does not exist")
+    return N(-Inf)
 end
 
 """

--- a/src/Sets/HPolyhedron.jl
+++ b/src/Sets/HPolyhedron.jl
@@ -98,6 +98,7 @@ direction.
 ### Output
 
 The support function of the polyhedron.
+If the polyhedron is empty, the result is `-Inf`.
 If a polytope is unbounded in the given direction, we throw an error.
 If a polyhedron is unbounded in the given direction, the result is `Inf`.
 """
@@ -105,8 +106,7 @@ function ρ(d::AbstractVector{N}, P::HPoly{N};
            solver=default_lp_solver(N)) where {N<:Real}
     lp, unbounded, empty = σ_helper(d, P, solver)
     if empty
-        error("the support function in direction $(d) is undefined because " *
-              "the polytope is empty")
+        return N(-Inf)
     elseif unbounded
         if P isa HPolytope
             error("the support function in direction $(d) is undefined " *

--- a/test/unit_Bloating.jl
+++ b/test/unit_Bloating.jl
@@ -42,7 +42,7 @@ for N in [Float64, Float32]
         @test σ(d, X) == σ(d, B + Bp)
         @test ρ(d, X) == ρ(d, B + Bp) == N(1 + ε)
         @test_throws ErrorException σ(N[1], Y)
-        @test_throws ErrorException ρ(N[1], Y)
+        @test ρ(N[1], Y) == N(-Inf)
         d = N[1, 99//100]
         @test σ(d, X) == σ(d, B + Bp)
         @test ρ(d, X) == ρ(d, B + Bp)

--- a/test/unit_EmptySet.jl
+++ b/test/unit_EmptySet.jl
@@ -42,6 +42,9 @@ for N in [Float64, Rational{Int}, Float32]
     # support vector
     @test_throws ErrorException σ(N[0], E)
 
+    # support function
+    @test ρ(N[0], E) == N(-Inf)
+
     # boundedness
     @test isbounded(E)
 

--- a/test/unit_Polyhedron.jl
+++ b/test/unit_Polyhedron.jl
@@ -42,6 +42,8 @@ for N in [Float64, Rational{Int}, Float32]
 
     # boundedness
     @test !isbounded(p_univ)
+    p_empty = HPolyhedron([HalfSpace(N[1], N(0)), HalfSpace(N[-1], N(-1))])
+    @test isbounded(p_empty)
 
     # universality
     @test !isuniversal(p)

--- a/test/unit_Polytope.jl
+++ b/test/unit_Polytope.jl
@@ -271,7 +271,7 @@ for N in [Float64]
         p_infeasible = HPolytope([LinearConstraint(N[1], N(0)),
                                   LinearConstraint(N[-1], N(-1))])
         @test_throws ErrorException σ(N[1], p_infeasible)
-        @test_throws ErrorException ρ(N[1], p_infeasible)
+        @test ρ(N[1], p_infeasible) == N(-Inf)
 
         # empty intersection
         A = [N(0) N(-1); N(-1) N(0); N(1) N(1)]


### PR DESCRIPTION
Closes #1779.

The first commit refactors the code a bit without functional changes (other than printing a better error message in the support function).

The second commit is a proposal to define the support function for empty sets as `-Inf`.