### PR TITLE
Better diameter and split methods for Interval

### DIFF
--- a/docs/src/lib/sets/Interval.md
+++ b/docs/src/lib/sets/Interval.md
@@ -32,6 +32,7 @@ scale(::N, ::Interval{N}) where {N<:Real}
 constraints_list(::Interval{N}) where {N<:Real}
 rectify(::Interval{N}) where {N<:Real}
 diameter(::Interval, ::Real=Inf)
+split(::Interval, ::AbstractVector{Int})
 ```
 Inherited from [`LazySet`](@ref):
 * [`singleton_list`](@ref singleton_list(::LazySet))

--- a/docs/src/lib/sets/Interval.md
+++ b/docs/src/lib/sets/Interval.md
@@ -30,10 +30,10 @@ plot_recipe(::Interval{N}, ::N=zero(N)) where {N<:Real}
 linear_map(::AbstractMatrix{N}, ::Interval{N}) where {N<:Real}
 scale(::N, ::Interval{N}) where {N<:Real}
 constraints_list(::Interval{N}) where {N<:Real}
-rectify(x::Interval{N}) where {N<:Real}
+rectify(::Interval{N}) where {N<:Real}
+diameter(::Interval, ::Real=Inf)
 ```
 Inherited from [`LazySet`](@ref):
-* [`diameter`](@ref diameter(::LazySet, ::Real))
 * [`singleton_list`](@ref singleton_list(::LazySet))
 
 Inherited from [`AbstractPolytope`](@ref):

--- a/src/Sets/Interval.jl
+++ b/src/Sets/Interval.jl
@@ -656,7 +656,7 @@ A real number representing the diameter.
 In one dimension all norms are the same.
 """
 function diameter(x::Interval, p::Real=Inf)
-    return norm(max(x) - min(x), p)
+    return norm(IntervalArithmetic.diam(x.dat), p)
 end
 
 """

--- a/src/Sets/Interval.jl
+++ b/src/Sets/Interval.jl
@@ -683,7 +683,7 @@ function split(x::Interval, k::Int)
     return [Interval(x2) for x2 in mince(x.dat, k)]
 end
 
-if VERSION < v"1.1"
+@static if VERSION < v"1.1"
     # IntervalArithmetic.mince() is not available -> define it here
     function mince(x::IntervalArithmetic.Interval, n)
         width = (x.hi - x.lo) / n

--- a/src/Sets/Interval.jl
+++ b/src/Sets/Interval.jl
@@ -655,3 +655,31 @@ In one dimension all norms are equivalent.
 function diameter(x::Interval, p::Real=Inf)
     return norm(max(x) - min(x), p)
 end
+
+"""
+    split(x::Interval, num_blocks)
+
+Partition an interval into uniform sub-intervals.
+
+### Input
+
+- `x`          -- interval
+- `num_blocks` -- number of blocks, possibly wrapped in a vector
+
+### Output
+
+A list of `Interval`s.
+"""
+function split(x::Interval, num_blocks::AbstractVector{Int})
+    @assert length(num_blocks) == 1 "an interval can only be split along one " *
+        "dimension"
+    return split(x, num_blocks[1])
+end
+
+function split(x::Interval, num_blocks::Int)
+    @assert num_blocks > 0 "can only split into a positive number of intervals"
+    if num_blocks == 1
+        return [x]
+    end
+    return [Interval(x2) for x2 in IntervalArithmetic.mince(x.dat, num_blocks)]
+end

--- a/src/Sets/Interval.jl
+++ b/src/Sets/Interval.jl
@@ -656,7 +656,7 @@ A real number representing the diameter.
 In one dimension all norms are the same.
 """
 function diameter(x::Interval, p::Real=Inf)
-    return norm(IntervalArithmetic.diam(x.dat), p)
+    return IntervalArithmetic.diam(x.dat)
 end
 
 """

--- a/src/Sets/Interval.jl
+++ b/src/Sets/Interval.jl
@@ -640,7 +640,7 @@ end
 """
     diameter(x::Interval, [p]::Real=Inf)
 
-Compute the diameter of an interval.
+Compute the diameter of an interval, defined as ``\\Vert b - a\\Vert`` in the ``p`-norm, where ``a`` (resp. ``b``) are the minimum (resp. maximum) of the given interval.
 
 ### Input
 

--- a/src/Sets/Interval.jl
+++ b/src/Sets/Interval.jl
@@ -653,7 +653,7 @@ A real number representing the diameter.
 
 ### Notes
 
-In one dimension all norms are equivalent.
+In one dimension all norms are the same.
 """
 function diameter(x::Interval, p::Real=Inf)
     return norm(max(x) - min(x), p)

--- a/src/Sets/Interval.jl
+++ b/src/Sets/Interval.jl
@@ -1,6 +1,6 @@
 import IntervalArithmetic
 using IntervalArithmetic: AbstractInterval
-if VERSION >= v"1.1"
+@static if VERSION >= v"1.1"
     using IntervalArithmetic: mince
 end
 import Base: +, -, *, ∈, ⊆, rand, min, max

--- a/src/Sets/Interval.jl
+++ b/src/Sets/Interval.jl
@@ -633,3 +633,25 @@ function rectify(x::Interval{N}) where {N<:Real}
         return Interval(zero(N), max(x.dat.hi, zero(N)))
     end
 end
+
+"""
+    diameter(x::Interval, [p]::Real=Inf)
+
+Compute the diameter of an interval.
+
+### Input
+
+- `x` -- interval
+- `p` -- (optional, default: `Inf`) norm
+
+### Output
+
+A real number representing the diameter.
+
+### Notes
+
+In one dimension all norms are equivalent.
+"""
+function diameter(x::Interval, p::Real=Inf)
+    return norm(max(x) - min(x), p)
+end

--- a/test/unit_Interval.jl
+++ b/test/unit_Interval.jl
@@ -117,6 +117,10 @@ for N in Ns
     x = Interval(N(1), N(3))
     @test diameter(x) == diameter(x, Inf) == diameter(x, 2) == N(2)
 
+    # split
+    @test split(x, 4) == [Interval(N(1), N(3//2)), Interval(N(3//2), N(2)),
+                          Interval(N(2), N(5//2)), Interval(N(5//2), N(3))]
+
     # concrete intersection
     A = Interval(N(5), N(7))
     B = Interval(N(3), N(6))

--- a/test/unit_Interval.jl
+++ b/test/unit_Interval.jl
@@ -113,6 +113,10 @@ for N in Ns
     h = convert(Hyperrectangle, x)
     @test h isa Hyperrectangle && center(h) == radius_hyperrectangle(h) == N[0.5]
 
+    # diameter
+    x = Interval(N(1), N(3))
+    @test diameter(x) == diameter(x, Inf) == diameter(x, 2) == N(2)
+
     # concrete intersection
     A = Interval(N(5), N(7))
     B = Interval(N(3), N(6))


### PR DESCRIPTION
I found it annoying that `split(rand(Interval), 2)` does not work and `split(rand(Interval), [2])` returns a list of `Hyperrectangle`s.

The first commit brings a faster implementation of `diameter` that I first thought I would use but then I decided to just use `IntervalArithmetic.mince(·)`.

x-ref: #2082