### PR TITLE
Use approximate zero test in samedir and fix isredundant

### DIFF
--- a/src/Arrays/Arrays.jl
+++ b/src/Arrays/Arrays.jl
@@ -9,7 +9,7 @@ using LinearAlgebra, SparseArrays
 using ..Assertions: @assert, activate_assertions
 # activate assertions by default
 activate_assertions(Arrays)
-using ..LazySets: _geq
+using ..LazySets: _geq, isapproxzero
 
 include("matrix_operations.jl")
 include("vector_operations.jl")

--- a/src/Arrays/vector_operations.jl
+++ b/src/Arrays/vector_operations.jl
@@ -96,12 +96,12 @@ function samedir(u::AbstractVector{N},
     no_factor = true
     factor = 0
     @inbounds for i in 1:length(u)
-        if u[i] == 0
-            if v[i] != 0
+        if isapproxzero(u[i])
+            if !isapproxzero(v[i])
                 return (false, 0)
             end
             continue
-        elseif v[i] == 0
+        elseif isapproxzero(v[i])
             return (false, 0)
         end
         if no_factor

--- a/src/Interfaces/AbstractHPolygon.jl
+++ b/src/Interfaces/AbstractHPolygon.jl
@@ -305,12 +305,19 @@ function isredundant(cmid::LinearConstraint{N},
     elseif is_right_turn(cleft.a, cright.a)
         # angle is 0° or 180°
         if samedir(cright.a, cleft.a)[1]
-            # angle is 0°, i.e., all three constraints have the same direction
-            # constraint is redundant unless it is tighter than the other two
-            @assert samedir(cright.a, cmid.a)[1] &&
-                    samedir(cleft.a, cmid.a)[1] "inconsistent constraints"
-            return !is_tighter_same_dir_2D(cmid, cright, strict=true) &&
-                   !is_tighter_same_dir_2D(cmid, cleft, strict=true)
+            # angle is 0°
+            if samedir(cright.a, cmid.a)[1] && samedir(cleft.a, cmid.a)[1]
+                # all three constraints have the same direction
+                # constraint is redundant unless it is tighter than the others
+                return !is_tighter_same_dir_2D(cmid, cright, strict=true) &&
+                       !is_tighter_same_dir_2D(cmid, cleft, strict=true)
+            else
+                # surrounding constraints have the same direction but the
+                # central constraint does not -> corner case with just three
+                # unbounding constraints (usually occurs during incremental
+                # addition of constraints)
+                return false
+            end
         else
             # angle is 180°
             samedir_check = true

--- a/src/Interfaces/AbstractHPolygon.jl
+++ b/src/Interfaces/AbstractHPolygon.jl
@@ -307,7 +307,8 @@ function isredundant(cmid::LinearConstraint{N},
         if samedir(cright.a, cleft.a)[1]
             # angle is 0°, i.e., all three constraints have the same direction
             # constraint is redundant unless it is tighter than the other two
-            @assert samedir(cright.a, cmid.a)[1] && samedir(cleft.a, cmid.a)[1]
+            @assert samedir(cright.a, cmid.a)[1] &&
+                    samedir(cleft.a, cmid.a)[1] "inconsistent constraints"
             return !is_tighter_same_dir_2D(cmid, cright, strict=true) &&
                    !is_tighter_same_dir_2D(cmid, cleft, strict=true)
         else

--- a/test/unit_Polygon.jl
+++ b/test/unit_Polygon.jl
@@ -494,6 +494,18 @@ for N in [Float64]
     H = HalfSpace([-0.012707966980287463, 3.809113859067846e-15], -0.2348665397215645)
     addconstraint!(Hs, H)
     @test length(Hs) == 4
+
+    # redundancy with almost-parallel constraints and order issues (#2169)
+    Hs = [
+        HalfSpace([1.3877787807814457e-17, 0.0], -7.27918967693285e-18)
+        HalfSpace([3.642919299551295e-17, 2.7755575615628914e-17], 3.194076233118193e-17)
+        HalfSpace([-6.938893903907228e-17, 0.03196481037863655], 0.1022675780516848)
+        HalfSpace([-0.022382796523655775, -3.469446951953614e-18], 0.05268494728581621)
+        HalfSpace([-8.673617379884035e-19, -0.01331598581298936], 0.020336411343083463)
+        HalfSpace([0.01620615792275367, -2.949029909160572e-17], 0.03845370605895632)
+       ]
+    P = HPolygon(copy(Hs))
+    @test ispermutation(P.constraints, Hs[3:6])
 end
 
 # default Float64 constructors


### PR DESCRIPTION
Closes #2169.

```julia
julia> P = HPolygon([
        HalfSpace([1.3877787807814457e-17, 0.0], -7.27918967693285e-18)
        HalfSpace([3.642919299551295e-17, 2.7755575615628914e-17], 3.194076233118193e-17)
        HalfSpace([-6.938893903907228e-17, 0.03196481037863655], 0.1022675780516848)
        HalfSpace([-0.022382796523655775, -3.469446951953614e-18], 0.05268494728581621)
        HalfSpace([-8.673617379884035e-19, -0.01331598581298936], 0.020336411343083463)
        HalfSpace([0.01620615792275367, -2.949029909160572e-17], 0.03845370605895632)
       ]);
```
In `master` this works but redundant constraints are not removed:
```julia
julia> P.constraints
6-element Array{HalfSpace{Float64,Array{Float64,1}},1}:
 HalfSpace{Float64,Array{Float64,1}}([3.642919299551295e-17, 2.7755575615628914e-17], 3.194076233118193e-17)
 HalfSpace{Float64,Array{Float64,1}}([1.3877787807814457e-17, 0.0], -7.27918967693285e-18)
 HalfSpace{Float64,Array{Float64,1}}([-6.938893903907228e-17, 0.03196481037863655], 0.1022675780516848)
 HalfSpace{Float64,Array{Float64,1}}([-0.022382796523655775, -3.469446951953614e-18], 0.05268494728581621)
 HalfSpace{Float64,Array{Float64,1}}([-8.673617379884035e-19, -0.01331598581298936], 0.020336411343083463)
 HalfSpace{Float64,Array{Float64,1}}([0.01620615792275367, -2.949029909160572e-17], 0.03845370605895632)
```
In this branch the constraints are removed but an assertion fails. A first inspection suggests that the constraints are not aligned in the right order.
```julia
ERROR: AssertionError: inconsistent constraints
Stacktrace:
 [1] macro expansion at .julia/dev/LazySets/src/Assertions/Assertions.jl:23 [inlined]
 [2] isredundant(::HalfSpace{Float64,Array{Float64,1}}, ::HalfSpace{Float64,Array{Float64,1}}, ::HalfSpace{Float64,Array{Float64,1}}) at .julia/dev/LazySets/src/Interfaces/AbstractHPolygon.jl:310
 [3] addconstraint!(::Array{HalfSpace{Float64,Array{Float64,1}},1}, ::HalfSpace{Float64,Array{Float64,1}}; linear_search::Bool, prune::Bool) at .julia/dev/LazySets/src/Interfaces/AbstractHPolygon.jl:469
 [4] HPolygon(::Array{HalfSpace{Float64,Array{Float64,1}},1}; sort_constraints::Bool, check_boundedness::Bool, prune::Bool) at .julia/dev/LazySets/src/Sets/HPolygon.jl:56
 [5] HPolygon(::Array{HalfSpace{Float64,Array{Float64,1}},1}) at .julia/dev/LazySets/src/Sets/HPolygon.jl:52
 [6] top-level scope at REPL[102]:1
 [7] eval(::Module, ::Any) at ./boot.jl:331
 [8] eval_user_input(::Any, ::REPL.REPLBackend) at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.4/REPL/src/REPL.jl:86
 [9] run_backend(::REPL.REPLBackend) at .julia/packages/Revise/XFtoQ/src/Revise.jl:1162
 [10] top-level scope at none:0
```