### PR TITLE
Add empty constructor for UnionSetArray

### DIFF
--- a/src/LazyOperations/UnionSetArray.jl
+++ b/src/LazyOperations/UnionSetArray.jl
@@ -21,6 +21,13 @@ end
 isoperationtype(::Type{<:UnionSetArray}) = true
 isconvextype(::Type{<:UnionSetArray}) = false
 
+# constructor for an empty union with optional size hint and numeric type
+function UnionSetArray(n::Int=0, N::Type=Float64)
+   arr = Vector{LazySet{N}}()
+   sizehint!(arr, n)
+   return UnionSetArray(arr)
+end
+
 # EmptySet is the neutral element for UnionSetArray
 @neutral(UnionSetArray, EmptySet)
 

--- a/test/LazyOperations/UnionSet.jl
+++ b/test/LazyOperations/UnionSet.jl
@@ -11,6 +11,9 @@ for N in [Float64, Rational{Int}, Float32]
     # array type (union of a finite number of convex sets)
     Uarr = UnionSetArray([B1, B2])
 
+    # constructor without argumenst
+    UnionSetArray()
+
     # swap
     U2 = swap(UXY)
     @test UXY.X == U2.Y && UXY.Y == U2.X


### PR DESCRIPTION
This PR brings a convenience function that we also have for other array set types.