### PR TITLE
Add point-set distance methods

### DIFF
--- a/docs/src/lib/binary_functions.md
+++ b/docs/src/lib/binary_functions.md
@@ -149,6 +149,6 @@ difference(::AbstractHyperrectangle{N}, ::AbstractHyperrectangle{N}) where {N}
 ## Distance
 
 ```@docs
-distance(::AbstractSingleton, ::Line; ::Real=2.0)
+distance(::AbstractSingleton, ::LazySet; ::Real=2.0)
 distance(::AbstractHyperrectangle, ::AbstractHyperrectangle; ::Real=2.0)
 ```

--- a/docs/src/lib/interfaces.md
+++ b/docs/src/lib/interfaces.md
@@ -386,6 +386,7 @@ genmat(::AbstractHyperrectangle)
 ngens(::AbstractHyperrectangle{N}) where {N}
 rectify(::AbstractHyperrectangle)
 volume(::AbstractHyperrectangle)
+distance(::AbstractVector, ::AbstractHyperrectangle{N}; ::Real=N(2)) where {N}
 ```
 
 ### Implementations

--- a/docs/src/lib/sets/HalfSpace.md
+++ b/docs/src/lib/sets/HalfSpace.md
@@ -28,6 +28,7 @@ remove_redundant_constraints
 remove_redundant_constraints!
 complement(::HalfSpace)
 project(::HalfSpace{N}, ::AbstractVector{Int}) where {N}
+distance(::AbstractVector, ::HalfSpace{N}) where {N}
 ```
 Inherited from [`LazySet`](@ref):
 * [`norm`](@ref norm(::LazySet, ::Real))

--- a/docs/src/lib/sets/Hyperplane.md
+++ b/docs/src/lib/sets/Hyperplane.md
@@ -18,6 +18,7 @@ isempty(::Hyperplane)
 constrained_dimensions(::Hyperplane)
 constraints_list(::Hyperplane)
 translate(::Hyperplane, ::AbstractVector)
+normalize(::Hyperplane{N}, p=N(2)) where {N}
 ```
 Inherited from [`LazySet`](@ref):
 * [`norm`](@ref norm(::LazySet, ::Real))

--- a/docs/src/lib/sets/Hyperplane.md
+++ b/docs/src/lib/sets/Hyperplane.md
@@ -19,6 +19,7 @@ constrained_dimensions(::Hyperplane)
 constraints_list(::Hyperplane)
 translate(::Hyperplane, ::AbstractVector)
 normalize(::Hyperplane{N}, p=N(2)) where {N}
+distance(::AbstractVector, ::Hyperplane{N}) where {N}
 ```
 Inherited from [`LazySet`](@ref):
 * [`norm`](@ref norm(::LazySet, ::Real))

--- a/src/ConcreteOperations/distance.jl
+++ b/src/ConcreteOperations/distance.jl
@@ -52,25 +52,34 @@ function distance(H1::AbstractHyperrectangle, H2::AbstractHyperrectangle;
 end
 
 """
-    distance(S::AbstractSingleton, L::Line; [p]::Real=2.0)
+    distance(S::AbstractSingleton, X::LazySet; [p]::Real=2.0)
 
-Compute the distance between the singleton `S` and the line `L` with respect to
+Compute the distance between the singleton `S` and the set `X` with respect to
 the given `p`-norm.
 
 ### Input
 
-- `S` -- singleton, i.e. a set with one element
-- `L` -- line
+- `S` -- singleton, i.e., a set with one element
+- `X` -- set
 - `p` -- (optional, default: `2.0`) the `p`-norm used; `p = 2.0` corresponds to
          the usual Euclidean norm
 
 ### Output
 
 A scalar representing the distance between the element wrapped by `S` and the
-line `L`.
+set `X`.
 """
-function distance(S::AbstractSingleton, L::Line; p::Real=2.0)
-    return distance(element(S), L; p=p)
+function distance(S::AbstractSingleton, X::LazySet; p::Real=2.0)
+    return distance(element(S), X; p=p)
 end
 
-distance(L::Line, S::AbstractSingleton; p::Real=2.0) = distance(S, L; p=p)
+distance(X::LazySet, S::AbstractSingleton; p::Real=2.0) = distance(S, X; p=p)
+
+distance(S1::AbstractSingleton, S2::AbstractSingleton; p::Real=2.0) =
+    distance(element(S1), element(S2); p=p)
+
+# disambiguation
+distance(S::AbstractSingleton, H::AbstractHyperrectangle; p::Real=2.0) =
+    distance(element(S), H; p=p)
+distance(H::AbstractHyperrectangle, S::AbstractSingleton; p::Real=2.0) =
+    distance(element(S), H; p=p)

--- a/src/Sets/HalfSpace.jl
+++ b/src/Sets/HalfSpace.jl
@@ -72,12 +72,16 @@ A new half-space whose normal direction ``a`` is normalized, i.e., such that
 ``‖a‖_p = 1`` holds.
 """
 function normalize(hs::HalfSpace{N}, p=N(2)) where {N}
-    nₐ = norm(hs.a, p)
-    a = LinearAlgebra.normalize(hs.a, p)
-    b = hs.b / nₐ
+    a, b = _normalize_halfspace(hs, p)
     return HalfSpace(a, b)
 end
 
+function _normalize_halfspace(H, p=2)
+    nₐ = norm(H.a, p)
+    a = LinearAlgebra.normalize(H.a, p)
+    b = H.b / nₐ
+    return a, b
+end
 
 # --- LazySet interface functions ---
 

--- a/src/Sets/HalfSpace.jl
+++ b/src/Sets/HalfSpace.jl
@@ -776,3 +776,25 @@ function iscomplement(H1::HalfSpace{N}, H2::HalfSpace) where {N}
     # check that the half-spaces touch each other
     return H1.b == factor * H2.b
 end
+
+"""
+    distance(x::AbstractVector, H::HalfSpace{N}) where {N}
+
+Compute the distance between point `x` and half-space `H` with respect to the
+Euclidean norm.
+
+### Input
+
+- `x` -- vector
+- `H` -- half-space
+
+### Output
+
+A scalar representing the distance between point `x` and half-space `H`.
+"""
+function distance(x::AbstractVector, H::HalfSpace{N}) where {N}
+    a, b = _normalize_halfspace(H, N(2))
+    return max(dot(x, a) - b, zero(N))
+end
+
+distance(H::HalfSpace, x::AbstractVector) = distance(x, H)

--- a/src/Sets/Hyperplane.jl
+++ b/src/Sets/Hyperplane.jl
@@ -37,6 +37,26 @@ end
 isoperationtype(::Type{<:Hyperplane}) = false
 isconvextype(::Type{<:Hyperplane}) = true
 
+"""
+    normalize(H::Hyperplane{N}, p=N(2)) where {N}
+
+Normalize a hyperplane.
+
+### Input
+
+- `H` -- hyperplane
+- `p`  -- (optional, default: `2`) norm
+
+### Output
+
+A new hyperplane whose normal direction ``a`` is normalized, i.e., such that
+``‖a‖_p = 1`` holds.
+"""
+function normalize(H::Hyperplane{N}, p=N(2)) where {N}
+    a, b = _normalize_halfspace(H, p)
+    return Hyperplane(a, b)
+end
+
 
 # --- polyhedron interface functions ---
 

--- a/src/Sets/Hyperplane.jl
+++ b/src/Sets/Hyperplane.jl
@@ -600,3 +600,25 @@ Hyperplane(expr::Num; N::Type{<:Real}=Float64) = Hyperplane(expr, _get_variables
 Hyperplane(expr::Num, vars; N::Type{<:Real}=Float64) = Hyperplane(expr, _vec(vars), N=N)
 
 end end  # quote / load_symbolics_hyperplane()
+
+"""
+    distance(x::AbstractVector, H::Hyperplane{N}) where {N}
+
+Compute the distance between point `x` and hyperplane `H` with respect to the
+Euclidean norm.
+
+### Input
+
+- `x` -- vector
+- `H` -- hyperplane
+
+### Output
+
+A scalar representing the distance between point `x` and hyperplane `H`.
+"""
+function distance(x::AbstractVector, H::Hyperplane{N}) where {N}
+    a, b = _normalize_halfspace(H, N(2))
+    return abs(dot(x, a) - b)
+end
+
+distance(H::Hyperplane, x::AbstractVector) = distance(x, H)

--- a/test/Sets/HalfSpace.jl
+++ b/test/Sets/HalfSpace.jl
@@ -154,6 +154,19 @@ for N in [Float64, Float32]
     @test norm(hs2.a) ≈ N(1) && hs2.b == hs1.b / norm(hs1.a)
     @test normalize(hs1, N(1)) == HalfSpace(N[1//3, 2//3], N(1))
     @test normalize(hs1, N(Inf)) == HalfSpace(N[1//2, 1], N(3//2))
+
+    # distance
+    H = HalfSpace(N[1, -1], N(0))  # x <= y
+    y = N[1, 1]  # closest point in the half-space
+    # point outside
+    x = N[2, 0]
+    @test distance(x, H) == distance(H, x) ≈ distance(x, y, p=N(2))
+    # point at the border
+    x = N[1, 1]
+    @test distance(x, H) == distance(H, x) ≈ distance(x, y, p=N(2))
+    # point strictly inside
+    x = N[0, 2]
+    @test distance(x, H) == distance(H, x) == N(0)
 end
 
 for N in [Float64]

--- a/test/Sets/Hyperplane.jl
+++ b/test/Sets/Hyperplane.jl
@@ -133,6 +133,16 @@ for N in [Float64, Rational{Int}, Float32]
     end
 end
 
+# tests that only work with Float64 and Float32
+for N in [Float64, Float32]
+    # normalization
+    H1 = Hyperplane(N[1e5, 2e5], N(3e5))
+    H2 = normalize(H1)
+    @test norm(H2.a) ≈ N(1) && H2.b == H1.b / norm(H1.a)
+    @test normalize(H1, N(1)) == Hyperplane(N[1//3, 2//3], N(1))
+    @test normalize(H1, N(Inf)) == Hyperplane(N[1//2, 1], N(3//2))
+end
+
 # Polyhedra tests that only work with Float64
 for N in [Float64]
     hp = Hyperplane(ones(N, 3), N(5))

--- a/test/Sets/Hyperplane.jl
+++ b/test/Sets/Hyperplane.jl
@@ -141,6 +141,13 @@ for N in [Float64, Float32]
     @test norm(H2.a) ≈ N(1) && H2.b == H1.b / norm(H1.a)
     @test normalize(H1, N(1)) == Hyperplane(N[1//3, 2//3], N(1))
     @test normalize(H1, N(Inf)) == Hyperplane(N[1//2, 1], N(3//2))
+
+    # distance
+    H = Hyperplane(N[1, -1], N(0))  # x <= y
+    y = N[1, 1]  # closest point in the half-space
+    for x in [N[2, 0], N[1, 1], N[0, 2]]
+        @test distance(x, H) == distance(H, x) ≈ distance(x, y, p=N(2))
+    end
 end
 
 # Polyhedra tests that only work with Float64

--- a/test/Sets/Hyperrectangle.jl
+++ b/test/Sets/Hyperrectangle.jl
@@ -276,3 +276,16 @@ for N in [Float64, Rational{Int}, Float32]
     @test permute(H, 1:3) == H
     @test permute(H, [2, 1, 3]) == Hyperrectangle(N[2, 1, 3], N[5, 4, 6])
 end
+
+# tests that only work with Float64 and Float32
+for N in [Float64, Float32]
+    # distance
+    H = Hyperrectangle(N[1, 2], N[2, 3])
+    xs = [N[1, 1], N[8, 1], N[1, 6], N[-3, 2], N[-4, -5]]
+    ys = [N[1, 1], N[3, 1], N[1, 5], N[-1, 2], N[-1, -1]]  # closest points in H
+    for (x, y) in zip(xs, ys)
+        for p in N[1, 2, Inf]
+            @test distance(x, H) == distance(H, x) ≈ distance(x, y, p=N(2))
+        end
+    end
+end


### PR DESCRIPTION
~This is PR based on #2802.~

Commits:
1. Add `normalize` for `Hyperplane`.
2. Add `distance` for a point and a `HalfSpace`.
3. Add `distance` for a point and a `Hyperplane`.
4. Add `distance` for a point and an `AbstractHyperrectangle`.
5. Let `distance` between two sets where one set is an `AbstractSingleton` fall back to the point-set distance.

