### PR TITLE
update vpolytope projection

### DIFF
--- a/src/Approximations/decompositions.jl
+++ b/src/Approximations/decompositions.jl
@@ -665,5 +665,17 @@ function project(V::Union{<:VPolygon{N}, <:VPolytope{N}},
     n = dim(V)
     M = projection_matrix(block, n, N)
     πvertices = broadcast(v -> M * v, vertices_list(V))
-    return VPolytope(πvertices)
+
+    m = size(M, 1)
+    if m == 1
+        # convex_hull in 1d returns the minimum and maximum points, in that order
+        aux = convex_hull(πvertices)
+        a = first(aux[1])
+        b = length(aux) == 1 ? a : first(aux[2])
+        return Interval(a, b)
+    elseif m == 2
+        return VPolygon(convex_hull(πvertices))
+    else
+        return VPolytope(πvertices)
+    end
 end

--- a/src/Approximations/decompositions.jl
+++ b/src/Approximations/decompositions.jl
@@ -674,7 +674,7 @@ function project(V::Union{<:VPolygon{N}, <:VPolytope{N}},
         b = length(aux) == 1 ? a : first(aux[2])
         return Interval(a, b)
     elseif m == 2
-        return VPolygon(convex_hull(πvertices))
+        return VPolygon(πvertices; apply_convex_hull=true)
     else
         return VPolytope(πvertices)
     end

--- a/test/unit_Polygon.jl
+++ b/test/unit_Polygon.jl
@@ -394,9 +394,10 @@ for N in [Float64, Float32, Rational{Int}]
 
     # test concrete projection
     V = VPolygon([N[0, 1], N[1, 0], N[-1, 0]])
-    @test project(V, [1]) == VPolytope([N[-1], N[1], N[0]])
+    @test project(V, [1]) == Interval(N(-1), N(1))
+    @test project(V, 1:2) == V
     V = VPolygon([N[1, 0], N[1, 1]])
-    @test project(V, [1]) == VPolytope([N[1], N[1]])
+    @test project(V, [1]) == Interval(N(1), N(1))
 end
 
 function same_constraints(v::Vector{<:LinearConstraint{N}})::Bool where N<:Real

--- a/test/unit_Polytope.jl
+++ b/test/unit_Polytope.jl
@@ -197,8 +197,9 @@ for N in [Float64, Rational{Int}, Float32]
 
     # test concrete projection
     V = VPolytope([N[0, 0, 1], N[0, 1, 0], N[0, -1, 0], N[1, 0, 0]])
-    @test project(V, [1]) == VPolytope([N[0], N[0], N[0], N[1]])
-    @test project(V, [1, 2]) == VPolytope([N[0, 0], N[0, 1], N[0, -1], N[1, 0]])
+    @test project(V, [1]) == Interval(N(0), N(1))
+    @test project(V, [1, 2]) == VPolygon([N[0, 0], N[0, 1], N[0, -1], N[1, 0]])
+    @test project(V, [1, 2, 3]) == V
 end
 
 # default Float64 constructors


### PR DESCRIPTION
follow up of https://github.com/JuliaReach/LazySets.jl/pull/2284, adds some dimensional checks and (runtime) dispatch. the drawback of this approach is the type-instability, but it has all other benefits such as specialized methods on the returned type. 