### PR TITLE
Allow for nonpositive lazy bloating

### DIFF
--- a/src/LazyOperations/Translation.jl
+++ b/src/LazyOperations/Translation.jl
@@ -91,8 +91,8 @@ For the support vector (resp. support function) along vector `d`, use `σ` and
 julia> σ([1.0, 0.0, 0.0], tr)
 3-element Vector{Float64}:
  5.0
- 3.0
- 3.0
+ 2.0
+ 2.0
 
 julia> ρ([1.0, 0.0, 0.0], tr)
 5.0

--- a/src/Sets/BallInf.jl
+++ b/src/Sets/BallInf.jl
@@ -178,7 +178,7 @@ If the direction has norm zero, the vertex with biggest values is returned.
 function σ(d::AbstractVector, B::BallInf)
     @assert length(d) == dim(B) "a $(length(d))-dimensional vector is " *
                                 "incompatible with a $(dim(B))-dimensional set"
-    return center(B) .+ sign_cadlag.(d) .* B.radius
+    return center(B) .+ sign.(d) .* B.radius
 end
 
 # Particular dispatch for SingleEntryVector

--- a/test/LazyOperations/AffineMap.jl
+++ b/test/LazyOperations/AffineMap.jl
@@ -26,7 +26,9 @@ for N in [Float64, Rational{Int}, Float32]
     @test αam isa AffineMap && αam.M == α * am.M && αam.v == α * am.v
 
     # support vector
-    @test σ(N[1, 0, 0], am) == N[2, 2, 3]
+    sv = σ(N[1, 0, 0], am)
+    @test sv[1] == N(2) &&
+          sv[2:3] ∈ linear_map(Diagonal(N[2, 3]), BallInf(zeros(N, 2), N(1)))
 
     # support function
     @test ρ(N[1, 0, 0], am) == N(2)

--- a/test/LazyOperations/Bloating.jl
+++ b/test/LazyOperations/Bloating.jl
@@ -7,32 +7,32 @@ for N in [Float64, Float32]
 
     # constructors
     X = Bloating(B, ε, p)
+    X⁻ = Bloating(B, -ε, p)
     Y = Bloating(E, ε, p)
     Z = Bloating(U, ε, p)
-    @test_throws AssertionError Bloating(B, N(0), p)
     @test_throws AssertionError Bloating(B, ε, N(9//10))
 
     # dimension
-    @test dim(X) == 2 && dim(Y) == 1 && dim(Z) == 3
+    @test dim(X) == dim(X⁻) == 2 && dim(Y) == 1 && dim(Z) == 3
 
     # isbounded
-    @test isbounded(X) && !isbounded(Z)
-    # @test isbounded(Y)  # currently crashes (see #1779)
+    @test isbounded(X) && isbounded(X⁻) && isbounded(Y) && !isbounded(Z)
 
     # isempty
-    @test !isempty(X) && isempty(Y) && !isempty(Z)
+    @test !isempty(X) && isbounded(X⁻) && isempty(Y) && !isempty(Z)
 
     # an_element
-    v = an_element(X)
-    @test v isa AbstractVector{N} && length(v) == 2
+    for S ∈ [X, X⁻, Z]
+        v = an_element(S)
+        @test v isa AbstractVector{N} && length(v) == dim(S)
+    end
     @test_throws ErrorException an_element(Y)
-    v = an_element(Z)
-    @test v isa AbstractVector{N} && length(v) == 3
 
     # tests for different norms
     for p in N[1, 2, Inf]
         B = BallInf(zeros(N, 2), N(1))
         X = Bloating(B, ε, p)
+        X⁻ = Bloating(B, -ε, p)
         E = HPolyhedron([HalfSpace(N[1], N(0)), HalfSpace(N[-1], N(-1))])
         Y = Bloating(E, ε, p)  # empty set
         Bp = Ballp(p, zeros(N, 2), ε)
@@ -41,11 +41,29 @@ for N in [Float64, Float32]
         d = N[1, 0]
         @test σ(d, X) == σ(d, B + Bp)
         @test ρ(d, X) == ρ(d, B + Bp) == N(1 + ε)
+        @test ρ(d, X⁻) == N(1 - ε)
+        if p != N(1)
+            @test ρ(d, X⁻) == dot(d, σ(d, X⁻))
+        end
         @test_throws ErrorException σ(N[1], Y)
         @test_throws ErrorException ρ(N[1], Y)
         d = N[1, 99//100]
         @test σ(d, X) == σ(d, B + Bp)
         @test ρ(d, X) == ρ(d, B + Bp)
+
+        # subset
+        if p == N(Inf)
+            @test X⁻ ⊆ B ⊆ X
+        elseif p == N(1)
+            @test B ⊆ X
+        end
+
+        # bloating of negative bloating gives the identity
+        if p != N(1)
+            # need to overapproximate because constraints_list is missing
+            B2 = box_approximation(Bloating(Bloating(B, ε, p), -ε, p))
+            @test isequivalent(B, B2)
+        end
 
         # tests for infinity norm
         if p == Inf

--- a/test/LazyOperations/Translation.jl
+++ b/test/LazyOperations/Translation.jl
@@ -18,7 +18,8 @@ for N in [Float64, Rational{Int}, Float32]
     @test dim(tr) == 3
 
     # support vector
-    @test σ(N[1, 0, 0], tr) == N[2, 1, 1]
+    sv = σ(N[1, 0, 0], tr)
+    @test sv[1] == N(2) && sv[2:3] ∈ BallInf(zeros(N, 2), N(1))
 
     # support function
     @test ρ(N[1, 0, 0], tr) == N(2)

--- a/test/Sets/BallInf.jl
+++ b/test/Sets/BallInf.jl
@@ -37,7 +37,7 @@ for N in [Float64, Rational{Int}, Float32]
     @test σ(d, b) == N[0, 3]
     d = N[-1, -1]
     @test σ(d, b) == N[0, 1]
-    d = N[0, -1]
+    d = N[1, -1]
     @test σ(d, b) == N[2, 1]
 
     # 2D BallInf radius =/= 1


### PR DESCRIPTION
The idea is to, instead of adding, remove the support vector of the corresponding ball. It works except for `p == 1` and `p == Inf`, because for these two cases the support vector is not unique. But there is a canonical support vector that makes the idea work as well. For `p == Inf` I changed the implementation to return that instead because it was easy. For `p == 1` I kept the old implementation and instead excluded that norm in `Bloating`.

Commits:

1. Change the implementation of σ for `BallInf` to give correct results with `p == Inf`. That also required to generalize some tests.
1. Allow for nonpositive bloating, excluding `p == 1` because σ there does not return the canonical support vector.

Indeed `Bloating(Bloating(S, -ε, p), ε, p)` is the same as `S` for `p > 1` now.

---

The 1-norm underapproximation does not seem correct.
EDIT: I excluded the 1-norm case. The plot below is old.

```julia
P = convex_hull(BallInf(zeros(2), 0.8), Ball1(zeros(2), 1.0))

plot(P)
plot!(Bloating(P, 0.1, 1.0))
plot!(Bloating(P, -0.1, 1.0))
```

![1](https://user-images.githubusercontent.com/9656686/127714051-1e10e9c8-94c5-464f-a4d9-928fb4c42835.png)

The 2-norm underapproximation seems correct:

```julia
plot(P)
plot!(overapproximate(Bloating(P, 0.1, 2.0), 1e-2))
plot!(overapproximate(Bloating(P, -0.1, 2.0), 1e-2))
```

![2](https://user-images.githubusercontent.com/9656686/127714063-ea7cf890-de4a-44c9-9727-73ffe081f748.png)

But then there is a strange issue in the epsilon-close approximation when using `1e-3` (not sure if the problem is in this PR or elsewhere).
EDIT: This does not happen for `p == Inf` with the new behavior.

```julia
plot(P)
plot!(overapproximate(Bloating(P, 0.1, 2.0), 1e-3))
plot!(overapproximate(Bloating(P, -0.1, 2.0), 1e-3))
```

![3](https://user-images.githubusercontent.com/9656686/127714072-5aad31c2-7120-491f-9df2-b4340ed80e6c.png)

Note that if I copy the constraints and create a new `HPolygon`, then the set looks correct. So I guess the sorting of the constraints is broken. So maybe, when finding new constraints, they are not in the order as they are expected.