### PR TITLE
Simpler Intersection for Lines

### DIFF
--- a/src/ConcreteOperations/intersection.jl
+++ b/src/ConcreteOperations/intersection.jl
@@ -70,8 +70,9 @@ Line{Float64,Array{Float64,1}}([1.0, 1.0], 1.0)
 """
 function intersection(L1::Line{N}, L2::Line{N}
                      ) where {N<:Real}
+    det = L1.a[1]*L2.a[2] - L1.a[2]*L2.a[1]
     # are the lines parallel?
-    if isapprox(L1.a[1]*L2.a[2], L2.a[1]*L1.a[2])
+    if isapproxzero(det)
         # are they the same line?
         if isapprox(L1.b, L2.b)
             return L1
@@ -80,9 +81,9 @@ function intersection(L1::Line{N}, L2::Line{N}
             return EmptySet{N}(dim(L1))
         end
     else
-        b = [L1.b, L2.b]
-        a = [transpose(L1.a); transpose(L2.a)]
-        return Singleton(a \ b)
+        x = (L1.b*L2.a[2] - L1.a[2]*L2.b)/det
+        y = (L1.a[1]*L2.b - L1.b*L2.a[1])/det
+        return Singleton([x, y])
     end
 end
 

--- a/src/ConcreteOperations/intersection.jl
+++ b/src/ConcreteOperations/intersection.jl
@@ -56,6 +56,12 @@ If the lines are identical, the result is the first line.
 If the lines are parallel and not identical, the result is the empty set.
 Otherwise the result is the only intersection point.
 
+### Algorithm
+
+We first check whether the lines are parallel.
+If not, we use [Cramer's rule](https://en.wikipedia.org/wiki/Cramer%27s_rule)
+to compute the intersection point.
+
 ### Examples
 
 The line ``y = -x + 1`` intersected with the line ``y = x``:

--- a/src/ConcreteOperations/intersection.jl
+++ b/src/ConcreteOperations/intersection.jl
@@ -71,9 +71,9 @@ Line{Float64,Array{Float64,1}}([1.0, 1.0], 1.0)
 function intersection(L1::Line{N}, L2::Line{N}
                      ) where {N<:Real}
     # are the lines parallel?
-    if (L1.a[1]*L2.a[2]) == (L2.a[1]*L1.a[2])
+    if isapprox(L1.a[1]*L2.a[2], L2.a[1]*L1.a[2])
         # are they the same line?
-        if (L1.b == L2.b)
+        if isapprox(L1.b, L2.b)
             return L1
         else
             # lines are parallel but not identical

--- a/src/ConcreteOperations/intersection.jl
+++ b/src/ConcreteOperations/intersection.jl
@@ -70,22 +70,19 @@ Line{Float64,Array{Float64,1}}([1.0, 1.0], 1.0)
 """
 function intersection(L1::Line{N}, L2::Line{N}
                      ) where {N<:Real}
-    b = [L1.b, L2.b]
-    a = [transpose(L1.a); transpose(L2.a)]
-    try
-        # results in LAPACKException or SingularException if parallel
-        return Singleton(a \ b)
-    catch e
-        @assert e isa LAPACKException || e isa SingularException "unexpected " *
-            "$(typeof(e)) from LAPACK occurred while intersecting lines:\n$e"
-        # lines are parallel
-        if an_element(L1) ∈ L2
-            # lines are identical
+    # are the lines parallel?
+    if (L1.a[1]*L2.a[2]) == (L2.a[1]*L1.a[2])
+        # are they the same line?
+        if (L1.b == L2.b)
             return L1
         else
             # lines are parallel but not identical
             return EmptySet{N}(dim(L1))
         end
+    else
+        b = [L1.b, L2.b]
+        a = [transpose(L1.a); transpose(L2.a)]
+        return Singleton(a \ b)
     end
 end
 


### PR DESCRIPTION
fixes #697

Really, the change is just checking if the lines intersect first. I'm not sure if that's what was desired, but I'm willing to amend as desired.

In case you care about my tests/benchmarks:
```julia
julia> using LazySets

julia> function simplerIntersect(L1::Line{N},L2::Line{N}) where {N<:Real}
         # are the lines parallel?
         if ((L1.a[1]==0 && L2.a[1] == 0) || (L1.a[2]==0 && L2.a[2] == 0) || (L1.a[1]*L2.a[2]) == (L2.a[1]*L1.a[2]) )
             # are they the same line?
             if (L1.b == L2.b)
                 return L1
             else
                 # lines are parallel but not identical
                 return EmptySet{N}(dim(L1))
             end
         else
             b = [L1.b, L2.b]
             a = [transpose(L1.a); transpose(L2.a)]
             return Singleton(a \ b)
         end
       end
simplerIntersect (generic function with 1 method)

julia> a = Line([1,1], 1)
Line{Int64,Array{Int64,1}}([1, 1], 1)

julia> b = Line([-1,1], 1)
Line{Int64,Array{Int64,1}}([-1, 1], 1)

julia> # obvious cross
       @assert intersection(a,b) == simplerIntersect(a,b)

julia> # parallel, same
       c = Line([1,1],[2,2])
Line{Float64,Array{Float64,1}}([-1.0, 1.0], 0.0)

julia> d = Line([2,2],[3,3])
Line{Float64,Array{Float64,1}}([-1.0, 1.0], 0.0)

julia> @assert intersection(d,c) == simplerIntersect(d,c)

julia> # parallel, not same
       e = Line([1,0],[2,1])
Line{Float64,Array{Float64,1}}([-1.0, 1.0], -1.0)

julia> @assert intersection(d,e) == simplerIntersect(d,e)

julia> # vert
       f = Line([1,0],0)
Line{Int64,Array{Int64,1}}([1, 0], 0)

julia> g = Line([2,0],0)
Line{Int64,Array{Int64,1}}([2, 0], 0)

julia> @assert intersection(f,g) == simplerIntersect(f,g)

julia> # horiz
       f = Line([0,1],0)
Line{Int64,Array{Int64,1}}([0, 1], 0)

julia> g = Line([0,2],0)
Line{Int64,Array{Int64,1}}([0, 2], 0)

julia> @assert intersection(f,g) == simplerIntersect(f,g)

julia> # both
       f = Line([1,0],0)
Line{Int64,Array{Int64,1}}([1, 0], 0)

julia> g = Line([0,2],0)
Line{Int64,Array{Int64,1}}([0, 2], 0)

julia> @assert intersection(f,g) == simplerIntersect(f,g)

julia> # randoms
       for i in 1:1000000
         r1 = rand(Line)
         r2 = rand(Line)
         @assert intersection(r1,r2) == simplerIntersect(r1,r2)
       end

julia> using BenchmarkTools

julia> @benchmark simplerIntersect(rand(Line),rand(Line))
BenchmarkTools.Trial: 
  memory estimate:  880 bytes
  allocs estimate:  14
  --------------
  minimum time:     743.451 ns (0.00% GC)
  median time:      788.736 ns (0.00% GC)
  mean time:        897.050 ns (8.98% GC)
  maximum time:     56.384 μs (98.25% GC)
  --------------
  samples:          10000
  evals/sample:     144

julia> @benchmark intersection(rand(Line),rand(Line))
BenchmarkTools.Trial: 
  memory estimate:  880 bytes
  allocs estimate:  14
  --------------
  minimum time:     765.157 ns (0.00% GC)
  median time:      822.795 ns (0.00% GC)
  mean time:        938.838 ns (9.20% GC)
  maximum time:     38.390 μs (96.95% GC)
  --------------
  samples:          10000
  evals/sample:     127
```