### PR TITLE
Add default uniform sampler

### DIFF
--- a/src/Utils/samples.jl
+++ b/src/Utils/samples.jl
@@ -43,12 +43,10 @@ See the documentation of the respective `Sampler`.
 function sample(X::LazySet{N}, num_samples::Int;
                 sampler=nothing,
                 rng::AbstractRNG=GLOBAL_RNG,
-                seed::Union{Int, Nothing}=nothing) where {N<:Real}
+                seed::Union{Int, Nothing}=nothing) where {N}
     @assert isbounded(X) "this function requires that the set `X` is bounded"
 
     if sampler == nothing
-        require(:Distributions; fun_name="sample",
-                explanation="using the default `RejectionSampler` algorithm")
         sampler = RejectionSampler
     end
     D = Vector{Vector{N}}(undef, num_samples) # preallocate output
@@ -57,7 +55,7 @@ function sample(X::LazySet{N}, num_samples::Int;
 end
 
 # without argument, returns a single element (instead of a singleton)
-function sample(X::LazySet{N}; kwargs...) where {N<:Real}
+function sample(X::LazySet{N}; kwargs...) where {N}
     return sample(X, 1; kwargs...)[1]
 end
 
@@ -65,9 +63,88 @@ end
 function _sample!(D::Vector{Vector{N}},
                   sampler::Sampler;
                   rng::AbstractRNG=GLOBAL_RNG,
-                  seed::Union{Int, Nothing}=nothing) where {N<:Real}
+                  seed::Union{Int, Nothing}=nothing) where {N}
     error("the method `_sample!` is not implemented for samplers of type " *
           "$(typeof(sampler))")
+end
+
+# =====================
+# Rejection Sampling
+# =====================
+
+# represents a uniform distribution over the interval [a, b]
+struct DefaultUniform{N}
+    a::N
+    b::N
+end
+
+using Random
+
+function Base.rand(rng::AbstractRNG, U::DefaultUniform)
+    (U.b - U.a) * rand(rng) + U.a
+end
+
+"""
+    RejectionSampler{S<:LazySet, D} <: Sampler
+
+Type used for rejection sampling of an arbitrary `LazySet` `X`.
+
+### Fields
+
+- `X`          -- (bounded) set to be sampled
+- `box_approx` -- Distribution from which the sample is drawn
+
+### Algorithm
+
+Draw a sample ``x`` from a uniform distribution of a box-overapproximation of the
+original set ``X`` in all ``n`` dimensions. The function rejects a drawn sample ``x``
+and redraws as long as the sample is not contained in the original set ``X``,
+i.e., ``x ∉ X``.
+"""
+struct RejectionSampler{S<:LazySet, D} <: Sampler
+    X::S
+    box_approx::Vector{D}
+end
+
+
+function RejectionSampler(X, distribution=DefaultUniform)
+    B = box_approximation(X)
+    box_approx = [distribution(low(B, i), high(B, i)) for i in 1:dim(B)]
+    return RejectionSampler(X, box_approx)
+end
+
+"""
+    _sample!(D::Vector{Vector{N}},
+             sampler::RejectionSampler;
+             rng::AbstractRNG=GLOBAL_RNG,
+             seed::Union{Int, Nothing}=nothing) where {N}
+
+Sample points using rejection sampling.
+
+### Input
+
+- `D`           -- output, vector of points
+- `sampler`     -- Sampler from which the points are sampled
+- `rng`         -- (optional, default: `GLOBAL_RNG`) random number generator
+- `seed`        -- (optional, default: `nothing`) seed for reseeding
+
+### Output
+
+A vector of `num_samples` vectors.
+"""
+function _sample!(D::Vector{Vector{N}},
+                  sampler::RejectionSampler;
+                  rng::AbstractRNG=GLOBAL_RNG,
+                  seed::Union{Int, Nothing}=nothing) where {N}
+    rng = reseed(rng, seed)
+    @inbounds for i in 1:length(D)
+        w = rand.(Ref(rng), sampler.box_approx)
+        while w ∉ sampler.X
+            w = rand.(Ref(rng), sampler.box_approx)
+        end
+        D[i] = w
+    end
+    return D
 end
 
 # =============================
@@ -194,74 +271,6 @@ function _sample_unit_nball_muller!(D::Vector{Vector{N}}, n::Int, p::Int;
         r = rand(rng, Zrad)
         β = r^one_over_n / sqrt(α)
         D[j] = v .* β
-    end
-    return D
-end
-
-# =====================
-# Rejection Sampling
-# =====================
-
-"""
-    RejectionSampler{S<:LazySet, D<:Distribution} <: Sampler
-
-Type used for rejection sampling of an arbitrary `LazySet` `X`.
-
-### Fields
-
-- `X`          -- (bounded) set to be sampled
-- `box_approx` -- Distribution from which the sample is drawn
-
-### Algorithm
-
-Draw a sample ``x`` from a uniform distribution of a box-overapproximation of the
-original set ``X`` in all ``n`` dimensions. The function rejects a drawn sample ``x``
-and redraws as long as the sample is not contained in the original set ``X``,
-i.e., ``x ∉ X``.
-"""
-struct RejectionSampler{S<:LazySet, D<:Distribution} <: Sampler
-    X::S
-    box_approx::Vector{D}
-end
-
-function RejectionSampler(X, distribution=Uniform)
-    B = box_approximation(X)
-    canonical_support = hcat(low(B), high(B))
-    dims = size(canonical_support, 1)
-    box_approx = [distribution(canonical_support[i,:]...) for i = 1:dims]
-    return RejectionSampler(X, box_approx)
-end
-
-"""
-    _sample!(D::Vector{Vector{N}},
-             sampler::RejectionSampler;
-             rng::AbstractRNG=GLOBAL_RNG,
-             seed::Union{Int, Nothing}=nothing) where {N<:Real}
-
-Sample points using rejection sampling.
-
-### Input
-
-- `D`           -- output, vector of points
-- `sampler`     -- Sampler from which the points are sampled
-- `rng`         -- (optional, default: `GLOBAL_RNG`) random number generator
-- `seed`        -- (optional, default: `nothing`) seed for reseeding
-
-### Output
-
-A vector of `num_samples` vectors.
-"""
-function _sample!(D::Vector{Vector{N}},
-                  sampler::RejectionSampler;
-                  rng::AbstractRNG=GLOBAL_RNG,
-                  seed::Union{Int, Nothing}=nothing) where {N<:Real}
-    rng = reseed(rng, seed)
-    @inbounds for i in 1:length(D)
-        w = rand.(Ref(rng), sampler.box_approx)
-        while w ∉ sampler.X
-            w = rand.(Ref(rng), sampler.box_approx)
-        end
-        D[i] = w
     end
     return D
 end

--- a/src/Utils/samples.jl
+++ b/src/Utils/samples.jl
@@ -78,8 +78,6 @@ struct DefaultUniform{N}
     b::N
 end
 
-using Random
-
 function Base.rand(rng::AbstractRNG, U::DefaultUniform)
     (U.b - U.a) * rand(rng) + U.a
 end
@@ -154,7 +152,7 @@ end
 function load_distributions_samples()
 return quote
 
-using .Distributions: Distribution, Uniform, Normal
+using .Distributions: Uniform, Normal
 import .Distributions
 
 # ======================================================

--- a/test/unit_samples.jl
+++ b/test/unit_samples.jl
@@ -1,4 +1,5 @@
-using Distributions: Uniform
+using Distributions: Uniform, Normal
+using LazySets: DefaultUniform
 
 for N in [Float64]
     P1 = BallInf([0.6, 0.1, -1.3, -0.4, 0.2], 0.6)
@@ -11,11 +12,16 @@ for N in [Float64]
     P3 = HPolyhedron([0.0 0.1], [3.0])
     P4 = Ball2([0.2, -0.3, -1.1, 0.6, -0.7], 0.4)
 
-    ## Test rand samples are contained in the set
+    # Test rand samples are contained in the set
     p1 = LazySets.sample(P1)
     @test p1 ∈ P1
     p1_samples = LazySets.sample(P1, 100)
     @test sum(p1_samples .∈ Ref(P1)) == length(p1_samples)
 
-    @test LazySets.RejectionSampler(P2).box_approx == [Uniform(-3.0,1.0), Uniform(-4.0,2.0)]
+    # default distribution
+    @test LazySets.RejectionSampler(P2).box_approx == [DefaultUniform(-3.0,1.0), DefaultUniform(-4.0,2.0)]
+
+    # specifying a distribution from Distributions.jl
+    @test LazySets.RejectionSampler(P2, Uniform).box_approx == [Uniform(-3.0, 1.0), Uniform(-4.0,2.0)]
+    @test LazySets.RejectionSampler(P2, Normal).box_approx == [Normal(-3.0, 1.0), Normal(-4.0, 2.0)]
 end


### PR DESCRIPTION
This PR adds a `DefaultUniform` struct and is set by default, this means the we can use `sample(X, m)` without having to load `Distributions` to sample using a uniform distribution, since that is already available in Julia Base.