### PR TITLE
Inherit all functions for AbstractCentrallySymmetricPolytope

### DIFF
--- a/docs/src/lib/interfaces.md
+++ b/docs/src/lib/interfaces.md
@@ -293,6 +293,8 @@ This interface defines the following functions:
 dim(::AbstractCentrallySymmetricPolytope)
 an_element(::AbstractCentrallySymmetricPolytope{N}) where {N<:Real}
 isempty(::AbstractCentrallySymmetricPolytope)
+isuniversal(::AbstractCentrallySymmetricPolytope{N}, ::Bool=false) where {N<:Real}
+center(::AbstractCentrallySymmetricPolytope{N}, ::Int) where {N<:Real}
 ```
 
 ### Implementations

--- a/src/Interfaces/AbstractCentrallySymmetricPolytope.jl
+++ b/src/Interfaces/AbstractCentrallySymmetricPolytope.jl
@@ -36,6 +36,7 @@ abstract type AbstractCentrallySymmetricPolytope{N<:Real} <: AbstractPolytope{N}
 
 isconvextype(::Type{<:AbstractCentrallySymmetricPolytope}) = true
 
+
 # --- common AbstractCentrallySymmetric functions (copy-pasted) ---
 
 
@@ -87,6 +88,57 @@ Return if a centrally symmetric, polytopic set is empty or not.
 
 `false`.
 """
-function isempty(P::AbstractCentrallySymmetricPolytope)
+function isempty(::AbstractCentrallySymmetricPolytope)
     return false
+end
+
+"""
+    isuniversal(S::AbstractCentrallySymmetricPolytope{N}, [witness]::Bool=false
+               ) where {N<:Real}
+
+Check whether a centrally symmetric polytope is universal.
+
+### Input
+
+- `S`       -- centrally symmetric polytope
+- `witness` -- (optional, default: `false`) compute a witness if activated
+
+### Output
+
+* If `witness` option is deactivated: `false`
+* If `witness` option is activated: `(false, v)` where ``v ∉ S``
+
+### Algorithm
+
+A witness is obtained by computing the support vector in direction
+`d = [1, 0, …, 0]` and adding `d` on top.
+"""
+function isuniversal(S::AbstractCentrallySymmetricPolytope{N},
+                     witness::Bool=false) where {N<:Real}
+    if witness
+        d = SingleEntryVector{N}(1, dim(S))
+        w = σ(d, S) + d
+        return (false, w)
+    else
+        return false
+    end
+end
+
+"""
+    center(H::AbstractCentrallySymmetricPolytope{N}, i::Int) where {N<:Real}
+
+Return the center along a given dimension of a centrally symmetric polytope.
+
+### Input
+
+- `S` -- centrally symmetric polytope
+- `i` -- dimension of interest
+
+### Output
+
+The center along a given dimension of the centrally symmetric polytope.
+"""
+@inline function center(S::AbstractCentrallySymmetricPolytope{N},
+                        i::Int) where {N<:Real}
+    return center(S)[i]
 end

--- a/test/unit_BallInf.jl
+++ b/test/unit_BallInf.jl
@@ -54,6 +54,11 @@ for N in [Float64, Rational{Int}, Float32]
     d = N[1, -1]
     @test σ(d, b) == N[2, -2]
 
+    # center
+    c = N[1, 2]
+    b = BallInf(c, N(2))
+    @test center(b) == c && center(b, 1) == N(1) && center(b, 2) == N(2)
+
     # support vector for single entry vector
     svec = σ(SingleEntryVector(2, 3, N(2)), BallInf(zeros(N, 3), N(2)))
     @test svec[1] ∈ Interval(N[-2, 2]) && svec[2] == N(2) && svec[3] ∈ Interval(N[-2, 2])

--- a/test/unit_interfaces.jl
+++ b/test/unit_interfaces.jl
@@ -34,6 +34,8 @@ check_method_implementation(LazySet, dim, Function[S -> (S{Float64},)])
 # center (from AbstractCentrallySymmetric)
 @test check_method_implementation(AbstractCentrallySymmetricPolytope, center,
                                   Function[S -> (S{Float64},)])
+@test check_method_implementation(AbstractCentrallySymmetricPolytope, center,
+                                  Function[S -> (S{Float64}, Int64)])
 
 # --- AbstractZonotope ---
 


### PR DESCRIPTION
Background: `center(rand(Ball2), 1)` works but `center(rand(BallInf), 1)` did not work - scandalous!