### PR TITLE
#2087 - Updates to template directions

### DIFF
--- a/docs/src/lib/approximations.md
+++ b/docs/src/lib/approximations.md
@@ -71,6 +71,7 @@ constraint(::LocalApproximation)
 ```@docs
 AbstractDirections
 isbounding
+isnormalized
 BoxDirections
 OctDirections
 BoxDiagDirections

--- a/src/Approximations/Approximations.jl
+++ b/src/Approximations/Approximations.jl
@@ -7,7 +7,7 @@ support vectors.
 module Approximations
 
 using LazySets, LazySets.Arrays, Requires, LinearAlgebra, SparseArrays
-using LazySets: _rtol, _normal_Vector
+using LazySets: _isapprox, _rtol, _normal_Vector
 using ..Assertions: @assert, activate_assertions
 # activate assertions by default
 activate_assertions(Approximations)

--- a/src/Approximations/overapproximate.jl
+++ b/src/Approximations/overapproximate.jl
@@ -548,13 +548,13 @@ A polyhedron overapproximating the set `X` with the directions from `dir`.
 If the directions are known to be bounded, the result is an `HPolytope`,
 otherwise the result is an `HPolyhedron`.
 """
-function overapproximate(X::LazySet{N}, dir::AbstractDirections{N}) where {N}
-    halfspaces = Vector{LinearConstraint{N, Vector{N}}}() # TODO: use vector element type in `dir`
+function overapproximate(X::LazySet{N}, dir::AbstractDirections{N, VN}) where {N, VN}
+    halfspaces = Vector{LinearConstraint{N, VN}}()
     sizehint!(halfspaces, length(dir))
     T = isbounding(dir) ? HPolytope : HPolyhedron
     H = T(halfspaces)
     for d in dir
-        addconstraint!(H, _normal_Vector(LinearConstraint(d, ρ(d, X)))) # TODO: fix after #2051
+        addconstraint!(H, LinearConstraint(d, ρ(d, X)))
     end
     return H
 end

--- a/src/Approximations/template_directions.jl
+++ b/src/Approximations/template_directions.jl
@@ -251,7 +251,7 @@ By default, each direction is represented in this iterator as a sparse vector:
 julia> eltype(dirs)
 SparseArrays.SparseVector{Float64,Int64}
 ```
-In two dimensions, the directions defined by `BoxDiagDirections` are normal to
+In two dimensions, the directions defined by `OctDirections` are normal to
 the facets of an octagon.
 
 ```jldoctest dirs_Oct

--- a/src/Approximations/template_directions.jl
+++ b/src/Approximations/template_directions.jl
@@ -76,7 +76,9 @@ Returns whether the given template directions is normalized with respect to the
 
 `true` if the 2-norm of each element in `ad` is one and `false` otherwise.
 """
-function isnormalized(ad::AbstractDirections) end
+function isnormalized(ad::AbstractDirections)
+    return false
+end
 
 # ==================================================
 # Box directions

--- a/src/Approximations/template_directions.jl
+++ b/src/Approximations/template_directions.jl
@@ -240,7 +240,7 @@ two,
 
 ```jldoctest dirs_Oct
 julia> dirs = OctDirections(2)
-OctDirections{Float64,SparseVector{Float64,Int64}}(2)
+OctDirections{Float64,SparseArrays.SparseVector{Float64,Int64}}(2)
 
 julia> length(dirs) # number of directions
 8
@@ -249,14 +249,14 @@ By default, each direction is represented in this iterator as a sparse vector:
 
 ```jldoctest dirs_Oct
 julia> eltype(dirs)
-SparseVector{Float64,Int64}
+SparseArrays.SparseVector{Float64,Int64}
 ```
 In two dimensions, the directions defined by `BoxDiagDirections` are normal to
 the facets of an octagon.
 
 ```jldoctest dirs_Oct
 julia> first(dirs)
-2-element SparseVector{Float64,Int64} with 2 stored entries:
+2-element SparseArrays.SparseVector{Float64,Int64} with 2 stored entries:
   [1]  =  1.0
   [2]  =  1.0
 
@@ -276,7 +276,7 @@ The numeric type can be specified as well:
 
 ```jldoctest
 julia> OctDirections{Rational{Int}}(10)
-OctDirections{Rational{Int64},SparseVector{Rational{Int64},Int64}}(10)
+OctDirections{Rational{Int64},SparseArrays.SparseVector{Rational{Int64},Int64}}(10)
 
 julia> length(ans)
 200

--- a/src/Approximations/template_directions.jl
+++ b/src/Approximations/template_directions.jl
@@ -180,7 +180,7 @@ dim(bd::BoxDirections) = bd.n
 isbounding(::Type{<:BoxDirections}) = true
 isnormalized(::Type{<:BoxDirections}) = true
 
-# The idea is that a positive states run through vectors wtih +1 entry,
+# The idea is that positive states run through vectors with +1 entry,
 # and negative states run through -1 entries
 # (1, 0)   state = 1
 # (0, 1)   state = 2

--- a/src/Approximations/template_directions.jl
+++ b/src/Approximations/template_directions.jl
@@ -116,7 +116,7 @@ Box directions representation.
 Box directions can be seen as the vectors where only one entry is ±1, and all
 other entries are 0. In dimension ``n``, there are ``2n`` such directions.
 
-The deafault vector representation used in this template is a
+The default vector representation used in this template is a
 `LazySets.Arrays.SingleEntryVector`, although other implementations can be used
 such as a regular `Vector` and a sparse vector, `SparseVector`.`
 

--- a/src/Approximations/template_directions.jl
+++ b/src/Approximations/template_directions.jl
@@ -31,9 +31,7 @@ Returns the dimension of the generated directions.
 
 The dimension of the generated directions.
 """
-function dim(ad::AbstractDirections)
-    return ad.n
-end
+function dim(ad::AbstractDirections) end
 
 """
     isbounding(ad::AbstractDirections)
@@ -110,6 +108,9 @@ BoxDirections(n::Int) = BoxDirections{Float64, SingleEntryVector{Float64}}(n)
 
 Base.eltype(::Type{BoxDirections{N, VN}}) where {N, VN} = VN
 Base.length(bd::BoxDirections) = 2 * bd.n
+
+# interface functions
+dim(bd::BoxDirections) = bd.n
 isbounding(::BoxDirections) = true
 isnormalized(::BoxDirections) = true
 
@@ -173,6 +174,9 @@ OctDirections(n::Int) = OctDirections{Float64, SparseVector{Int, Int}}(n)
 
 Base.eltype(::Type{OctDirections{N, VN}}) where {N, VN} = VN
 Base.length(od::OctDirections) = 2 * od.n^2
+
+# interface function
+dim(od::OctDirections) = od.n
 isbounding(::OctDirections) = true
 
 function Base.iterate(od::OctDirections{N, SparseVector{Int, Int}}) where {N}
@@ -259,6 +263,9 @@ BoxDiagDirections(n::Int) = BoxDiagDirections{Float64, Vector{N}}(n)
 
 Base.eltype(::Type{BoxDiagDirections{N, VN}}) where {N, VN} = VN
 Base.length(bdd::BoxDiagDirections) = bdd.n == 1 ? 2 : 2^bdd.n + 2 * bdd.n
+
+# interface function
+dim(bdd::BoxDiagDirections) = bdd.n
 isbounding(::BoxDiagDirections) = true
 
 function Base.iterate(bdd::BoxDiagDirections{N, Vector{N}}) where {N}
@@ -357,7 +364,9 @@ end
 # common functions
 Base.eltype(::Type{PolarDirections{N, VN}}) where {N, VN} = VN
 Base.length(pd::PolarDirections) = length(pd.stack)
-dim(::PolarDirections) = 2
+
+# interface functions
+dim(pd::PolarDirections) = 2
 isbounding(pd::PolarDirections) = pd.Nφ > 2
 
 function Base.iterate(pd::PolarDirections{N, Vector{N}}, state::Int=1) where {N}
@@ -461,6 +470,8 @@ end
 # common functions
 Base.eltype(::Type{SphericalDirections{N, VN}}) where {N, VN} = VN
 Base.length(sd::SphericalDirections) = length(sd.stack)
+
+# interface functions
 dim(::SphericalDirections) = 3
 isbounding(sd::SphericalDirections) = sd.Nθ > 2 && sd.Nφ > 2
 
@@ -529,6 +540,9 @@ end
 
 Base.eltype(::Type{CustomDirections{N, VN}}) where {N, VN} = VN
 Base.length(cd::CustomDirections) = length(cd.directions)
+
+# interface functions
+dim(cd::CustomDirections) = cd.n
 isbounding(cd::CustomDirections) = cd.isbounding
 
 function Base.iterate(cd::CustomDirections{N}, state::Int=1) where {N}

--- a/src/Approximations/template_directions.jl
+++ b/src/Approximations/template_directions.jl
@@ -512,20 +512,21 @@ struct PolarDirections{N<:AbstractFloat, VN<:AbstractVector{N}} <: AbstractDirec
     stack::Vector{VN} # stores the polar directions
 end
 
-# convenience constructor for type Float64
+# convenience constructors
 PolarDirections(Nφ::Int) = PolarDirections{Float64, Vector{Float64}}(Nφ)
+PolarDirections{N}(Nφ::Int) where {N} = PolarDirections{N, Vector{N}}(Nφ)
 
-function PolarDirections{Float64, Vector{Float64}}(Nφ::Int)
+function PolarDirections{N, Vector{N}}(Nφ::Int) where {N}
     if Nφ <= 0
         throw(ArgumentError("Nφ = $Nφ is invalid; it shoud be at least 1"))
     end
-    stack = Vector{Vector{Float64}}(undef, Nφ)
-    φ = range(0.0, 2*pi, length=Nφ+1)  # discretization of the polar angle
+    stack = Vector{Vector{N}}(undef, Nφ)
+    φ = range(N(0), N(2*pi), length=Nφ+1)  # discretization of the polar angle
 
     @inbounds for i in 1:Nφ  # skip last (repeated) angle
-        stack[i] = [cos(φ[i]), sin(φ[i])]
+        stack[i] = N[cos(φ[i]), sin(φ[i])]
     end
-    return PolarDirections{Float64, Vector{Float64}}(Nφ, stack)
+    return PolarDirections{N, Vector{N}}(Nφ, stack)
 end
 
 Base.eltype(::Type{PolarDirections{N, VN}}) where {N, VN} = VN
@@ -533,7 +534,7 @@ Base.length(pd::PolarDirections) = pd.Nφ
 
 # interface functions
 dim(pd::PolarDirections) = 2
-isbounding(pd::Type{<:PolarDirections}) = pd.Nφ > 2
+isbounding(pd::PolarDirections) = pd.Nφ > 2
 isnormalized(::Type{<:PolarDirections}) = true
 
 function Base.iterate(pd::PolarDirections{N, Vector{N}}, state::Int=1) where {N}
@@ -614,28 +615,29 @@ end
 # convenience constructors
 SphericalDirections(Nθ::Int) = SphericalDirections(Nθ, Nθ)
 SphericalDirections(Nθ::Int, Nφ::Int) = SphericalDirections{Float64, Vector{Float64}}(Nθ::Int, Nφ::Int)
+SphericalDirections{N}(Nθ::Int, Nφ::Int) where {N} = SphericalDirections{N, Vector{N}}(Nθ::Int, Nφ::Int)
 
-function SphericalDirections{Float64, Vector{Float64}}(Nθ::Int, Nφ::Int)
+function SphericalDirections{N, Vector{N}}(Nθ::Int, Nφ::Int) where {N}
     if Nθ <= 1 || Nφ <= 1
         throw(ArgumentError("(Nθ, Nφ) = ($Nθ, $Nφ) is invalid; both shoud be at least 2"))
     end
-    stack = Vector{Vector{Float64}}()
-    θ = range(0.0, pi, length=Nθ)    # discretization of the azimuthal angle
-    φ = range(0.0, 2*pi, length=Nφ)  # discretization of the polar angle
+    stack = Vector{Vector{N}}()
+    θ = range(N(0), N(pi), length=Nθ)    # discretization of the azimuthal angle
+    φ = range(N(0), N(2*pi), length=Nφ)  # discretization of the polar angle
 
     # add north pole (θ = 0)
-    push!(stack, Float64[0, 0, 1])
+    push!(stack, N[0, 0, 1])
 
     # add south pole (θ = pi)
-    push!(stack, Float64[0, 0, -1])
+    push!(stack, N[0, 0, -1])
 
     for φᵢ in φ[1:Nφ-1]  # delete repeated angle
         for θⱼ in θ[2:Nθ-1] # delete north and south poles
-            d = [sin(θⱼ)*cos(φᵢ), sin(θⱼ)*sin(φᵢ), cos(θⱼ)]
+            d = N[sin(θⱼ)*cos(φᵢ), sin(θⱼ)*sin(φᵢ), cos(θⱼ)]
             push!(stack, d)
         end
     end
-    return SphericalDirections{Float64, Vector{Float64}}(Nθ, Nφ, stack)
+    return SphericalDirections{N, Vector{N}}(Nθ, Nφ, stack)
 end
 
 Base.eltype(::Type{SphericalDirections{N, VN}}) where {N, VN} = VN
@@ -643,7 +645,7 @@ Base.length(sd::SphericalDirections) = length(sd.stack)
 
 # interface functions
 dim(::SphericalDirections) = 3
-isbounding(sd::Type{<:SphericalDirections}) = sd.Nθ > 2 && sd.Nφ > 2
+isbounding(sd::SphericalDirections) = sd.Nθ > 2 && sd.Nφ > 2
 isnormalized(::Type{<:SphericalDirections}) = true
 
 function Base.iterate(sd::SphericalDirections, state::Int=1)

--- a/src/Approximations/template_directions.jl
+++ b/src/Approximations/template_directions.jl
@@ -501,7 +501,7 @@ The integer passed as an argument is used to discretize ``φ``:
 
 ```jldoctest; filter = r"2246[0-9]*e-16"
 julia> pd = PolarDirections(2)
-PolarDirections{Float64,Array{Float64,1}}(2, [[1.0, 0.0], [-1.0, 1.2246467991473532e-16]])
+PolarDirections{Float64,Array{Float64,1}}(2, Array{Float64,1}[[1.0, 0.0], [-1.0, 1.2246467991473532e-16]])
 
 julia> length(pd)
 2
@@ -582,8 +582,7 @@ A `SphericalDirections` template can be built in different ways. If you pass
 only one integer, the same value is used to discretize both ``θ`` and ``φ``:
 
 ```jldoctest spherical_directions; filter = r"1232[0-9]*e-17.*2246[0-9]*e-16.*1232[0-9]*e-17"
-julia> sd = SphericalDirections(3)
-SphericalDirections{Float64,Array{Float64,1}}(3, 3, [[0.0, 0.0, 1.0], [0.0, 0.0, -1.0], [1.0, 0.0, 6.123233995736766e-17], [-1.0, 1.2246467991473532e-16, 6.123233995736766e-17]])
+julia> sd = SphericalDirections(3);
 
 julia> sd.Nθ, sd.Nφ
 (3, 3)
@@ -687,7 +686,7 @@ Creating a template with box directions in dimension two:
 
 ```jldoctest
 julia> dirs = CustomDirections([[1.0, 0.0], [-1.0, 0.0], [0.0, 1.0], [0.0, -1.0]])
-CustomDirections{Float64,Array{Float64,1}}([[1.0, 0.0], [-1.0, 0.0], [0.0, 1.0], [0.0, -1.0]], 2, true, true)
+CustomDirections{Float64,Array{Float64,1}}(Array{Float64,1}[[1.0, 0.0], [-1.0, 0.0], [0.0, 1.0], [0.0, -1.0]], 2, true, true)
 
 julia> LazySets.Approximations.isbounding(dirs)
 true

--- a/src/Approximations/template_directions.jl
+++ b/src/Approximations/template_directions.jl
@@ -118,7 +118,7 @@ other entries are 0. In dimension ``n``, there are ``2n`` such directions.
 
 The default vector representation used in this template is a
 `LazySets.Arrays.SingleEntryVector`, although other implementations can be used
-such as a regular `Vector` and a sparse vector, `SparseVector`.`
+such as a regular `Vector` and a sparse vector, `SparseVector`.
 
 ### Examples
 

--- a/src/Approximations/template_directions.jl
+++ b/src/Approximations/template_directions.jl
@@ -181,7 +181,7 @@ isbounding(::Type{<:BoxDirections}) = true
 isnormalized(::Type{<:BoxDirections}) = true
 
 # The idea is that positive states run through vectors with +1 entry,
-# and negative states run through -1 entries
+# and negative states run through vectors with -1 entry
 # (1, 0)   state = 1
 # (0, 1)   state = 2
 # (0, -1)  state = -2

--- a/src/Approximations/template_directions.jl
+++ b/src/Approximations/template_directions.jl
@@ -76,6 +76,8 @@ function isbounding(ad::Type{<:AbstractDirections})
     return false
 end
 
+isbounding(::AD) where {AD<:AbstractDirections} = isbounding(AD)
+
 """
     isnormalized(ad::Type{<:AbstractDirections})
 
@@ -94,6 +96,8 @@ function isnormalized(ad::Type{<:AbstractDirections})
     return false
 end
 
+isnormalized(::AD) where {AD<:AbstractDirections} = isnormalized(AD)
+
 # ==================================================
 # Box directions
 # ==================================================
@@ -101,7 +105,7 @@ end
 """
     BoxDirections{N, VN} <: AbstractDirections{N, VN}
 
-Box direction representation.
+Box directions representation.
 
 ### Fields
 
@@ -118,7 +122,45 @@ such as a regular `Vector` and a sparse vector, `SparseVector`.`
 
 ### Examples
 
+The template can be constructed by passing the dimension. For example, in dimension
+two,
 
+```jldoctest dirs_Box
+julia> dirs = BoxDirections(2)
+BoxDirections{Float64,LazySets.Arrays.SingleEntryVector{Float64}}(2)
+
+julia> length(dirs)
+4
+```
+
+By default, each direction is represented in this iterator as a `SingleEntryVector`,
+i.e. a vector with only one non-zero element,
+
+```jldoctest dirs_Box
+julia> eltype(dirs)
+LazySets.Arrays.SingleEntryVector{Float64}
+```
+In two dimensions, the directions defined by `BoxDirections` are normal to the
+facets of a box.
+
+```jldoctest dirs_Box
+julia> collect(dirs)
+4-element Array{LazySets.Arrays.SingleEntryVector{Float64},1}:
+ [1.0, 0.0]
+ [0.0, 1.0]
+ [0.0, -1.0]
+ [-1.0, 0.0]
+```
+
+The numeric type can be specified as well:
+
+```jldoctest
+julia> BoxDirections{Rational{Int}}(10)
+BoxDirections{Rational{Int64},LazySets.Arrays.SingleEntryVector{Rational{Int64}}}(10)
+
+julia> length(ans)
+20
+```
 """
 struct BoxDirections{N, VN<:AbstractVector{N}} <: AbstractDirections{N, VN}
     n::Int
@@ -135,8 +177,8 @@ Base.length(bd::BoxDirections) = 2 * bd.n
 
 # interface functions
 dim(bd::BoxDirections) = bd.n
-isbounding(::Type{BoxDirections}) = true
-isnormalized(::Type{BoxDirections}) = true
+isbounding(::Type{<:BoxDirections}) = true
+isnormalized(::Type{<:BoxDirections}) = true
 
 # The idea is that a positive states run through vectors wtih +1 entry,
 # and negative states run through -1 entries
@@ -163,11 +205,11 @@ function Base.iterate(bd::BoxDirections{N, Vector{N}}, state::Int=1) where {N}
     return (vec, state)
 end
 
-function Base.iterate(bd::BoxDirections{N, SparseVector{Int, Int}}, state::Int=1) where {N}
+function Base.iterate(bd::BoxDirections{N, SparseVector{N, Int}}, state::Int=1) where {N}
     if state == 0
         return nothing
     end
-    vec = sparsevec(convert(N, sign(state)), [abs(state)], bd.n)
+    vec = sparsevec([abs(state)], convert(N, sign(state)), bd.n)
     state = (state == bd.n) ? -bd.n : state + 1
     return (vec, state)
 end
@@ -179,7 +221,7 @@ end
 """
     OctDirections{N, VN} <: AbstractDirections{N, VN}
 
-Octagon direction representation.
+Octagon directions representation.
 
 ### Fields
 
@@ -188,23 +230,77 @@ Octagon direction representation.
 ### Notes
 
 Octagon directions consist of all vectors that are zero almost everywhere except
-in two dimensions ``i``, ``j`` (possibly ``i = j``) where it is ``±1``.
+in two dimensions ``i``, ``j`` (possibly ``i = j``) where it is ``±1``. In dimension
+``n``, there are ``2n^2`` such directions.
+
+## Examples
+
+The template can be constructed by passing the dimension. For example, in dimension
+two,
+
+```jldoctest dirs_Oct
+julia> dirs = OctDirections(2)
+OctDirections{Float64,SparseVector{Float64,Int64}}(2)
+
+julia> length(dirs) # number of directions
+8
+```
+By default, each direction is represented in this iterator as a sparse vector:
+
+```jldoctest dirs_Oct
+julia> eltype(dirs)
+SparseVector{Float64,Int64}
+```
+In two dimensions, the directions defined by `BoxDiagDirections` are normal to
+the facets of an octagon.
+
+```jldoctest dirs_Oct
+julia> first(dirs)
+2-element SparseVector{Float64,Int64} with 2 stored entries:
+  [1]  =  1.0
+  [2]  =  1.0
+
+julia> Vector.(collect(dirs))
+8-element Array{Array{Float64,1},1}:
+ [1.0, 1.0]
+ [1.0, -1.0]
+ [-1.0, 1.0]
+ [-1.0, -1.0]
+ [1.0, 0.0]
+ [0.0, 1.0]
+ [0.0, -1.0]
+ [-1.0, 0.0]
+```
+
+The numeric type can be specified as well:
+
+```jldoctest
+julia> OctDirections{Rational{Int}}(10)
+OctDirections{Rational{Int64},SparseVector{Rational{Int64},Int64}}(10)
+
+julia> length(ans)
+200
+```
 """
 struct OctDirections{N, VN} <: AbstractDirections{N, VN}
     n::Int
 end
 
 # constructor for type Float64
-OctDirections(n::Int) = OctDirections{Float64, SparseVector{Int, Int}}(n)
+OctDirections(n::Int) = OctDirections{Float64, SparseVector{Float64, Int}}(n)
+
+# constructor where only N is specified
+OctDirections{N}(n::Int) where {N} = OctDirections{N, SparseVector{N, Int}}(n)
 
 Base.eltype(::Type{OctDirections{N, VN}}) where {N, VN} = VN
 Base.length(od::OctDirections) = 2 * od.n^2
 
-# interface function
+# interface functions
 dim(od::OctDirections) = od.n
-isbounding(::OctDirections) = true
+isbounding(::Type{<:OctDirections}) = true
+isnormalized(::Type{<:OctDirections}) = false
 
-function Base.iterate(od::OctDirections{N, SparseVector{Int, Int}}) where {N}
+function Base.iterate(od::OctDirections{N, SparseVector{N, Int}}) where {N}
     if od.n == 1
         # fall back to box directions in 1D case
         return iterate(od, 1)
@@ -221,7 +317,7 @@ end
 # - i = i + 1, j = i + 1
 # - for any pair (i, j) create four vectors [..., i: ±1, ..., j: ±1, ...]
 # in the end continue with box directions
-function Base.iterate(od::OctDirections{N, SparseVector{Int, Int}}, state::Tuple) where {N}
+function Base.iterate(od::OctDirections{N, SparseVector{N, Int}}, state::Tuple) where {N}
     # continue with octagon directions
     vec = state[1]
     i = state[2]
@@ -254,9 +350,9 @@ function Base.iterate(od::OctDirections{N, SparseVector{Int, Int}}, state::Tuple
     return (copy(vec), (vec, i, j))
 end
 
-function Base.iterate(od::OctDirections{N, SparseVector{Int, Int}}, state::Int) where {N}
+function Base.iterate(od::OctDirections{N, SparseVector{N, Int}}, state::Int) where {N}
     # continue with box directions
-    return iterate(BoxDirections{N, SparseVector{Int, Int}}(od.n), state)
+    return iterate(BoxDirections{N, SparseVector{N, Int}}(od.n), state)
 end
 
 # ==================================================
@@ -266,7 +362,7 @@ end
 """
     BoxDiagDirections{N, VN} <: AbstractDirections{N, VN}
 
-Box-diagonal direction representation.
+Box-diagonal directions representation.
 
 ### Fields
 
@@ -291,7 +387,7 @@ BoxDiagDirections{Float64,Array{Float64,1}}(2)
 julia> length(dirs) # number of directions
 8
 ```
-Each direction is represented in this iterator as a regular vector:
+By default, each direction is represented in this iterator as a regular vector:
 
 ```jldoctest dirs_BoxDiag
 julia> eltype(dirs)
@@ -317,7 +413,7 @@ The numeric type can be specified as well:
 
 ```jldoctest
 julia> BoxDiagDirections{Rational{Int}}(10)
-BoxDiagDirections{Rational{Int64},Array{Rational{Int64},1}}(100)
+BoxDiagDirections{Rational{Int64},Array{Rational{Int64},1}}(10)
 
 julia> length(ans)
 1044
@@ -338,8 +434,8 @@ Base.length(bdd::BoxDiagDirections) = bdd.n == 1 ? 2 : 2^bdd.n + 2 * bdd.n
 
 # interface function
 dim(bdd::BoxDiagDirections) = bdd.n
-isbounding(::BoxDiagDirections) = true
-isnormalized(::BoxDiagDirections) = true
+isbounding(::Type{<:BoxDiagDirections}) = true
+isnormalized(::Type{<:BoxDiagDirections}) = false
 
 function Base.iterate(bdd::BoxDiagDirections{N, Vector{N}}) where {N}
     return (ones(N, bdd.n), ones(N, bdd.n))
@@ -382,16 +478,18 @@ Polar directions representation.
 
 ### Fields
 
-- `Nφ`    -- length of the partition of the polar angle
+- `Nφ` -- length of the partition of the polar angle
 
 ### Notes
 
 The `PolarDirections` constructor provides a sample of the unit sphere
-in ``\\mathbb{R}^2``, which is parameterized by the polar angles
-``φ ∈ Dφ := [0, 2π]`` respectively; see the wikipedia entry
-[Polar coordinate system](https://en.wikipedia.org/wiki/Polar_coordinate_system).
-The domain ``Dφ`` is discretized in ``Nφ`` pieces.
-Then the Cartesian components of each direction are obtained with
+in ``\\mathbb{R}^2``, which is parameterized by the polar angle
+``φ ∈ Dφ := [0, 2π]``; see the wikipedia entry
+[Polar coordinate system](https://en.wikipedia.org/wiki/Polar_coordinate_system)
+for details.
+
+The integer argument ``Nφ`` defines how many samples of ``Dφ`` are taken. The
+Cartesian components of each direction are obtained with
 
 ```math
 [cos(φᵢ), sin(φᵢ)].
@@ -402,12 +500,10 @@ Then the Cartesian components of each direction are obtained with
 The integer passed as an argument is used to discretize ``φ``:
 
 ```jldoctest; filter = r"2246[0-9]*e-16"
-julia> using LazySets.Approximations: PolarDirections
-
 julia> pd = PolarDirections(2)
-PolarDirections{Float64}(2, Array{Float64,1}[[1.0, 0.0], [-1.0, 1.22465e-16]])
+PolarDirections{Float64,Array{Float64,1}}(2, [[1.0, 0.0], [-1.0, 1.2246467991473532e-16]])
 
-julia> pd.Nφ
+julia> length(pd)
 2
 ```
 """
@@ -416,34 +512,32 @@ struct PolarDirections{N<:AbstractFloat, VN<:AbstractVector{N}} <: AbstractDirec
     stack::Vector{VN} # stores the polar directions
 end
 
-# convenience constructor
-PolarDirections(Nφ::Int) = PolarDirections{Float64}(Nφ)
+# convenience constructor for type Float64
+PolarDirections(Nφ::Int) = PolarDirections{Float64, Vector{Float64}}(Nφ)
 
-function PolarDirections{Float64}(Nφ::Int)
+function PolarDirections{Float64, Vector{Float64}}(Nφ::Int)
     if Nφ <= 0
         throw(ArgumentError("Nφ = $Nφ is invalid; it shoud be at least 1"))
     end
-    stack = Vector{Vector{Float64}}()
-    # discretization of the polar angle
-    φ = range(0.0, 2*pi, length=Nφ+1)
+    stack = Vector{Vector{Float64}}(undef, Nφ)
+    φ = range(0.0, 2*pi, length=Nφ+1)  # discretization of the polar angle
 
-    for φᵢ in φ[1:Nφ]  # skip last (repeated) angle
-        d = [cos(φᵢ), sin(φᵢ)]
-        push!(stack, d)
+    @inbounds for i in 1:Nφ  # skip last (repeated) angle
+        stack[i] = [cos(φ[i]), sin(φ[i])]
     end
     return PolarDirections{Float64, Vector{Float64}}(Nφ, stack)
 end
 
-# common functions
 Base.eltype(::Type{PolarDirections{N, VN}}) where {N, VN} = VN
-Base.length(pd::PolarDirections) = length(pd.stack)
+Base.length(pd::PolarDirections) = pd.Nφ
 
 # interface functions
 dim(pd::PolarDirections) = 2
-isbounding(pd::PolarDirections) = pd.Nφ > 2
+isbounding(pd::Type{<:PolarDirections}) = pd.Nφ > 2
+isnormalized(::Type{<:PolarDirections}) = true
 
 function Base.iterate(pd::PolarDirections{N, Vector{N}}, state::Int=1) where {N}
-    state == length(pd.stack)+1 && return nothing
+    state == pd.Nφ + 1 && return nothing
     return (pd.stack[state], state + 1)
 end
 
@@ -467,9 +561,12 @@ Spherical directions representation.
 The `SphericalDirections` constructor provides a sample of the unit sphere
 in ``\\mathbb{R}^3``, which is parameterized by the azimuthal and polar angles
 ``θ ∈ Dθ := [0, π]`` and ``φ ∈ Dφ := [0, 2π]`` respectively, see the wikipedia
-entry [Spherical coordinate system](https://en.wikipedia.org/wiki/Spherical_coordinate_system).
-The domains ``Dθ`` and ``Dφ`` are discretized in ``Nθ`` and ``Nφ`` respectively.
-Then the Cartesian components of each direction are obtained with
+entry [Spherical coordinate system](https://en.wikipedia.org/wiki/Spherical_coordinate_system)
+for details.
+
+The integer arguments ``Nθ`` and ``Nφ`` define how many samples along the domains
+``Dθ`` and ``Dφ`` respectively are taken. The Cartesian components of each direction
+are obtained with
 
 ```math
 [sin(θᵢ)*cos(φᵢ), sin(θᵢ)*sin(φᵢ), cos(θᵢ)].
@@ -480,30 +577,31 @@ are not considered more than once.
 
 ### Examples
 
-A `SphericalDirections` can be built in different ways. If you pass only one integer,
-it is used to discretize both ``θ`` and ``φ``:
+A `SphericalDirections` template can be built in different ways. If you pass
+only one integer, the same value is used to discretize both ``θ`` and ``φ``:
 
 ```jldoctest spherical_directions; filter = r"1232[0-9]*e-17.*2246[0-9]*e-16.*1232[0-9]*e-17"
-julia> using LazySets.Approximations: SphericalDirections
-
 julia> sd = SphericalDirections(3)
-SphericalDirections{Float64}(3, 3, Array{Float64,1}[[0.0, 0.0, 1.0], [0.0, 0.0, -1.0], [1.0, 0.0, 6.12323e-17], [-1.0, 1.22465e-16, 6.12323e-17]])
+SphericalDirections{Float64,Array{Float64,1}}(3, 3, [[0.0, 0.0, 1.0], [0.0, 0.0, -1.0], [1.0, 0.0, 6.123233995736766e-17], [-1.0, 1.2246467991473532e-16, 6.123233995736766e-17]])
 
 julia> sd.Nθ, sd.Nφ
 (3, 3)
+
+julia> length(sd)
+4
 ```
 
 Pass two integers to control the discretization in ``θ`` and in ``φ`` separately:
 
 ```jldoctest spherical_directions
-julia> sd_4_5 = SphericalDirections(4, 5);
+julia> sd = SphericalDirections(4, 5);
 
-julia> length(sd_4_5)
+julia> length(sd)
 10
 
-julia> sd_4_8 = SphericalDirections(4, 8);
+julia> sd = SphericalDirections(4, 8);
 
-julia> length(sd_4_8)
+julia> length(sd)
 16
 ```
 """
@@ -540,16 +638,16 @@ function SphericalDirections{Float64, Vector{Float64}}(Nθ::Int, Nφ::Int)
     return SphericalDirections{Float64, Vector{Float64}}(Nθ, Nφ, stack)
 end
 
-# common functions
 Base.eltype(::Type{SphericalDirections{N, VN}}) where {N, VN} = VN
 Base.length(sd::SphericalDirections) = length(sd.stack)
 
 # interface functions
 dim(::SphericalDirections) = 3
-isbounding(sd::SphericalDirections) = sd.Nθ > 2 && sd.Nφ > 2
+isbounding(sd::Type{<:SphericalDirections}) = sd.Nθ > 2 && sd.Nφ > 2
+isnormalized(::Type{<:SphericalDirections}) = true
 
 function Base.iterate(sd::SphericalDirections, state::Int=1)
-    state == length(sd.stack)+1 && return nothing
+    state == length(sd.stack) + 1 && return nothing
     return (sd.stack[state], state + 1)
 end
 
@@ -570,34 +668,49 @@ User-defined template directions.
 
 ### Notes
 
-Since custom directions may not be bounded, boundedness can either be asserted
-in the constructor or it will be determined automatically by performing an
-experiment (more precisely, we overapproximate the unit ball in the infinity
-norm using the given directions).
+This struct is a wrapper type for a set of user-defined directions which are
+iterated over. It has fields for the list of directions, the set dimension,
+and (boolean) cache fields for the boundedness and normalization properties.
+The latter are checked by default upon construction.
+
+To check boundedness, we overapproximate the unit ball in the infinity
+norm using the given directions and check if the resulting set is bounded.
 
 The dimension will also be determined automatically, unless the empty vector is
 passed (in which case the optional argument `n` needs to be specified).
+
+## Examples
+
+Creating a template with box directions in dimension two:
+
+```jldoctest
+julia> dirs = CustomDirections([[1.0, 0.0], [-1.0, 0.0], [0.0, 1.0], [0.0, -1.0]])
+CustomDirections{Float64,Array{Float64,1}}([[1.0, 0.0], [-1.0, 0.0], [0.0, 1.0], [0.0, -1.0]], 2, true, true)
+
+julia> LazySets.Approximations.isbounding(dirs)
+true
+
+julia> LazySets.Approximations.isnormalized(dirs)
+true
+```
 """
 struct CustomDirections{N, VN<:AbstractVector{N}} <: AbstractDirections{N, VN}
     directions::Vector{VN}
     n::Int
-    isbounding::Bool
-
-    function CustomDirections{N, VN}(directions::Vector{VN};
-                                     n::Int=determine_dimension(directions),
-                                     isbounding::Bool=_isbounding(directions)) where {N, VN<:AbstractVector{N}}
-        return new{N, VN}(directions, n, isbounding)
-    end
+    bounded::Bool
+    normalized::Bool
 end
 
-# convenience constructor
-CustomDirections(directions::Vector{VN};
-                 n::Int=determine_dimension(directions),
-                 isbounding::Bool=_isbounding(directions)
-                ) where {N, VN<:AbstractVector{N}} =
-    CustomDirections{N, VN}(directions; n=n, isbounding=isbounding)
+function CustomDirections(directions::Vector{VN},
+                          n::Int=_determine_dimension(directions);
+                          check_boundedness::Bool=true,
+                          check_normalization::Bool=true) where {N, VN<:AbstractVector{N}}
+    bounded = check_boundedness ? _isbounding(directions) : false
+    normalized = check_normalization ? _isnormalized(directions) : false
+    return CustomDirections(directions, n, bounded, normalized)
+end
 
-function determine_dimension(directions)
+function _determine_dimension(directions)
     isempty(directions) && throw(ArgumentError("empty template directions " *
                                                "need a specified dimension"))
     return length(directions[1])
@@ -611,12 +724,19 @@ function _isbounding(directions::Vector{VN}) where {N, VN<:AbstractVector{N}}
     return isbounded(P)
 end
 
+function _isnormalized(directions::Vector{VN}) where {N, VN<:AbstractVector{N}}
+    return all(x -> _isapprox(x, one(N)), norm.(directions, 2))
+end
+
 Base.eltype(::Type{CustomDirections{N, VN}}) where {N, VN} = VN
 Base.length(cd::CustomDirections) = length(cd.directions)
 
 # interface functions
 dim(cd::CustomDirections) = cd.n
-isbounding(cd::CustomDirections) = cd.isbounding
+isbounding(cd::Type{<:CustomDirections}) = false # it is not a property of the type
+isbounding(cd::CustomDirections) = cd.bounded
+isnormalized(cd::Type{<:CustomDirections}) = false # it is not a property of the type
+isnormalized(cd::CustomDirections) = cd.normalized
 
 function Base.iterate(cd::CustomDirections{N}, state::Int=1) where {N}
     if state > length(cd.directions)

--- a/src/Approximations/template_directions.jl
+++ b/src/Approximations/template_directions.jl
@@ -8,13 +8,27 @@ Abstract type for template direction representations.
 
 ### Notes
 
-All subtypes should implement the standard iterator methods from `Base` and the
-function `dim(d<:AbstractDirections)`.
-
 This type is parameterzed by `N` and `VN`, where:
 
 - `N` stands for the numeric type
 - `VN` stands for the vector type with coefficients of type `N`
+
+Each subtype is an iterator over a set of prescribed directions.
+
+All subtypes should implement the standard iterator methods from `Base`, namely
+`Base.length` (returns the number of directions in the template), and `Base.iterate`.
+Moreover, the following methods should be implemented:
+
+- `dim`    -- return the ambient dimension of the template
+- `eltype` -- return the type of each vector in the template
+
+Optionally, subtypes may implement:
+
+- `isbounding`   -- (defaults to `false`) return `true` if an overapproximation with
+                    a list of template directions results in a bounded set, given a
+                    bounded input set, and `false` otherwise
+- `isnormalized` -- (defaults to `false`) returns `true` if each direction in the
+                    given template has norm one w.r.t. the usual vector 2-norm
 """
 abstract type AbstractDirections{N, VN} end
 
@@ -34,7 +48,7 @@ The dimension of the generated directions.
 function dim(ad::AbstractDirections) end
 
 """
-    isbounding(ad::AbstractDirections)
+    isbounding(ad::Type{<:AbstractDirections})
 
 Checks if an overapproximation with a list of template directions results in a
 bounded set, given a bounded input set.
@@ -58,12 +72,12 @@ By default, this function returns `false` in order to be conservative.
 Custom subtypes of `AbstractDirections` should hence add a method for this
 function.
 """
-function isbounding(ad::AbstractDirections)
+function isbounding(ad::Type{<:AbstractDirections})
     return false
 end
 
 """
-    isnormalized(ad::AbstractDirections)
+    isnormalized(ad::Type{<:AbstractDirections})
 
 Returns whether the given template directions is normalized with respect to the
 2-norm.
@@ -76,7 +90,7 @@ Returns whether the given template directions is normalized with respect to the
 
 `true` if the 2-norm of each element in `ad` is one and `false` otherwise.
 """
-function isnormalized(ad::AbstractDirections)
+function isnormalized(ad::Type{<:AbstractDirections})
     return false
 end
 
@@ -95,7 +109,12 @@ Box direction representation.
 
 ### Notes
 
-The set representation used in this template is a `LazySets.Arrays.SingleEntryVector`.
+Box directions can be seen as the vectors where only one entry is ±1, and all
+other entries are 0. In dimension ``n``, there are ``2n`` such directions.
+
+The deafault vector representation used in this template is a
+`LazySets.Arrays.SingleEntryVector`, although other implementations can be used
+such as a regular `Vector` and a sparse vector, `SparseVector`.`
 
 ### Examples
 
@@ -108,23 +127,27 @@ end
 # convenience constructor for type Float64
 BoxDirections(n::Int) = BoxDirections{Float64, SingleEntryVector{Float64}}(n)
 
+# constructor where only N is specified
+BoxDirections{N}(n::Int) where {N} = BoxDirections{N, SingleEntryVector{N}}(n)
+
 Base.eltype(::Type{BoxDirections{N, VN}}) where {N, VN} = VN
 Base.length(bd::BoxDirections) = 2 * bd.n
 
 # interface functions
 dim(bd::BoxDirections) = bd.n
-isbounding(::BoxDirections) = true
-isnormalized(::BoxDirections) = true
+isbounding(::Type{BoxDirections}) = true
+isnormalized(::Type{BoxDirections}) = true
 
+# The idea is that a positive states run through vectors wtih +1 entry,
+# and negative states run through -1 entries
+# (1, 0)   state = 1
+# (0, 1)   state = 2
+# (0, -1)  state = -2
+# (-1, 0)  state = -1
 function Base.iterate(bd::BoxDirections{N, SingleEntryVector{N}}, state::Int=1) where {N}
     if state == 0
         return nothing
     end
-    # note that:
-    # (1, 0)   state = 1
-    # (0, 1)   state = 2
-    # (0, -1)  state = -2
-    # (-1, 0)  state = -1
     vec = SingleEntryVector(abs(state), bd.n, convert(N, sign(state)))
     state = (state == bd.n) ? -bd.n : state + 1
     return (vec, state)
@@ -254,14 +277,61 @@ Box-diagonal direction representation.
 Box-diagonal directions can be seen as the union of diagonal directions (all
 entries are ±1) and box directions (one entry is ±1, all other entries are 0).
 The iterator first enumerates all diagonal directions, and then all box
-directions.
+directions. In dimension ``n``, there are in total ``2^n + 2n`` such directions.
+
+## Examples
+
+The template can be constructed by passing the dimension. For example, in dimension
+two,
+
+```jldoctest dirs_BoxDiag
+julia> dirs = BoxDiagDirections(2)
+BoxDiagDirections{Float64,Array{Float64,1}}(2)
+
+julia> length(dirs) # number of directions
+8
+```
+Each direction is represented in this iterator as a regular vector:
+
+```jldoctest dirs_BoxDiag
+julia> eltype(dirs)
+Array{Float64,1}
+```
+In two dimensions, the directions defined by `BoxDiagDirections` are normal to
+the facets of an octagon.
+
+```jldoctest dirs_BoxDiag
+julia> collect(dirs)
+8-element Array{Array{Float64,1},1}:
+ [1.0, 1.0]
+ [-1.0, 1.0]
+ [1.0, -1.0]
+ [-1.0, -1.0]
+ [1.0, 0.0]
+ [0.0, 1.0]
+ [0.0, -1.0]
+ [-1.0, 0.0]
+```
+
+The numeric type can be specified as well:
+
+```jldoctest
+julia> BoxDiagDirections{Rational{Int}}(10)
+BoxDiagDirections{Rational{Int64},Array{Rational{Int64},1}}(100)
+
+julia> length(ans)
+1044
+```
 """
 struct BoxDiagDirections{N, VN} <: AbstractDirections{N, VN}
     n::Int
 end
 
 # constructor for type Float64
-BoxDiagDirections(n::Int) = BoxDiagDirections{Float64, Vector{N}}(n)
+BoxDiagDirections(n::Int) = BoxDiagDirections{Float64, Vector{Float64}}(n)
+
+# constructor where only N is specified
+BoxDiagDirections{N}(n::Int) where {N} = BoxDiagDirections{N, Vector{N}}(n)
 
 Base.eltype(::Type{BoxDiagDirections{N, VN}}) where {N, VN} = VN
 Base.length(bdd::BoxDiagDirections) = bdd.n == 1 ? 2 : 2^bdd.n + 2 * bdd.n
@@ -269,6 +339,7 @@ Base.length(bdd::BoxDiagDirections) = bdd.n == 1 ? 2 : 2^bdd.n + 2 * bdd.n
 # interface function
 dim(bdd::BoxDiagDirections) = bdd.n
 isbounding(::BoxDiagDirections) = true
+isnormalized(::BoxDiagDirections) = true
 
 function Base.iterate(bdd::BoxDiagDirections{N, Vector{N}}) where {N}
     return (ones(N, bdd.n), ones(N, bdd.n))

--- a/src/Approximations/template_directions.jl
+++ b/src/Approximations/template_directions.jl
@@ -233,7 +233,7 @@ Octagon directions consist of all vectors that are zero almost everywhere except
 in two dimensions ``i``, ``j`` (possibly ``i = j``) where it is ``±1``. In dimension
 ``n``, there are ``2n^2`` such directions.
 
-## Examples
+### Examples
 
 The template can be constructed by passing the dimension. For example, in dimension
 two,

--- a/test/unit_Zonotope.jl
+++ b/test/unit_Zonotope.jl
@@ -200,7 +200,7 @@ for N in [Float64]
     # 2D
     Z = Zonotope(N[0, 0], Matrix{N}(I, 2, 2))
     P = HPolytope(constraints_list(Z))
-    for d in LazySets.Approximations.BoxDiagDirections{N}(2)
+    for d in BoxDiagDirections{N}(2)
         @test ρ(d, P) == ρ(d, Z)
     end
     # sparse matrix (#1468)

--- a/test/unit_template_directions.jl
+++ b/test/unit_template_directions.jl
@@ -92,7 +92,7 @@ for N in [Float64]
 
         # custom directions
         # empty list of directions
-        dir = CustomDirections(Vector{N}[]; n=n)
+        dir = CustomDirections(Vector{N}[], n)
         @test dim(dir) == n
         P = overapproximate(X, dir)
         @test isempty(constraints_list(P))


### PR DESCRIPTION
Closes #2087.
Closes #2051.

This change is breaking.

---

Remains:

- [x] fix doctests
- [x] fix tests
- [x] fix/add some examples in the template directions docstrings