### PR TITLE
Faster support function for zonotopic sets

### DIFF
--- a/src/Interfaces/AbstractZonotope.jl
+++ b/src/Interfaces/AbstractZonotope.jl
@@ -241,7 +241,7 @@ the generator matrix of `Z`.
 
 """
 function ρ(d::AbstractVector{N}, Z::AbstractZonotope{N}) where {N<:Real}
-    return dot(center(Z), d) + sum(abs.(transpose(genmat(Z)) * d))
+    return dot(center(Z), d) + sum(abs, transpose(genmat(Z)) * d)
 end
 
 """


### PR DESCRIPTION
The change reduces one array allocation.

```julia
Z = rand(Zonotope, dim=4, num_generators=20)
d = rand(4);

@btime _ρ($d, $Z)  # this branch
@btime __ρ($d, $Z) # master

  135.111 ns (1 allocation: 240 bytes)
  164.918 ns (2 allocations: 480 bytes)
26.098671846834662
```