### PR TITLE
Generalize special case for concrete projection of polyhedra

### DIFF
--- a/docs/src/lib/interfaces.md
+++ b/docs/src/lib/interfaces.md
@@ -74,10 +74,10 @@ surface(::LazySet{N}) where {N}
 area(::LazySet{N}) where {N}
 concretize(::LazySet)
 complement(::LazySet)
-project(::LazySet, ::AbstractVector{Int}, ::Nothing)
-project(::LazySet, ::AbstractVector{Int}, ::Type{<:LazySet})
-project(::LazySet, ::AbstractVector{Int}, ::Pair{<:UnionAll, <:Real})
-project(::LazySet, ::AbstractVector{Int}, ::Real)
+project(S::LazySet{N}, ::AbstractVector{Int}, ::Nothing, ::Int=dim(S)) where {N}
+project(S::LazySet, ::AbstractVector{Int}, ::Type{<:LazySet}, ::Int=dim(S))
+project(S::LazySet, ::AbstractVector{Int}, ::Pair{<:UnionAll, <:Real}, ::Int=dim(S))
+project(S::LazySet, ::AbstractVector{Int}, ::Real, ::Int=dim(S))
 ```
 
 Plotting is available for general one- or two-dimensional `LazySet`s, provided

--- a/docs/src/lib/lazy_operations/LinearMap.md
+++ b/docs/src/lib/lazy_operations/LinearMap.md
@@ -15,7 +15,7 @@ an_element(::LinearMap)
 vertices_list(::LinearMap)
 constraints_list(::LinearMap)
 linear_map(::AbstractMatrix, ::LinearMap)
-project(::LazySet, ::AbstractVector{Int}, ::Type{<:LinearMap})
+project(S::LazySet{N}, ::AbstractVector{Int}, ::Type{<:LinearMap}, ::Int=dim(S)) where {N}
 ```
 Inherited from [`AbstractAffineMap`](@ref):
 * [`isempty`](@ref isempty(::AbstractAffineMap))

--- a/src/Interfaces/AbstractPolyhedron_functions.jl
+++ b/src/Interfaces/AbstractPolyhedron_functions.jl
@@ -1094,10 +1094,7 @@ function project(P::AbstractPolyhedron{N}, block::AbstractVector{Int}) where {N}
 
     # general case
     if general_case
-        n = dim(P)
-        M = projection_matrix(block, n, N)
-        lm = linear_map(M, P)
-        clist = constraints_list(lm)
+        clist = _project_polyhedron(P, block)
     end
 
     if isbounded(P)
@@ -1105,4 +1102,9 @@ function project(P::AbstractPolyhedron{N}, block::AbstractVector{Int}) where {N}
     else
          return HPolyhedron(clist)
     end
+end
+
+function _project_polyhedron(P::LazySet, block)
+    lm = project(P, block, nothing)
+    return constraints_list(lm)
 end


### PR DESCRIPTION
This PR generalizes the concrete projection of polyhedra based on the idea of the constrained dimensions (#1213).
As a bonus it also removes the boundedness check of the `HPolytope` in the end.

#### Idea

If a constraint's constrained dimensions all get projected away, the constraint becomes redundant and we can just ignore it.

#### Example

A 2D `Hyperrectangle` can be projected exactly to dimension 1 (`x`). This is still true if we consider the constraint representation. The constraints have the form `ax + 0y <= b` or `0x + ay <= b`. In the first case one can project away the redundant dimension `y`. In the second case one can drop the whole constraint. (Note that this is only correct because we assume that our half-spaces are feasible.)

#### Advantage

- The implementation is more efficient for a class of cases; in particular we do not require `Polyhedra`/`CDDLib` in this case.

```julia
julia> P = convert(HPolytope, rand(BallInf));

julia> @btime project($P, [1])  # master
glp_simplex: unable to recover undefined or non-optimal solution
  496.385 μs (1328 allocations: 56.42 KiB)
HPolytope{Float64,Array{Float64,1}}(HalfSpace{Float64,Array{Float64,1}}[
 HalfSpace{Float64,Array{Float64,1}}([1.0], -1.8694508399505545),
 HalfSpace{Float64,Array{Float64,1}}([-1.0], 3.714432065736666)])

julia> @btime project($P, [1])  # this branch
  694.282 ns (16 allocations: 1.23 KiB)
HPolytope{Float64,Array{Float64,1}}(HalfSpace{Float64,Array{Float64,1}}[
 HalfSpace{Float64,Array{Float64,1}}([1.0], -1.8694508399505545),
 HalfSpace{Float64,Array{Float64,1}}([-1.0], 3.714432065736666)])
```

#### Disadvantages

- There is a very minor overhead compared to the previous implementation for the previous special case because of additional checks.
- The implementation got more complicated.