### PR TITLE
#589 - More efficient box approximation of specific set types

### DIFF
--- a/src/Approximations/box_approximation.jl
+++ b/src/Approximations/box_approximation.jl
@@ -284,3 +284,19 @@ function box_approximation(P::Union{VPolytope, VPolygon})
     end
     return Hyperrectangle(center, radius)
 end
+
+# centrally symmetric sets only require n support-function evaluations
+function box_approximation(X::AbstractCentrallySymmetric{N}) where {N}
+    n = dim(X)
+    c = center(X)
+    r = Vector{N}(undef, n)
+    @inbounds for i in 1:n
+        r[i] = ρ(SingleEntryVector(i, n, one(N)), X) - c[i]
+    end
+    return Hyperrectangle(c, r)
+end
+
+# balls result in a hypercube with the same radius
+function box_approximation(B::Union{Ball1, Ball2, BallInf, Ballp})
+    return Hyperrectangle(center(B), fill(B.radius, dim(B)))
+end

--- a/src/Sets/Ball2.jl
+++ b/src/Sets/Ball2.jl
@@ -337,7 +337,7 @@ ball using factorials. For details see the wikipedia article
 function volume(B::Ball2)
     n = dim(B)
     k = div(n, 2)
-    R = radius(B)
+    R = B.radius
     if iseven(n)
         vol = Base.pi^k * R^n / factorial(k)
     else

--- a/test/unit_overapproximate.jl
+++ b/test/unit_overapproximate.jl
@@ -146,6 +146,10 @@ for N in [Float64, Float32]
     o = overapproximate_lmap(50)
     @test o.center == N[1, 1] && o.radius == N[2, 2]
 
+    # box approximation of centrally symmetric set
+    e = Ellipsoid(zeros(N, 2), N[2 -1; -1 2])
+    @test box_approximation(e).radius ≈ N[sqrt(2), sqrt(2)]
+
     # Approximation of a 2D centered unit ball in norm 1
     # All vertices v should be like this:
     # ‖v‖ >= 1 and ‖v‖ <= 1+ε


### PR DESCRIPTION
Closes #589.

```julia
julia> E = rand(Ellipsoid);
julia> B = rand(Ball2);

# this branch
julia> @btime box_approximation($E)
  74.695 ns (1 allocation: 96 bytes)
Hyperrectangle{Float64,Array{Float64,1},Array{Float64,1}}([0.0, 0.0], [1.4142135623730951, 1.4142135623730951])

julia> @btime box_approximation($B)
  52.039 ns (1 allocation: 96 bytes)
Hyperrectangle{Float64,Array{Float64,1},Array{Float64,1}}([-1.3320384136380545, -0.5810181282958253], [0.3527491162460336, 0.3527491162460336])

# master
julia> @btime box_approximation($E)
  126.373 ns (3 allocations: 224 bytes)
Hyperrectangle{Float64,Array{Float64,1},Array{Float64,1}}([0.0, 0.0], [1.4142135623730951, 1.4142135623730951])

julia> @btime box_approximation($B)
  289.367 ns (7 allocations: 608 bytes)
Hyperrectangle{Float64,Array{Float64,1},Array{Float64,1}}([-1.3320384136380545, -0.5810181282958253], [0.35274911624603367, 0.35274911624603367])
```

The second commit is unrelated but also brings a speedup.

```julia
# this branch
julia> @btime volume($B)
  10.424 ns (0 allocations: 0 bytes)
33.510321638291124

# master
julia> @btime volume($B)
  508.309 ns (9 allocations: 928 bytes)
33.510321638291124
```