### PR TITLE
Redefine copy(::LazySet)

### DIFF
--- a/src/Interfaces/LazySet.jl
+++ b/src/Interfaces/LazySet.jl
@@ -571,7 +571,7 @@ end
 """
     copy(S::LazySet)
 
-Return a deep copy of the given set by copying its values recursively.
+Return a copy of the given set by copying its values recursively.
 
 ### Input
 
@@ -583,11 +583,14 @@ A copy of `S`.
 
 ### Notes
 
-This function performs a `deepcopy` of each field in `S`, resulting in a
-completely independent object. See the documentation of `?deepcopy` for further
-details.
+This function performs a `copy` of each field in `S`.
+See the documentation of `?copy` for further details.
 """
-copy(S::LazySet) = deepcopy(S)
+function copy(S::T) where {T<:LazySet}
+    args = [copy(getfield(S, f)) for f in fieldnames(T)]
+    BT = basetype(S)
+    return BT(args...)
+end
 
 """
     tosimplehrep(S::LazySet)

--- a/test/Sets/Polytope.jl
+++ b/test/Sets/Polytope.jl
@@ -190,7 +190,7 @@ for N in [Float64, Rational{Int}, Float32]
     # copy (see #1002)
     p, q = [N(1)], [N(2)]
     P = VPolytope([p, q])
-    Pcopy = copy(P)
+    Pcopy = deepcopy(P)
     p[1] = N(5)
     # test that Pcopy is independent of P ( = deepcopy)
     @test Pcopy.vertices[1] == [N(1)]


### PR DESCRIPTION
This PR proposes to change the semantics of `copy` to that in `Base` (see #2261).
```julia
help?> copy

  copy(x)

  Create a shallow copy of x: the outer structure is copied, but not all internal values.
  For example, copying an array produces a new array with identically-same elements as the original.
```

The old behavior is readily available with `deepcopy` (no method definition needed).

The implementation is generic but not bulletproof because it relies on a constructor with the arguments being the fields of the struct, in the right order. I would add tests that this works for each type (and define methods where it does not), but first I wanted to ask @mforets if you agree with that new behavior.

Also note that the generic implementation is slower than the old implementation, probably because it allocates an additional list. The speedup announced in #2261 would come by implementing specific methods for each concrete type.

```julia
julia> H = rand(Hyperrectangle)
Hyperrectangle{Float64,Array{Float64,1},Array{Float64,1}}([-1.0889864788669317, -1.4096632306286592], [0.017572299116926156, 1.4546162432722907])

julia> @btime deepcopy($H)  # old implementation
  458.046 ns (7 allocations: 720 bytes)
Hyperrectangle{Float64,Array{Float64,1},Array{Float64,1}}([-1.0889864788669317, -1.4096632306286592], [0.017572299116926156, 1.4546162432722907])

julia> @btime copy($H)  # new implementation
  610.816 ns (9 allocations: 496 bytes)
Hyperrectangle{Float64,Array{Float64,1},Array{Float64,1}}([-1.0889864788669317, -1.4096632306286592], [0.017572299116926156, 1.4546162432722907])
```

Note that the behavior does not change drastically. For example, arrays of floats are still copied:

```julia
julia> H2 = copy(H)
Hyperrectangle{Float64,Array{Float64,1},Array{Float64,1}}([-1.0889864788669317, -1.4096632306286592], [0.017572299116926156, 1.4546162432722907])

julia> H2.center[1] = 0.0
0.0

julia> H.center, H2.center
([-1.0889864788669317, -1.4096632306286592], [0.0, -1.4096632306286592])
```

However, nested arrays are not deep-copied, which may not be what we want (e.g., lists of vertices/constraints would be shared):

```julia
julia> v1 = [[1.0]]
1-element Array{Array{Float64,1},1}:
 [1.0]

julia> v2 = copy(v1)
1-element Array{Array{Float64,1},1}:
 [1.0]

julia> v2[1][1] = 0.0
0.0

julia> v1, v2
([[0.0]], [[0.0]])
```