### PR TITLE
#2265 - Use iterator methods `constraints` and `vertices`

### DIFF
--- a/src/Approximations/approximate.jl
+++ b/src/Approximations/approximate.jl
@@ -33,7 +33,7 @@ original set is contained in either the positive or negative orthant or
 is axis-aligned.
 """
 function approximate(R::Rectification; apply_convex_hull::Bool=false)
-    vlist = [rectify(v) for v in vertices_list(set(R))]
+    vlist = [rectify(v) for v in vertices(set(R))]
     if apply_convex_hull
         vlist = convex_hull(vlist)
     end

--- a/src/Approximations/decompositions.jl
+++ b/src/Approximations/decompositions.jl
@@ -636,7 +636,7 @@ julia> project(P, [1, 2]) |> constraints_list
 """
 function project(P::AbstractPolyhedron{N}, block::AbstractVector{Int}) where {N}
     if constrained_dimensions(P) ⊆ block
-        clist = [HalfSpace(c.a[block], c.b) for c in constraints_list(P)]
+        clist = [HalfSpace(c.a[block], c.b) for c in constraints(P)]
     else
         n = dim(P)
         M = projection_matrix(block, n, N)

--- a/src/ConcreteOperations/isdisjoint.jl
+++ b/src/ConcreteOperations/isdisjoint.jl
@@ -1015,7 +1015,7 @@ function is_intersection_empty(P::AbstractPolyhedron{N},
                               ) where {N<:Real}
     if algorithm == "sufficient"
         # sufficient check for empty intersection using half-space checks
-        for Hi in constraints_list(P)
+        for Hi in constraints(P)
             if is_intersection_empty(X, Hi)
                 if witness
                     return (true, N[])

--- a/src/ConcreteOperations/issubset.jl
+++ b/src/ConcreteOperations/issubset.jl
@@ -240,7 +240,7 @@ end
 
 # check whether P ⊆ S by testing if each vertex of P belongs to S
 function _issubset_vertices_list(P, S, witness)
-    for v in vertices_list(P)
+    for v in vertices(P)
         if v ∉ S
             if witness
                 return (false, v)

--- a/src/ConcreteOperations/issubset.jl
+++ b/src/ConcreteOperations/issubset.jl
@@ -297,7 +297,7 @@ function _issubset_constraints_list(S::LazySet{N}, P::LazySet{N},
                                     witness::Bool=false) where {N<:Real}
     @assert dim(S) == dim(P)
 
-    @inbounds for H in constraints_list(P)
+    @inbounds for H in constraints(P)
         if !_leq(ρ(H.a, S), H.b)
             if witness
                 return (false, σ(H.a, S))

--- a/src/Interfaces/AbstractHPolygon.jl
+++ b/src/Interfaces/AbstractHPolygon.jl
@@ -96,9 +96,9 @@ A new polygon in constraint representation whose normal directions ``a_i``
 are normalized, i.e., such that ``‖a_i‖_p = 1`` holds.
 """
 function normalize(P::AbstractHPolygon{N}, p=N(2)) where {N<:Real}
-    constraints = [normalize(hs, p) for hs in constraints_list(P)]
+    clist = [normalize(hs, p) for hs in constraints(P)]
     T = basetype(P)
-    return T(constraints)
+    return T(clist)
 end
 
 

--- a/src/Interfaces/AbstractPolyhedron_functions.jl
+++ b/src/Interfaces/AbstractPolyhedron_functions.jl
@@ -55,7 +55,7 @@ function ∈(x::AbstractVector{N}, P::AbstractPolyhedron{N}) where {N<:Real}
     @assert length(x) == dim(P) "a $(length(x))-dimensional point cannot be " *
         "an element of a $(dim(P))-dimensional set"
 
-    for c in constraints_list(P)
+    for c in constraints(P)
         if !_leq(dot(c.a, x), c.b)
             return false
         end
@@ -732,7 +732,7 @@ function _linear_map_hrep(M::AbstractMatrix{N}, P::AbstractPolyhedron{N},
 
     # append zeros to the existing constraints, in the last m-n coordinates
     # TODO: cast to common vector type instead of Vector(c.a), see #1942, #1952
-    cext = [HalfSpace(vcat(Vector(c.a), zeros(N, m-n)), c.b) for c in constraints_list(P)]
+    cext = [HalfSpace(vcat(Vector(c.a), zeros(N, m-n)), c.b) for c in constraints(P)]
 
     # now fix the last m-n coordinates to zero
     id_out = Matrix(one(N)*I, m-n, m-n)
@@ -760,7 +760,7 @@ function _linear_map_hrep(M::AbstractMatrix{N}, P::AbstractPolyhedron{N},
     # extend the polytope storing the y variables first
     # append zeros to the existing constraints, in the last m-n coordinates
     # TODO: cast to common vector type instead of hard-coding Vector(c.a), see #1942 and #1952
-    Ax_leq_b = [Polyhedra.HalfSpace(vcat(zeros(N, m), Vector(c.a)), c.b) for c in constraints_list(P)]
+    Ax_leq_b = [Polyhedra.HalfSpace(vcat(zeros(N, m), Vector(c.a)), c.b) for c in constraints(P)]
     y_eq_Mx = [Polyhedra.HyperPlane(vcat(₋Id_m[i, :], Vector(M[i, :])), zero(N)) for i in 1:m]
 
     Phrep = Polyhedra.hrep(y_eq_Mx, Ax_leq_b)

--- a/src/Interfaces/LazySet.jl
+++ b/src/Interfaces/LazySet.jl
@@ -1012,7 +1012,7 @@ This function relies on `vertices_list`, which raises an error if the set is
 not polytopic (e.g., unbounded).
 """
 function singleton_list(P::LazySet)
-    return [Singleton(x) for x in vertices_list(P)]
+    return [Singleton(x) for x in vertices(P)]
 end
 
 """

--- a/src/LazyOperations/Intersection.jl
+++ b/src/LazyOperations/Intersection.jl
@@ -444,8 +444,7 @@ function ρ_helper(d::AbstractVector{N}, cap::Intersection{N, S1, S2}; kwargs...
 
     # more precise algorithm
     @assert isbounded(cap.X) "the first set in the intersection must be bounded"
-    return minimum([ρ(d, cap.X ∩ Hi; kwargs...)
-                   for Hi in constraints_list(cap.Y)])
+    return minimum([ρ(d, cap.X ∩ Hi; kwargs...) for Hi in constraints(cap.Y)])
 end
 
 """

--- a/src/Sets/HPolygon.jl
+++ b/src/Sets/HPolygon.jl
@@ -182,8 +182,8 @@ function translate(P::HPolygon{N}, v::AbstractVector{N}; share::Bool=false
                   ) where {N<:Real}
     @assert length(v) == dim(P) "cannot translate a $(dim(P))-dimensional " *
                                 "set by a $(length(v))-dimensional vector"
-    constraints = [translate(c, v; share=share) for c in constraints_list(P)]
-    return HPolygon(constraints;
+    clist = [translate(c, v; share=share) for c in constraints(P)]
+    return HPolygon(clist;
                     sort_constraints=false, check_boundedness=false,
                     prune=false)
 end

--- a/src/Sets/HPolygonOpt.jl
+++ b/src/Sets/HPolygonOpt.jl
@@ -218,8 +218,8 @@ function translate(P::HPolygonOpt{N}, v::AbstractVector{N}; share::Bool=false
                   ) where {N<:Real}
     @assert length(v) == dim(P) "cannot translate a $(dim(P))-dimensional " *
                                 "set by a $(length(v))-dimensional vector"
-    constraints = [translate(c, v; share=share) for c in constraints_list(P)]
-    return HPolygonOpt(constraints, P.ind;
+    clist = [translate(c, v; share=share) for c in P.constraints]
+    return HPolygonOpt(clist, P.ind;
                        sort_constraints=false, check_boundedness=false,
                        prune=false)
 end

--- a/src/Sets/HPolyhedron.jl
+++ b/src/Sets/HPolyhedron.jl
@@ -306,9 +306,9 @@ A new polyhedron in constraint representation whose normal directions ``a_i``
 are normalized, i.e., such that ``‖a_i‖_p = 1`` holds.
 """
 function normalize(P::HPoly{N}, p=N(2)) where {N<:Real}
-    constraints = [normalize(hs, p) for hs in constraints_list(P)]
+    clist = [normalize(hs, p) for hs in constraints(P)]
     T = basetype(P)
-    return T(constraints)
+    return T(clist)
 end
 
 """
@@ -407,9 +407,9 @@ function translate(P::HPoly{N}, v::AbstractVector{N}; share::Bool=false
                   ) where {N<:Real}
     @assert length(v) == dim(P) "cannot translate a $(dim(P))-dimensional " *
                                 "set by a $(length(v))-dimensional vector"
-    constraints = [translate(c, v; share=share) for c in constraints_list(P)]
+    clist = [translate(c, v; share=share) for c in constraints(P)]
     T = basetype(P)
-    return T(constraints)
+    return T(clist)
 end
 
 # ========================================================

--- a/src/Sets/HalfSpace.jl
+++ b/src/Sets/HalfSpace.jl
@@ -517,7 +517,7 @@ function _linear_map_hrep_helper(M::AbstractMatrix{N}, P::HalfSpace{N},
 end
 
 # TODO: after #2032, #2041 remove use of this function
-_normal_Vector(P::LazySet) = [LinearConstraint(convert(Vector, c.a), c.b) for c in constraints_list(P)]
+_normal_Vector(P::LazySet) = [LinearConstraint(convert(Vector, c.a), c.b) for c in constraints(P)]
 _normal_Vector(c::LinearConstraint) = LinearConstraint(convert(Vector, c.a), c.b)
 
 

--- a/src/Sets/VPolygon.jl
+++ b/src/Sets/VPolygon.jl
@@ -638,7 +638,7 @@ We add the vector to each vertex of the polygon.
 function translate(P::VPolygon{N}, v::AbstractVector{N}) where {N<:Real}
     @assert length(v) == dim(P) "cannot translate a $(dim(P))-dimensional " *
                                 "set by a $(length(v))-dimensional vector"
-    return VPolygon([x + v for x in vertices_list(P)])
+    return VPolygon([x + v for x in vertices(P)])
 end
 
 """

--- a/src/Sets/VPolytope.jl
+++ b/src/Sets/VPolytope.jl
@@ -334,7 +334,7 @@ We add the vector to each vertex of the polytope.
 function translate(P::VPolytope{N}, v::AbstractVector{N}) where {N<:Real}
     @assert length(v) == dim(P) "cannot translate a $(dim(P))-dimensional " *
                                 "set by a $(length(v))-dimensional vector"
-    return VPolytope([x + v for x in vertices_list(P)])
+    return VPolytope([x + v for x in vertices(P)])
 end
 
 # --- AbstractPolytope interface functions ---

--- a/src/convert.jl
+++ b/src/convert.jl
@@ -235,7 +235,7 @@ function convert(::Type{HPOLYGON}, P::HPolytope{N, VN};
                  prune::Bool=true) where {N<:Real, VN<:AbstractVector{N}, HPOLYGON<:AbstractHPolygon}
     @assert dim(P) == 2 "polytope must be two-dimensional for conversion"
     H = HPOLYGON(Vector{LinearConstraint{N, VN}}())
-    for ci in constraints_list(P)
+    for ci in constraints(P)
         addconstraint!(H, ci; prune=prune)
     end
     return H


### PR DESCRIPTION
Closes #2265.

---

EDIT: I second-guess this changeset. #2331 made me realize that the iterator pattern in Julia creates additional allocations that makes full iteration more expensive than direct collection in a list. I suggest one of the following changes instead (where I favor 2):

1. Only apply the changes to places with a fail-fast behavior, e.g.:
```julia
function _issubset_vertices_list(P, S, witness)
    for v in vertices(P)
        if v ∉ S
            if witness
                return (false, v)
...
```

2. Add another function (e.g., `vertices_enum`) which returns either `vertices` or `vertices_list` - whichever is faster. For `Singleton`s for instance the `vertices` iteration is faster (see the benchmark below), but for most other set types the `vertices_list` iteration is faster.

---

My benchmarks showed the same runtime/allocations as in `master`. This is not very surprising because we currently only have a dummy implementation that falls back to the corresponding `_list` function. But in combination with #2264 we already gain something:

```julia
julia> S = rand(Singleton);

julia> @btime singleton_list($S);  # combined branches
  41.808 ns (1 allocation: 96 bytes)

julia> @btime singleton_list($S);  # master
  91.619 ns (2 allocations: 192 bytes)
```