### PR TITLE
Add explicit conversion in generic vertices list of hyperrectangular set 

### DIFF
--- a/src/Interfaces/AbstractHyperrectangle.jl
+++ b/src/Interfaces/AbstractHyperrectangle.jl
@@ -189,7 +189,7 @@ function vertices_list(H::AbstractHyperrectangle{N}) where {N<:Real}
     trivector = Vector{Int8}(undef, n)
     m = 1
     c = center(H)
-    v = copy(c)
+    v = convert(Vector{N}, copy(c))
     @inbounds for i in 1:n
         ri = radius_hyperrectangle(H, i)
         if iszero(ri)


### PR DESCRIPTION
Related to https://github.com/JuliaReach/LazySets.jl/issues/1983. It doesn't close it, because the type of the vertices can (and should) be preserved. I'll address that on a separate PR. 