### PR TITLE
#1940 - Overapproximate a lazy affine map with a hyperrectangle 

### DIFF
--- a/src/Approximations/overapproximate.jl
+++ b/src/Approximations/overapproximate.jl
@@ -1503,7 +1503,7 @@ and `v` the translation vector, a tight hyperrectangular overapproximation of
 `M * H + v` is obtained by transforming `c ↦ M*c+v` and `r ↦ abs.(M) * r`, where
 `abs.(⋅)` denotes the element-wise absolute value operator.
 """
-function overapproximate(am::AffineMap{N, <:AbstractHyperrectangle{N}},
+function overapproximate(am::AbstractAffineMap{N, <:AbstractHyperrectangle{N}},
                          ::Type{<:Hyperrectangle}) where {N<:Real}
     M, X, v = am.M, am.X, am.v
     center_MXv = M * center(X) + v

--- a/src/Approximations/overapproximate.jl
+++ b/src/Approximations/overapproximate.jl
@@ -1479,3 +1479,34 @@ function overapproximate(Z::Zonotope{N}, ::Type{<:Zonotope}, r::Union{Integer, R
     end
     return Zonotope(c, Gred)
 end
+
+"""
+    overapproximate(am::AffineMap{N, <:AbstractHyperrectangle{N}},
+                    ::Type{<:Hyperrectangle}) where {N}
+
+Overapproximate the affine map of a hyperrectangular set
+using a hyperrectangle.
+
+### Input
+
+- `S`              -- affine map of a hyperrectangular set
+- `Hyperrectangle` -- type for dispatch
+
+### Output
+
+A hyperrectangle.
+
+### Algorithm
+
+If `c` and `r` denote the center and vector radius of a hyperrectangle `H`
+and `v` the translation vector, a tight hyperrectangular overapproximation of
+`M * H + v` is obtained by transforming `c ↦ M*c+v` and `r ↦ abs.(M) * c`, where
+`abs.(⋅)` denotes the element-wise absolute value operator.
+"""
+function overapproximate(am::AffineMap{N, <:AbstractHyperrectangle{N}},
+                         ::Type{<:Hyperrectangle}) where {N<:Real}
+    M, X, v = am.M, am.X, am.v
+    center_MXv = M * center(X) + v
+    radius_MX = abs.(M) * radius_hyperrectangle(X)
+    return Hyperrectangle(center_MXv, radius_MX)
+end

--- a/src/Approximations/overapproximate.jl
+++ b/src/Approximations/overapproximate.jl
@@ -1489,7 +1489,7 @@ using a hyperrectangle.
 
 ### Input
 
-- `S`              -- affine map of a hyperrectangular set
+- `am`              -- affine map of a hyperrectangular set
 - `Hyperrectangle` -- type for dispatch
 
 ### Output

--- a/src/Approximations/overapproximate.jl
+++ b/src/Approximations/overapproximate.jl
@@ -1481,7 +1481,7 @@ function overapproximate(Z::Zonotope{N}, ::Type{<:Zonotope}, r::Union{Integer, R
 end
 
 """
-    overapproximate(am::AffineMap{N, <:AbstractHyperrectangle{N}},
+    overapproximate(am::AbstractAffineMap{N, <:AbstractHyperrectangle{N}},
                     ::Type{<:Hyperrectangle}) where {N}
 
 Overapproximate the affine map of a hyperrectangular set

--- a/src/Approximations/overapproximate.jl
+++ b/src/Approximations/overapproximate.jl
@@ -190,7 +190,7 @@ A hyperrectangle.
 
 If `c` and `r` denote the center and vector radius of a hyperrectangle `H`,
 a tight hyperrectangular overapproximation of `M * H` is obtained by transforming
-`c ↦ M*c` and `r ↦ abs.(M) * c`, where `abs.(⋅)` denotes the element-wise absolute
+`c ↦ M*c` and `r ↦ abs.(M) * r`, where `abs.(⋅)` denotes the element-wise absolute
 value operator.
 """
 function overapproximate(lm::LinearMap{N, <:AbstractHyperrectangle{N}},

--- a/src/Approximations/overapproximate.jl
+++ b/src/Approximations/overapproximate.jl
@@ -1505,7 +1505,7 @@ and `v` the translation vector, a tight hyperrectangular overapproximation of
 """
 function overapproximate(am::AbstractAffineMap{N, <:AbstractHyperrectangle{N}},
                          ::Type{<:Hyperrectangle}) where {N<:Real}
-    M, X, v = matrix(am), set(X), vector(am)
+    M, X, v = matrix(am), set(am), vector(am)
     center_MXv = M * center(X) + v
     radius_MX = abs.(M) * radius_hyperrectangle(X)
     return Hyperrectangle(center_MXv, radius_MX)

--- a/src/Approximations/overapproximate.jl
+++ b/src/Approximations/overapproximate.jl
@@ -1500,7 +1500,7 @@ A hyperrectangle.
 
 If `c` and `r` denote the center and vector radius of a hyperrectangle `H`
 and `v` the translation vector, a tight hyperrectangular overapproximation of
-`M * H + v` is obtained by transforming `c ↦ M*c+v` and `r ↦ abs.(M) * c`, where
+`M * H + v` is obtained by transforming `c ↦ M*c+v` and `r ↦ abs.(M) * r`, where
 `abs.(⋅)` denotes the element-wise absolute value operator.
 """
 function overapproximate(am::AffineMap{N, <:AbstractHyperrectangle{N}},

--- a/src/Approximations/overapproximate.jl
+++ b/src/Approximations/overapproximate.jl
@@ -1489,7 +1489,7 @@ using a hyperrectangle.
 
 ### Input
 
-- `am`              -- affine map of a hyperrectangular set
+- `am`             -- affine map of a hyperrectangular set
 - `Hyperrectangle` -- type for dispatch
 
 ### Output

--- a/src/Approximations/overapproximate.jl
+++ b/src/Approximations/overapproximate.jl
@@ -1505,7 +1505,7 @@ and `v` the translation vector, a tight hyperrectangular overapproximation of
 """
 function overapproximate(am::AbstractAffineMap{N, <:AbstractHyperrectangle{N}},
                          ::Type{<:Hyperrectangle}) where {N<:Real}
-    M, X, v = am.M, am.X, am.v
+    M, X, v = matrix(am), set(X), vector(am)
     center_MXv = M * center(X) + v
     radius_MX = abs.(M) * radius_hyperrectangle(X)
     return Hyperrectangle(center_MXv, radius_MX)

--- a/test/unit_overapproximate.jl
+++ b/test/unit_overapproximate.jl
@@ -115,6 +115,11 @@ for N in [Float64, Rational{Int}, Float32]
     # HPolytope error messages
     @test_throws ArgumentError overapproximate(Singleton(N[0, 0]), HPolytope)
     @test_throws ArgumentError overapproximate(Singleton(N[0]), HPolytope)
+
+    # Hyperrectangle of AffineMap
+    A = N[1 2; 1 3; 1 4]; X = Hyperrectangle(N[0, 1], N[0, 1]); b = N[1, 2, 3];
+    am = AffineMap(A, X, b)
+    @test overapproximate(am, Hyperrectangle) == Hyperrectangle(N[3, 5, 7], N[2, 3, 4])
 end
 
 # tests that do not work with Rational{Int}


### PR DESCRIPTION
Closes #1940.