### PR TITLE
#2070 - Scaling from the right

### DIFF
--- a/src/LazyOperations/LinearMap.jl
+++ b/src/LazyOperations/LinearMap.jl
@@ -131,6 +131,11 @@ function *(map::Union{AbstractMatrix, UniformScaling, AbstractVector, Real}, X::
     return LinearMap(map, X)
 end
 
+# scaling from the right
+function *(X::LazySet, map::Real)
+    return LinearMap(map, X)
+end
+
 # convenience constructor from a vector
 function LinearMap(v::AbstractVector, X::LazySet)
     n = dim(X)

--- a/test/unit_LinearMap.jl
+++ b/test/unit_LinearMap.jl
@@ -33,6 +33,7 @@ for N in [Float64, Rational{Int}, Float32]
     # scalar multiplication
     b = BallInf(N[0, 0], N(1))
     lm = N(2) * b
+    @test lm == b * N(2)
     # repeated scalar multiplication
     lm2 = N(2) * lm
     # Test Dimension


### PR DESCRIPTION
Closes #2070.

I left the type annotation `map::Real` as in the rest of the file, although i don't know why we don't allow any scalar-like object ( = `Number`) in the `LinearMap` type. .. (it is probably for historical reasons :) )