### PR TITLE
Fix docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ branches:
 jobs:
   include:
     - stage: "Documentation"
-      julia: 1.3
+      julia: 1.4
       os: linux
       script:
         - julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd()));

--- a/src/Approximations/overapproximate.jl
+++ b/src/Approximations/overapproximate.jl
@@ -1545,8 +1545,8 @@ We preprocess the directions in that respect.
 ### Algorithm
 
 We solve a linear program parametric in the vertices ``v_j`` of `X` and the
-directions ``d_k`` in `dir` presented in [1, Section 4.2] (adapting the notation
-to the one used in this library).
+directions ``d_k`` in `dir` presented in Section 4.2 in [1], adapting the
+notation to the one used in this library.
 
 ```math
     \\min \\sum_{k=1}^l α_k \\


### PR DESCRIPTION
* fix an error message when building the docs:
```julia
┌ Warning: invalid local link: unresolved path in lib/approximations.md
│   link = "adapting the notation to the one used in this library"
└ @ Documenter.Writers.HTMLWriter ~/.julia/packages/Documenter/IGqbY/src/Writers/HTMLWriter.jl:1179
```
* use Julia v1.4 for building the docs (is probably slightly faster)

Note that there is another error message:
```julia
┌ Warning: invalid local link: unresolved path in lib/interfaces.md
│   link = "../utils/#LazySets.Arrays.is_right_turn"
└ @ Documenter.Writers.HTMLWriter ~/.julia/packages/Documenter/IGqbY/src/Writers/HTMLWriter.jl:1179
```
https://github.com/JuliaReach/LazySets.jl/blob/2629a6f4d3ef4f34562d6b57abd317246b0cf410/src/Interfaces/AbstractPolygon.jl#L139

I tried several things and concluded that this can probably not be fixed in an elegant way. My guess about the problem is that we process `utils.md` after `interfaces.md`, so the target of that link does not exist yet. In the resulting documentation the link works normally, though.