### PR TITLE
Update AffineMap docstring 

### DIFF
--- a/src/Approximations/ballinf_approximation.jl
+++ b/src/Approximations/ballinf_approximation.jl
@@ -18,7 +18,7 @@ A tight ball in the infinity norm.
 ### Algorithm
 
 The center and radius of the box are obtained by evaluating the support function
-of the given convex set along the canonical directions.
+of the given set along the canonical directions.
 """
 function ballinf_approximation(S::LazySet{N}) where {N}
     n = dim(S)

--- a/src/ConcreteOperations/issubset.jl
+++ b/src/ConcreteOperations/issubset.jl
@@ -38,12 +38,12 @@ end
 """
     ⊆(X::LazySet, P::LazySet, [witness]::Bool=false)
 
-Check whether a convex set is contained in a polyhedral set, and if not,
+Check whether a set is contained in a polyhedral set, and if not,
 optionally compute a witness.
 
 ### Input
 
-- `X`       -- inner convex set
+- `X`       -- inner set
 - `Y`       -- outer polyhedral set
 - `witness` -- (optional, default: `false`) compute a witness if activated
 

--- a/src/Interfaces/AbstractPolyhedron_functions.jl
+++ b/src/Interfaces/AbstractPolyhedron_functions.jl
@@ -889,7 +889,7 @@ end
     an_element(P::AbstractPolyhedron{N};
                [solver]=default_lp_solver(N)) where {N}
 
-Return some element of a convex set.
+Return some element of a polyhedron.
 
 ### Input
 

--- a/src/LazyOperations/AffineMap.jl
+++ b/src/LazyOperations/AffineMap.jl
@@ -4,26 +4,33 @@ export AffineMap
     AffineMap{N, S<:LazySet{N}, NM, MAT<:AbstractMatrix{NM},
               VN<:AbstractVector{NM}} <: AbstractAffineMap{N, S}
 
-Type that represents an affine transformation ``M⋅X ⊕ v`` of a convex set ``X``.
+Type that represents an affine transformation ``M⋅X ⊕ v`` of a set ``X``,
+that is the set
+
+```
+Y = \\{ y ∈ \\mathbb{R}^n : y = Mx + v,\\qquad x ∈ X \\}.
+```
+If ``X`` is ``n``-dimensional then ``M`` should be an ``m × n`` matrix and  ``v ∈ \\mathbb{R}^m`.
 
 ### Fields
 
-- `M` -- matrix/linear map
-- `X` -- convex set
+- `M` -- matrix
+- `X` -- set
 - `v` -- translation vector
+
+The fields' getter functions are `matrix`, `set` and `vector` respectively.
 
 ### Notes
 
 An affine map is the composition of a linear map and a translation. This type is
 parametric in the coefficients of the linear map, `NM`, which may be different from
-the numeric type of the wrapped set (`N`). However, the numeric type of the
+the numeric type of the wrapped set, `N`. However, the numeric type of the
 translation vector should be `NM`.
 
 ### Examples
 
 For the examples we create a ``3×2`` matrix, a two-dimensional unit square, and
-a three-dimensional vector.
-Then we combine them in an `AffineMap`.
+a three-dimensional vector. Then we combine them in an `AffineMap`.
 
 ```jldoctest constructors
 julia> A = [1 2; 1 3; 1 4]; X = BallInf([0, 0], 1); b2 = [1, 2]; b3 = [1, 2, 3];
@@ -34,8 +41,7 @@ AffineMap{Int64,BallInf{Int64,Array{Int64,1}},Int64,Array{Int64,2},Array{Int64,1
 
 For convenience, `A` does not need to be a matrix but we also allow to use
 `UniformScaling`s resp. scalars (interpreted as a scaling, i.e., a scaled
-identity matrix).
-Scaling by ``1`` is ignored and simplified to a pure `Translation`.
+identity matrix). Scaling by ``1`` is ignored and simplified to a pure `Translation`.
 
 ```jldoctest constructors
 julia> using LinearAlgebra
@@ -51,8 +57,7 @@ Translation{Int64,Array{Int64,1},BallInf{Int64,Array{Int64,1}}}(BallInf{Int64,Ar
 ```
 
 Applying a linear map to an `AffineMap` object combines the two maps into a new
-`AffineMap` instance.
-Again we can make use of the conversion for convenience.
+`AffineMap` instance. Again we can make use of the conversion for convenience.
 
 ```jldoctest constructors
 julia> B = [2 0; 0 2]; am2 = B * am


### PR DESCRIPTION
See https://github.com/JuliaReach/LazySets.jl/issues/1837

The PRs updates the AffineMap docstring. Also removed "convex" in a few other places.