### PR TITLE
Bump Documenter version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -21,7 +21,7 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 [compat]
 CDDLib = "0.6"
 Distributions = "0.19, 0.20, 0.21, 0.22"
-Documenter = "0.23.0"
+Documenter = "0.23, 0.24, 0.25"
 Expokit = "0.2"
 GLPK = "0.11, 0.12, 0.13"
 GLPKMathProgInterface = "0.4, 0.5"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -15,6 +15,6 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 TaylorModels = "314ce334-5f6e-57ae-acf6-00b6e903104a"
 
 [compat]
-BenchmarkTools = "≥ 0.4.2"
-Documenter = "^0.23"
-StaticArrays = "≥ 0.10.3"
+BenchmarkTools = "0.4.2, 0.5"
+Documenter = "0.23, 0.24, 0.25"
+StaticArrays = "0.10.3, 0.11, 0.12"


### PR DESCRIPTION
For the record, there is a warning but that has been there before this PR as well:
```julia
Warning: invalid local link: unresolved path in lib/interfaces.md
│   link.text =
│    1-element Array{Any,1}:
│     Markdown.Code("", "is_right_turn")
│   link.url = "../utils/#LazySets.Arrays.is_right_turn"
```