### PR TITLE
#2280 - Pass kwarg to affine_map

### DIFF
--- a/src/Interfaces/LazySet.jl
+++ b/src/Interfaces/LazySet.jl
@@ -385,7 +385,7 @@ function diameter(S::LazySet, p::Real=Inf)
 end
 
 """
-    affine_map(M::AbstractMatrix, X::LazySet, v::AbstractVector)
+    affine_map(M::AbstractMatrix, X::LazySet, v::AbstractVector; kwargs...)
 
 Compute a concrete affine map.
 
@@ -403,8 +403,8 @@ A set representing the affine map of `X`.
 
 The implementation applies the functions `linear_map` and `translate`.
 """
-function affine_map(M::AbstractMatrix, X::LazySet, v::AbstractVector)
-    return translate(linear_map(M, X), v)
+function affine_map(M::AbstractMatrix, X::LazySet, v::AbstractVector; kwargs...)
+    return translate(linear_map(M, X; kwargs...), v)
 end
 
 """

--- a/test/unit_BallInf.jl
+++ b/test/unit_BallInf.jl
@@ -135,6 +135,8 @@ for N in [Float64, Rational{Int}, Float32]
     am = affine_map(M, B, v)
     @test ispermutation(vertices_list(am),
                         [N[4, 1], N[0, 1], N[-2, -3], N[2, -3]])
+    amv = affine_map(M, B, v, algorithm="vrep") # pass a custom algorithm
+    @test amv isa VPolygon && isequivalent(am, amv)
 
     # volume
     B = BallInf(N[0, 0], N(1))


### PR DESCRIPTION
Closes #2280.

we can add a test with an algorithm choice for `linear_map` which is not the default choice.