### PR TITLE
intersection between line and line segment

### DIFF
--- a/src/ConcreteOperations/intersection.jl
+++ b/src/ConcreteOperations/intersection.jl
@@ -90,37 +90,41 @@ function intersection(L1::Line{N}, L2::Line{N}
 end
 
 """
-    intersection(X::LineSegment{N}, hp::Line{N}
-                ) where {N<:Real}
+    intersection(a::LineSegment{N}, b::Line{N}) where {N<:Real}
+
 Compute the intersection of a line and a line segment.
+
 ### Input
+
 - `a`  -- LineSegment
 - `b` -- Line
+
 ### Output
+
 If the sets do not intersect, the result is the empty set.
 Otherwise the result is the singleton or line segment that describes the intersection.
 """
 
 function intersection(a::LineSegment{N}, b::Line{N}) where {N<:Real}
-  # cast a as line
-  ap = Line(a.p, a.q)
-  # find intersection between a' and b
-  m = intersection(ap, b)
-  if m == b
-    # if this equals b, then all of the segment is the intersection
-    return a
-  elseif typeof(m) <: Singleton && m.element ∈ a
-    # if the intersection between lines is in the segment
-    return m
-  else
-    # no intersection
-    return EmptySet(max(dim(a), dim(b)))
-  end
+    # cast a as line
+    ap = Line(a.p, a.q)
+    # find intersection between a' and b
+    m = intersection(ap, b)
+    if m == ap
+        # if this equals a, then all of the segment is the intersection
+        return a
+    elseif typeof(m) <: Singleton && m.element ∈ a
+        # if the intersection between lines is in the segment
+        return m
+    else
+        # no intersection
+        return EmptySet{N}(2)
+    end
 end
 
 # symmetric method
-function intersection(a::Line, b::LineSegment)
-  return intersection(b,a)
+function intersection(a::Line{N}, b::LineSegment{N}) where {N<:Real}
+    return intersection(b,a)
 end
 
 """

--- a/src/ConcreteOperations/intersection.jl
+++ b/src/ConcreteOperations/intersection.jl
@@ -90,6 +90,40 @@ function intersection(L1::Line{N}, L2::Line{N}
 end
 
 """
+    intersection(X::LineSegment{N}, hp::Line{N}
+                ) where {N<:Real}
+Compute the intersection of a line and a line segment.
+### Input
+- `a`  -- LineSegment
+- `b` -- Line
+### Output
+If the sets do not intersect, the result is the empty set.
+Otherwise the result is the singleton or line segment that describes the intersection.
+"""
+
+function intersection(a::LineSegment{N}, b::Line{N}) where {N<:Real}
+  # cast a as line
+  ap = Line(a.p, a.q)
+  # find intersection between a' and b
+  m = intersection(ap, b)
+  if m == b
+    # if this equals b, then all of the segment is the intersection
+    return a
+  elseif typeof(m) <: Singleton && m.element ∈ a
+    # if the intersection between lines is in the segment
+    return m
+  else
+    # no intersection
+    return EmptySet(max(dim(a), dim(b)))
+  end
+end
+
+# symmetric method
+function intersection(a::Line, b::LineSegment)
+  return intersection(b,a)
+end
+
+"""
     intersection(H1::AbstractHyperrectangle{N},
                  H2::AbstractHyperrectangle{N}
                 ) where {N<:Real}

--- a/src/ConcreteOperations/intersection.jl
+++ b/src/ConcreteOperations/intersection.jl
@@ -113,7 +113,7 @@ function intersection(a::LineSegment{N}, b::Line{N}) where {N<:Real}
     if m == ap
         # if this equals a, then all of the segment is the intersection
         return a
-    elseif typeof(m) <: Singleton && m.element ∈ a
+    elseif m isa Singleton && m.element ∈ a
         # if the intersection between lines is in the segment
         return m
     else


### PR DESCRIPTION
Fixes #262 


Draft due to an error I don't understand when testing:

```julia
function i1(a::LineSegment, b::Line)
  # cast a as line
  ap = Line(a.p, a.q)
  # find intersection between a' and b
  m = intersection(ap, b)
  if m == b
    # if this equals b, then all of the segment is the intersection
    return a
  elseif typeof(m) <: Singleton && m.element ∈ a
    # if the intersection between lines is in the segment
    return m
  else
    # no intersection
    return EmptySet(max(dim(a), dim(b)))
  end
end

# handle reverse case
function i1(a::Line, b::LineSegment)
  return i1(b,a)
end

## tests
s1 = LineSegment([-5,-5], [5,5])
t = Line(s1.p, s1.q)
# same as s1
l1 = Line([0,0], [5,5])
# intersects out of s1
l2 = Line([10,10], [6,0])
# parallel to s1
l3 = Line([0,1], [5,6])
# intersects within
l4 = Line([5,-5], [-5,5])


i1(s1, l1)
i1(s1, l2)
i1(s1, l3)
i1(s1, l4)
```
throws 

```julia
julia> i1(s1, l4)
ERROR: MethodError: no method matching iterate(::LineSegment{Int64,Array{Int64,1}})
Closest candidates are:
  iterate(::Core.SimpleVector) at essentials.jl:603
  iterate(::Core.SimpleVector, ::Any) at essentials.jl:603
  iterate(::ExponentialBackOff) at error.jl:253
  ...
Stacktrace:
 [1] in(::Array{Float64,1}, ::LineSegment{Int64,Array{Int64,1}}) at ./operators.jl:1041
 [2] i1(::LineSegment{Int64,Array{Int64,1}}, ::Line{Float64,Array{Float64,1}}) at ./REPL[159]:9
 [3] top-level scope at REPL[170]:1
```
In the second and fourth test case. I'm probably missing something silly.