### PR TITLE
Use faster 2d directions algorithm by default

### DIFF
--- a/docs/src/lib/utils.md
+++ b/docs/src/lib/utils.md
@@ -40,6 +40,7 @@ binary_search_constraints
 get_radius!
 is_tighter_same_dir_2D
 sign_cadlag
+_leq_trig
 _random_zero_sum_vector
 rectify
 require(::Symbol)

--- a/src/Interfaces/AbstractPolygon.jl
+++ b/src/Interfaces/AbstractPolygon.jl
@@ -140,6 +140,10 @@ directions using the right-hand rule (see [`is_right_turn`](@ref)).
 In particular, this method does not use the arctangent.
 """
 function <=(u::AbstractVector{N}, v::AbstractVector{N}) where {N<:Real}
+    return _leq_quadrant(u, v)
+end
+
+function _leq_quadrant(u::AbstractVector{N}, v::AbstractVector{N}) where {N<:Real}
     qu, qv = quadrant(u), quadrant(v)
     if qu == qv
         # same quadrant, check right-turn with center 0
@@ -147,4 +151,32 @@ function <=(u::AbstractVector{N}, v::AbstractVector{N}) where {N<:Real}
     end
     # different quadrant
     return qu < qv
+end
+
+"""
+    _leq_trig(u::AbstractVector{N}, v::AbstractVector{N}) where {N<:AbstractFloat}
+
+Compares two 2D vectors by their direction.
+
+### Input
+
+- `u` --  first 2D direction
+- `v` --  second 2D direction
+
+### Output
+
+`true` iff ``\\arg(u) [2π] ≤ \\arg(v) [2π]``.
+
+### Notes
+
+The argument is measured in counter-clockwise fashion, with the 0 being the
+direction (1, 0).
+
+### Algorithm
+
+The implementation uses the arctangent function with sign, `atan`, which for two
+arguments implements the [`atan2` function](https://en.wikipedia.org/wiki/Atan2).
+"""
+function _leq_trig(u::AbstractVector{N}, v::AbstractVector{N}) where {N<:AbstractFloat}
+    return jump2pi(atan(u[2], u[1])) <= jump2pi(atan(v[2], v[1]))
 end

--- a/src/Interfaces/AbstractPolygon.jl
+++ b/src/Interfaces/AbstractPolygon.jl
@@ -141,7 +141,7 @@ In particular, this method does not use the arctangent.
 """
 function <=(u::AbstractVector{N}, v::AbstractVector{N}) where {N<:Real}
     @assert length(u) == length(v) == 2 "comparison of vectors `u` and `v` " *
-           "by their direction requires they are are of length 2, " *
+           "by their direction requires they are of length 2, " *
            "but their lengths are $(length(u)) and $(length(v)) respectively"
 
     return _leq_quadrant(u, v)

--- a/src/Interfaces/AbstractPolygon.jl
+++ b/src/Interfaces/AbstractPolygon.jl
@@ -140,9 +140,9 @@ directions using the right-hand rule (see [`is_right_turn`](@ref)).
 In particular, this method does not use the arctangent.
 """
 function <=(u::AbstractVector{N}, v::AbstractVector{N}) where {N<:Real}
-    @assert length(u) == length(v) == 2 "comparison of vectors by their direction " *
-           "requires that the vectors `u` and `v` are of length 2, but their lengths " *
-           "are $(length(u)) and $(length(v)) respectively"
+    @assert length(u) == length(v) == 2 "comparison of vectors `u` and `v` " *
+           "by their direction requires they are are of length 2, " *
+           "but their lengths are $(length(u)) and $(length(v)) respectively"
 
     return _leq_quadrant(u, v)
 end

--- a/src/Interfaces/AbstractPolygon.jl
+++ b/src/Interfaces/AbstractPolygon.jl
@@ -140,6 +140,10 @@ directions using the right-hand rule (see [`is_right_turn`](@ref)).
 In particular, this method does not use the arctangent.
 """
 function <=(u::AbstractVector{N}, v::AbstractVector{N}) where {N<:Real}
+    @assert length(u) == length(v) == 2 "comparison of vectors by their direction " *
+           "requires that the vectors `u` and `v` are of length 2, but their lengths " *
+           "are $(length(u)) and $(length(v)) respectively"
+
     return _leq_quadrant(u, v)
 end
 

--- a/src/Interfaces/AbstractPolygon.jl
+++ b/src/Interfaces/AbstractPolygon.jl
@@ -148,33 +148,3 @@ function <=(u::AbstractVector{N}, v::AbstractVector{N}) where {N<:Real}
     # different quadrant
     return qu < qv
 end
-
-"""
-    <=(u::AbstractVector{N}, v::AbstractVector{N}) where {N<:AbstractFloat}
-
-Compares two 2D vectors by their direction.
-
-### Input
-
-- `u` --  first 2D direction
-- `v` --  second 2D direction
-
-### Output
-
-True iff ``\\arg(u) [2π] ≤ \\arg(v) [2π]``
-
-### Notes
-
-The argument is measured in counter-clockwise fashion, with the 0 being the
-direction (1, 0).
-
-### Algorithm
-
-The implementation uses the arctangent function with sign, `atan`, which for two
-arguments implements the
-[`atan2` function](https://en.wikipedia.org/wiki/Atan2).
-"""
-function <=(u::AbstractVector{N},
-            v::AbstractVector{N}) where {N<:AbstractFloat}
-    return jump2pi(atan(u[2], u[1])) <= jump2pi(atan(v[2], v[1]))
-end


### PR DESCRIPTION
The version of directions comparison using quadrants is both faster and more general than the version using `jump2pi`. For these reasons, we could remove the implementation altogether.

```julia
julia> p = rand(HPolygon);

julia> d = rand(2);

julia> @btime σ($d, $p); # master
  737.704 ns (12 allocations: 688 bytes)

julia> @btime σ($d, $p); # this branch
  632.355 ns (12 allocations: 688 bytes)
```