### PR TITLE
Generalize AbstractHyperrectangle -> Zonotope conversion

### DIFF
--- a/docs/src/lib/conversion.md
+++ b/docs/src/lib/conversion.md
@@ -33,7 +33,6 @@ convert(::Type{VPolygon}, ::AbstractHPolygon)
 convert(::Type{VPolygon}, ::AbstractPolytope)
 convert(::Type{VPolytope}, ::AbstractPolytope)
 convert(::Type{VPolytope}, ::HPolytope)
-convert(::Type{Zonotope}, ::AbstractHyperrectangle{N}) where {N}
 convert(::Type{Zonotope}, ::AbstractZonotope)
 convert(::Type{IntervalArithmetic.IntervalBox}, ::AbstractHyperrectangle)
 convert(::Type{Hyperrectangle}, ::IntervalArithmetic.IntervalBox)

--- a/src/Initialization/init_StaticArrays.jl
+++ b/src/Initialization/init_StaticArrays.jl
@@ -1,3 +1,4 @@
 using .StaticArrays: SMatrix, SVector, MMatrix, MVector, SA
 
 eval(load_split_static())
+eval(load_genmat_2D_static())

--- a/src/Initialization/init_StaticArrays.jl
+++ b/src/Initialization/init_StaticArrays.jl
@@ -2,3 +2,5 @@ using .StaticArrays: SMatrix, SVector, MMatrix, MVector, SA
 
 eval(load_split_static())
 eval(load_genmat_2D_static())
+eval(load_genmat_ballinf_static())
+eval(load_genmat_hyperrectangle_static())

--- a/src/Sets/BallInf.jl
+++ b/src/Sets/BallInf.jl
@@ -119,6 +119,22 @@ function isflat(B::BallInf)
     return isapproxzero(B.radius)
 end
 
+function load_genmat_ballinf_static()
+return quote
+    function genmat(B::BallInf{N, SVector{L, N}}) where {L, N}
+        r = B.radius
+        if isapproxzero(B.radius)
+            return SMatrix{L, 0, N, 0}()
+        else
+            gens = zeros(MMatrix{L, L})
+            @inbounds for i in 1:L
+                gens[i, i] = r
+            end
+            return SMatrix(gens)
+        end
+    end
+end
+end
 
 # --- AbstractCentrallySymmetric interface functions ---
 

--- a/src/Sets/Hyperrectangle.jl
+++ b/src/Sets/Hyperrectangle.jl
@@ -146,6 +146,23 @@ function radius_hyperrectangle(H::Hyperrectangle{N}) where {N<:Real}
     return H.radius
 end
 
+function load_genmat_hyperrectangle_static()
+return quote
+    function genmat(H::Hyperrectangle{N, SVector{L, N}, SVector{L, N}}) where {L, N}
+        gens = zeros(MMatrix{L, L})
+        nzcol = Vector{Int}()
+        sizehint!(nzcol, L)
+        @inbounds for i in 1:L
+            r = H.radius[i]
+            if !isapproxzero(r)
+                gens[i, i] = r
+                push!(nzcol, i)
+            end
+        end
+        return SMatrix(gens[:, nzcol])
+    end
+end
+end
 
 # --- AbstractCentrallySymmetric interface functions ---
 

--- a/src/convert.jl
+++ b/src/convert.jl
@@ -280,8 +280,12 @@ Converts a hyperrectangular set to a zonotope.
 
 A zonotope.
 """
-function convert(::Type{Zonotope}, H::AbstractHyperrectangle{N}) where {N}
-    if isflat(H)
+function convert(ZT::Type{Zonotope}, H::AbstractHyperrectangle{N}) where {N}
+    if dim(H) == 2
+        return _convert_2D(ZT, H)
+    end
+
+    if prune && isflat(H)
         r = radius_hyperrectangle(H)
         n = length(r)
 
@@ -302,6 +306,58 @@ function convert(::Type{Zonotope}, H::AbstractHyperrectangle{N}) where {N}
     end
     return Zonotope(center(H), G)
 end
+
+function _convert_2D(::Type{Zonotope}, H::AbstractHyperrectangle{N}) where {N}
+    c = center(H)
+    rx = radius_hyperrectangle(H, 1)
+    ry = radius_hyperrectangle(H, 2)
+    G = _genmat_2D_prune(c, rx, ry)
+    return Zonotope(c, G)
+end
+
+@inline function _genmat_2D_prune(c::AbstractVector{N}, rx, ry) where {N}
+    flat_x = isapproxzero(rx)
+    flat_y = isapproxzero(ry)
+    ncols = !flat_x + !flat_y
+    G = Matrix{N}(undef, 2, ncols)
+    if !flat_x
+        @inbounds begin G[1] = rx; G[2] = zero(N) end
+        if !flat_y
+            @inbounds begin G[3] = zero(N); G[4] = ry end
+        end
+    elseif !flat_y
+        @inbounds begin G[1] = zero(N); G[2] = ry end
+    end
+    return G
+end
+
+function load_genmat_2D_static()
+return quote
+    @inline function _genmat_2D_prune(c::SVector{L, N}, rx, ry) where {L, N}
+        flat_x = isapproxzero(rx)
+        flat_y = isapproxzero(ry)
+        if !flat_x && !flat_y
+            G = SMatrix{2, 2, N, 4}(rx, zero(N), zero(N), ry)
+        elseif !flat_x && flat_y
+            G = SMatrix{2, 1, N, 2}(rx, zero(N))
+        elseif flat_x && !flat_y
+            G = SMatrix{2, 1, N, 2}(zero(N), ry)
+        else
+            G = SMatrix{2, 0, N, 0}()
+        end
+        return G
+    end
+
+    # this function is type-stable, though it doesn't prune the generators according
+    # to flat dimensions of H
+    function _convert_2D_static(::Type{Zonotope}, H::AbstractHyperrectangle{N}) where {N}
+        c = center(H)
+        rx = radius_hyperrectangle(H, 1)
+        ry = radius_hyperrectangle(H, 2)
+        G = SMatrix{2, 2, N, 4}(rx, zero(N), zero(N), ry)
+        return Zonotope(c, G)
+    end
+end end  # quote / load_genmat_2D_static
 
 function convert(::Type{Zonotope}, S::Singleton{N, VN}) where {N, VN<:AbstractVector{N}}
     MT = LazySets.Arrays._matrix_type(VN)

--- a/src/convert.jl
+++ b/src/convert.jl
@@ -285,7 +285,7 @@ function convert(ZT::Type{Zonotope}, H::AbstractHyperrectangle{N}) where {N}
         return _convert_2D(ZT, H)
     end
 
-    if prune && isflat(H)
+    if isflat(H)
         r = radius_hyperrectangle(H)
         n = length(r)
 

--- a/src/convert.jl
+++ b/src/convert.jl
@@ -284,27 +284,7 @@ function convert(ZT::Type{Zonotope}, H::AbstractHyperrectangle{N}) where {N}
     if dim(H) == 2
         return _convert_2D(ZT, H)
     end
-
-    if isflat(H)
-        r = radius_hyperrectangle(H)
-        n = length(r)
-
-        nzgen = 0
-        Gnz = Vector{N}()
-        sizehint!(Gnz, n * n)
-        @inbounds for (i, ri) in enumerate(r)
-            if ri != zero(N)
-                col = zeros(N, n)
-                col[i] = ri
-                append!(Gnz, col)
-                nzgen += 1
-            end
-        end
-        G = reshape(Gnz, n, nzgen)
-    else
-        G = genmat(H)
-    end
-    return Zonotope(center(H), G)
+    return Zonotope(center(H), genmat(H))
 end
 
 function _convert_2D(::Type{Zonotope}, H::AbstractHyperrectangle{N}) where {N}

--- a/src/convert.jl
+++ b/src/convert.jl
@@ -337,6 +337,10 @@ return quote
         G = SMatrix{2, 2, N, 4}(rx, zero(N), zero(N), ry)
         return Zonotope(c, G)
     end
+
+    function _convert_static(::Type{Zonotope}, H::Hyperrectangle{N, <:SVector, <:SVector}) where {N}
+        return Zonotope(center(H), _genmat_static(H))
+    end
 end end  # quote / load_genmat_2D_static
 
 function convert(::Type{Zonotope}, S::Singleton{N, VN}) where {N, VN<:AbstractVector{N}}

--- a/src/convert.jl
+++ b/src/convert.jl
@@ -311,11 +311,11 @@ function _convert_2D(::Type{Zonotope}, H::AbstractHyperrectangle{N}) where {N}
     c = center(H)
     rx = radius_hyperrectangle(H, 1)
     ry = radius_hyperrectangle(H, 2)
-    G = _genmat_2D_prune(c, rx, ry)
+    G = _genmat_2D(c, rx, ry)
     return Zonotope(c, G)
 end
 
-@inline function _genmat_2D_prune(c::AbstractVector{N}, rx, ry) where {N}
+@inline function _genmat_2D(c::AbstractVector{N}, rx, ry) where {N}
     flat_x = isapproxzero(rx)
     flat_y = isapproxzero(ry)
     ncols = !flat_x + !flat_y
@@ -333,7 +333,7 @@ end
 
 function load_genmat_2D_static()
 return quote
-    @inline function _genmat_2D_prune(c::SVector{L, N}, rx, ry) where {L, N}
+    @inline function _genmat_2D(c::SVector{L, N}, rx, ry) where {L, N}
         flat_x = isapproxzero(rx)
         flat_y = isapproxzero(ry)
         if !flat_x && !flat_y

--- a/test/unit_BallInf.jl
+++ b/test/unit_BallInf.jl
@@ -175,6 +175,11 @@ for N in [Float64, Rational{Int}, Float32]
    B = BallInf(SA[N(0), N(0)], N(0))  # flat case
    ZB = convert(Zonotope, B)
    @test ZB == Zonotope(SVector{2}(N[0, 0]), SMatrix{2, 0, N, 0}())
+   # specialized method (no prunning)
+   B = BallInf(SA[1.0, 2.0], 1.0)
+   ZB = LazySets._convert_2D_static(Zonotope, B)
+   @test ZB == Zonotope(SA[1.0, 2.0], SA[1.0 0.0; 0.0 1.0])
+
 
    # internal function
    B = BallInf(SA[N(0), N(0)], N(1))

--- a/test/unit_Hyperrectangle.jl
+++ b/test/unit_Hyperrectangle.jl
@@ -236,15 +236,9 @@ for N in [Float64, Rational{Int}, Float32]
           Hyperrectangle(N[0, 0], N[1, 1])
 
     # conversion to a zonotope
-    if N <: Rational
-        H = Hyperrectangle(low=N[5//10, 6//10], high=N[124//10, 2355//10])
-        Hz = convert(Zonotope, H)
-        @test Hz == Zonotope(N[129//20, 2361//20], N[119//20 0//1; 0//1 2349//20])
-    else
-        H = Hyperrectangle(low=N[0.5, 0.6], high=N[12.4, 235.5])
-        Hz = convert(Zonotope, H)
-        @test Hz == Zonotope(N[6.45, 118.05], N[5.95 0.0; 0.0 117.45])
-    end
+    H = Hyperrectangle(low=N[5//10, 6//10], high=N[124//10, 2355//10])
+    Hz = convert(Zonotope, H)
+    @test Hz == Zonotope(N[129//20, 2361//20], N[119//20 0//1; 0//1 2349//20])
 
     # conversion of a hyperrectangle with static array components to a zonotope
     # the specialized method for 2D static arrays is also tested

--- a/test/unit_Hyperrectangle.jl
+++ b/test/unit_Hyperrectangle.jl
@@ -248,20 +248,11 @@ for N in [Float64, Rational{Int}, Float32]
 
     # conversion of a hyperrectangle with static array components to a zonotope
     # the specialized method for 2D static arrays is also tested
-    if N <: Rational
-        H = Hyperrectangle(low=SA[5//10, 6//10], high=N[124//10, 2355//10])
-        Hz = convert(Zonotope, H)
-        Hz_sp = LazySets._convert_2D_static(Zonotope, H)
-        Z = Zonotope(SA[129//20, 2361//20], SA[119//20 0//1; 0//1 2349//20])
-        @test Hz == Z && Hz_sp == Z
-
-    else
-        H = Hyperrectangle(low=SA[0.5, 0.6], high=SA[12.4, 235.5])
-        Hz = convert(Zonotope, H)
-        Hz_sp = LazySets._convert_2D_static(Zonotope, H)
-        Z = Zonotope(SA[6.45, 118.05], SA[5.95 0.0; 0.0 117.45])
-        @test Hz == Z && H == Z
-    end
+    H = Hyperrectangle(low=SA[N(5//10), N(6//10)], high=N[N(124//10), N(2355//10)])
+    Hz = convert(Zonotope, H)
+    Hz_sp = LazySets._convert_2D_static(Zonotope, H)
+    Z = Zonotope(SA[N(129//20), N(2361//20)], SA[N(119//20) N(0//1); N(0//1) N(2349//20)])
+    @test Hz == Z && Hz_sp == Z
 
     # rectification
     H = Hyperrectangle(N[-1, 2], N[4, 5])

--- a/test/unit_Hyperrectangle.jl
+++ b/test/unit_Hyperrectangle.jl
@@ -235,6 +235,34 @@ for N in [Float64, Rational{Int}, Float32]
     @test convert(Hyperrectangle, SymmetricIntervalHull(Singleton(N[1, 1]))) ==
           Hyperrectangle(N[0, 0], N[1, 1])
 
+    # conversion to a zonotope
+    if N <: Rational
+        H = Hyperrectangle(low=N[5//10, 6//10], high=N[124//10, 2355//10])
+        Hz = convert(Zonotope, H)
+        @test Hz == Zonotope(N[129//20, 2361//20], N[119//20 0//1; 0//1 2349//20])
+    else
+        H = Hyperrectangle(low=N[0.5, 0.6], high=N[12.4, 235.5])
+        Hz = convert(Zonotope, H)
+        @test Hz == Zonotope(N[6.45, 118.05], N[5.95 0.0; 0.0 117.45])
+    end
+
+    # conversion of a hyperrectangle with static array components to a zonotope
+    # the specialized method for 2D static arrays is also tested
+    if N <: Rational
+        H = Hyperrectangle(low=SA[5//10, 6//10], high=N[124//10, 2355//10])
+        Hz = convert(Zonotope, H)
+        Hz_sp = LazySets._convert_2D_static(Zonotope, H)
+        Z = Zonotope(SA[129//20, 2361//20], SA[119//20 0//1; 0//1 2349//20])
+        @test Hz == Z && Hz_sp == Z
+
+    else
+        H = Hyperrectangle(low=SA[0.5, 0.6], high=SA[12.4, 235.5])
+        Hz = convert(Zonotope, H)
+        Hz_sp = LazySets._convert_2D_static(Zonotope, H)
+        Z = Zonotope(SA[6.45, 118.05], SA[5.95 0.0; 0.0 117.45])
+        @test Hz == Z && H == Z
+    end
+
     # rectification
     H = Hyperrectangle(N[-1, 2], N[4, 5])
     Hrect = rectify(H)


### PR DESCRIPTION
Closes #2248.
Closes #1879.

---

This PR incorporates the change from https://github.com/JuliaReach/LazySets.jl/pull/2251.

Moreover, i added static versions for `BallInf` generators and `Hyperrectangle` generators. For the latter, i couldn't find a efficient implementation which considers the (runtime) behavior of possibly zero radius components. So i kept both versions. The reference notebook is again https://nbviewer.jupyter.org/github/mforets/escritoire/blob/master/2020/Week42/LazySets%232248.ipynb