### PR TITLE
Revise usage of 'all'

### DIFF
--- a/src/Approximations/decompositions.jl
+++ b/src/Approximations/decompositions.jl
@@ -118,9 +118,7 @@ degree of accuracy, and template directions.
 These options are exemplified below, where we use the following example.
 
 ```jldoctest decompose_examples
-julia> using LazySets.Approximations: decompose
-
-julia> S = Ball2(zeros(4), 1.);  # set to be decomposed (4D 2-norm unit ball)
+julia> S = Ball2(zeros(4), 1.0);  # set to be decomposed (4D 2-norm unit ball)
 
 julia> P2d = [1:2, 3:4];  # a partition with two blocks of size two
 
@@ -132,14 +130,14 @@ julia> P1d = [[1], [2], [3], [4]];  # a partition with four blocks of size one
 We can decompose using polygons in constraint representation:
 
 ```jldoctest decompose_examples
-julia> all([ai isa HPolygon for ai in array(decompose(S, P2d, HPolygon))])
+julia> all(ai isa HPolygon for ai in array(decompose(S, P2d, HPolygon)))
 true
 ```
 
 For decomposition into 1D subspaces, we can use `Interval`:
 
 ```jldoctest decompose_examples
-julia> all([ai isa Interval for ai in array(decompose(S, P1d, Interval))])
+julia> all(ai isa Interval for ai in array(decompose(S, P1d, Interval)))
 true
 ```
 
@@ -183,8 +181,6 @@ function of the given input set over the template directions.
 For example, octagonal 2D approximations of the set `S` are obtained with:
 
 ```jldoctest decompose_examples
-julia> using LazySets.Approximations: OctDirections
-
 julia> B = decompose(S, P2d, OctDirections);
 
 julia> length(B.array) == 2 && all(dim(bi) == 2 for bi in B.array)

--- a/src/Approximations/template_directions.jl
+++ b/src/Approximations/template_directions.jl
@@ -723,9 +723,11 @@ User-defined template directions.
 
 ### Fields
 
-- `directions` -- list of template directions
-- `n`          -- dimension
-- `isbounding` -- boundedness status
+- `directions`          -- list of template directions
+- `n`                   -- (optional; default: computed from `directions) dimension
+- `check_boundedness`   -- (optional; default: `true`) flag to check boundedness
+- `check_normalization` -- (optional; default: `true`) flag to check whether all
+                           directions are normalized
 
 ### Notes
 
@@ -792,7 +794,7 @@ function _isbounding(directions::Vector{VN}) where {N, VN<:AbstractVector{N}}
 end
 
 function _isnormalized(directions::Vector{VN}) where {N, VN<:AbstractVector{N}}
-    return all(x -> _isapprox(x, one(N)), norm.(directions, 2))
+    return all(x -> _isapprox(norm(x, 2), one(N)), directions)
 end
 
 Base.eltype(::Type{CustomDirections{N, VN}}) where {N, VN} = VN

--- a/src/Sets/ZeroSet.jl
+++ b/src/Sets/ZeroSet.jl
@@ -152,7 +152,7 @@ function ∈(x::AbstractVector, Z::ZeroSet)
     @assert length(x) == dim(Z)
 
     N = promote_type(eltype(x), eltype(Z))
-    return all(i -> x[i] == zero(N), eachindex(x))
+    return all(==(zero(N)), x)
 end
 
 """


### PR DESCRIPTION
Inspired by [this](https://docs.julialang.org/en/v1/manual/style-guide/#Do-not-write-x-f(x)).

```julia
julia> n = 1000;


julia> Z = ZeroSet(n); x = zeros(n);

julia> @btime $x ∈ $Z;
  85.407 μs (1000 allocations: 15.63 KiB)  # master
  754.619 ns (0 allocations: 0 bytes)  # this branch


julia> d = fill([1.0, 0, 0, 0], n);

julia> @btime LazySets.Approximations._isnormalized($d);
  15.814 μs (1 allocation: 7.94 KiB)  # master
  14.916 μs (0 allocations: 0 bytes)  # this branch
```