### PR TITLE
#2811 - special case of genmat of sparse hyperrectangle

### DIFF
--- a/src/Sets/Hyperrectangle.jl
+++ b/src/Sets/Hyperrectangle.jl
@@ -175,6 +175,11 @@ return quote
 end
 end
 
+function genmat(H::Hyperrectangle{N, SparseVector{N, T}, SparseVector{N, T}}) where {N, T}
+    n = dim(H)
+    return sparse(1:n, 1:n, H.radius, n, n)
+end
+
 # --- AbstractCentrallySymmetric interface functions ---
 
 

--- a/test/Sets/Hyperrectangle.jl
+++ b/test/Sets/Hyperrectangle.jl
@@ -23,7 +23,6 @@ for N in [Float64, Rational{Int}, Float32]
     @test ispermutation(gens, [N[1, 0], N[0, 1]])
     @test genmat(h) ∈ [N[1 0; 0 1], N[0 1; 1 0]]
     @test ngens(h) == 2
-    @test genmat(h) isa SparseMatrixCSC
     h_flat = Hyperrectangle(N[1, 2, 3, 4, 5], N[1, 0, 2, 0, 3])
     @test collect(generators(h_flat)) ==
         [SingleEntryVector(1, 5, N(1)), SingleEntryVector(3, 5, N(2)),
@@ -96,6 +95,9 @@ for N in [Float64, Rational{Int}, Float32]
     # diameter
     @test diameter(h) == norm(N[5, 3] - N[1, 1], Inf)
 
+    # generators matrix for sparse hyperrectangle
+    @test genmat(Hyperrectangle(sparsevec(N[3, 2]), sparsevec(N[2, 1]))) isa SparseMatrixCSC
+        
     # alternative constructor
     c = ones(N, 2)
     r = N[2, 3]

--- a/test/Sets/Hyperrectangle.jl
+++ b/test/Sets/Hyperrectangle.jl
@@ -23,6 +23,7 @@ for N in [Float64, Rational{Int}, Float32]
     @test ispermutation(gens, [N[1, 0], N[0, 1]])
     @test genmat(h) ∈ [N[1 0; 0 1], N[0 1; 1 0]]
     @test ngens(h) == 2
+    @test genmat(h) isa SparseMatrixCSC
     h_flat = Hyperrectangle(N[1, 2, 3, 4, 5], N[1, 0, 2, 0, 3])
     @test collect(generators(h_flat)) ==
         [SingleEntryVector(1, 5, N(1)), SingleEntryVector(3, 5, N(2)),


### PR DESCRIPTION
Closes #2811.


This could be generalized to `AbstractHyperrectangle` or `AbstractZonotope`, but it does the job..