### PR TITLE
#2453 - Vertices list of IntervalArithmetic types

### DIFF
--- a/src/Sets/Interval.jl
+++ b/src/Sets/Interval.jl
@@ -696,3 +696,19 @@ end
         return result
     end
 end
+
+function vertices_list(x::IntervalArithmetic.Interval{N}) where {N}
+    a = IntervalArithmetic.inf(x)
+    b = IntervalArithmetic.sup(x)
+    ST = IntervalArithmetic.SVector{1, N}
+    if _isapprox(a, b)
+        vlist = [ST(a)]
+    else
+        vlist = [ST(a), ST(b)]
+    end
+    return vlist
+end
+
+function vertices_list(H::IntervalArithmetic.IntervalBox)
+    return vertices_list(convert(Hyperrectangle, H))
+end

--- a/test/unit_Interval.jl
+++ b/test/unit_Interval.jl
@@ -206,7 +206,7 @@ for N in Ns
     @test rectify(x) == x
 
     # list of vertices of IA types
-    b = (0 .. 1) × (0 .. 1)
+    b = IA.IntervalBox(IA.Interval(0 , 1), IA.Interval(0, 1))
     vlistIB = vertices_list(b)
     @test is_cyclic_permutation(vlistIB, [SA[N(1), N(1)], SA[N(0), N(1)], SA[N(1), N(0)], SA[N(0), N(0)]])
 

--- a/test/unit_Interval.jl
+++ b/test/unit_Interval.jl
@@ -204,4 +204,12 @@ for N in Ns
     @test rectify(x) == Interval(N(0), N(2))
     x = Interval(N(1), N(2))
     @test rectify(x) == x
+
+    # list of vertices of IA types
+    b = (0 .. 1) × (0 .. 1)
+    vlistIB = vertices_list(b)
+    @test is_cyclic_permutation(vlistIB, [SA[N(1), N(1)], SA[N(0), N(1)], SA[N(1), N(0)], SA[N(0), N(0)]])
+
+    vlistI = vertices_list(b[1])
+    @test is_cyclic_permutation(vlistI, [SA[N(0)], SA[N(1)]]
 end

--- a/test/unit_Interval.jl
+++ b/test/unit_Interval.jl
@@ -211,5 +211,5 @@ for N in Ns
     @test is_cyclic_permutation(vlistIB, [SA[N(1), N(1)], SA[N(0), N(1)], SA[N(1), N(0)], SA[N(0), N(0)]])
 
     vlistI = vertices_list(b[1])
-    @test is_cyclic_permutation(vlistI, [SA[N(0)], SA[N(1)]]
+    @test is_cyclic_permutation(vlistI, [SA[N(0)], SA[N(1)]])
 end


### PR DESCRIPTION
Closes #2453.

Notes:

- The method for `IntervalBox` can certainly be improved, but this is better than nothing (we can improve it as a follow-up PR).
- The method for `Interval` creates static arrays because that's consistent with the implementation of the interval box type (note that the conversion from `IntervalBox` to `Hyperrectangle` returns SArrays already).