### PR TITLE
#1837 - Updates for SymmetricIntervalHull

### DIFF
--- a/src/LazyOperations/SymmetricIntervalHull.jl
+++ b/src/LazyOperations/SymmetricIntervalHull.jl
@@ -264,8 +264,10 @@ function get_radius!(sih::SymmetricIntervalHull{N},
                      i::Int,
                      n::Int=dim(sih)) where {N}
     if sih.cache[i] == -one(N)
-        right_bound = σ(sparsevec([i], [one(N)], n), sih.X)
-        left_bound = σ(sparsevec([i], [-one(N)], n), sih.X)
+        d = SingleEntryVector(i, n, one(N))
+        right_bound = σ(d, sih.X)
+        d = SingleEntryVector(i, n, -one(N))
+        left_bound = σ(d, sih.X)
         sih.cache[i] = max(right_bound[i], abs(left_bound[i]))
     end
     return sih.cache[i]


### PR DESCRIPTION
See #1837.

- remove convexity assumption in docstrings
- reorder some methods to keep them together
- faster `get_radius!`

```julia
julia> X = rand(Ball2);
julia> Y = SymmetricIntervalHull(X);

julia> @time LazySets.get_radius!(Y, 1, 2)  # master
  0.000015 seconds (31 allocations: 2.484 KiB)
2.486354302955953

julia> @time LazySets.get_radius!(Y, 1, 2)  # this branch
  0.000006 seconds (3 allocations: 208 bytes)
2.486354302955953
```