### PR TITLE
WIP - Star set with a lazy intersection predicate

### DIFF
--- a/src/Approximations/Approximations.jl
+++ b/src/Approximations/Approximations.jl
@@ -10,7 +10,7 @@ using LazySets, LazySets.Arrays, Requires, LinearAlgebra, SparseArrays,
       MathProgBase
 
 using LazySets: _isapprox, _leq, _geq, _rtol, _normal_Vector, isapproxzero,
-                default_lp_solver, _isbounded_stiemke
+                default_lp_solver, _isbounded_stiemke, ρ_upper_bound
 
 import LazySets: distance, project
 

--- a/src/Approximations/box_approximation.jl
+++ b/src/Approximations/box_approximation.jl
@@ -110,6 +110,25 @@ functions in the same directions.
     return c, r
 end
 
+@inline function box_approximation_helper(S::StarLI{N}) where {N}
+    n = dim(S)
+    c = Vector{N}(undef, n)
+    r = Vector{N}(undef, n)
+    @inbounds for i in 1:n
+        htop = ρ_upper_bound(SingleEntryVector(i, n, one(N)), S)
+        hbottom = -ρ_upper_bound(SingleEntryVector(i, n, -one(N)), S)
+        c[i] = (htop + hbottom) / 2
+        r[i] = (htop - hbottom) / 2
+        if r[i] < 0
+            # contradicting bounds => set is empty
+            # terminate with first radius entry being negative
+            r[1] = r[i]
+            break
+        end
+    end
+    return c, r
+end
+
 # ===============
 # Specializations
 # ===============

--- a/src/LazyOperations/Intersection.jl
+++ b/src/LazyOperations/Intersection.jl
@@ -98,8 +98,10 @@ struct Intersection{N, S1<:LazySet{N}, S2<:LazySet{N}} <: LazySet{N}
     cache::IntersectionCache
 
     # default constructor with dimension check
-    function Intersection(X::LazySet{N}, Y::LazySet{N}; cache::IntersectionCache=IntersectionCache()) where {N}
-        @assert dim(X) == dim(Y) "sets in an intersection must have the same dimension"
+    function Intersection(X::LazySet{N}, Y::LazySet{N}; cache::IntersectionCache=IntersectionCache(), check::Bool=true) where {N}
+        if check
+            @assert dim(X) == dim(Y) "sets in an intersection must have the same dimension"
+        end
         return new{N, typeof(X), typeof(Y)}(X, Y, cache)
     end
 end

--- a/src/LazySets.jl
+++ b/src/LazySets.jl
@@ -126,6 +126,7 @@ include("LazyOperations/Rectification.jl")  # must come after UnionSet
 # =======
 include("Interfaces/aliases.jl")
 include("Sets/Star.jl")
+include("Sets/StarLI.jl")
 
 # =============================
 # Conversions between set types

--- a/src/Sets/StarLI.jl
+++ b/src/Sets/StarLI.jl
@@ -1,0 +1,179 @@
+export StarLI,
+       center,
+       basis,
+       predicate,
+       intersection!,
+       dim
+
+"""
+    StarLI{N, VN<:AbstractVector{N}, MN<:AbstractMatrix{N}, S1<:LazySet{N}, S2<:LazySet{N}, IT<:Intersection{N, S1, S2}} <: AbstractPolyhedron{N}
+
+Generalized star set with a lazy predicate, i.e.
+
+```math
+X = \\{x ∈ \\mathbb{R}^n : x = x₀ + \\sum_{i=1}^m α_i v_i,~~\\textrm{s.t. } P(α) = ⊤ \\},
+```
+where ``x₀ ∈ \\mathbb{R}^n`` is the center, the ``m`` vectors ``v₁, …, vₘ`` form
+the basis of the star set, and the combination factors
+``α = (α₁, …, αₘ) ∈ \\mathbb{R}^m`` are the predicates' decision variables,
+i.e. ``P : α ∈ \\mathbb{R}^m → \\{⊤, ⊥\\}`` where the lazy predicate is such that
+``P(α) = ⊤`` if and only if ``α ∈ Y ∩ Z`` for given sets ``Y`` and ``Z``.
+
+### Fields
+
+- `c` -- vector that represents the center
+- `V` -- matrix where each column corresponds to a basis vector
+- `P` -- lazy intersection that represents the predicate
+"""
+struct StarLI{N, VN<:AbstractVector{N}, MN<:AbstractMatrix{N}, S1<:LazySet{N}, S2<:LazySet{N}, IT<:Intersection{N, S1, S2}} <: AbstractPolyhedron{N}
+    c::VN # center
+    V::MN # basis
+    P::IT # predicate
+
+    # default constructor with size checks
+    function StarLI(c::VN, V::MN, P::IT) where {N, VN<:AbstractVector{N}, MN<:AbstractMatrix{N}, S1<:LazySet{N}, S2<:LazySet{N}, IT<:Intersection{N, S1, S2}}
+        @assert length(c) == size(V, 1) "the center of the basis vectors should be compatible, " *
+                                        "but they are of length $(length(c)) and $(size(V, 1)) respectively"
+
+        @assert dim(P) == size(V, 2) "the number of basis vectors should be compatible " *
+                                     "with the predicates' dimension, but they are $(size(V, 2)) and $(dim(P)) respectively"
+
+        return new{N, VN, MN, S1, S2, IT}(c, V, P)
+    end
+end
+
+# constructor from center and list of generators
+function StarLI(c::VN, vlist::AbstractVector{VN}, P::IT) where {N, VN<:AbstractVector{N}, IT<:Intersection{N}}
+    V = to_matrix(vlist, length(c))
+    return Star(c, V, P)
+end
+
+# constructor from a zonotope (no additional constraints)
+# default constructor with size checks
+function StarLI(c::VN, V::MN, Z::ZT) where {N, VN<:AbstractVector{N}, MN<:AbstractMatrix{N}, ZT<:AbstractZonotope{N}}
+    Pempty = HPolyhedron{N, Vector{N}}()
+    return StarLI(c, V, Intersection(Z, Pempty, check=false))
+end
+
+isoperationtype(::Type{<:StarLI}) = false
+isconvextype(::Type{<:StarLI}) = true
+
+# =================================================
+# Star set with lazy constraints getter functions
+# =================================================
+
+center(X::StarLI) = X.c
+
+basis(X::StarLI) = X.V
+
+predicate(X::StarLI) = X.P
+
+# =============================
+# LazySets interface functions
+# =============================
+
+function dim(X::StarLI)
+    return length(X.c)
+end
+
+function ρ(d::AbstractVector, X::StarLI)
+    P = concretize(predicate(X))
+    μ = ρ(_At_mul_B(basis(X), d), P)
+    return μ + dot(d, center(X))
+end
+
+function ρ_upper_bound(d::AbstractVector, X::StarLI)
+    P = predicate(X)
+    a = ρ(_At_mul_B(basis(X), d), P.X)
+    b = ρ(_At_mul_B(basis(X), d), P.Y)
+    μ = min(a, b)
+    return μ + dot(d, center(X))
+end
+
+# TODO
+#function box_approximation(X::StarLI)
+    # use ρ_upper_bound
+#end
+
+function σ(d::AbstractVector, X::StarLI)
+    # exact
+    A = basis(X)
+    P = concretize(predicate(X))
+    return A * σ(_At_mul_B(A, d), P) + center(X)
+end
+
+function an_element(X::StarLI)
+    return basis(X) * an_element(predicate(X)) + center(X)
+end
+
+function isempty(X::StarLI)
+    return isempty(predicate(X))
+end
+
+function ∈(x::AbstractVector, X::StarLI)
+    return basis(X) \ (x - center(X)) ∈ predicate(X)
+end
+
+function vertices_list(X::StarLI; apply_convex_hull::Bool=true)
+    P = predicate(X)
+    Pint = intersection(P.X, P.Y)
+    S = Star(X.c, X.V, Pint)
+    am = convert(STAR, S)
+    return vertices_list(am, apply_convex_hull=apply_convex_hull)
+end
+
+function constraints_list(X::StarLI)
+    P = predicate(X)
+    Pint = intersection(P.X, P.Y)
+    S = Star(X.c, X.V, Pint)
+    am = convert(STAR, X)
+    return constraints_list(am)
+end
+
+function linear_map(M::AbstractMatrix, X::StarLI)
+    c′ = M * X.c
+    V′ = M * X.V
+    P′ = X.P
+    return StarLI(c′, V′, P′)
+end
+
+function affine_map(M::AbstractMatrix, X::StarLI, v::AbstractVector)
+    c′ = M * X.c + v
+    V′ = M * X.V
+    P′ = X.P
+    return Star(c′, V′, P′)
+end
+
+function rand(::Type{StarLI};
+              N::Type{<:Real}=Float64,
+              dim::Int=2,
+              rng::AbstractRNG=GLOBAL_RNG,
+              seed::Union{Int, Nothing}=nothing)
+    rng = reseed(rng, seed)
+    Z = rand(Zonotope, N=N, dim=dim, rng=rng, seed=seed)
+    X = convert(StarLI, Z)
+    return X
+end
+
+# ============================
+# Concrete intersection
+# ============================
+
+function intersection!(X::StarLI{N, VN, MN, S1, S2}, H::HalfSpace) where {N, VN, MN, S1<:AbstractZonotope{N}, S2<:HPolyhedron{N}}
+    P = predicate(X)
+    _intersection_star!(center(X), basis(X), P.Y, H)
+    return X
+end
+
+function intersection(X::StarLI{N, VN, MN, S1, S2}, H::HalfSpace) where {N, VN, MN, S1<:AbstractZonotope{N}, S2<:HPolyhedron{N}}
+    c = center(X)
+    V = basis(X)
+    P = predicate(X)
+
+    Pnew = copy(P)
+    Xnew = StarLI(c, V, Pnew)
+    return intersection!(Xnew, H)
+end
+
+# symmetric methods
+intersection(H::HalfSpace, X::StarLI) = intersection(X, H)

--- a/src/Sets/StarLI.jl
+++ b/src/Sets/StarLI.jl
@@ -141,7 +141,7 @@ function affine_map(M::AbstractMatrix, X::StarLI, v::AbstractVector)
     c′ = M * X.c + v
     V′ = M * X.V
     P′ = X.P
-    return Star(c′, V′, P′)
+    return StarLI(c′, V′, P′)
 end
 
 function rand(::Type{StarLI};

--- a/src/convert.jl
+++ b/src/convert.jl
@@ -1244,3 +1244,7 @@ function convert(::Type{Star}, P::AbstractPolyhedron{N}) where {N}
     V = Matrix(one(N)*I, n, n)
     return Star(c, V, P)
 end
+
+function convert(::Type{StarLI}, X::Star)
+    return StarLI(X.c, X.V, X.P)
+end


### PR DESCRIPTION
This type is a variation of the star set where the predicate is a lazy intersection. The main advantage over `Star` is that we now have an `HPolyhedron` "buffer" in the predicate so we can accumulate results for intersections without having to compute over the "initial" zonotope (i'm assuming that the predicate is `P = X \cap Y`  where `X` is a zonotope and `Y` is an `HPolyhedron`).