### PR TITLE
#1987 - VPolygon constructor from matrix columns

### DIFF
--- a/src/Sets/VPolygon.jl
+++ b/src/Sets/VPolygon.jl
@@ -36,18 +36,6 @@ vertices. For example, we can build the right triangle
 ```jldoctest polygon_vrep
 julia> P = VPolygon([[0, 0], [1, 0], [0, 1]])
 VPolygon{Int64,Array{Int64,1}}(Array{Int64,1}[[0, 0], [1, 0], [0, 1]])
-
-julia> eltype(P)
-Int64
-```
-The element type of the polygon can be changed by using a different vector type:
-
-```jldoctest polygon_vrep
-julia> P = VPolygon([[0, 0], [1, 0], [0, 1.]]) # mind the dot in [0, 1.]
-VPolygon{Float64,Array{Float64,1}}(Array{Float64,1}[[0.0, 0.0], [1.0, 0.0], [0.0, 1.0]])
-
-julia> eltype(P)
-Float64
 ```
 
 Alternatively, a `VPolygon` can be constructed passing a matrix of vertices,

--- a/src/Sets/VPolygon.jl
+++ b/src/Sets/VPolygon.jl
@@ -100,7 +100,7 @@ function VPolygon(vertices_matrix::MT; apply_convex_hull::Bool=true,
     @assert size(vertices_matrix, 1) == 2 "the number of rows of the matrix of vertices " *
                                            "should be 2, but it is $(size(vertices_matrix, 1))"
 
-    vertices = [vertices_matrix[:, i] for i in 1:size(vertices_matrix, 2)]
+    vertices = [vertices_matrix[:, j] for j in 1:size(vertices_matrix, 2)]
     return VPolygon(vertices; apply_convex_hull=apply_convex_hull, algorithm=algorithm)
 end
 

--- a/src/Sets/VPolygon.jl
+++ b/src/Sets/VPolygon.jl
@@ -59,8 +59,8 @@ julia> M = [0 1 0; 0 0 1.]
  0.0  1.0  0.0
  0.0  0.0  1.0
 
- julia> VPolygon(M)
- VPolygon{Float64,Array{Float64,1}}(Array{Float64,1}[[0.0, 0.0], [1.0, 0.0], [0.0, 1.0]])
+julia> VPolygon(M)
+VPolygon{Float64,Array{Float64,1}}(Array{Float64,1}[[0.0, 0.0], [1.0, 0.0], [0.0, 1.0]])
 ```
 """
 struct VPolygon{N<:Real, VN<:AbstractVector{N}} <: AbstractPolygon{N}

--- a/src/Sets/VPolygon.jl
+++ b/src/Sets/VPolygon.jl
@@ -40,7 +40,7 @@ VPolygon{Int64,Array{Int64,1}}(Array{Int64,1}[[0, 0], [1, 0], [0, 1]])
 julia> eltype(P)
 Int64
 ```
-The element type of the polygon canbe changed by using a different vector type:
+The element type of the polygon can be changed by using a different vector type:
 
 ```jldoctest polygon_vrep
 julia> P = VPolygon([[0, 0], [1, 0], [0, 1.]]) # mind the dot in [0, 1.]

--- a/test/unit_Polygon.jl
+++ b/test/unit_Polygon.jl
@@ -377,6 +377,11 @@ for N in [Float64, Float32, Rational{Int}]
 
     # empty VPolygon: conversion to hrep
     @test tohrep(VPolygon{N}()) isa EmptySet{N}
+
+    # test VPolygon constructor given the matrix of vertices
+    m = N[4 0; 6 2; 4 4]'
+    P = VPolygon(m)
+    @test is_cyclic_permutation(vertices_list(P), [N[4, 0], N[6, 2], N[4, 4]])
 end
 
 function same_constraints(v::Vector{<:LinearConstraint{N}})::Bool where N<:Real


### PR DESCRIPTION
Closes #1987.

Remains:

- [x] Add unit test.

---

One can now do:

```julia
julia> using Revise, LazySets, StaticArrays
[ Info: Recompiling stale cache file /home/mforets/.julia/compiled/v1.2/LazySets/NjrGc.ji for LazySets [b4f0291d-fe17-52bc-9479-3d1a343d9043]

julia> S = @SMatrix(rand(2, 5))
2×5 SArray{Tuple{2,5},Float64,2,10} with indices SOneTo(2)×SOneTo(5):
 0.102972  0.988928  0.607964  0.734651  0.684164
 0.58481   0.228841  0.959816  0.586697  0.976767

julia> VPolygon(S)
VPolygon{Float64,SArray{Tuple{2},Float64,1,2}}(SArray{Tuple{2},Float64,1,2}[[0.10297164611362897, 0.5848102125715933], [0.9889278626351026, 0.22884117625522804]
, [0.6841638744333696, 0.9767668061708363], [0.6079638683572919, 0.9598158901016935]])
```