### PR TITLE
#2187 - Sort constraints in HPolygon intersection

### DIFF
--- a/src/ConcreteOperations/intersection.jl
+++ b/src/ConcreteOperations/intersection.jl
@@ -586,7 +586,9 @@ function intersection(P1::AbstractHPolygon{N},
         deleteat!(c, length(c)-duplicates+1:length(c))
     end
 
-    P = HPolygon(c, sort_constraints=false)
+    # TODO see #2187: the above code does *not* sort the constraints correctly.
+    # after fixing the above code, we should pass sort_constraints=false again
+    P = HPolygon(c, sort_constraints=true)
     if prune
         remove_redundant_constraints!(P)
         if isempty(P)

--- a/test/unit_Polygon.jl
+++ b/test/unit_Polygon.jl
@@ -518,6 +518,12 @@ for N in [Float64, Float32]
     addconstraint!(p2, p2.constraints[2])
     @test length(p2.constraints) == 6
 
+    # correct sorting of constraints in intersection (#2187)
+    h = Hyperrectangle(N[0.98069, 0.85020],
+                       N[0.00221, 0.00077])
+    p = overapproximate(Ball2(N[1, 1], N(15//100)), 1e-4)
+    @test !isempty(intersection(HPolygon(constraints_list(h)), p))
+
     # test that concrete minkowski sum of a singleton and a polygon works
     x = VPolygon([N[1, 1]])
     y = VPolygon([N[1.1, 2.2], N[0.9, 2.2], N[0.9, 2.0], N[1.1, 2.0]])


### PR DESCRIPTION
Closes #2187.

The problem (see #2187's OP) is that `intersection` of two `HPolygon`s is supposed to combine the constraints in a sorted order but it does not. This PR proposes a quick fix: sort them in the end.
Ultimately the code should be fixed, but since it is complicated and the issue has been open for several months, I think we should first fix the bug and then propose an efficient fix later.