### PR TITLE
#2245 - Add constrained dimensions of a line

### DIFF
--- a/docs/src/lib/sets/Line.md
+++ b/docs/src/lib/sets/Line.md
@@ -24,6 +24,7 @@ normalize!(::Line, ::Real=2.0)
 distance(::AbstractVector, ::Line, ::Real=2.0)
 distance(::AbstractSingleton, ::Line, ::Real=2.0)
 linear_map(::AbstractMatrix, ::Line)
+constrained_dimensions(::Line)
 ```
 Inherited from [`LazySet`](@ref):
 * [`norm`](@ref norm(::LazySet, ::Real))

--- a/src/Sets/Line.jl
+++ b/src/Sets/Line.jl
@@ -495,3 +495,39 @@ function _linear_map(M::AbstractMatrix, L::Line)
     Md = M * L.d
     return Line(Mp, Md)
 end
+
+"""
+    constrained_dimensions(L::Line)
+
+Return the indices in which a line is constrained.
+
+### Input
+
+- `L` -- line
+
+### Output
+
+A vector of ascending indices `i` such that the line is constrained in dimension
+`i`.
+
+### Algorithm
+
+For each coordinate ``i``, vectors of the form ``x_i = p_i + λ n_i`` are constrained
+(i.e. they belong to the line and are bounded) if and only if ``n_i`` is zero.
+Hence, this function returns all indices of the normal vector ``n`` for which
+the ``i``-th coordinate is nonzero.
+
+### Examples
+
+The line ``y = 5`` in two dimensions can be written as ``p = [0, 5]`` and
+``n = [1, 0]``. This line constrains dimension ``2``.
+
+```jldoctest
+julia> constrained_dimensions(Line([0, 5.], [1, 0.]))
+1-element Array{Int64,1}:
+ 2
+```
+"""
+function constrained_dimensions(L::Line)
+    return findall(isapproxzero, L.n)
+end

--- a/test/unit_Line.jl
+++ b/test/unit_Line.jl
@@ -58,4 +58,7 @@ for N in [Float64, Rational{Int}, Float32]
         rot = N[0 -1; 1 0] # π/2 ccw rotation
         @test isequivalent(linear_map(rot, l), Line(N[-1, 0], N[0, 1]))
     end
+
+    # constrained dimensions
+    @test constrained_dimensions(l1) == [2]
 end


### PR DESCRIPTION
Closes https://github.com/JuliaReach/LazySets.jl/issues/2245.

---

Adding #2245 as i had done it already. Here the interpretation of a "constrained dimension" is that the set is bounded along the i-the dimension, otherwise it is "unconstrained". In fact, as discussed in #2245, for half-spaces the interpretation is the same. 

On the other hand, one can't blindly apply the `constrained_dimensions` to the BFPSV19 algorithm implemented in Reachability.jl (not yet available in RA) because it requires equality with the projection of the set along the constrained dimensions, times the cartesian prod with the universal set in the unconstrained dimensions.. using a line, one only gets an overapproximation. 