### PR TITLE
Fix membership test for line segments

### DIFF
--- a/src/Sets/LineSegment.jl
+++ b/src/Sets/LineSegment.jl
@@ -165,8 +165,8 @@ function ∈(x::AbstractVector{N}, L::LineSegment{N}) where {N<:Real}
     q = L.q
     if isapproxzero(right_turn(p, q, x))
         # check if the point is inside the box approximation of the line segment
-        return min(p[1], q[1]) <= x[1] <= max(p[1], q[1]) &&
-               min(p[2], q[2]) <= x[2] <= max(p[2], q[2])
+        return _leq(min(p[1], q[1]), x[1]) && _leq(x[1], max(p[1], q[1])) &&
+               _leq(min(p[2], q[2]), x[2]) && _leq(x[2], max(p[2], q[2]))
     else
         return false
     end

--- a/test/unit_LineSegment.jl
+++ b/test/unit_LineSegment.jl
@@ -31,12 +31,12 @@ for N in [Float64, Rational{Int}, Float32]
     @test N[1.5, 1.6] ∉ l
 
     # approximate membership test
-    @test N[1.5, 1.5] ∈ LineSegment(N[1.5, 1.50000000000001], N[1.5, 2.0])
     if N == Float64
-        r = LazySets._rtol(Float64)
-        LazySets.set_rtol(Float64, 1e-20)
+        @test N[1.5, 1.5] ∈ LineSegment(N[1.5, 1.50000000000001], N[1.5, 2.0])
+        r = LazySets._rtol(N)
+        LazySets.set_rtol(N, 1e-20)
         @test !(N[1.5, 1.5] ∈ LineSegment(N[1.5, 1.50000000000001], N[1.5, 2.0]))
-        LazySets.set_rtol(Float64, r)
+        LazySets.set_rtol(N, r)
     end
 
     # center/generators

--- a/test/unit_LineSegment.jl
+++ b/test/unit_LineSegment.jl
@@ -30,6 +30,15 @@ for N in [Float64, Rational{Int}, Float32]
     @test N[7, 4] ∉ l
     @test N[1.5, 1.6] ∉ l
 
+    # approximate membership test
+    @test N[1.5, 1.5] ∈ LineSegment(N[1.5, 1.50000000000001], N[1.5, 2.0])
+    if N == Float64
+        r = LazySets._rtol(Float64)
+        LazySets.set_rtol(Float64, 1e-20)
+        @test !(N[1.5, 1.5] ∈ LineSegment(N[1.5, 1.50000000000001], N[1.5, 2.0]))
+        LazySets.set_rtol(Float64, r)
+    end
+
     # center/generators
     @test center(l) == N[1.5, 1.5]
     @test collect(generators(l)) ∈ [[N[1/2, 1/2]], [N[-1/2, -1/2]]]


### PR DESCRIPTION
Closes https://github.com/JuliaReach/LazySets.jl/issues/1485.

The test was inspired from https://discourse.julialang.org/t/less-than-approx-equals/45436. Note that without the change in this PR, the membership test fails irrespective of the LazySets tolerances.