### PR TITLE
#1745 - Use SingleEntryVector in box overapproximation

### DIFF
--- a/src/Approximations/box_approximations.jl
+++ b/src/Approximations/box_approximations.jl
@@ -110,18 +110,12 @@ The lengths of the sides can be recovered from the distance among support
 functions in the same directions.
 """
 @inline function box_approximation_helper(S::LazySet{N}) where {N<:Real}
-    zero_N = zero(N)
-    one_N = one(N)
     n = dim(S)
     c = Vector{N}(undef, n)
     r = Vector{N}(undef, n)
-    d = zeros(N, n)
     @inbounds for i in 1:n
-        d[i] = one_N
-        htop = ρ(d, S)
-        d[i] = -one_N
-        hbottom = -ρ(d, S)
-        d[i] = zero_N
+        htop = ρ(SingleEntryVector(i, n, one(N)), S)
+        hbottom = -ρ(SingleEntryVector(i, n, -one(N)), S)
         c[i] = (htop + hbottom) / 2
         r[i] = (htop - hbottom) / 2
         if r[i] < 0


### PR DESCRIPTION
Closes #1745.

As discussed in the issue, this change does not always improve performance. I am fine with doing the change because currently we do not dispatch on `SingleEntryVector`, so eventually there may be a speedup.

Below are some experiments with:
* `Ball1` and `Ball2` (slower)
* `Zonotope` (equal)
* `VPolytope` (created with `Ps = [rand(VPolytope, dim=n) for n in [1, 5, 10, 20]]`) and a `Translation` of a `Zonotope` (faster)

`master`:
```julia
julia> for n in [1, 10, 100, 1000]
           X = rand(Ball1, dim=n)
           @btime box_approximation($X)
       end
  296.956 ns (8 allocations: 704 bytes)
  2.867 μs (44 allocations: 6.75 KiB)
  94.638 μs (404 allocations: 352.66 KiB)
  9.050 ms (4004 allocations: 31.03 MiB)

julia> for n in [1, 10, 100, 1000]
           X = rand(Ball2, dim=n)
           @btime box_approximation($X)
       end
  235.835 ns (6 allocations: 512 bytes)
  1.968 μs (24 allocations: 3.63 KiB)
  35.601 μs (204 allocations: 177.66 KiB)
  3.188 ms (2004 allocations: 15.53 MiB)

julia> for n in [1, 10, 100, 1000]
           X = rand(Zonotope, dim=n, num_generators=10)
           @btime box_approximation($X)
       end
  878.132 ns (10 allocations: 576 bytes)
  1.022 μs (10 allocations: 1.41 KiB)
  2.263 μs (10 allocations: 9.91 KiB)
  13.815 μs (11 allocations: 94.30 KiB)

julia> for P in Ps
           @btime box_approximation($P)
       end
  214.978 ns (4 allocations: 320 bytes)
  1.329 μs (4 allocations: 416 bytes)
  6.135 μs (4 allocations: 512 bytes)
  40.196 μs (4 allocations: 752 bytes)

julia> for n in [1, 10, 100, 1000]
           X = rand(Zonotope, dim=n, num_generators=10) + rand(n)
           @btime box_approximation($X)
       end
  463.199 ns (8 allocations: 960 bytes)
  4.734 μs (44 allocations: 6.75 KiB)
  80.461 μs (404 allocations: 65.16 KiB)
  10.172 ms (4004 allocations: 648.84 KiB)
```
this branch:
```julia
julia> for n in [1, 10, 100, 1000]
           X = rand(Ball1, dim=n)
           @btime box_approximation($X)
       end
  252.916 ns (7 allocations: 608 bytes)
  2.563 μs (43 allocations: 6.59 KiB)
  108.096 μs (403 allocations: 351.78 KiB)
  11.061 ms (4003 allocations: 31.02 MiB)

julia> for n in [1, 10, 100, 1000]
           X = rand(Ball2, dim=n)
           @btime box_approximation($X)
       end
  195.322 ns (5 allocations: 416 bytes)
  1.956 μs (23 allocations: 3.47 KiB)
  106.950 μs (203 allocations: 176.78 KiB)
  10.749 ms (2003 allocations: 15.52 MiB)

julia> for n in [1, 10, 100, 1000]
           X = rand(Zonotope, dim=n, num_generators=10)
           @btime box_approximation($X)
       end
  880.660 ns (10 allocations: 576 bytes)
  1.030 μs (10 allocations: 1.41 KiB)
  2.259 μs (10 allocations: 9.91 KiB)
  13.474 μs (11 allocations: 94.30 KiB)

julia> for P in Ps
           @btime box_approximation($P)
       end
  139.917 ns (3 allocations: 224 bytes)
  898.024 ns (3 allocations: 288 bytes)
  4.944 μs (3 allocations: 352 bytes)
  45.622 μs (3 allocations: 512 bytes)

julia> for n in [1, 10, 100, 1000]
           X = rand(Zonotope, dim=n, num_generators=10) + rand(n)
           @btime box_approximation($X)
       end
  422.445 ns (11 allocations: 1.19 KiB)
  3.894 μs (83 allocations: 10.03 KiB)
  77.139 μs (803 allocations: 98.66 KiB)
  4.793 ms (8003 allocations: 984.66 KiB)
```