### PR TITLE
#1227 - Efficient subset check between CartesianProducts

### DIFF
--- a/docs/src/lib/binary_functions.md
+++ b/docs/src/lib/binary_functions.md
@@ -122,6 +122,7 @@ pontryagin_difference
 ⊆(::LazySet{N}, ::Universe{N}, ::Bool=false) where {N<:Real}
 ⊆(::Universe{N}, ::LazySet{N}, ::Bool=false) where {N<:Real}
 ⊆(::LazySet{N}, ::Complement{N}, ::Bool=false) where {N<:Real}
+⊆(::CartesianProduct{N}, ::CartesianProduct{N}, ::Bool=false) where {N<:Real}
 ⊆(::CartesianProductArray{N}, ::CartesianProductArray{N}, ::Bool=false) where {N<:Real}
 ```
 

--- a/src/ConcreteOperations/issubset.jl
+++ b/src/ConcreteOperations/issubset.jl
@@ -985,7 +985,9 @@ witness.
 
 This algorithm requires that the two Cartesian products share the same block
 structure.
-Depending on the value of `check_block_equality`, we check this property.
+If `check_block_equality` is activated, we check this property and, if it does
+not hold, we use a fallback implementation based on conversion to constraint
+representation (assuming that the sets are polyhedral).
 
 ### Algorithm
 
@@ -1000,8 +1002,7 @@ function ⊆(X::CartesianProduct{N}, Y::CartesianProduct{N}, witness::Bool=false
     n1 = dim(X.X)
     n2 = dim(X.Y)
     if check_block_equality && (n1 != dim(Y.X) || n2 != dim(Y.Y))
-        throw(ArgumentError("this inclusion check requires Cartesian products" *
-                            "with the same block structure"))
+        return invoke(⊆, Tuple{LazySet{N}, LazySet{N}, Bool}, X, Y, witness)
     end
 
     # check first block
@@ -1056,7 +1057,9 @@ compute a witness.
 
 This algorithm requires that the two Cartesian products share the same block
 structure.
-Depending on the value of `check_block_equality`, we check this property.
+If `check_block_equality` is activated, we check this property and, if it does
+not hold, we use a fallback implementation based on conversion to constraint
+representation (assuming that the sets are polyhedral).
 
 ### Algorithm
 
@@ -1074,8 +1077,7 @@ function ⊆(X::CartesianProductArray{N},
     aX = array(X)
     aY = array(Y)
     if check_block_equality && !same_block_structure(aX, aY)
-        throw(ArgumentError("this inclusion check requires Cartesian products" *
-                            "with the same block structure"))
+        return invoke(⊆, Tuple{LazySet{N}, LazySet{N}, Bool}, X, Y, witness)
     end
 
     for i in 1:length(aX)

--- a/test/unit_CartesianProduct.jl
+++ b/test/unit_CartesianProduct.jl
@@ -139,6 +139,22 @@ for N in [Float64, Float32, Rational{Int}]
         @test concretize(cp) === cp
     end
 
+    # inclusion
+    # same block structure
+    cp1 = CartesianProduct(Ball1(N[2], N(1)), Ball1(N[0, 0], N(2)))
+    cp2 = CartesianProduct(Interval(N(1), N(3)), BallInf(N[0, 0], N(3)))
+    res, w = ⊆(cp1, cp2, true)
+    @test cp1 ⊆ cp2 && res && w == N[]
+    res, w = ⊆(cp2, cp1, true)
+    @test cp2 ⊈ cp1 && !res && w ∈ cp2 && w ∉ cp1
+    # different block structure
+    cp1 = CartesianProduct(Interval(N(1), N(2)), BallInf(N[1, 1], N(1)))
+    cp2 = CartesianProduct(BallInf(N[1, 1], N(2)), Interval(N(0), N(2)))
+    res, w = ⊆(cp1, cp2, true)
+    @test cp1 ⊆ cp2 && res && w == N[]
+    res, w = ⊆(cp2, cp1, true)
+    @test cp2 ⊈ cp1 && !res && w ∈ cp2 && w ∉ cp1
+
     # ==================================
     # Conversions of Cartesian Products
     # ==================================
@@ -297,6 +313,13 @@ for N in [Float64, Float32, Rational{Int}]
     # inclusion
     cpa1 = CartesianProductArray(aX)
     cpa2 = CartesianProductArray(aY)
+    res, w = ⊆(cpa1, cpa2, true)
+    @test cpa1 ⊆ cpa2 && res && w == N[]
+    res, w = ⊆(cpa2, cpa1, true)
+    @test cpa2 ⊈ cpa1 && !res && w ∈ cpa2 && w ∉ cpa1
+    # different block structure
+    cpa1 = CartesianProductArray([Interval(N(1), N(2)), BallInf(N[1, 1], N(1))])
+    cpa2 = CartesianProductArray([BallInf(N[1, 1], N(2)), Interval(N(0), N(2))])
     res, w = ⊆(cpa1, cpa2, true)
     @test cpa1 ⊆ cpa2 && res && w == N[]
     res, w = ⊆(cpa2, cpa1, true)


### PR DESCRIPTION
Closes #1227.

Additionally this PR adds a subset check between `CartesianProductArray`s of different block structure by using the fallback implementation.

~Tests were already present.~

```julia
# two non-subset blocks

julia> @time X ⊆ Y
  0.000024 seconds (111 allocations: 7.453 KiB)
false

julia> @time ⊆(X, Y, true)
  0.000032 seconds (151 allocations: 9.891 KiB)
(false,   [1]  =  -0.989371
  [2]  =  0.890032
  [3]  =  1.15984
  [4]  =  2.03698)

### this branch

julia> @time X ⊆ Y
  0.000003 seconds
false

julia> @time ⊆(X, Y, true)
  0.000005 seconds (4 allocations: 272 bytes)
(false, [-0.9893707748634932, 0.6090025573953656, 0.6279955152649557, 0.38677706906864234])


# first block is a subset

julia> @time X ⊆ Y
  0.000025 seconds (129 allocations: 8.672 KiB)
false

julia> @time ⊆(X, Y, true)
  0.000030 seconds (163 allocations: 10.703 KiB)
(false,   [1]  =  -0.427312
  [2]  =  0.890032
  [3]  =  1.15984
  [4]  =  2.03698)

### this branch

julia> @time X ⊆ Y
  0.000003 seconds
false

julia> @time ⊆(X, Y, true)
    0.000005 seconds (6 allocations: 384 bytes)
(false, [-0.23845042779673375, 0.6386840809336349, 1.159841586170895, 0.6386840809336349])


# both blocks are subsets

julia> @time X ⊆ Y
  0.000025 seconds (147 allocations: 9.891 KiB)
true

julia> @time ⊆(X, Y, true)
  0.000026 seconds (149 allocations: 10.000 KiB)
(true, Float64[])

### this branch

julia> @time X ⊆ Y
  0.000003 seconds
true

julia> @time ⊆(X, Y, true)
  0.000004 seconds (6 allocations: 336 bytes)
(true, Float64[])
```