### PR TITLE
Special case for order 1 zonotopes

### DIFF
--- a/src/Initialization/init_StaticArrays.jl
+++ b/src/Initialization/init_StaticArrays.jl
@@ -1,3 +1,3 @@
-using .StaticArrays: SMatrix, SVector, MMatrix, MVector
+using .StaticArrays: SMatrix, SVector, MMatrix, MVector, SA
 
-eval(load_static_arrays())
+eval(load_split_static())

--- a/src/Interfaces/AbstractZonotope.jl
+++ b/src/Interfaces/AbstractZonotope.jl
@@ -438,7 +438,11 @@ function vertices_list(Z::AbstractZonotope{N};
         return vertices_list(convert(Interval, Z))
 
     elseif n == 2
-        return _vertices_list_2D(c, G, apply_convex_hull=apply_convex_hull)
+        if p == 1
+            return _vertices_list_iterative_ord1(c, G, apply_convex_hull=apply_convex_hull)
+        else
+            return _vertices_list_2D(c, G, apply_convex_hull=apply_convex_hull)
+        end
 
     else
         return _vertices_list_iterative(c, G, apply_convex_hull=apply_convex_hull)

--- a/src/Interfaces/AbstractZonotope.jl
+++ b/src/Interfaces/AbstractZonotope.jl
@@ -426,7 +426,7 @@ this method; otherwise, redundant vertices may be present.
 function vertices_list(Z::AbstractZonotope{N};
                        apply_convex_hull::Bool=true) where {N<:Real}
     c = center(Z)
-    G = remove_zero_columns(genmat(Z))
+    G = genmat(Z)
     n, p = size(G)
 
     # empty generators => sole vertex is the center
@@ -439,13 +439,16 @@ function vertices_list(Z::AbstractZonotope{N};
 
     elseif n == 2
         if p == 1
-            return _vertices_list_iterative_ord1(c, G, apply_convex_hull=apply_convex_hull)
+            return _vertices_list_2D_order_one_half(c, G, apply_convex_hull=apply_convex_hull)
+        elseif p == 2
+            return _vertices_list_2D_order_one(c, G, apply_convex_hull=apply_convex_hull)
         else
             return _vertices_list_2D(c, G, apply_convex_hull=apply_convex_hull)
         end
 
     else
-        return _vertices_list_iterative(c, G, apply_convex_hull=apply_convex_hull)
+        Gred = remove_zero_columns(G)
+        return _vertices_list_iterative(c, Gred, apply_convex_hull=apply_convex_hull)
     end
 end
 

--- a/src/Sets/Zonotope.jl
+++ b/src/Sets/Zonotope.jl
@@ -604,9 +604,6 @@ end
 
 function _vertices_list_iterative(c::VN, G::MN; apply_convex_hull::Bool) where {N, VN<:AbstractVector{N}, MN<:AbstractMatrix{N}}
     p = size(G, 2)
-    if p == 1
-        return _vertices_list_iterative_ord1(c, G, apply_convex_hull=apply_convex_hull)
-    end
     vlist = Vector{VN}()
     sizehint!(vlist, 2^p)
 

--- a/src/Sets/Zonotope.jl
+++ b/src/Sets/Zonotope.jl
@@ -399,7 +399,7 @@ end
 
 _split_ret(Z₁::Zonotope, Z₂::Zonotope) = (Z₁, Z₂)
 
-function load_static_arrays()
+function load_split_static()
 return quote
 
 function _split_ret(Z₁::Zonotope{N, SV, SM}, Z₂::Zonotope{N, SV, SM}) where {N, n, p, SV<:MVector{n, N}, SM<:MMatrix{n, p, N}}
@@ -408,7 +408,7 @@ function _split_ret(Z₁::Zonotope{N, SV, SM}, Z₂::Zonotope{N, SV, SM}) where 
     return Z₁, Z₂
 end
 
-end end  # quote / load_static_arrays
+end end  # quote / load_split_static
 
 function _split(Z::Zonotope, gens::AbstractVector, n::AbstractVector)
     p = length(gens)
@@ -614,8 +614,19 @@ function _vertices_list_iterative(c::VN, G::MN; apply_convex_hull::Bool) where {
     return apply_convex_hull ? convex_hull!(vlist) : vlist
 end
 
+# special case 2D zonotope of order 1/2
+function _vertices_list_2D_order_one_half(c::VN, G::MN; apply_convex_hull::Bool) where {N, VN<:AbstractVector{N}, MN}
+    vlist = Vector{VN}(undef, 2)
+    g = view(G, :, 1)
+    @inbounds begin
+        vlist[1] = c .+ g
+        vlist[2] = c .- g
+    end
+    return apply_convex_hull ? _two_points_2d!(vlist) : vlist
+end
+
 # special case 2D zonotope of order 1
-function _vertices_list_iterative_ord1(c::VN, G::MN; apply_convex_hull::Bool) where {N, VN<:AbstractVector{N}, MN<:AbstractMatrix{N}}
+function _vertices_list_2D_order_one(c::VN, G::MN; apply_convex_hull::Bool) where {N, VN<:AbstractVector{N}, MN}
     vlist = Vector{VN}(undef, 4)
     a = [one(N), one(N)]
     b = [one(N), -one(N)]

--- a/src/Sets/Zonotope.jl
+++ b/src/Sets/Zonotope.jl
@@ -68,10 +68,10 @@ We can collect its vertices using `vertices_list`:
 ```jldoctest zonotope_label
 julia> vertices_list(Z)
 4-element Array{Array{Float64,1},1}:
- [0.9, -0.1]
- [0.9, 0.1]
- [1.1, -0.1]
  [1.1, 0.1]
+ [0.9, 0.1]
+ [0.9, -0.1]
+ [1.1, -0.1]
 ```
 
 The support vector along a given direction can be computed using `σ`


### PR DESCRIPTION
This PR makes two changes:

1) speedup computation of vertices of a 2d zonotope of order 1, it goes from ~2us (master) to ~500ns (this branch). (*)

2) fix the `_vertices_list_iterative` such that the type of the vertices corresponds to the type of the center of the zonotope. before, it was hardcoding `Vector{N}`, which is a bad idea that prevents from obtaining an SArray output if the input is SArray.

(*) Using static arrays, runs in ~60ns.

cc @yupbank 