### PR TITLE
Add Sutherland–Hodgman VPolygon intersection algorithm

### DIFF
--- a/docs/src/lib/binary_functions.md
+++ b/docs/src/lib/binary_functions.md
@@ -69,7 +69,8 @@ intersection(::Interval{N}, ::Hyperplane{N}) where {N<:Real}
 intersection(::Interval{N}, ::LazySet{N}) where {N<:Real}
 intersection(::AbstractHPolygon{N}, ::AbstractHPolygon{N}, ::Bool=true) where {N<:Real}
 intersection(::AbstractPolyhedron{N}, ::AbstractPolyhedron{N}) where {N<:Real}
-intersection(::Union{VPolytope{N}, VPolygon{N}}, ::Union{VPolytope{N}, VPolygon{N}}) where {N<:Real}
+intersection(::Union{VPolytope{N}, VPolygon{N}}, ::Union{VPolytope{N}, VPolygon{N}}) where {N}
+intersection(::VPolygon{N}, ::VPolygon{N}; ::Bool=true) where {N}
 intersection(::UnionSet{N}, ::LazySet{N}) where {N<:Real}
 intersection(::UnionSetArray{N}, ::LazySet{N}) where {N<:Real}
 intersection(::Universe{N}, ::LazySet{N}) where {N<:Real}

--- a/docs/src/lib/sets/EmptySet.md
+++ b/docs/src/lib/sets/EmptySet.md
@@ -25,6 +25,7 @@ linear_map(::AbstractMatrix{N}, ::EmptySet{N}) where {N}
 translate(::EmptySet{N}, ::AbstractVector{N}) where {N<:Real}
 plot_recipe(::EmptySet{N}, ::N=zero(N)) where {N<:Real}
 RecipesBase.apply_recipe(::AbstractDict{Symbol,Any}, ::EmptySet{N}, ::N=zero(N)) where {N<:Real}
+area(::EmptySet{N}) where {N}
 ```
 Inherited from [`LazySet`](@ref):
 * [`norm`](@ref norm(::LazySet, ::Real))

--- a/src/ConcreteOperations/intersection.jl
+++ b/src/ConcreteOperations/intersection.jl
@@ -695,8 +695,8 @@ Compute the intersection of two polygons in vertex representation.
 
 ### Input
 
-- `P1`        -- polytope in vertex representation
-- `P2`        -- polytope in vertex representation
+- `P1` -- polygon in vertex representation
+- `P2` -- polygon in vertex representation
 
 ### Output
 

--- a/src/ConcreteOperations/intersection.jl
+++ b/src/ConcreteOperations/intersection.jl
@@ -658,8 +658,8 @@ function intersection(P::AbstractPolyhedron{N}, X::Interval{N}
 end
 
 """
-    intersection(P1::Union{VPolytope{N}, VPolygon{N}},
-                 P2::Union{VPolytope{N}, VPolygon{N}};
+    intersection(P1::VPolytope{N},
+                 P2::VPolytope{N};
                  [backend]=default_polyhedra_backend(P1, N),
                  [prunefunc]=removevredundancy!) where {N<:Real}
 
@@ -676,21 +676,44 @@ Compute the intersection of two polytopes in vertex representation.
 
 ### Output
 
-A `VPolygon` if both arguments are `VPolygon`s, and a `VPolytope` otherwise.
+A `VPolytope`.
 """
-function intersection(P1::Union{VPolytope{N}, VPolygon{N}},
-                      P2::Union{VPolytope{N}, VPolygon{N}};
+function intersection(P1::VPolytope{N},
+                      P2::VPolytope{N};
                       backend=default_polyhedra_backend(P1, N),
                       prunefunc=removevredundancy!) where {N<:Real}
-    Q1 = polyhedron(convert(VPolytope, P1); backend=backend)
-    Q2 = polyhedron(convert(VPolytope, P2); backend=backend)
+    Q1 = polyhedron(P1; backend=backend)
+    Q2 = polyhedron(P2; backend=backend)
     Pint = Polyhedra.intersect(Q1, Q2)
-    prunefunc(Pint)
-    res = VPolytope(Pint)
-    if P1 isa VPolygon && P2 isa VPolygon
-        return convert(VPolygon, res)
-    end
-    return res
+    return VPolytope(Pint)
+end
+
+"""
+    intersection(P1::VPolygon, P2::VPolygon)
+
+Compute the intersection of two polygons in vertex representation.
+
+### Input
+
+- `P1`        -- polytope in vertex representation
+- `P2`        -- polytope in vertex representation
+
+### Output
+
+A `VPolygon`.
+
+### Algorithm
+
+This function applies the [Sutherland–Hodgman polygon
+clipping algorithm](https://en.wikipedia.org/wiki/Sutherland%E2%80%93Hodgman_algorithm).
+The implementation is based on the one found in
+[rosetta code](http://www.rosettacode.org/wiki/Sutherland-Hodgman_polygon_clipping#Julia).
+"""
+function intersection(P1::VPolygon, P2::VPolygon)
+    v1 = vertices_list(P1)
+    v2 = vertices_list(P2)
+    v12 = _intersection_vrep(v1, v2)
+    return VPolygon(v12)
 end
 
 """

--- a/src/ConcreteOperations/intersection.jl
+++ b/src/ConcreteOperations/intersection.jl
@@ -690,7 +690,8 @@ function intersection(P1::VPolytope{N},
 end
 
 """
-    intersection(P1::VPolygon, P2::VPolygon)
+    intersection(P1::VPolygon{N}, P2::VPolygon{N};
+                 apply_convex_hull::Bool=true) where {N}
 
 Compute the intersection of two polygons in vertex representation.
 
@@ -698,10 +699,12 @@ Compute the intersection of two polygons in vertex representation.
 
 - `P1` -- polygon in vertex representation
 - `P2` -- polygon in vertex representation
+- `apply_convex_hull` -- (default, optional: `true`) use the flag to skip the
+                         computation of the convex hull in the resulting `VPolygon`
 
 ### Output
 
-A `VPolygon`.
+A `VPolygon` or an `EmptySet` if the intersection is empty.
 
 ### Algorithm
 
@@ -710,11 +713,16 @@ clipping algorithm](https://en.wikipedia.org/wiki/Sutherland%E2%80%93Hodgman_alg
 The implementation is based on the one found in
 [rosetta code](http://www.rosettacode.org/wiki/Sutherland-Hodgman_polygon_clipping#Julia).
 """
-function intersection(P1::VPolygon, P2::VPolygon)
+function intersection(P1::VPolygon{N}, P2::VPolygon{N};
+                      apply_convex_hull::Bool=true) where {N}
     v1 = vertices_list(P1)
     v2 = vertices_list(P2)
     v12 = _intersection_vrep(v1, v2)
-    return VPolygon(v12)
+    if isempty(v12)
+        return EmptySet{N}(2)
+    else
+        return VPolygon(v12, apply_convex_hull=apply_convex_hull)
+    end
 end
 
 """

--- a/src/ConcreteOperations/intersection.jl
+++ b/src/ConcreteOperations/intersection.jl
@@ -685,6 +685,7 @@ function intersection(P1::VPolytope{N},
     Q1 = polyhedron(P1; backend=backend)
     Q2 = polyhedron(P2; backend=backend)
     Pint = Polyhedra.intersect(Q1, Q2)
+    prunefunc(Pint)
     return VPolytope(Pint)
 end
 

--- a/src/Sets/EmptySet.jl
+++ b/src/Sets/EmptySet.jl
@@ -359,3 +359,20 @@ In the special case of an empty set, we define the sequence as `nothing`.
 function plot_recipe(∅::EmptySet{N}, ε::N=zero(N)) where {N<:Real}
     return []
 end
+
+"""
+    area(∅::EmptySet{N}) where {N}
+
+Return the area of an empty set.
+
+### Input
+
+- `∅` -- empty set
+
+### Output
+
+The zero element of type `N`.
+"""
+function area(∅::EmptySet{N}) where {N}
+    return zero(N)
+end

--- a/test/unit_Polygon.jl
+++ b/test/unit_Polygon.jl
@@ -217,12 +217,12 @@ for N in [Float64, Float32, Rational{Int}]
     @test length(constraints_list(p3)) == 4
 
     # concrete intersection of V-rep
-    p = VPolygon([N[0, 0], N[1, 0], N[0, 1], N[1, 1]])
-    q = VPolygon([N[1, -1/2], N[-1/2, 1], N[-1/2, -1/2]])
-    x = intersection(p, q)
-    o = VPolygon([N[0, 0], N[1/2, 0], N[0, 1/2]])
-    @test x ⊆ o && o ⊆ x # TODO use isequivalent
-    @test LazySets._intersection_vrep(p.vertices, q.vertices) == x.vertices
+    paux = VPolygon([N[0, 0], N[1, 0], N[0, 1], N[1, 1]])
+    qaux = VPolygon([N[1, -1/2], N[-1/2, 1], N[-1/2, -1/2]])
+    xaux = intersection(paux, qaux)
+    oaux = VPolygon([N[0, 0], N[1/2, 0], N[0, 1/2]])
+    @test xaux ⊆ oaux && oaux ⊆ xaux # TODO use isequivalent
+    @test LazySets._intersection_vrep(paux.vertices, qaux.vertices) == xaux.vertices
 
     # check that tighter constraints are used in intersection (#883)
     h1 = HalfSpace([N(1), N(0)], N(3))

--- a/test/unit_Polygon.jl
+++ b/test/unit_Polygon.jl
@@ -199,6 +199,10 @@ for N in [Float64, Float32, Rational{Int}]
                                                 N[9,12], N[7, 12], N[4, 10]])
     end
 
+    # ===================================
+    # Concrete intersection
+    # ===================================
+
     # concrete intersection of H-rep
     p2 = HPolygon{N}()
     c1 = LinearConstraint(N[2, 2], N(14))
@@ -211,6 +215,14 @@ for N in [Float64, Float32, Rational{Int}]
     addconstraint!(p2, c2)
     p3 = intersection(p, p2)
     @test length(constraints_list(p3)) == 4
+
+    # concrete intersection of V-rep
+    p = VPolygon([N[0, 0], N[1, 0], N[0, 1], N[1, 1]])
+    q = VPolygon([N[1, -1/2], N[-1/2, 1], N[-1/2, -1/2]])
+    x = intersection(p, q)
+    o = VPolygon([N[0, 0], N[1/2, 0], N[0, 1/2]])
+    @test x ⊆ o && o ⊆ x # TODO use isequivalent
+    @test LazySets._intersection_vrep(p.vertices, q.vertices) == x.vertices
 
     # check that tighter constraints are used in intersection (#883)
     h1 = HalfSpace([N(1), N(0)], N(3))

--- a/test/unit_Polytope.jl
+++ b/test/unit_Polytope.jl
@@ -399,25 +399,25 @@ for N in [Float64]
         @test ispermutation(vertices_list(cap), vlist)
 
         # 2D intersection
-        p = VPolytope([N[0, 0], N[1, 0], N[0, 1], N[1, 1]])
-        q = VPolytope([N[1, -1/2], N[-1/2, 1], N[-1/2, -1/2]])
-        x = intersection(p, q)
-        o = VPolytope([N[0, 0], N[1/2, 0], N[0, 1/2]])
-        @test x ⊆ o && o ⊆ x # TODO use isequivalent
+        paux = VPolytope([N[0, 0], N[1, 0], N[0, 1], N[1, 1]])
+        qaux = VPolytope([N[1, -1/2], N[-1/2, 1], N[-1/2, -1/2]])
+        xaux = intersection(paux, qaux)
+        oaux = VPolytope([N[0, 0], N[1/2, 0], N[0, 1/2]])
+        @test xaux ⊆ oaux && oaux ⊆ xaux # TODO use isequivalent
 
         # mixed types
-        p = VPolygon([N[0, 0], N[1, 0], N[0, 1], N[1, 1]])
-        q = VPolytope([N[1, -1/2], N[-1/2, 1], N[-1/2, -1/2]])
-        x = intersection(p, q)
-        o = VPolytope([N[0, 0], N[1/2, 0], N[0, 1/2]])
-        @test x ⊆ o && o ⊆ x # TODO use isequivalent
+        paux = VPolygon([N[0, 0], N[1, 0], N[0, 1], N[1, 1]])
+        qaux = VPolytope([N[1, -1/2], N[-1/2, 1], N[-1/2, -1/2]])
+        xaux = intersection(paux, qaux)
+        oaux = VPolytope([N[0, 0], N[1/2, 0], N[0, 1/2]])
+        @test xaux ⊆ oaux && oaux ⊆ xaux # TODO use isequivalent
 
         # 1D set
-        p = VPolytope([N[0], N[1]])
-        q = VPolytope([N[-1/2], N[1/2]])
-        x = intersection(p, q)
-        o = VPolytope([N[0], N[1/2]])
-        @test x ⊆ o && o ⊆ x # TODO use isequivalent
+        paux = VPolytope([N[0], N[1]])
+        qaux = VPolytope([N[-1/2], N[1/2]])
+        xaux = intersection(paux, qaux)
+        oaux = VPolytope([N[0], N[1/2]])
+        @test xaux ⊆ oaux && oaux ⊆ xaux # TODO use isequivalent
 
         # isuniversal
         answer, w = isuniversal(p1, true)

--- a/test/unit_Polytope.jl
+++ b/test/unit_Polytope.jl
@@ -398,6 +398,27 @@ for N in [Float64]
         cap = intersection(p1, p3)
         @test ispermutation(vertices_list(cap), vlist)
 
+        # 2D intersection
+        p = VPolytope([N[0, 0], N[1, 0], N[0, 1], N[1, 1]])
+        q = VPolytope([N[1, -1/2], N[-1/2, 1], N[-1/2, -1/2]])
+        x = intersection(p, q)
+        o = VPolytope([N[0, 0], N[1/2, 0], N[0, 1/2]])
+        @test x ⊆ o && o ⊆ x # TODO use isequivalent
+
+        # mixed types
+        p = VPolygon([N[0, 0], N[1, 0], N[0, 1], N[1, 1]])
+        q = VPolytope([N[1, -1/2], N[-1/2, 1], N[-1/2, -1/2]])
+        x = intersection(p, q)
+        o = VPolytope([N[0, 0], N[1/2, 0], N[0, 1/2]])
+        @test x ⊆ o && o ⊆ x # TODO use isequivalent
+
+        # 1D set
+        p = VPolytope([N[0], N[1]])
+        q = VPolytope([N[-1/2], N[1/2]])
+        x = intersection(p, q)
+        o = VPolytope([N[0], N[1/2]])
+        @test x ⊆ o && o ⊆ x # TODO use isequivalent
+
         # isuniversal
         answer, w = isuniversal(p1, true)
         @test !isuniversal(p1) && !answer && w ∉ p1


### PR DESCRIPTION
This is a standard algorithm, see https://en.wikipedia.org/wiki/Sutherland%E2%80%93Hodgman_algorithm. The code follows that of http://www.rosettacode.org/wiki/Sutherland-Hodgman_polygon_clipping#Julia.

Related to https://github.com/JuliaReach/LazySets.jl/issues/698.

