### PR TITLE
#1837 - Updates for UnionSetArray

### DIFF
--- a/src/LazyOperations/UnionSetArray.jl
+++ b/src/LazyOperations/UnionSetArray.jl
@@ -8,11 +8,11 @@ export UnionSetArray,
 """
    UnionSetArray{N, S<:LazySet{N}}
 
-Type that represents the set union of a finite number of convex sets.
+Type that represents the set union of a finite number of sets.
 
 ### Fields
 
-- `array` -- array of convex sets
+- `array` -- array of sets
 """
 struct UnionSetArray{N, S<:LazySet{N}}
    array::Vector{S}
@@ -40,15 +40,15 @@ end
 """
    dim(cup::UnionSetArray)
 
-Return the dimension of the set union of a finite number of convex sets.
+Return the dimension of the set union of a finite number of sets.
 
 ### Input
 
-- `cup` -- union of a finite number of convex sets
+- `cup` -- union of a finite number of sets
 
 ### Output
 
-The ambient dimension of the union of a finite number of convex sets.
+The ambient dimension of the union of a finite number of sets.
 """
 function dim(cup::UnionSetArray)
    return dim(cup.array[1])
@@ -57,15 +57,15 @@ end
 """
    array(cup::UnionSetArray)
 
-Return the array of a union of a finite number of convex sets.
+Return the array of the union of a finite number of sets.
 
 ### Input
 
-- `cup` -- union of a finite number of convex sets
+- `cup` -- union of a finite number of sets
 
 ### Output
 
-The array that holds the union of a finite number of convex sets.
+The array that holds the sets.
 """
 function array(cup::UnionSetArray)
    return cup.array
@@ -74,18 +74,18 @@ end
 """
    σ(d::AbstractVector, cup::UnionSetArray; [algorithm]="support_vector")
 
-Return the support vector of the union of a finite number of convex sets in
-a given direction.
+Return the support vector of the union of a finite number of sets in a given
+direction.
 
 ### Input
 
 - `d`         -- direction
-- `cup`       -- union of a finite number of convex sets
+- `cup`       -- union of a finite number of sets
 - `algorithm` -- (optional, default: "support_vector"): the algorithm to compute
-                the support vector; if "support_vector", use the support
-                vector of each argument; if "support_function" use the support
-                function of each argument and evaluate the support vector of only
-                one of them
+                 the support vector; if "support_vector", use the support
+                 vector of each argument; if "support_function" use the support
+                 function of each argument and evaluate the support vector of
+                 only one of them
 
 ### Output
 
@@ -93,17 +93,19 @@ The support vector in the given direction.
 
 ### Algorithm
 
-The support vector of the union of a finite number of convex sets ``X₁, X₂, ...``
-can be obtained as the vector that maximizes the support function, i.e.
-it is sufficient to find the ``\\argmax(ρ(d, X₂), ρ(d, X₂), ...])`` and evaluate
-its support vector.
+The support vector of the union of a finite number of sets ``X₁, X₂, ...`` can
+be obtained as the vector that maximizes the support function, i.e., it is
+sufficient to find the ``\\argmax([ρ(d, X₂), ρ(d, X₂), ...])`` and evaluate its
+support vector.
 
 The default implementation, with option `algorithm="support_vector"`, computes
-the support vector of all ``X₁, X₂, ...`` and then compares the support function using
-a dot product. If it happens that the support function can be more efficiently
-computed (without passing through the support vector), consider using the alternative
-`algorithm="support_function"` implementation, which evaluates the support function
-of each set directly and then calls only the support vector of one of the ``Xᵢ``.
+the support vector of all ``X₁, X₂, ...`` and then compares the support function
+using a dot product.
+
+If the support function can be computed more efficiently, the alternative
+implementation `algorithm="support_function"` can be used, which evaluates the
+support function of each set directly and then calls only the support vector of
+one of the ``Xᵢ``.
 """
 function σ(d::AbstractVector, cup::UnionSetArray; algorithm="support_vector")
    A = array(cup)
@@ -127,13 +129,13 @@ end
 """
    ρ(d::AbstractVector, cup::UnionSetArray)
 
-Return the support function of the union of a finite number of convex sets in
-a given direction.
+Return the support function of the union of a finite number of sets in a given
+direction.
 
 ### Input
 
 - `d`   -- direction
-- `cup` -- union of a finite number of convex sets
+- `cup` -- union of a finite number of sets
 
 ### Output
 
@@ -141,46 +143,50 @@ The support function in the given direction.
 
 ### Algorithm
 
-The support function of the union of a finite number of convex sets ``X₁, X₂, ...``
+The support function of the union of a finite number of sets ``X₁, X₂, ...``
 can be obtained as the maximum of ``ρ(d, X₂), ρ(d, X₂), ...``.
 """
 function ρ(d::AbstractVector, cup::UnionSetArray)
    A = array(cup)
-   ρarray = map(Xi -> ρ(d, Xi), A)
-   return maximum(ρarray)
+   return maximum(Xi -> ρ(d, Xi), A)
 end
 
 """
    an_element(cup::UnionSetArray)
 
-Return some element of a union of a finite number of convex sets.
+Return some element of the union of a finite number of sets.
 
 ### Input
 
-- `cup` -- union of a finite number of convex sets
+- `cup` -- union of a finite number of sets
 
 ### Output
 
-An element in the union of a finite number of convex sets.
+An element in the union of a finite number of sets.
 
 ### Algorithm
 
 We use `an_element` on the first wrapped set.
 """
 function an_element(cup::UnionSetArray)
-   return an_element(array(cup)[1])
+    for Xi in array(cup)
+        if !isempty(Xi)
+            return an_element(Xi)
+        end
+    end
+    error("an empty set does not have any element")
 end
 
 """
    ∈(x::AbstractVector, cup::UnionSetArray)
 
-Check whether a given point is contained in a union of a finite number of convex
+Check whether a given point is contained in the union of a finite number of
 sets.
 
 ### Input
 
 - `x`   -- point/vector
-- `cup` -- union of a finite number of convex sets
+- `cup` -- union of a finite number of sets
 
 ### Output
 
@@ -193,11 +199,11 @@ end
 """
    isempty(cup::UnionSetArray)
 
-Check whether a union of a finite number of convex sets is empty.
+Check whether the union of a finite number of sets is empty.
 
 ### Input
 
-- `cup` -- union of a finite number of convex sets
+- `cup` -- union of a finite number of sets
 
 ### Output
 
@@ -210,11 +216,11 @@ end
 """
    isbounded(cup::UnionSetArray)
 
-Determine whether a union of a finite number of convex sets is bounded.
+Determine whether the union of a finite number of sets is bounded.
 
 ### Input
 
-- `cup` -- union of a finite number of convex sets
+- `cup` -- union of a finite number of sets
 
 ### Output
 
@@ -228,11 +234,11 @@ end
     vertices_list(cup::UnionSetArray; apply_convex_hull::Bool=false,
                   backend=nothing)
 
-Return the list of vertices of a union of a finite number of convex sets.
+Return the list of vertices of the union of a finite number of sets.
 
 ### Input
 
-- `cup`               -- union of a finite number of convex sets
+- `cup`               -- union of a finite number of sets
 - `apply_convex_hull` -- (optional, default: `false`) if `true`, post-process
                          the vertices using a convex-hull algorithm
 - `backend`           -- (optional, default: `nothing`) backend for computing

--- a/test/LazyOperations/UnionSet.jl
+++ b/test/LazyOperations/UnionSet.jl
@@ -74,6 +74,10 @@ for N in [Float64, Rational{Int}, Float32]
         @test ispermutation(vertices_list(U, apply_convex_hull=true),
             [N[1, -1], N[-1, 1], N[-1, -1], N[1, 2], N[2, 1]])
     end
+
+    # an_element and membership
+    Uarr = UnionSetArray([EmptySet{N}(2), B1])
+    @test an_element(Uarr) ∈ Uarr
 end
 
 for N in [Float64]


### PR DESCRIPTION
See #1837.

- remove convexity assumption in docstrings
- fix `an_element` if the first sets are empty
- faster `ρ`

```julia
julia> d = rand(2);
julia> X = UnionSetArray([rand(BallInf) for _ in 1:10]);

julia> @time ρ(d, X)  # master
  0.000006 seconds (2 allocations: 176 bytes)
1.4787628756277493

julia> @time ρ(d, X)  # this branch
  0.000005 seconds (1 allocation: 16 bytes)
1.4787628756277493
```