### PR TITLE
#2644 - Fix _update_plot_limits! for empty inputs

### DIFF
--- a/src/Plotting/plot_recipes.jl
+++ b/src/Plotting/plot_recipes.jl
@@ -45,6 +45,8 @@ end
 
 function _update_plot_limits!(lims, X::LazySet)
     box = box_approximation(X)
+    isempty(box) && return nothing  # can happen if X is empty or flat
+
     box_min = low(box)
     box_max = high(box)
     for (idx,symbol) in enumerate([:x, :y])


### PR DESCRIPTION
Closes #2644.

I could not reproduce the problem with "simple" sets (not like the one in #2644).