### PR TITLE
#2782 - Faster symmetric_interval_hull of singletons

### DIFF
--- a/src/Approximations/symmetric_interval_hull.jl
+++ b/src/Approximations/symmetric_interval_hull.jl
@@ -78,3 +78,15 @@ function symmetric_interval_hull(S::AbstractSingleton{N}) where {N}
     r = abs.(element(S))
     return Hyperrectangle(zeros(N, n), r)
 end
+
+function symmetric_interval_hull(X::LinearMap{N, <:AbstractSingleton}) where {N}
+    n = dim(X)
+    r = abs.(X.M * element(X.X))
+    return Hyperrectangle(zeros(N, n), r)
+end
+
+function symmetric_interval_hull(X::MinkowskiSum{N, <:AbstractSingleton, <:AbstractSingleton}) where {N}
+    n = dim(X)
+    r = abs.(element(X.X) + element(X.Y))
+    return Hyperrectangle(zeros(N, n), r)
+end

--- a/src/Approximations/symmetric_interval_hull.jl
+++ b/src/Approximations/symmetric_interval_hull.jl
@@ -72,3 +72,9 @@ function symmetric_interval_hull(H::Hyperrectangle{N}) where {N}
     end
     return Hyperrectangle(zeros(N, n), r)
 end
+
+function symmetric_interval_hull(S::AbstractSingleton{N}) where {N}
+    n = dim(S)
+    r = abs.(element(S))
+    return Hyperrectangle(zeros(N, n), r)
+end

--- a/test/Approximations/symmetric_interval_hull.jl
+++ b/test/Approximations/symmetric_interval_hull.jl
@@ -1,4 +1,11 @@
 for N in [Float64, Rational{Int}, Float32]
     S = Singleton(N[1, -2, 3, -4])
-    @test symmetric_interval_hull(S) == Hyperrectangle(zeros(N, 4), N[1, 2, 3, 4])
+    H = Hyperrectangle(zeros(N, 4), N[1, 2, 3, 4])
+    @test symmetric_interval_hull(S) == H
+
+    M = Diagonal(ones(N, 4))
+    @test symmetric_interval_hull(M * S) == H
+
+    H2 = Hyperrectangle(zeros(N, 4), 2 * N[1, 2, 3, 4])
+    @test symmetric_interval_hull(S + S) == H2
 end

--- a/test/Approximations/symmetric_interval_hull.jl
+++ b/test/Approximations/symmetric_interval_hull.jl
@@ -1,0 +1,4 @@
+for N in [Float64, Rational{Int}, Float32]
+    S = Singleton(N[1, -2, 3, -4])
+    @test symmetric_interval_hull(S) == Hyperrectangle(zeros(N, 4), N[1, 2, 3, 4])
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -157,6 +157,7 @@ if test_suite_basic
     @time @testset "LazySets.Approximations.template_directions" begin include("Approximations/template_directions.jl") end
     @time @testset "LazySets.Approximations.box_approximation" begin include("Approximations/box_approximation.jl") end
     @time @testset "LazySets.Approximations.ballinf_approximation" begin include("Approximations/ballinf_approximation.jl") end
+    @time @testset "LazySets.Approximations.symmetric_interval_hull" begin include("Approximations/symmetric_interval_hull.jl") end
     @time @testset "LazySets.Approximations.radiusdiameter" begin include("Approximations/radiusdiameter.jl") end
     @time @testset "LazySets.Approximations.decompose" begin include("Approximations/decompose.jl") end
     @time @testset "LazySets.Approximations.distance" begin include("Approximations/distance.jl") end


### PR DESCRIPTION
Closes #2782.

```julia
julia> S = rand(Singleton, dim=1000);

julia> @time symmetric_interval_hull(S);  # master
  0.002510 seconds (5 allocations: 31.781 KiB)

julia> @time symmetric_interval_hull(S);  # this branch
  0.000012 seconds (3 allocations: 15.906 KiB)
```
---
```julia
julia> @time symmetric_interval_hull(M*S);  # master
  2.491252 seconds (2.01 k allocations: 15.534 MiB)

julia> @time symmetric_interval_hull(concretize(M*S));  # proposal from #2782
  0.007192 seconds (7 allocations: 39.750 KiB)

julia> @time symmetric_interval_hull(M*S);  # this branch
  0.000738 seconds (5 allocations: 23.875 KiB)
```
---
```julia
julia> @time symmetric_interval_hull(S+S);  # master
  0.005102 seconds (6 allocations: 31.812 KiB)

julia> @time symmetric_interval_hull(concretize(S+S));  # idea from #2782
  0.002465 seconds (7 allocations: 39.750 KiB)

julia> @time symmetric_interval_hull(S+S);  # this branch
  0.000018 seconds (5 allocations: 23.875 KiB)

```