### PR TITLE
#2785 - Faster SIH of a linear map of a hyperrectangle

### DIFF
--- a/src/Approximations/symmetric_interval_hull.jl
+++ b/src/Approximations/symmetric_interval_hull.jl
@@ -64,11 +64,11 @@ end
     return c >= zero(N) ? c + r : -c + r
 end
 
-function symmetric_interval_hull(H::Hyperrectangle{N}) where {N}
+function symmetric_interval_hull(H::AbstractHyperrectangle{N}) where {N}
     n = dim(H)
     r = Vector{N}(undef, n)
     @inbounds for i in 1:n
-        r[i] = _maxabs(H.center[i], H.radius[i])
+        r[i] = _maxabs(center(H, i), radius_hyperrectangle(H, i))
     end
     return Hyperrectangle(zeros(N, n), r)
 end
@@ -88,5 +88,13 @@ end
 function symmetric_interval_hull(X::MinkowskiSum{N, <:AbstractSingleton, <:AbstractSingleton}) where {N}
     n = dim(X)
     r = abs.(element(X.X) + element(X.Y))
+    return Hyperrectangle(zeros(N, n), r)
+end
+
+function symmetric_interval_hull(lm::LinearMap{N, <:AbstractHyperrectangle}) where {N}
+    n = dim(lm)
+    M = lm.M
+    H = lm.X
+    r = abs.(M * center(H)) .+ abs.(M) * radius_hyperrectangle(H)
     return Hyperrectangle(zeros(N, n), r)
 end

--- a/test/Approximations/symmetric_interval_hull.jl
+++ b/test/Approximations/symmetric_interval_hull.jl
@@ -1,11 +1,20 @@
 for N in [Float64, Rational{Int}, Float32]
+    # singleton
     S = Singleton(N[1, -2, 3, -4])
     H = Hyperrectangle(zeros(N, 4), N[1, 2, 3, 4])
     @test symmetric_interval_hull(S) == H
 
+    # linear map of singleton
     M = Diagonal(ones(N, 4))
     @test symmetric_interval_hull(M * S) == H
 
+    # Minkowski sum of singletons
     H2 = Hyperrectangle(zeros(N, 4), 2 * N[1, 2, 3, 4])
     @test symmetric_interval_hull(S + S) == H2
+
+    # linear map of hyperrectangle
+    M = Diagonal(N[1, -1, -2, 2])
+    H1 = Hyperrectangle(5 * ones(N, 4), N[1, 2, 3, 4])
+    H2 = Hyperrectangle(zeros(N, 4), N[6, 7, 16, 18])
+    @test symmetric_interval_hull(M * H1) == H2
 end


### PR DESCRIPTION
Closes #2785.

```julia
julia> H = rand(Hyperrectangle, dim=1000);


julia> M = sprand(1000, 1000, 0.01);

julia> @time symmetric_interval_hull(M*H);  # master
 29.072374 seconds (2.01 k allocations: 15.534 MiB, 0.04% gc time)

julia> @time symmetric_interval_hull(M*H);  # this branch
  0.000179 seconds (11 allocations: 195.625 KiB)


julia> M = rand(1000, 1000);

julia> @time symmetric_interval_hull(M*H);  # master
  2.494493 seconds (2.01 k allocations: 15.534 MiB)

julia> @time symmetric_interval_hull(M*H);  # this branch
  0.009323 seconds (8 allocations: 7.661 MiB)
```