### PR TITLE
#1837 - Updates for MinkowskiSum & MinkowskiSumArray

### DIFF
--- a/docs/src/lib/lazy_operations/MinkowskiSum.md
+++ b/docs/src/lib/lazy_operations/MinkowskiSum.md
@@ -17,8 +17,8 @@ dim(::MinkowskiSum)
 isbounded(::MinkowskiSum)
 isempty(::MinkowskiSum)
 constraints_list(::MinkowskiSum)
-∈(x::AbstractVector, ms::MinkowskiSum{N, S1, S2}) where {N, S1<:AbstractSingleton, S2<:LazySet}
-vertices_list(MS::MinkowskiSum{N, Z1, Z2}) where {N, Z1<:AbstractZonotope{N}, Z2<:AbstractZonotope{N}}
+∈(::AbstractVector, ::MinkowskiSum{N, S1, S2}) where {N, S1<:AbstractSingleton, S2<:LazySet}
+vertices_list(::MinkowskiSum)
 ```
 Inherited from [`LazySet`](@ref):
 * [`norm`](@ref norm(::LazySet, ::Real))

--- a/src/LazyOperations/CachedMinkowskiSumArray.jl
+++ b/src/LazyOperations/CachedMinkowskiSumArray.jl
@@ -156,11 +156,11 @@ function σ(d::AbstractVector, cms::CachedMinkowskiSumArray)
         else
             # has only stored the support vector of the first k sets
             @assert k < l "invalid cache index"
-            svec = svec1 + σ_helper(d, @view arr[k+1:l])
+            svec = svec1 + _σ_msum_array(d, @view arr[k+1:l])
         end
     else
         # first-time computation of support vector
-        svec = σ_helper(d, arr)
+        svec = _σ_msum_array(d, arr)
     end
     # NOTE: make a copy of the direction vector (can be modified outside)
     cache[copy(d)] = CachedPair(l, svec)

--- a/src/LazyOperations/MinkowskiSum.jl
+++ b/src/LazyOperations/MinkowskiSum.jl
@@ -7,12 +7,12 @@ export MinkowskiSum, ⊕,
 """
     MinkowskiSum{N, S1<:LazySet{N}, S2<:LazySet{N}} <: LazySet{N}
 
-Type that represents the Minkowski sum of two convex sets.
+Type that represents the Minkowski sum of two sets.
 
 ### Fields
 
-- `X` -- first convex set
-- `Y` -- second convex set
+- `X` -- first set
+- `Y` -- second set
 
 ### Notes
 
@@ -47,8 +47,8 @@ Convenience constructor for Minkowski sum.
 
 ### Input
 
-- `X` -- a convex set
-- `Y` -- another convex set
+- `X` -- a set
+- `Y` -- another set
 
 ### Output
 
@@ -74,7 +74,7 @@ Return a new `MinkowskiSum` object with the arguments swapped.
 
 ### Input
 
-- `ms` -- Minkowski sum of two convex sets
+- `ms` -- Minkowski sum of two sets
 
 ### Output
 
@@ -246,32 +246,24 @@ function concretize(ms::MinkowskiSum)
     return minkowski_sum(concretize(ms.X), concretize(ms.Y))
 end
 
-# ================
-# Helper functions
-# ================
-
-@inline function σ_helper(d::AbstractVector{N},
-                          array::AbstractVector{<:LazySet}) where {N}
-    svec = zeros(N, length(d))
-    for sj in array
-        svec += σ(d, sj)
-    end
-    return svec
-end
-
 """
-    vertices_list(ms::MinkowskiSum{N, Z1, Z2}) where {N, Z1<:AbstractZonotope{N}, Z2<:AbstractZonotope{N}}
+    vertices_list(ms::MinkowskiSum)
 
-Return the list of vertices for the Minkowski sum of two zonotopic sets.
+Return the list of vertices for the Minkowski sum of two sets.
 
 ### Input
 
-- `ms` -- Minkowski sum of two zonotopic sets
+- `ms` -- Minkowski sum of two sets
 
 ### Output
 
-The list of vertices of the Minkowski sum of two zonotopic sets.
+The list of vertices of the Minkowski sum of two sets.
+
+### Algorithm
+
+We compute the concrete Minkowski sum (via `minkowski_sum`) and call
+`vertices_list` on the result.
 """
-function vertices_list(ms::MinkowskiSum{N, Z1, Z2}) where {N, Z1<:AbstractZonotope{N}, Z2<:AbstractZonotope{N}}
+function vertices_list(ms::MinkowskiSum)
     return vertices_list(minkowski_sum(ms.X, ms.Y))
 end

--- a/src/LazyOperations/MinkowskiSumArray.jl
+++ b/src/LazyOperations/MinkowskiSumArray.jl
@@ -8,11 +8,11 @@ export MinkowskiSumArray,
 """
    MinkowskiSumArray{N, S<:LazySet{N}} <: LazySet{N}
 
-Type that represents the Minkowski sum of a finite number of convex sets.
+Type that represents the Minkowski sum of a finite number of sets.
 
 ### Fields
 
-- `array` -- array of convex sets
+- `array` -- array of sets
 
 ### Notes
 
@@ -55,7 +55,7 @@ end
 """
    array(msa::MinkowskiSumArray)
 
-Return the array of a Minkowski sum of a finite number of convex sets.
+Return the array of a Minkowski sum of a finite number of sets.
 
 ### Input
 
@@ -63,7 +63,7 @@ Return the array of a Minkowski sum of a finite number of convex sets.
 
 ### Output
 
-The array of a Minkowski sum of a finite number of convex sets.
+The array of a Minkowski sum of a finite number of sets.
 """
 function array(msa::MinkowskiSumArray)
    return msa.array
@@ -103,7 +103,12 @@ The support vector in the given direction.
 If the direction has norm zero, the result depends on the summand sets.
 """
 function σ(d::AbstractVector, msa::MinkowskiSumArray)
-   return σ_helper(d, msa.array)
+   return _σ_msum_array(d, msa.array)
+end
+
+@inline function _σ_msum_array(d::AbstractVector{N},
+                               array::AbstractVector{<:LazySet}) where {N}
+    return sum(σ(d, Xi) for Xi in array)
 end
 
 """
@@ -133,11 +138,11 @@ end
 """
 	isbounded(msa::MinkowskiSumArray)
 
-Determine whether a Minkowski sum of a finite number of convex sets is bounded.
+Determine whether a Minkowski sum of a finite number of sets is bounded.
 
 ### Input
 
-- `msa` -- Minkowski sum of a finite number of convex sets
+- `msa` -- Minkowski sum of a finite number of sets
 
 ### Output
 


### PR DESCRIPTION
See #1837.

- remove convexity assumption in docstrings
- move helper function `σ_helper` and rename to `_σ_msum_array`
- faster `_σ_msum_array`
- generalize `vertices_list(::MinkowskiSum)` (there was nothing specific to the set arguments in the old method)

```julia
julia> d = rand(2);
julia> X = MinkowskiSumArray([rand(Ball2), rand(Ball1)]);

julia> @time σ(d, X)  # master
  0.000013 seconds (6 allocations: 576 bytes)
2-element Vector{Float64}:
  0.14808679137967445
 -1.1446662574273074

julia> @time σ(d, X)  # this branch
  0.000010 seconds (6 allocations: 416 bytes)
2-element Vector{Float64}:
  0.14808679137967445
 -1.1446662574273074

# ---

julia> Y = rand(Ball1) + rand(BallInf);

julia> vertices_list(Y)  # master
ERROR: MethodError: no method matching vertices_list(::MinkowskiSum{Float64, Ball1{Float64, Vector{Float64}}, BallInf{Float64, Vector{Float64}}})

julia> vertices_list(Y)  # this branch
# works
```