### PR TITLE
Improve AbstractHyperrectangular -> Zonotope 2D convert methods for static arrays

### DIFF
--- a/src/Initialization/init_StaticArrays.jl
+++ b/src/Initialization/init_StaticArrays.jl
@@ -1,3 +1,4 @@
 using .StaticArrays: SMatrix, SVector, MMatrix, MVector, SA
 
 eval(load_split_static())
+eval(load_genmat_2D_static())

--- a/src/convert.jl
+++ b/src/convert.jl
@@ -280,8 +280,12 @@ Converts a hyperrectangular set to a zonotope.
 
 A zonotope.
 """
-function convert(::Type{Zonotope}, H::AbstractHyperrectangle{N}) where {N}
-    if isflat(H)
+function convert(ZT::Type{Zonotope}, H::AbstractHyperrectangle{N}) where {N}
+    if dim(H) == 2
+        return _convert_2D(ZT, H)
+    end
+
+    if prune && isflat(H)
         r = radius_hyperrectangle(H)
         n = length(r)
 
@@ -302,6 +306,58 @@ function convert(::Type{Zonotope}, H::AbstractHyperrectangle{N}) where {N}
     end
     return Zonotope(center(H), G)
 end
+
+function _convert_2D(::Type{Zonotope}, H::AbstractHyperrectangle{N}) where {N}
+    c = center(H)
+    rx = radius_hyperrectangle(H, 1)
+    ry = radius_hyperrectangle(H, 2)
+    G = _genmat_2D_prune(c, rx, ry)
+    return Zonotope(c, G)
+end
+
+@inline function _genmat_2D_prune(c::AbstractVector{N}, rx, ry) where {N}
+    flat_x = isapproxzero(rx)
+    flat_y = isapproxzero(ry)
+    ncols = !flat_x + !flat_y
+    G = Matrix{N}(undef, 2, ncols)
+    if !flat_x
+        @inbounds begin G[1] = rx; G[2] = zero(N) end
+        if !flat_y
+            @inbounds begin G[3] = zero(N); G[4] = ry end
+        end
+    elseif !flat_y
+        @inbounds begin G[1] = zero(N); G[2] = ry end
+    end
+    return G
+end
+
+function load_genmat_2D_static()
+return quote
+    @inline function _genmat_2D_prune(c::SVector{L, N}, rx, ry) where {L, N}
+        flat_x = isapproxzero(rx)
+        flat_y = isapproxzero(ry)
+        if !flat_x && !flat_y
+            G = SMatrix{2, 2, N, 4}(rx, zero(N), zero(N), ry)
+        elseif !flat_x && flat_y
+            G = SMatrix{2, 1, N, 2}(rx, zero(N))
+        elseif flat_x && !flat_y
+            G = SMatrix{2, 1, N, 2}(zero(N), ry)
+        else
+            G = SMatrix{2, 0, N, 0}()
+        end
+        return G
+    end
+
+    # this function is type-stable, though it doesn't prune the generators according
+    # to flat dimensions of H
+    function _convert_2D_static(::Type{Zonotope}, H::AbstractHyperrectangle{N}) where {N}
+        c = center(H)
+        rx = radius_hyperrectangle(H, 1)
+        ry = radius_hyperrectangle(H, 2)
+        G = SMatrix{2, 2, N, 4}(rx, zero(N), zero(N), ry)
+        return Zonotope(c, G)
+    end
+end end  # quote / load_genmat_2D_static
 
 function convert(::Type{Zonotope}, S::Singleton{N, VN}) where {N, VN<:AbstractVector{N}}
     MT = LazySets.Arrays._matrix_type(VN)

--- a/src/convert.jl
+++ b/src/convert.jl
@@ -285,7 +285,7 @@ function convert(ZT::Type{Zonotope}, H::AbstractHyperrectangle{N}) where {N}
         return _convert_2D(ZT, H)
     end
 
-    if prune && isflat(H)
+    if isflat(H)
         r = radius_hyperrectangle(H)
         n = length(r)
 

--- a/src/convert.jl
+++ b/src/convert.jl
@@ -311,11 +311,11 @@ function _convert_2D(::Type{Zonotope}, H::AbstractHyperrectangle{N}) where {N}
     c = center(H)
     rx = radius_hyperrectangle(H, 1)
     ry = radius_hyperrectangle(H, 2)
-    G = _genmat_2D_prune(c, rx, ry)
+    G = _genmat_2D(c, rx, ry)
     return Zonotope(c, G)
 end
 
-@inline function _genmat_2D_prune(c::AbstractVector{N}, rx, ry) where {N}
+@inline function _genmat_2D(c::AbstractVector{N}, rx, ry) where {N}
     flat_x = isapproxzero(rx)
     flat_y = isapproxzero(ry)
     ncols = !flat_x + !flat_y
@@ -333,7 +333,7 @@ end
 
 function load_genmat_2D_static()
 return quote
-    @inline function _genmat_2D_prune(c::SVector{L, N}, rx, ry) where {L, N}
+    @inline function _genmat_2D(c::SVector{L, N}, rx, ry) where {L, N}
         flat_x = isapproxzero(rx)
         flat_y = isapproxzero(ry)
         if !flat_x && !flat_y

--- a/test/unit_BallInf.jl
+++ b/test/unit_BallInf.jl
@@ -159,6 +159,27 @@ for N in [Float64, Rational{Int}, Float32]
 
     # vertices iterator
     @test ispermutation(collect(vertices(B)), vertices_list(B))
+
+    # conversion to a zonoope
+    B = BallInf(N[0, 0], N(1))
+    ZB = convert(Zonotope, B)
+    @test ZB == Zonotope(N[0, 0], N[1 0; 0 1])
+    B = BallInf(N[0, 0], N(0))  # flat case
+    ZB = convert(Zonotope, B)
+    @test ZB == Zonotope(N[0, 0], Matrix{N}(undef, 2, 0))
+
+   # conversion to a zonotope, static arrays
+   B = BallInf(SA[N(0), N(0)], N(1))
+   ZB = convert(Zonotope, B)
+   @test ZB == Zonotope(SVector{2}(N[0, 0]), SMatrix{2, 2}(N[1 0; 0 1]))
+   B = BallInf(SA[N(0), N(0)], N(0))  # flat case
+   ZB = convert(Zonotope, B)
+   @test ZB == Zonotope(SVector{2}(N[0, 0]), SMatrix{2, 0, N, 0}())
+
+   # internal function
+   B = BallInf(SA[N(0), N(0)], N(1))
+   Zs = LazySets._convert_2D_static(Zonotope, B)
+   @test Zs == Zonotope(SVector{2}(N[0, 0]), SMatrix{2, 2}(N[1 0; 0 1]))
 end
 
 # tests that only work with Float64


### PR DESCRIPTION
This PR improves the runtime performance of abstract hyperrectangle -> zonotope convert methods, in particular for static arrays in two dimensions. These changes are related to https://github.com/JuliaReach/LazySets.jl/issues/2248, though it doesn't yet fix the underlying issue there (which should be fixed in the fallback), i'll address them in a separate PR.

Reference notebook: https://nbviewer.jupyter.org/github/mforets/escritoire/blob/master/2020/Week42/LazySets%232248.ipynb

The performance improvement in 2D is ~2.5x with less allocs. But more importantly, if the input hyperrectangular set has static array vectors, now the output has that type too.

For applications that want the maximum performance (and that you don't have/care about hyperrectangles with flat sides), I added the unexported function `LazySets._convert_2D_static`, for which the conversion is immediate as seen in the tests.