### PR TITLE
#2319 - Invalid local links in documentation

### DIFF
--- a/src/Interfaces/AbstractPolyhedron_functions.jl
+++ b/src/Interfaces/AbstractPolyhedron_functions.jl
@@ -935,7 +935,7 @@ Determine whether a polyhedron is bounded.
 We first check if the polyhedron has more than `max(dim(P), 1)` constraints,
 which is a necessary condition for boundedness.
 
-If so, we check boundedness via [`_isbounded_stiemke`](@ref).
+If so, we check boundedness via `_isbounded_stiemke`.
 """
 function isbounded(P::AbstractPolyhedron{N}; solver=default_lp_solver(N)) where {N}
     constraints = constraints_list(P)

--- a/src/Interfaces/AbstractZonotope.jl
+++ b/src/Interfaces/AbstractZonotope.jl
@@ -372,7 +372,8 @@ A translated zonotope.
 
 ### Notes
 
-See also [@ref](`translate!`) for the in-place version.
+See also [`translate!(Z::AbstractZonotope, v::AbstractVector)`](@ref) for the
+in-place version.
 
 ### Algorithm
 
@@ -398,7 +399,8 @@ A translated zonotope.
 
 ### Notes
 
-See also [@ref](`translate`) for the out-of-place version.
+See also [`translate(Z::AbstractZonotope, v::AbstractVector)`](@ref) for the
+out-of-place version.
 
 ### Algorithm
 

--- a/src/Interfaces/LazySet.jl
+++ b/src/Interfaces/LazySet.jl
@@ -265,8 +265,8 @@ Determine whether a set is bounded.
 
 ### Algorithm
 
-See the documentation of [`_isbounded_unit_dimensions`](@ref) or
-[`_isbounded_stiemke`](@ref) for details.
+See the documentation of `_isbounded_unit_dimensions` or `_isbounded_stiemke`
+for details.
 """
 function isbounded(S::LazySet; algorithm="support_function")
     if algorithm == "support_function"


### PR DESCRIPTION
Closes #2319.

The first commit fixes broken links.
The second commit removes broken links that I could not get to work after trying all kinds of things.