### PR TITLE
fix generator columns for the nonlinear terms in TM -> Zono conversion

### DIFF
--- a/src/Approximations/overapproximate.jl
+++ b/src/Approximations/overapproximate.jl
@@ -835,7 +835,7 @@ range evaluation using interval arithmetic:
 
 ```julia
 julia> X = box_approximation(Z)
-Hyperrectangle{Float64}([1.0, -2.1], [2.5, 6.5])
+Hyperrectangle{Float64,Array{Float64,1},Array{Float64,1}}([1.0, -2.1], [2.5, 6.5])
 
 julia> Y = evaluate(vTM[1], vTM[1].dom) × evaluate(vTM[2], vTM[2].dom)
 [-1.5, 3.5] × [-8.60001, 4.40001]
@@ -858,7 +858,8 @@ This function also works if the polynomials are non-linear; for example suppose
 that we add a third polynomial with a quadratic term:
 
 ```julia
-julia> p3 = Taylor1([0.9, 3.0, 1.0], 3);
+julia> p3 = Taylor1([0.9, 3.0, 1.0], 3)
+ 0.9 + 3.0 t + 1.0 t² + 𝒪(t⁴)
 
 julia> vTM = [TaylorModel1(pi, I, x₀, D) for pi in [p1, p2, p3]]
 3-element Array{TaylorModel1{Float64,Float64},1}:
@@ -995,16 +996,16 @@ We refer to the algorithm description for the univariate case.
 """
 function overapproximate(vTM::Vector{TaylorModelN{N, T, S}},
                          ::Type{<:Zonotope}) where {N, T, S}
-        m = length(vTM)
-        n = N # number of variables is get_numvars() in TaylorSeries
+    m = length(vTM)
+    n = N # number of variables is get_numvars() in TaylorSeries
 
-        # preallocations
-        c = Vector{T}(undef, m) # center of the zonotope
-        gen_lin = Matrix{T}(undef, m, n) # generator of the linear part
-        gen_rem = Vector{T}(undef, m) # generators for the remainder
+    # preallocations
+    c = Vector{T}(undef, m) # center of the zonotope
+    gen_lin = Matrix{T}(undef, m, n) # generator of the linear part
+    gen_rem = Vector{T}(undef, m) # generators for the remainder
 
-        # compute overapproximation
-        return _overapproximate_vTM_zonotope!(vTM, c, gen_lin, gen_rem)
+    # compute overapproximation
+    return _overapproximate_vTM_zonotope!(vTM, c, gen_lin, gen_rem)
 end
 
 function _overapproximate_vTM_zonotope!(vTM, c, gen_lin, gen_rem)

--- a/test/Approximations/overapproximate.jl
+++ b/test/Approximations/overapproximate.jl
@@ -1,7 +1,7 @@
 using LazySets.Approximations: project
 
 @static if VERSION >= v"1.4"
-    using LazySets.Approximations: get_linear_coeffs
+    using LazySets.Approximations: get_linear_coeffs, _nonlinear_polynomial
 end
 
 for N in [Float64, Rational{Int}, Float32]
@@ -423,6 +423,16 @@ for N in [Float64]
         y = set_variables("y", numvars=2, order=1)
         p = zero(y[1])
         @test get_linear_coeffs(p) == N[0, 0]
+
+        # auxiliary function to get nonlinear coefficients of TaylorN
+        x = set_variables("x", numvars=2, order=10)
+        p = (1 + x[1] - 2x[2])^2
+        @test _nonlinear_polynomial(p) == x[1]^2 - 4x[1]*x[2] + 4x[2]^2
+
+        # auxiliary function to get nonlinear coefficients of Taylor1
+        t = Taylor1(6)
+        qq = 1.0 + 2.0*t + 3t^2 + 6t^3
+        @test _nonlinear_polynomial(qq) == 3t^2 + 6t^3
 
         # Zonotope approximation of convex hull array of zonotopes
         Z1 = Zonotope(N[3, 0], N[1 2 1; 1 1 2])

--- a/test/Approximations/overapproximate.jl
+++ b/test/Approximations/overapproximate.jl
@@ -430,7 +430,7 @@ for N in [Float64]
         @test _nonlinear_polynomial(p) == x[1]^2 - 4x[1]*x[2] + 4x[2]^2
 
         # auxiliary function to get nonlinear coefficients of Taylor1
-        t = Taylor1(6)
+        t = TaylorModels.Taylor1(6)
         qq = 1.0 + 2.0*t + 3t^2 + 6t^3
         @test _nonlinear_polynomial(qq) == 3t^2 + 6t^3
 


### PR DESCRIPTION
this is a fix to the fact that:

```julia
using TaylorSeries

x = set_variables("x", numvars=2, order=10)
2-element Array{TaylorN{Float64},1}:
  1.0 x₁ + 𝒪(‖x‖¹¹)
  1.0 x₂ + 𝒪(‖x‖¹¹)

p = (1 + x[1] - 2x[2])^2
 1.0 + 2.0 x₁ - 4.0 x₂ + 1.0 x₁² - 4.0 x₁ x₂ + 4.0 x₂² + 𝒪(‖x‖¹¹)

p - constant_term(p) - linear_polynomial(p)
 0.0 + 𝒪(‖x‖²)
```
which fails because the order of linear_polynomial is 1. hence we implement `_nonlinear_polynomial` that has the correct order. discussed on slack with @dpsanders