### PR TITLE
Improve InverseLinearMap's vertices_list

### DIFF
--- a/src/LazyOperations/InverseLinearMap.jl
+++ b/src/LazyOperations/InverseLinearMap.jl
@@ -267,10 +267,9 @@ function vertices_list(ilm::InverseLinearMap; prune::Bool=true)
     vlist_X = vertices_list(ilm.X)
 
     # create resulting vertices list
-    vlist = Vector{eltype(vlist_X)}()
-    sizehint!(vlist, length(vlist_X))
-    for v in vlist_X
-        push!(vlist, ilm.M \ v)
+    vlist = Vector{eltype(vlist_X)}(undef, length(vlist_X))
+    @inbounds for (i, vi) in enumerate(vlist_X)
+        vlist[i] = ilm.M \ vi
     end
 
     return prune ? convex_hull(vlist) : vlist


### PR DESCRIPTION
```julia
julia> X = InverseLinearMap(rand(2,2), rand(BallInf));

julia> @time vertices_list(X);  # master
  0.000025 seconds (22 allocations: 2.094 KiB)

julia> @time vertices_list(X);  # this branch
  0.000018 seconds (21 allocations: 2.078 KiB)
```

Also, I marked `InverseLinearMap` as solved in #1837 because there is no convexity assumption in that file.