### PR TITLE
#1983 - Fix type of hyperrectangle vertices

### DIFF
--- a/src/Interfaces/AbstractHyperrectangle.jl
+++ b/src/Interfaces/AbstractHyperrectangle.jl
@@ -189,7 +189,8 @@ function vertices_list(H::AbstractHyperrectangle{N}) where {N<:Real}
     trivector = Vector{Int8}(undef, n)
     m = 1
     c = center(H)
-    v = copy(c)
+    v = similar(c)
+    copyto!(v, c)
     @inbounds for i in 1:n
         ri = radius_hyperrectangle(H, i)
         if iszero(ri)
@@ -204,7 +205,7 @@ function vertices_list(H::AbstractHyperrectangle{N}) where {N<:Real}
     # create vertices by modifying the three-valued vector and constructing the
     # corresponding point; for efficiency, we create a copy of the old point and
     # modify every entry that has changed in the three-valued vector
-    vlist = Vector{Vector{N}}(undef, m)
+    vlist = Vector{typeof(c)}(undef, m)
     vlist[1] = copy(v)
     @inbounds for i in 2:m
         for j in 1:length(v)


### PR DESCRIPTION
Closes #1983.
Closes #2092.

In relation to an earlier attempt (https://github.com/JuliaReach/LazySets.jl/pull/2095), here `simlar -> copyto!` prevents from having to write specialized code for static arrays, essentially because `copy` of an SArray returns an SArray, while `similar` of an SArray returns a (mutable) MArray.

Moreover, with `vlist = Vector{typeof(c)}(undef, m)` the type of the vectors is the same as the center of the input.

I've tested that it works fine with usual vectors (no changes), with static vectors and with sparse vectors. Examples:

```julia
julia> using Revise, LazySets, StaticArrays, BenchmarkTools, Test

julia> Hyperrectangle(SA[1, 2.], SA[0.5, 0.5])
Hyperrectangle{Float64,SArray{Tuple{2},Float64,1,2},SArray{Tuple{2},Float64,1,2}}([1.0, 2.0], [0.5, 0.5])

julia> vertices_list(H)
4-element Array{SArray{Tuple{2},Float64,1,2},1}:
 [1.5, 2.5]
 [0.5, 2.5]
 [1.5, 1.5]
 [0.5, 1.5]

julia> @btime vertices_list($H)
  49.933 ns (2 allocations: 240 bytes)
4-element Array{SArray{Tuple{2},Float64,1,2},1}:
 [1.5, 2.5]
 [0.5, 2.5]
 [1.5, 1.5]
 [0.5, 1.5]

julia> @inferred vertices_list(H)
4-element Array{SArray{Tuple{2},Float64,1,2},1}:
 [1.5, 2.5]
 [0.5, 2.5]
 [1.5, 1.5]
 [0.5, 1.5]

julia> q = Hyperrectangle(Vector(H.center), Vector(H.radius));

julia> @inferred vertices_list(q)
4-element Array{Array{Float64,1},1}:
 [1.5, 2.5]
 [0.5, 2.5]
 [1.5, 1.5]
 [0.5, 1.5]

julia> @btime vertices_list($q)
  177.522 ns (7 allocations: 688 bytes)
4-element Array{Array{Float64,1},1}:
 [1.5, 2.5]
 [0.5, 2.5]
 [1.5, 1.5]
 [0.5, 1.5]
```