### PR TITLE
#1209 - Concrete projection of BallX, EmptySet, Universe

### DIFF
--- a/src/Interfaces/AbstractPolyhedron_functions.jl
+++ b/src/Interfaces/AbstractPolyhedron_functions.jl
@@ -990,6 +990,8 @@ A polyhedron representing the projection of `P` on the dimensions specified by
 `block`.
 If `P` was bounded, the result is an `HPolytope`; otherwise the result is an
 `HPolyhedron`.
+Note that there are more specific methods for specific input types, which give a
+different output type; e.g., projecting a `Ball1` results in a `Ball1`.
 
 ### Algorithm
 
@@ -1003,11 +1005,11 @@ If `P` was bounded, the result is an `HPolytope`; otherwise the result is an
 Consider the four-dimensional cross-polytope (unit ball in the 1-norm):
 
 ```jldoctest project_polyhedron
-julia> P = Ball1(zeros(4), 1.0);
+julia> P = convert(HPolytope, Ball1(zeros(4), 1.0));
 ```
 
-All dimensions are constrained, and computing the (trivial) projection on the whole
-space behaves as expected:
+All dimensions are constrained, and computing the (trivial) projection on the
+whole space behaves as expected:
 
 ```jldoctest project_polyhedron
 julia> constrained_dimensions(P)
@@ -1017,9 +1019,7 @@ julia> constrained_dimensions(P)
  3
  4
 
-julia> P_1234 = project(P, [1, 2, 3, 4]);
-
-julia> P_1234 == convert(HPolytope, P)
+julia> project(P, [1, 2, 3, 4]) == P
 true
 ```
 Each constraint of the cross polytope is constrained in all dimensions.

--- a/src/Sets/Ball1.jl
+++ b/src/Sets/Ball1.jl
@@ -284,3 +284,7 @@ function translate(B::Ball1, v::AbstractVector)
                                 "set by a $(length(v))-dimensional vector"
     return Ball1(center(B) + v, B.radius)
 end
+
+function project(B::Ball1, block::AbstractVector{Int})
+    return Ball1(B.center[block], B.radius)
+end

--- a/src/Sets/Ball2.jl
+++ b/src/Sets/Ball2.jl
@@ -374,3 +374,7 @@ function volume(B::Ball2)
     end
     return vol
 end
+
+function project(B::Ball2, block::AbstractVector{Int})
+    return Ball2(B.center[block], B.radius)
+end

--- a/src/Sets/BallInf.jl
+++ b/src/Sets/BallInf.jl
@@ -356,3 +356,7 @@ function volume(B::BallInf)
     vol = _vol_prod(B, n)
     return vol
 end
+
+function project(B::BallInf, block::AbstractVector{Int})
+    return BallInf(B.center[block], B.radius)
+end

--- a/src/Sets/Ballp.jl
+++ b/src/Sets/Ballp.jl
@@ -262,3 +262,7 @@ function translate(B::Ballp, v::AbstractVector)
                                 "set by a $(length(v))-dimensional vector"
     return Ballp(B.p, center(B) + v, B.radius)
 end
+
+function project(B::Ballp, block::AbstractVector{Int})
+    return Ballp(B.p, B.center[block], B.radius)
+end

--- a/src/Sets/EmptySet.jl
+++ b/src/Sets/EmptySet.jl
@@ -376,3 +376,7 @@ The zero element of type `N`.
 function area(∅::EmptySet{N}) where {N}
     return zero(N)
 end
+
+function project(∅::EmptySet{N}, block::AbstractVector{Int}) where {N}
+    return EmptySet{N}(length(block))
+end

--- a/src/Sets/Universe.jl
+++ b/src/Sets/Universe.jl
@@ -347,3 +347,7 @@ function linear_map_inverse(Minv::AbstractMatrix{N}, U::Universe{N}) where {N}
     n = size(Minv, 2)
     return Universe{N}(n)
 end
+
+function project(U::Universe{N}, block::AbstractVector{Int}) where {N}
+    return Universe{N}(length(block))
+end

--- a/test/unit_Ball1.jl
+++ b/test/unit_Ball1.jl
@@ -96,4 +96,8 @@ for N in [Float64, Rational{Int}, Float32]
                                 HalfSpace(N[-1, 1], N(1)),  # -x + y <= 1
                                 HalfSpace(N[1, -1], N(1)), # x - y <= 1
                                 HalfSpace(N[-1, -1], N(1))])  # x + y >= -1
+
+    # projection
+    b4 = Ball1(N[4, 3, 2, 1], N(2))
+    @test project(b4, [2, 4]) == Ball1(N[3, 1], N(2))
 end

--- a/test/unit_Ball2.jl
+++ b/test/unit_Ball2.jl
@@ -126,4 +126,8 @@ for N in [Float64, Float32]
     # volume in dimension 3
     B = Ball2(zeros(N, 3), N(2))
     @test volume(B) ≈ 4/3 * pi * radius(B)^3
+
+    # projection
+    b4 = Ball2(N[4, 3, 2, 1], N(2))
+    @test project(b4, [2, 4]) == Ball2(N[3, 1], N(2))
 end

--- a/test/unit_BallInf.jl
+++ b/test/unit_BallInf.jl
@@ -180,11 +180,14 @@ for N in [Float64, Rational{Int}, Float32]
    ZB = LazySets._convert_2D_static(Zonotope, B)
    @test ZB == Zonotope(SA[1.0, 2.0], SA[1.0 0.0; 0.0 1.0])
 
-
    # internal function
    B = BallInf(SA[N(0), N(0)], N(1))
    Zs = LazySets._convert_2D_static(Zonotope, B)
    @test Zs == Zonotope(SVector{2}(N[0, 0]), SMatrix{2, 2}(N[1 0; 0 1]))
+
+    # projection
+    b4 = BallInf(N[4, 3, 2, 1], N(2))
+    @test project(b4, [2, 4]) == BallInf(N[3, 1], N(2))
 end
 
 # tests that only work with Float64

--- a/test/unit_BallInf.jl
+++ b/test/unit_BallInf.jl
@@ -185,6 +185,13 @@ for N in [Float64, Rational{Int}, Float32]
    Zs = LazySets._convert_2D_static(Zonotope, B)
    @test Zs == Zonotope(SVector{2}(N[0, 0]), SMatrix{2, 2}(N[1 0; 0 1]))
 
+    # set difference
+    B = BallInf(N[0, 0, 0], N(1))
+    @test isempty(difference(B, B))
+
+    # volume
+    @test volume(B) ≈ N(8)
+
     # projection
     b4 = BallInf(N[4, 3, 2, 1], N(2))
     @test project(b4, [2, 4]) == BallInf(N[3, 1], N(2))

--- a/test/unit_Ballp.jl
+++ b/test/unit_Ballp.jl
@@ -52,4 +52,8 @@ for N in [Float64, Float32]
 
     # translation
     @test translate(b, N[1, 2]) == Ballp(N(3), N[1, 2], N(2))
+
+    # projection
+    b4 = Ballp(N(3), N[4, 3, 2, 1], N(2))
+    @test project(b4, [2, 4]) == Ballp(N(3), N[3, 1], N(2))
 end

--- a/test/unit_EmptySet.jl
+++ b/test/unit_EmptySet.jl
@@ -81,6 +81,9 @@ for N in [Float64, Rational{Int}, Float32]
     for X in [B, Singleton(N[0, 0])]
         @test isdisjoint(E, X) && isdisjoint(X, E)
     end
+
+    # projection
+    @test project(EmptySet{N}(5), [1, 4, 5]) == EmptySet{N}(3)
 end
 
 # tests that only work with Float64 and Float32

--- a/test/unit_Hyperrectangle.jl
+++ b/test/unit_Hyperrectangle.jl
@@ -263,14 +263,7 @@ for N in [Float64, Rational{Int}, Float32]
     q = Hyperrectangle(low=N[0], high=N[0.5])
     @test convert(Interval, difference(h, q).array[1]) == Interval(N(0.5), N(1))
 
-    # another set difference test in higher-dimensions
-    b = BallInf(N[0, 0, 0], N(1))
-    @test isempty(difference(b, b))
-
-    # volume of a hyperrectangular set
-    b = BallInf(N[0, 0, 0], N(1))
-    @test volume(b) ≈ N(8)
-
-    # concete projection
-    @test project(BallInf(zeros(N, 4), N(1)), [1, 2]) == Hyperrectangle(zeros(N, 2), ones(N, 2))
+    # concrete projection
+    @test project(Hyperrectangle(N[4, 3, 2, 1], N[8, 7, 6, 5]), [2, 4]) ==
+        Hyperrectangle(N[3, 1], N[7, 5])
 end

--- a/test/unit_Universe.jl
+++ b/test/unit_Universe.jl
@@ -91,6 +91,9 @@ for N in [Float64, Rational{Int}, Float32]
     # inverse linear map
     M = ones(N, 2, 3)
     @test linear_map_inverse(M, U) == Universe{N}(3)
+
+    # projection
+    @test project(Universe{N}(5), [1, 4, 5]) == Universe{N}(3)
 end
 
 # default Float64 constructor


### PR DESCRIPTION
See #1209.
~Requires #2475.~

Concrete `project()` for:
* `Ball1`, `Ball2`, `BallInf`, `Ballp`
* `EmptySet`
* `Universe`