### PR TITLE
#2264 - vertices iterator for AbstractHyperrectangle

### DIFF
--- a/docs/src/lib/interfaces.md
+++ b/docs/src/lib/interfaces.md
@@ -364,6 +364,7 @@ radius(::AbstractHyperrectangle, ::Real=Inf)
 σ(::AbstractVector, ::AbstractHyperrectangle)
 ρ(::AbstractVector, ::AbstractHyperrectangle)
 ∈(::AbstractVector, ::AbstractHyperrectangle)
+vertices(::AbstractHyperrectangle)
 vertices_list(::AbstractHyperrectangle)
 constraints_list(::AbstractHyperrectangle{N}) where {N}
 high(::AbstractHyperrectangle)

--- a/test/unit_Hyperrectangle.jl
+++ b/test/unit_Hyperrectangle.jl
@@ -196,6 +196,14 @@ for N in [Float64, Rational{Int}, Float32]
     P = linear_map(Diagonal(N[1, 2, 3, 4]), overapproximate(H1 * H1))
     @test P isa Zonotope
 
+    # vertices
+    H = Hyperrectangle(N[1, 2], N[3, 4])  # non-flat
+    @test ispermutation(collect(vertices(H)), vertices_list(H)) &&
+          ispermutation(vertices_list(H), [N[-2, -2], [4, -2], [-2, 6], [4, 6]])
+    H = Hyperrectangle(N[1, 2], N[3, 0])  # flat
+    @test ispermutation(collect(vertices(H)), vertices_list(H)) &&
+          ispermutation(vertices_list(H), [N[-2, 2], [4, 2]])
+
     # check that vertices_list is computed correctly if the hyperrectangle
     # is "degenerate"/flat, i.e., its radius contains zeros
     # these tests would crash if all 2^100 vertices were computed (see #92)


### PR DESCRIPTION
See #2264.

I was surprised that the iterator is generally slower. It is faster if it is not exhausted, though. I checked everything and I would conclude that the additional allocations are due to the way iteration is implemented: creation of a new `Tuple` in each iteration.

Defining the generator implementation:

```julia
function vertices2(H::AbstractHyperrectangle)
    n = dim(H)
    c = center(H)
    r = radius_hyperrectangle(H)
    p = Iterators.product(fill([1, -1], n)...)
    return Base.Generator(x -> c .+ r .* x, p)
end
```

```julia
julia> H = rand(Hyperrectangle, dim=10);

julia> function f(H)
           for v in LazySets.vertices2(H)
           end
       end;

julia> function g(H)
           for v in vertices(H)
           end
       end;

julia> function h(H)
           for v in vertices_list(H)
           end
       end;

julia> function f2(H, k)
           for (i, v) in enumerate(LazySets.vertices2(H))
               if i == k
                   return
               end
           end
       end;

julia> function g2(H, k)
           for (i, v) in enumerate(vertices(H))
               if i == k
                   return
               end
           end
       end;

julia> function h2(H, k)
           for (i, v) in enumerate(vertices_list(H))
               if i == k
                   return
               end
           end
       end;

# generate all vertices
julia> @btime f($H)
  400.304 μs (6151 allocations: 816.67 KiB)

julia> @btime g($H)
  62.453 μs (2052 allocations: 192.31 KiB)

julia> @btime h($H)
  50.713 μs (1027 allocations: 168.38 KiB)

# generate only k vertices
julia> @btime f2($H, 2)
  1.055 μs (15 allocations: 1.78 KiB)

julia> @btime g2($H, 2)
  249.454 ns (9 allocations: 752 bytes)

julia> @btime h2($H, 2)  # h/h2 are equivalent independent of k
  50.362 μs (1027 allocations: 168.38 KiB)

julia> @btime g2($H, 3)
  323.396 ns (12 allocations: 992 bytes)

julia> @btime f2($H, 4)
  1.448 μs (23 allocations: 2.88 KiB)

julia> @btime g2($H, 4)
  395.905 ns (15 allocations: 1.20 KiB)
```
The last two runs show that Incrementing `k` leads to three new allocations of size 240 bytes. One of them is of course the additional vertex that is generated. The two other allocations are probably the `Tuple`s; at least I do not see where else the code would allocate anything depending on `k`.