### PR TITLE
Use tuple instead of vector

### DIFF
--- a/src/Sets/Zonotope.jl
+++ b/src/Sets/Zonotope.jl
@@ -607,7 +607,7 @@ function _vertices_list_iterative(c::VN, G::MN; apply_convex_hull::Bool) where {
     vlist = Vector{VN}()
     sizehint!(vlist, 2^p)
 
-    for ξi in Iterators.product([[1, -1] for i = 1:p]...)
+    for ξi in Iterators.product([(1, -1) for i = 1:p]...)
         push!(vlist, c .+ G * collect(ξi))
     end
 


### PR DESCRIPTION
This is a minor improvement.

```julia
julia> p = 4

julia> @btime for ξi in Iterators.product([[1, -1] for i = 1:$p]...)  # master
           collect(ξi)
       end
  3.174 μs (71 allocations: 6.08 KiB)

julia> @btime for ξi in Iterators.product([(1, -1) for i = 1:$p]...)  # this branch
           collect(ξi)
       end
  2.996 μs (71 allocations: 5.92 KiB)

julia> p = 10

julia> @btime for ξi in Iterators.product([[1, -1] for i = 1:$p]...)  # master
           collect(ξi)
       end
  202.285 μs (4109 allocations: 689.28 KiB)

julia> @btime for ξi in Iterators.product([(1, -1) for i = 1:$p]...)  # this branch
           collect(ξi)
       end
  201.645 μs (4109 allocations: 688.89 KiB)
```