### PR TITLE
Updates for ConvexHullArray

### DIFF
--- a/src/LazyOperations/ConvexHullArray.jl
+++ b/src/LazyOperations/ConvexHullArray.jl
@@ -98,7 +98,7 @@ Return the dimension of the convex hull of a finite number of sets.
 The ambient dimension of the convex hull of a finite number of sets.
 """
 function dim(cha::ConvexHullArray)
-    @assert !isempty(cha.array)
+    @assert !isempty(cha.array) "an empty convex hull is not allowed"
     return dim(cha.array[1])
 end
 
@@ -113,18 +113,19 @@ Return the support vector of a convex hull array in a given direction.
 - `cha` -- convex hull array
 """
 function σ(d::AbstractVector, cha::ConvexHullArray)
-    s = σ(d, cha.array[1])
-    ri = dot(d, s)
-    rmax = ri
-    for (i, chi) in enumerate(cha.array[2:end])
+    @assert !isempty(cha.array) "an empty convex hull is not allowed"
+    svec = d
+    N = eltype(d)
+    rmax = N(-Inf)
+    for chi in cha.array
         si = σ(d, chi)
         ri = dot(d, si)
         if ri > rmax
             rmax = ri
-            s = si
+            svec = si
         end
     end
-    return s
+    return svec
 end
 
 """
@@ -147,7 +148,7 @@ This algorihm calculates the maximum over all ``ρ(d, X_i)`` where the
 ``X_1, …, X_k`` are the sets in the array `cha`.
 """
 function ρ(d::AbstractVector, cha::ConvexHullArray)
-    return maximum([ρ(d, Xi) for Xi in array(cha)])
+    return maximum(ρ(d, Xi) for Xi in array(cha))
 end
 
 """
@@ -221,7 +222,7 @@ function constraints_list(X::ConvexHullArray{N, Singleton{N, VT}}) where {N, VT}
 end
 
 # membership in convex hull array of singletons
-function ∈(x::AbstractVector{N}, X::ConvexHullArray{N, Singleton{N, VT}}) where {N, VT}
+function ∈(x::AbstractVector, X::ConvexHullArray)
     n = length(x)
     ST = n == 2 ? VPolygon : VPolytope
     V = convert(ST, X)

--- a/src/LazyOperations/ConvexHullArray.jl
+++ b/src/LazyOperations/ConvexHullArray.jl
@@ -10,7 +10,7 @@ export ConvexHullArray, CHArray,
 """
     ConvexHullArray{N, S<:LazySet{N}} <: LazySet{N}
 
-Type that represents the symbolic convex hull of a finite number of convex sets.
+Type that represents the symbolic convex hull of a finite number of sets.
 
 ### Fields
 
@@ -29,7 +29,7 @@ Constructors:
 
 ### Examples
 
-Convex hull of 100 two-dimensional balls whose centers follows a sinusoidal:
+Convex hull of 100 two-dimensional balls whose centers follow a sinusoidal:
 
 ```jldoctest
 julia> b = [Ball2([2*pi*i/100, sin(2*pi*i/100)], 0.05) for i in 1:100];
@@ -70,7 +70,7 @@ const CHArray = ConvexHullArray
 """
     array(cha::ConvexHullArray)
 
-Return the array of a convex hull of a finite number of convex sets.
+Return the array of a convex hull of a finite number of sets.
 
 ### Input
 
@@ -78,7 +78,7 @@ Return the array of a convex hull of a finite number of convex sets.
 
 ### Output
 
-The array of a convex hull of a finite number of convex sets.
+The array of a convex hull of a finite number of sets.
 """
 function array(cha::ConvexHullArray)
     return cha.array
@@ -87,7 +87,7 @@ end
 """
     dim(cha::ConvexHullArray)
 
-Return the dimension of the convex hull of a finite number of convex sets.
+Return the dimension of the convex hull of a finite number of sets.
 
 ### Input
 
@@ -95,7 +95,7 @@ Return the dimension of the convex hull of a finite number of convex sets.
 
 ### Output
 
-The ambient dimension of the convex hull of a finite number of convex sets.
+The ambient dimension of the convex hull of a finite number of sets.
 """
 function dim(cha::ConvexHullArray)
     @assert !isempty(cha.array)
@@ -153,12 +153,11 @@ end
 """
     isbounded(cha::ConvexHullArray)
 
-Determine whether a convex hull of a finite number of convex sets is
-bounded.
+Determine whether a convex hull of a finite number of sets is bounded.
 
 ### Input
 
-- `cha` -- convex hull of a finite number of convex sets
+- `cha` -- convex hull of a finite number of sets
 
 ### Output
 
@@ -189,11 +188,11 @@ end
     vertices_list(cha::ConvexHullArray; apply_convex_hull::Bool=true,
                   backend=nothing)
 
-Return the list of vertices of the convex hull of a finite number of convex sets.
+Return the list of vertices of the convex hull of a finite number of sets.
 
 ### Input
 
-- `cha`               -- convex hull of a finite number of convex sets
+- `cha`               -- convex hull of a finite number of sets
 - `apply_convex_hull` -- (optional, default: `true`) if `true`, post-process the
                          vertices using a convex-hull algorithm
 - `backend`           -- (optional, default: `nothing`) backend for computing


### PR DESCRIPTION
See #1837.

The second commit brings the following improvements:
- assertion
- membership for arbitrary `CHArray`s (the code was already general, so I just removed the type restriction)
- faster support function/vector

```julia
julia> @time ρ(d, X)  # master
  0.000007 seconds (2 allocations: 176 bytes)
2.860035012482964

julia> @time ρ(d, X)  # this branch
  0.000006 seconds (1 allocation: 16 bytes)
2.860035012482964


julia> @time σ(d, X)  # master
  0.000010 seconds (11 allocations: 1.156 KiB)
2-element Vector{Float64}:
 3.007942344104169
 3.278858578896459

julia> @time σ(d, X)  # this branch
  0.000006 seconds (10 allocations: 960 bytes)
2-element Vector{Float64}:
 3.007942344104169
 3.278858578896459
```