### PR TITLE
#1769 - Faster box approximation of VPolytope

### DIFF
--- a/src/Approximations/overapproximate.jl
+++ b/src/Approximations/overapproximate.jl
@@ -1513,6 +1513,24 @@ function overapproximate(am::AbstractAffineMap{N, <:AbstractHyperrectangle{N}},
     return Hyperrectangle(center_MXv, radius_MX)
 end
 
+function overapproximate(P::Union{VPolytope, VPolygon},
+                         ::Type{<:Hyperrectangle}) where {N<:Real}
+    n = dim(P)
+    vlist = vertices_list(P)
+    low = copy(vlist[1])
+    high = copy(vlist[1])
+    @inbounds for v in @view vlist[2:length(vlist)]
+        for i in 1:n
+            if v[i] > high[i]
+                high[i] = v[i]
+            elseif v[i] < low[i]
+                low[i] = v[i]
+            end
+        end
+    end
+    return Hyperrectangle(low=low, high=high)
+end
+
 """
     overapproximate(X::LazySet{N}, ::Type{<:Zonotope},
                     dir::AbstractDirections{N};

--- a/test/unit_box_approximation.jl
+++ b/test/unit_box_approximation.jl
@@ -29,6 +29,11 @@ for N in [Float64, Rational{Int}, Float32]
     @test h.center ≈ hexp.center
     @test h.radius ≈ hexp.radius
 
+    # Box approximation of a VPolytope
+    P = VPolytope([N[0, 0], N[2, 1], N[1, 2]])
+    H = box_approximation(P)
+    @test H == Hyperrectangle(N[1, 1], N[1, 1])
+
     # empty set
     E = EmptySet{N}(2)
     @test box_approximation(E) == E


### PR DESCRIPTION
Closes #1769.

In 2D this implementation is less efficient for a moderate number of vertices due to the additional conversion from `low`/`high` in the `Hyperrectangle` constructor. I guess in higher dimensions it will be more useful. Should I remove the dispatch for `VPolygon` or add an `invoke` of the old method based on the number of vertices?

```julia
julia> P1 = VPolytope([[0.0, 0.0], [2.0, 1.0], [1.0, 2.0]]);
julia> P2 = VPolytope([rand(2) for _ in 1:100]);
julia> P3 = VPolytope([rand(2) for _ in 1:1000]);

# this branch

julia> @time box_approximation(P1)
[0.0, 0.0][2.0, 2.0]
  0.000008 seconds (5 allocations: 416 bytes)
Hyperrectangle{Float64,Array{Float64,1},Array{Float64,1}}([1.0, 1.0], [1.0, 1.0])
julia> @time box_approximation(P2)
[0.001830275380493962, 0.005165832293896333][0.9791389830947983, 0.9914106144943142]
    0.000009 seconds (5 allocations: 416 bytes)
Hyperrectangle{Float64,Array{Float64,1},Array{Float64,1}}([0.49048462923764613, 0.4982882233941053], [0.48865435385715217, 0.49312239110020895])
julia> @time box_approximation(P3)
  0.000024 seconds (5 allocations: 416 bytes)
Hyperrectangle{Float64,Array{Float64,1},Array{Float64,1}}([0.4991620587806421, 0.4983966049474178], [0.49909969477169713, 0.4978833437247012])

# master

julia> @time box_approximation(P1)
  0.000004 seconds (3 allocations: 224 bytes)
Hyperrectangle{Float64,Array{Float64,1},Array{Float64,1}}([1.0, 1.0], [1.0, 1.0])
julia> @time box_approximation(P2)
  0.000008 seconds (3 allocations: 224 bytes)
Hyperrectangle{Float64,Array{Float64,1},Array{Float64,1}}([0.49048462923764613, 0.4982882233941053], [0.48865435385715217, 0.49312239110020895])
julia> @time box_approximation(P3)
  0.000049 seconds (3 allocations: 224 bytes)
Hyperrectangle{Float64,Array{Float64,1},Array{Float64,1}}([0.4991620587806421, 0.4983966049474178], [0.49909969477169713, 0.4978833437247012])
```