### PR TITLE
#1879 - Generalize conversion from AbstractHyperrectangle to Zonotope

### DIFF
--- a/docs/src/lib/conversion.md
+++ b/docs/src/lib/conversion.md
@@ -33,7 +33,6 @@ convert(::Type{VPolygon}, ::AbstractHPolygon)
 convert(::Type{VPolygon}, ::AbstractPolytope)
 convert(::Type{VPolytope}, ::AbstractPolytope)
 convert(::Type{VPolytope}, ::HPolytope)
-convert(::Type{Zonotope}, ::AbstractHyperrectangle{N}) where {N}
 convert(::Type{Zonotope}, ::AbstractZonotope)
 convert(::Type{IntervalArithmetic.IntervalBox}, ::AbstractHyperrectangle)
 convert(::Type{Hyperrectangle}, ::IntervalArithmetic.IntervalBox)

--- a/src/convert.jl
+++ b/src/convert.jl
@@ -241,43 +241,6 @@ function convert(::Type{HPOLYGON}, P::HPolytope{N, VN};
     return H
 end
 
-"""
-    convert(::Type{Zonotope}, H::AbstractHyperrectangle)
-
-Converts a hyperrectangular set to a zonotope.
-
-### Input
-
-- `Zonotope` -- type, used for dispatch
-- `H`        -- hyperrectangular set
-
-### Output
-
-A zonotope.
-"""
-function convert(::Type{Zonotope}, H::AbstractHyperrectangle{N}) where {N}
-    if isflat(H)
-        r = radius_hyperrectangle(H)
-        n = length(r)
-
-        nzgen = 0
-        Gnz = Vector{N}()
-        sizehint!(Gnz, n * n)
-        @inbounds for (i, ri) in enumerate(r)
-            if ri != zero(N)
-                col = zeros(N, n)
-                col[i] = ri
-                append!(Gnz, col)
-                nzgen += 1
-            end
-        end
-        G = reshape(Gnz, n, nzgen)
-    else
-        G = genmat(H)
-    end
-    return Zonotope(center(H), G)
-end
-
 function convert(::Type{Zonotope}, S::Singleton{N, VN}) where {N, VN<:AbstractVector{N}}
     MT = LazySets.Arrays._matrix_type(VN)
     zero_genmat = MT(undef, dim(S), 0)


### PR DESCRIPTION
Closes #1879.

The fallback implementation has the same result but is faster:

```julia
julia> H1 = Hyperrectangle([0.0, 0.0], [1.0, 2.0]); H2 = Hyperrectangle([0.0, 0.0], [1.0, 0.0]);

# master
julia> @time convert(Zonotope, H1), convert(Zonotope, H2)
  0.000021 seconds (20 allocations: 1.188 KiB)
(Zonotope{Float64,Array{Float64,1},Array{Float64,2}}([0.0, 0.0], [1.0 0.0; 0.0 2.0]), Zonotope{Float64,Array{Float64,1},Array{Float64,2}}([0.0, 0.0], [1.0; 0.0]))

# this branch
julia> @time convert(Zonotope, H1), convert(Zonotope, H2)
  0.000019 seconds (11 allocations: 624 bytes)
(Zonotope{Float64,Array{Float64,1},Array{Float64,2}}([0.0, 0.0], [1.0 0.0; 0.0 2.0]), Zonotope{Float64,Array{Float64,1},Array{Float64,2}}([0.0, 0.0], [1.0; 0.0]))
```