### PR TITLE
Fix docs (project methods)

### DIFF
--- a/docs/src/lib/interfaces.md
+++ b/docs/src/lib/interfaces.md
@@ -74,9 +74,9 @@ surface(::LazySet{N}) where {N}
 area(::LazySet{N}) where {N}
 concretize(::LazySet)
 complement(::LazySet)
-project(S::LazySet{N}, ::AbstractVector{Int}, ::Nothing, ::Int=dim(S)) where {N}
-project(S::LazySet, ::AbstractVector{Int}, ::Type{<:LazySet}, ::Int=dim(S))
-project(S::LazySet, ::AbstractVector{Int}, ::Pair{<:UnionAll, <:Real}, ::Int=dim(S))
+project(S::LazySet{N}, ::AbstractVector{Int}, ::Nothing=nothing, ::Int=dim(S)) where {N}
+project(S::LazySet, ::AbstractVector{Int}, ::Type{var"#s27"} where var"#s27"<:LazySet, ::Int=dim(S))
+project(S::LazySet, ::AbstractVector{Int}, ::Pair{var"#s14",var"#s12"} where var"#s12"<:Real where var"#s14"<:UnionAll, ::Int=dim(S))
 project(S::LazySet, ::AbstractVector{Int}, ::Real, ::Int=dim(S))
 ```
 

--- a/docs/src/lib/lazy_operations/LinearMap.md
+++ b/docs/src/lib/lazy_operations/LinearMap.md
@@ -15,7 +15,7 @@ an_element(::LinearMap)
 vertices_list(::LinearMap)
 constraints_list(::LinearMap)
 linear_map(::AbstractMatrix, ::LinearMap)
-project(S::LazySet{N}, ::AbstractVector{Int}, ::Type{<:LinearMap}, ::Int=dim(S)) where {N}
+project(S::LazySet{N}, ::AbstractVector{Int}, ::Type{T} where T<:LinearMap, ::Int=dim(S)) where {N}
 ```
 Inherited from [`AbstractAffineMap`](@ref):
 * [`isempty`](@ref isempty(::AbstractAffineMap))


### PR DESCRIPTION
This fixes the docs error that sometimes happens since #2475.

Don't ask me why
```julia
 project(S::LazySet, ::AbstractVector{Int}, ::Type{var"#s27"} where var"#s27"<:LazySet, ::Int=dim(S))
```
works but
```julia
 project(S::LazySet, ::AbstractVector{Int}, ::Type{T} where T<:LazySet, ::Int=dim(S))
```
does not...