### PR TITLE
Better error message in minkowski_sum of V-reps

### DIFF
--- a/src/ConcreteOperations/minkowski_sum.jl
+++ b/src/ConcreteOperations/minkowski_sum.jl
@@ -413,6 +413,7 @@ function _minkowski_sum_vrep_nd(vlist1::Vector{VT}, vlist2::Vector{VT};
     end
     if apply_convex_hull
         if backend == nothing
+            require(:Polyhedra; fun_name="minkowski_sum")
             backend = default_polyhedra_backend_nd(N)
             solver = default_lp_solver_polyhedra(N)
         end


### PR DESCRIPTION
In `master`:
```julia
julia> Z = minkowski_sum(X, Y)
ERROR: UndefVarError: default_polyhedra_backend_nd not defined
```
This branch:
```julia
julia> Z = minkowski_sum(X, Y)
ERROR: AssertionError: package 'Polyhedra' not loaded (it is required for executing `minkowski_sum`)
```
I am not 100% sure about the error message but I think it is better to have that.