### PR TITLE
Test for HPolyhedron's an_element method

### DIFF
--- a/test/unit_Polyhedron.jl
+++ b/test/unit_Polyhedron.jl
@@ -130,6 +130,11 @@ for N in [Float64]
     d = N[0, -1]
     @test σ(d, p) == N[0, 0]
 
+    # an_element
+    P = HPolyhedron([HalfSpace(N[3//50, -4//10], N(1)),
+                     HalfSpace(N[-1//50, 1//10], N(-1))])
+    @test an_element(P) ∈ P
+
     # boundedness
     @test isbounded(p)
 


### PR DESCRIPTION
`an_element` was not tested.
The test fails for an `HPolytope` because the polyhedron is unbounded in the direction `[1, 0]` that we use in the implementation.
Also note that `an_element` returns `[Inf, Inf]`.
```julia
julia> N = Float64; P = HPolyhedron([HalfSpace(N[3//50, -4//10], N(1)),
                                     HalfSpace(N[-1//50, 1//10], N(-1))]);

julia> an_element(P)
2-element Array{Float64,1}:
 Inf
 Inf
```