### PR TITLE
#1926 - Add isboundedtype function

### DIFF
--- a/docs/src/lib/interfaces.md
+++ b/docs/src/lib/interfaces.md
@@ -58,6 +58,7 @@ basetype
 norm(::LazySet, ::Real=Inf)
 radius(::LazySet, ::Real=Inf)
 diameter(::LazySet, ::Real=Inf)
+isboundedtype(::Type{<:LazySet})
 isbounded(::LazySet)
 _isbounded_unit_dimensions(::LazySet{N}) where {N}
 an_element(::LazySet{N}) where {N}

--- a/src/Interfaces/AbstractCentrallySymmetric.jl
+++ b/src/Interfaces/AbstractCentrallySymmetric.jl
@@ -45,6 +45,10 @@ The ambient dimension of the set.
     return length(center(S))
 end
 
+function isboundedtype(::Type{<:AbstractCentrallySymmetric})
+    return true
+end
+
 """
     isbounded(S::AbstractCentrallySymmetric)
 

--- a/src/Interfaces/AbstractPolytope.jl
+++ b/src/Interfaces/AbstractPolytope.jl
@@ -38,6 +38,10 @@ isconvextype(::Type{<:AbstractPolytope}) = true
 # Common AbstractPolytope functions
 # =============================================
 
+function isboundedtype(::Type{<:AbstractPolytope})
+    return true
+end
+
 """
     isbounded(P::AbstractPolytope)
 

--- a/src/Interfaces/LazySet.jl
+++ b/src/Interfaces/LazySet.jl
@@ -12,6 +12,7 @@ export LazySet,
        diameter,
        an_element,
        isbounded,
+       isboundedtype,
        neutral,
        absorbing,
        tosimplehrep,
@@ -247,6 +248,31 @@ function σ end
 Alias for the support vector σ.
 """
 const support_vector = σ
+
+"""
+    isboundedtype(::Type{<:LazySet})
+
+Determine whether a set type only represents bounded sets.
+
+### Input
+
+- `LazySet` -- set type for dispatch
+
+### Output
+
+`true` if the set type only represents bounded sets.
+Note that some sets may still represent an unbounded set even though their type
+actually does not (example: [`HPolytope`](@ref), because the construction with
+non-bounding linear constraints is allowed).
+
+### Notes
+
+By default this function returns `false`.
+All set types that can determine boundedness should override this behavior.
+"""
+function isboundedtype(::Type{T}) where {T<:LazySet}
+    return false
+end
 
 """
     isbounded(S::LazySet)

--- a/src/LazyOperations/Complement.jl
+++ b/src/LazyOperations/Complement.jl
@@ -114,6 +114,14 @@ function isempty(C::Complement)
     return isuniversal(C.X)
 end
 
+function isboundedtype(::Type{<:Complement{<:Real, <:Universe}})
+    return true
+end
+
+function isboundedtype(::Type{<:Complement})
+    return false
+end
+
 # --  Fallback implementation, requires constraints list of C.X --
 
 """

--- a/src/Sets/EmptySet.jl
+++ b/src/Sets/EmptySet.jl
@@ -85,6 +85,10 @@ function ρ(d::AbstractVector, ∅::EmptySet)
     error("the support function of an empty set does not exist")
 end
 
+function isboundedtype(::Type{<:EmptySet})
+    return true
+end
+
 """
     isbounded(∅::EmptySet)
 

--- a/test/unit_Ball2.jl
+++ b/test/unit_Ball2.jl
@@ -57,7 +57,7 @@ for N in [Float64, Float32]
     @test σ(d, b) == N[0, -2]
 
     # boundedness
-    @test isbounded(b)
+    @test isbounded(b) && isboundedtype(typeof(b))
 
     # isempty
     @test !isempty(b)

--- a/test/unit_Complement.jl
+++ b/test/unit_Complement.jl
@@ -49,4 +49,8 @@ for N in [Float64, Rational{Int}, Float32]
     c = complement(N[0 1; 1 0] * H)
     @test c isa UnionSetArray && length(array(c)) == 1
     @test first(array(c)) == HalfSpace(N[0, -1], N(-1)) # complement of y <= 1 is y >= 1
+
+    # boundedness
+    @test isboundedtype(typeof(Complement(Universe{N}(2))))
+    @test !isboundedtype(typeof(Complement(EmptySet{N}(2))))
 end

--- a/test/unit_EmptySet.jl
+++ b/test/unit_EmptySet.jl
@@ -43,7 +43,7 @@ for N in [Float64, Rational{Int}, Float32]
     @test_throws ErrorException σ(N[0], E)
 
     # boundedness
-    @test isbounded(E)
+    @test isbounded(E) && isboundedtype(typeof(E))
 
     # isuniversal
     res, w = isuniversal(E, true)

--- a/test/unit_LazySet.jl
+++ b/test/unit_LazySet.jl
@@ -2,4 +2,5 @@ for ST in LazySets.subtypes(LazySet, true)
     # check that certain methods are implemented
     isconvextype(ST)
     isoperationtype(ST)
+    isboundedtype(ST)
 end

--- a/test/unit_Polyhedron.jl
+++ b/test/unit_Polyhedron.jl
@@ -161,7 +161,7 @@ for N in [Float64, Float32]
     p_univ = HPolyhedron{N}()
 
     # boundedness
-    @test !isbounded(p_univ)
+    @test !isbounded(p_univ) && !isboundedtype(typeof(p_univ))
     @test isbounded(p)
     @test !isbounded(HPolyhedron([HalfSpace(N[1, 0], N(1))]))
 

--- a/test/unit_Polytope.jl
+++ b/test/unit_Polytope.jl
@@ -45,9 +45,9 @@ for N in [Float64, Rational{Int}, Float32]
     @test_throws ErrorException σ(N[0], HPolytope{N}())
 
     # boundedness
-    @test isbounded(p) && isbounded(p, false)
+    @test isbounded(p) && isbounded(p, false) && isboundedtype(typeof(p))
     p2 = HPolytope{N}()
-    @test isbounded(p2) && !isbounded(p2, false)
+    @test isbounded(p2) && !isbounded(p2, false) && isboundedtype(typeof(p2))
 
     # isuniversal
     answer, w = isuniversal(p, true)


### PR DESCRIPTION
Closes #1926.
Closes #1979 (I copied the code for `isboundedtype(::Type{<:LazySet})` from there and extended it to the current code base).