### PR TITLE
Add HPolytope with MT + let macro work on tuples

### DIFF
--- a/src/Initialization/init_ModelingToolkit.jl
+++ b/src/Initialization/init_ModelingToolkit.jl
@@ -4,8 +4,38 @@ eval(quote
                             simplify,
                             Operation
 
+   """
+       _vec(vars::NTuple{L, Union{<:Operation, <:Vector{Operation}}}) where {L}
+
+   Transform a tuple of operations into one vector of operations.
+
+   ### Input
+
+   - `vars` -- tuple where each element is either an `Operation` or a vector of operations
+
+   ### Output
+
+   A vector of `Operation` obtained by concatenating each tuple component.
+
+   ## Examples
+
+   ```julia
+   julia> vars = @variables x[1:2] y
+   (Operation[x₁, x₂], y)
+
+   julia> _vec(vars)
+   3-element Array{Operation,1}:
+    x₁
+    x₂
+    y
+   ```
+   """
+    function _vec(vars::NTuple{L, Union{<:Operation, <:Vector{Operation}}}) where {L}
+        return collect(reduce(vcat, vars))
+    end
 end)
 
 eval(load_modeling_toolkit_hyperplane())
 eval(load_modeling_toolkit_halfspace())
 eval(load_modeling_toolkit_hpolyhedron())
+eval(load_modeling_toolkit_hpolytope())

--- a/src/Initialization/init_ModelingToolkit.jl
+++ b/src/Initialization/init_ModelingToolkit.jl
@@ -23,7 +23,7 @@ eval(quote
    julia> vars = @variables x[1:2] y
    (Operation[x₁, x₂], y)
 
-   julia> _vec(vars)
+   julia> LazySets._vec(vars)
    3-element Array{Operation,1}:
     x₁
     x₂

--- a/src/Sets/HPolytope.jl
+++ b/src/Sets/HPolytope.jl
@@ -233,3 +233,49 @@ end
 function _vertices_list(P::HPolytope, backend)
     return vertices_list(P, backend=backend)
 end
+
+# ============================================
+# Functionality that requires ModelingToolkit
+# ============================================
+function load_modeling_toolkit_hpolytope()
+
+return quote
+
+"""
+    HPolytope(expr::Vector{<:Operation}, vars=get_variables(first(expr)); N::Type{<:Real}=Float64)
+
+Return the polytope in half-space representation given by a list of symbolic expressions.
+
+### Input
+
+- `expr` -- vector of symbolic expressions that describes each half-space
+- `vars` -- (optional, default: `get_variables(expr)`), if an array of variables is given,
+            use those as the ambient variables in the set with respect to which derivations
+            take place; otherwise, use only the variables which appear in the given
+            expression (but be careful because the order may change)
+- `N`    -- (optional, default: `Float64`) the numeric type of the returned half-space
+
+### Output
+
+An `HPolytope`.
+
+### Examples
+
+```julia
+julia> using ModelingToolkit
+
+julia> vars = @variables x y
+(x, y)
+
+julia> HPolytope([x <= 1, x >= 0, y <= 1, y >= 0], vars)
+HPolytope{Float64,Array{Float64,1}}(HalfSpace{Float64,Array{Float64,1}}[HalfSpace{Float64,Array{Float64,1}}([1.0, 0.0], 1.0),
+HalfSpace{Float64,Array{Float64,1}}([-1.0, 0.0], 0.0), HalfSpace{Float64,Array{Float64,1}}([0.0, 1.0], 1.0),
+HalfSpace{Float64,Array{Float64,1}}([0.0, -1.0], 0.0)])
+```
+"""
+function HPolytope(expr::Vector{<:Operation}, vars=get_variables(first(expr));
+                   N::Type{<:Real}=Float64, check_boundedness::Bool=false)
+    return HPolytope([HalfSpace(ex, vars; N=N) for ex in expr], check_boundedness=check_boundedness)
+end
+
+end end  # quote / load_modeling_toolkit_hpolytope()

--- a/src/Sets/HalfSpace.jl
+++ b/src/Sets/HalfSpace.jl
@@ -528,7 +528,7 @@ function load_modeling_toolkit_halfspace()
 return quote
 
 """
-    HalfSpace(expr::Operation, vars=get_variables(expr); N::Type{<:Real}=Float64)
+    HalfSpace(expr::Operation, vars::Union{<:Operation, <:Vector{Operation}}=get_variables(expr); N::Type{<:Real}=Float64)
 
 Return the half-space given by a symbolic expression.
 
@@ -593,7 +593,7 @@ Note in particular that strict inequalities are relaxed as being smaller-or-equa
 Finally, the returned set is the half-space with normal vector `[a1, …, an]` and
 displacement `b`.
 """
-function HalfSpace(expr::Operation, vars=get_variables(expr); N::Type{<:Real}=Float64)
+function HalfSpace(expr::Operation, vars::Union{<:Operation, <:Vector{Operation}}=get_variables(expr); N::Type{<:Real}=Float64)
 
     # find sense and normalize
     if expr.op == <
@@ -632,6 +632,11 @@ function HalfSpace(expr::Operation, vars=get_variables(expr); N::Type{<:Real}=Fl
     β = -N(ModelingToolkit.substitute(sexpr, zeroed_vars).value)
 
     return HalfSpace(coeffs, β)
+end
+
+function HalfSpace(expr::Operation, vars::NTuple{L, Union{<:Operation, <:Vector{Operation}}}; N::Type{<:Real}=Float64) where {L}
+    vars = _vec(vars)
+    return HalfSpace(expr, vars, N=N)
 end
 
 end end  # quote / load_modeling_toolkit_halfspace()

--- a/src/Sets/Hyperplane.jl
+++ b/src/Sets/Hyperplane.jl
@@ -486,7 +486,7 @@ function load_modeling_toolkit_hyperplane()
 return quote
 
 """
-    Hyperplane(expr::Operation, vars=get_variables(expr); N::Type{<:Real}=Float64)
+    Hyperplane(expr::Operation, vars::Union{<:Operation, <:Vector{Operation}}=get_variables(expr); N::Type{<:Real}=Float64)
 
 Return the hyperplane given by a symbolic expression.
 
@@ -535,7 +535,7 @@ Therefore, the order in which the variables appear in `vars` affects the final r
 Finally, the returned set is the hyperplane with normal vector `[a1, …, an]` and
 displacement `b`.
 """
-function Hyperplane(expr::Operation, vars=get_variables(expr); N::Type{<:Real}=Float64)
+function Hyperplane(expr::Operation, vars::Union{<:Operation, <:Vector{Operation}}=get_variables(expr); N::Type{<:Real}=Float64)
     (expr.op == ==) || throw(ArgumentError("expected an expression of the form `ax == b`, got $expr"))
 
     # simplify to the form a*x + β == 0
@@ -550,6 +550,11 @@ function Hyperplane(expr::Operation, vars=get_variables(expr); N::Type{<:Real}=F
     β = -N(ModelingToolkit.substitute(sexpr, zeroed_vars).value)
 
     return Hyperplane(coeffs, β)
+end
+
+function Hyperplane(expr::Operation, vars::NTuple{L, Union{<:Operation, <:Vector{Operation}}}; N::Type{<:Real}=Float64) where {L}
+    vars = _vec(vars)
+    return Hyperplane(expr, vars, N=N)
 end
 
 end end  # quote / load_modeling_toolkit_hyperplane()

--- a/test/unit_Hyperplane.jl
+++ b/test/unit_Hyperplane.jl
@@ -128,4 +128,8 @@ end
     # test with sparse variables
     @variables x[1:5]
     @test Hyperplane(2x[1] + 5x[4] == 10., x) == Hyperplane([2.0, 0.0, 0.0, 5.0, 0.0], 10.0)
+
+    # test passing a combination of operations
+    vars = @variables x[1:2] t
+    @test Hyperplane(x[1] == t, vars) == Hyperplane([1.0, 0.0, -1.0], 0.0)
 end


### PR DESCRIPTION
The PR contains two updates:

- add macro for `HPolytope`

- in master one has to extract the tuple argument

```julia
vars, = @variables x[1:2]
HalfSpace(x[1] <= 1, x)
```
with this branch we can do

```julia
vars = @variables x[1:2]
HalfSpace(x[1] <= 1, x)
```
