### PR TITLE
Add chebyshev_center for Interval

### DIFF
--- a/src/Sets/Interval.jl
+++ b/src/Sets/Interval.jl
@@ -692,3 +692,10 @@ end
 function vertices_list(H::IntervalArithmetic.IntervalBox)
     return vertices_list(convert(Hyperrectangle, H))
 end
+
+function chebyshev_center(x::Interval{N}; compute_radius::Bool=false) where {N}
+    if compute_radius
+        return center(x), zero(N)
+    end
+    return center(x)
+end

--- a/test/Sets/Interval.jl
+++ b/test/Sets/Interval.jl
@@ -214,4 +214,9 @@ for N in [Float64, Float32, Rational{Int}]
 
     vlistI = vertices_list(b[1])
     @test is_cyclic_permutation(vlistI, [SA[N(0)], SA[N(1)]])
+
+    # Chebyshev center
+    c = chebyshev_center(x)
+    c2, r = chebyshev_center(x, compute_radius=true)
+    @test c == c2 == center(x) && r == zero(N)
 end


### PR DESCRIPTION
`master`:
```julia
julia> c = chebyshev_center(Interval(1.0, 2.0))
glp_simplex: unable to recover undefined or non-optimal solution
ERROR: MethodError: no method matching sethrep!(::Polyhedra.Interval{Float64, StaticArrays.SVector{1, Float64}, StaticArrays.Size{(1,)}}, ::Polyhedra.Intersection{Float64, StaticArrays.SVector{1, Float64}, StaticArrays.Size{(1,)}})
Closest candidates are:
  sethrep!(::Any, ::Any, ::Any) at ~/.julia/packages/Polyhedra/ajeAR/src/defaultlibrary.jl:115
  sethrep!(::DefaultPolyhedron, ::HRepresentation) at ~/.julia/packages/Polyhedra/ajeAR/src/defaultlibrary.jl:120
  sethrep!(::DefaultPolyhedron, ::HRepresentation, ::Any) at ~/.julia/packages/Polyhedra/ajeAR/src/defaultlibrary.jl:120
```