### PR TITLE
#1453 - Remove redundant generators in constraints_list

### DIFF
--- a/docs/src/lib/interfaces.md
+++ b/docs/src/lib/interfaces.md
@@ -348,6 +348,7 @@ constraints_list(::AbstractZonotope{N}; ::Bool=true) where {N<:AbstractFloat}
 vertices_list(::AbstractZonotope)
 order(::AbstractZonotope)
 togrep(::AbstractZonotope)
+remove_redundant_generators(::AbstractZonotope)
 ```
 
 ### Implementations

--- a/src/Sets/Zonotope.jl
+++ b/src/Sets/Zonotope.jl
@@ -666,10 +666,10 @@ function remove_redundant_generators(Z::Zonotope{N}) where {N}
         return _remove_redundant_generators_1d(Z)
     end
 
-    deleted = false
     G = genmat(Z)
     G = remove_zero_columns(G)
     p = size(G, 2)
+    deleted = p < ngens(Z)
     done = falses(p)
     G_new = _vector_type(typeof(G))[]  # list of new column vectors
     @inbounds for j1 in 1:p

--- a/test/Sets/Zonotope.jl
+++ b/test/Sets/Zonotope.jl
@@ -232,7 +232,12 @@ for N in [Float64, Rational{Int}, Float32]
         if G2 != nothing
             @test genmat(remove_redundant_generators(Z)) == G2
         end
+
     end
+    Z = Zonotope(zeros(N, 3), N[0 0 0; 0 1 0; 0 0 0])
+    Z2 = remove_redundant_generators(Z)
+    @test center(Z) == center(Z2)
+    @test genmat(Z2) == N[0 1 0]'
 end
 
 for N in [Float64]


### PR DESCRIPTION
Closes #1453.

- I added `remove_redundant_generators(::AbstractZonotope)` because otherwise the call might fail. All non-`Zonotope` subtypes do not store the generators and hence the implementation is just the identity.
- I pulled up the handling of the 1D case because that is always more efficient. I also removed the `view` there because it is slower than just using `sum`. And I outsourced that code to a helper function.
- In contrast to the proposal in https://github.com/JuliaReach/LazySets.jl/issues/1453#issuecomment-812109639 I just perform the same checks again on the reduced zonotope. If that is not correct, I can change it.

I did not know what test to add because I could not find an error. Here is an example where the output changes.

```julia
julia> Z = Zonotope(rand(2), [2. 3 1; 0 0 1]);

julia> constraints_list(Z)  # master
6-element Vector{HalfSpace{Float64, Vector{Float64}}}:
 HalfSpace{Float64, Vector{Float64}}([0.0, -1.0], 0.6611828781793785)
 HalfSpace{Float64, Vector{Float64}}([-0.0, 1.0], 1.3388171218206215)
 HalfSpace{Float64, Vector{Float64}}([0.0, -1.0], 0.6611828781793785)  # duplicate
 HalfSpace{Float64, Vector{Float64}}([-0.0, 1.0], 1.3388171218206215)  # duplicate
 HalfSpace{Float64, Vector{Float64}}([0.7071067811865475, -0.7071067811865475], 3.975112612743048)
 HalfSpace{Float64, Vector{Float64}}([-0.7071067811865475, 0.7071067811865475], 3.0959551991224266)

julia> constraints_list(Z)  # this branch
4-element Vector{HalfSpace{Float64, Vector{Float64}}}:
 HalfSpace{Float64, Vector{Float64}}([0.0, -1.0], 0.6611828781793785)
 HalfSpace{Float64, Vector{Float64}}([-0.0, 1.0], 1.3388171218206215)
 HalfSpace{Float64, Vector{Float64}}([0.7071067811865475, -0.7071067811865475], 3.975112612743048)
 HalfSpace{Float64, Vector{Float64}}([-0.7071067811865475, 0.7071067811865475], 3.0959551991224266)
```