### PR TITLE
Alternative polytope sampler

### DIFF
--- a/test/ConcreteOperations/samples.jl
+++ b/test/ConcreteOperations/samples.jl
@@ -9,8 +9,7 @@ for N in [Float64]
          0.0 -1.0]
     b = [1.0, 2.0, 3.0, 4.0]
     P2 = HPolyhedron(A, b)
-    P3 = HPolyhedron([0.0 0.1], [3.0])
-    P4 = Ball2([0.2, -0.3, -1.1, 0.6, -0.7], 0.4)
+    P3 = VPolygon([N[0, -1], N[2, 1]])
 
     # Test rand samples are contained in the set
     p1 = LazySets.sample(P1)
@@ -21,9 +20,13 @@ for N in [Float64]
     # default distribution
     @test LazySets.RejectionSampler(P2).distribution == [DefaultUniform(-3.0,1.0), DefaultUniform(-4.0,2.0)]
 
-    # polytope sampler
-    p1_samples = LazySets.sample(P1, 100, sampler=LazySets.RandomWalkSampler())
-    @test all(v ∈ P1 for v in p1_samples)
+    # random-walk sampler
+    for P in [P1, P2, P3]
+        for sampler in [LazySets.RandomWalkSampler(true), LazySets.RandomWalkSampler(false)]
+            p_samples = LazySets.sample(P, 100, sampler=sampler)
+            @test all(v ∈ P for v in p_samples)
+        end
+    end
 
     # specifying a distribution from Distributions.jl
     @test LazySets.RejectionSampler(P2, Uniform).distribution == [Uniform(-3.0, 1.0), Uniform(-4.0,2.0)]


### PR DESCRIPTION
Alternative to #2547 that seems more biased toward the edges. Related to #2536.

The idea is to start from the Chebyshev center and then walk toward random vertices. Crucially, some vertices can be skipped, which has the effect that the samples are not biased toward the center.

TODOs:
* [x] ~find a better name or~ merge with the existing `PolytopeSampler` via an option
* [x] docs
* [x] test

---

```julia
julia> using LazySets, Polyhedra, Plots
julia> X = rand(VPolygon);
julia> @time V = sample(X, 1000, sampler=LazySets.PolytopeSampler);
  0.000688 seconds (8.01 k allocations: 758.172 KiB)
julia> @time V2 = sample(X, 1000, sampler=LazySets.PolytopeSampler2);  # sampler from this branch
glp_simplex: unable to recover undefined or non-optimal solution
glp_simplex: unable to recover undefined or non-optimal solution
  1.107326 seconds (1.30 M allocations: 67.599 MiB)

julia> plot(X)
julia> scatter!([v[1] for v in V], [v[2] for v in V])
julia> scatter!([v[1] for v in V2], [v[2] for v in V2])
```

![sampling](https://user-images.githubusercontent.com/9656686/107385714-6e983c80-6af3-11eb-8844-4f7d84c9768c.png)