### PR TITLE
Always use constraint representation in linear_map_cartesian_product

### DIFF
--- a/src/LazyOperations/CartesianProduct.jl
+++ b/src/LazyOperations/CartesianProduct.jl
@@ -267,14 +267,12 @@ Concrete linear map of a (polyhedral) Cartesian product.
 
 ### Output
 
-A polytope.
+A polytope if `cp` is bounded and a polyhedron otherwise.
 
 ### Algorithm
 
-We check if the matrix is invertible.
-If so, we convert the Cartesian product to constraint representation.
-Otherwise, we convert the Cartesian product to vertex representation.
-In both cases, we then call `linear_map` on the resulting polytope.
+We convert the Cartesian product to constraint representation and then call
+`linear_map` on the corresponding polyhedron.
 """
 function linear_map(M::AbstractMatrix{N}, cp::CartesianProduct{N}
                    ) where {N<:Real}
@@ -285,13 +283,8 @@ function linear_map_cartesian_product(M, cp)
     @assert dim(cp) == size(M, 2) "a linear map of size $(size(M)) cannot " *
                                   "be applied to a set of dimension $(dim(cp))"
 
-    if !isinvertible(M)
-        # use vertex representation
-        P = VPolytope(vertices_list(cp))
-    else
-        # use constraint representation
-        T = isbounded(cp) ? HPolytope : HPolyhedron
-        P = T(constraints_list(cp))
-    end
+    # use constraint representation
+    T = isbounded(cp) ? HPolytope : HPolyhedron
+    P = T(constraints_list(cp))
     return linear_map(M, P)
 end

--- a/test/unit_CartesianProduct.jl
+++ b/test/unit_CartesianProduct.jl
@@ -128,8 +128,8 @@ for N in [Float64, Float32, Rational{Int}]
         length(constraints_list(cp)) == 4
     M = N[2 1; 0 0]  # singular matrix
     lm = linear_map(M, cp)
-    @test lm isa VPolytope{N} &&
-        box_approximation(lm) == Hyperrectangle(N[7//2, 0], N[3//2, 0])
+    @test lm isa (N == Float64 ? HPolytope{N} : HPolytope)
+    @test box_approximation(lm) == Hyperrectangle(N[7//2, 0], N[3//2, 0])
 
     # ==================================
     # Conversions of Cartesian Products
@@ -253,8 +253,8 @@ for N in [Float64, Float32, Rational{Int}]
         length(constraints_list(cpa)) == 4
     M = N[2 1; 0 0]  # singular matrix
     lm = linear_map(M, cpa)
-    @test lm isa VPolytope{N} &&
-        box_approximation(lm) == Hyperrectangle(N[7//2, 0], N[3//2, 0])
+    @test lm isa (N == Float64 ? HPolytope{N} : HPolytope)
+    @test box_approximation(lm) == Hyperrectangle(N[7//2, 0], N[3//2, 0])
 
     # ========================================
     # Conversions of Cartesian Product Arrays


### PR DESCRIPTION
This allows to compute the linear map with a singular matrix of an unbounded polyhedral Cartesian product (and should often be faster in the bounded case).