### PR TITLE
Faster symmetric_interval_hull for ExponentialMap of singletons and hyperrectangles

### DIFF
--- a/src/Approximations/Approximations.jl
+++ b/src/Approximations/Approximations.jl
@@ -10,7 +10,7 @@ using LazySets, LazySets.Arrays, Requires, LinearAlgebra, SparseArrays,
       MathProgBase
 
 using LazySets: _isapprox, _leq, _geq, _rtol, _normal_Vector, isapproxzero,
-                default_lp_solver, _isbounded_stiemke
+                default_lp_solver, _isbounded_stiemke, require
 
 import LazySets: project
 

--- a/src/Approximations/init.jl
+++ b/src/Approximations/init.jl
@@ -1,6 +1,7 @@
 function __init__()
-    @require TaylorModels = "314ce334-5f6e-57ae-acf6-00b6e903104a" include("init_TaylorModels.jl")
+    @require Expokit = "a1e7a1ef-7a5d-5822-a38c-be74e1bb89f4" include("init_Expokit.jl")
     @require IntervalMatrices = "5c1f47dc-42dd-5697-8aaa-4d102d140ba9" include("init_IntervalMatrices.jl")
     @require IntervalConstraintProgramming = "138f1668-1576-5ad7-91b9-7425abbf3153" include("init_IntervalConstraintProgramming.jl")
     @require StaticArrays = "90137ffa-7385-5640-81b9-e52037218182" include("init_StaticArrays.jl")
+    @require TaylorModels = "314ce334-5f6e-57ae-acf6-00b6e903104a" include("init_TaylorModels.jl")
 end

--- a/src/Approximations/init_Expokit.jl
+++ b/src/Approximations/init_Expokit.jl
@@ -1,0 +1,9 @@
+function load_expokit()
+return quote
+
+using .Expokit: expmv
+
+end end  # quote / load_expokit
+
+
+eval(load_expokit())

--- a/src/Approximations/symmetric_interval_hull.jl
+++ b/src/Approximations/symmetric_interval_hull.jl
@@ -98,3 +98,27 @@ function symmetric_interval_hull(lm::LinearMap{N, <:AbstractHyperrectangle}) whe
     r = abs.(M * center(H)) .+ abs.(M) * radius_hyperrectangle(H)
     return Hyperrectangle(zeros(N, n), r)
 end
+
+function symmetric_interval_hull(E::ExponentialMap{N, <:AbstractSingleton}) where {N}
+    require(:Expokit; fun_name="symmetric_interval_hull")
+
+    v = expmv(one(N), E.spmexp.M, element(E.X))
+    c = zeros(N, dim(E))
+    r = abs.(v)
+    return Hyperrectangle(c, r)
+end
+
+function symmetric_interval_hull(E::ExponentialMap{N, <:AbstractHyperrectangle}) where {N}
+    require(:Expokit; fun_name="symmetric_interval_hull")
+
+    H = set(E)
+    n = dim(H)
+    x = zeros(N, n)
+    r = abs.(expmv(one(N), E.spmexp.M, center(H)))
+    @inbounds for i in 1:n
+        x[i] = radius_hyperrectangle(H, i)
+        r .+= abs.(expmv(one(N), E.spmexp.M, x))
+        x[i] = 0
+    end
+    return Hyperrectangle(zeros(N, n), r)
+end

--- a/src/Approximations/symmetric_interval_hull.jl
+++ b/src/Approximations/symmetric_interval_hull.jl
@@ -117,6 +117,10 @@ function symmetric_interval_hull(E::ExponentialMap{N, <:AbstractHyperrectangle})
     r = abs.(expmv(one(N), E.spmexp.M, center(H)))
     @inbounds for i in 1:n
         x[i] = radius_hyperrectangle(H, i)
+        if isapproxzero(x[i])
+            x[i] = 0
+            continue
+        end
         r .+= abs.(expmv(one(N), E.spmexp.M, x))
         x[i] = 0
     end

--- a/src/LazySets.jl
+++ b/src/LazySets.jl
@@ -47,6 +47,7 @@ import .Arrays: distance,
 # ===================
 # Auxiliary functions
 # ===================
+include("Utils/require.jl")
 include("Utils/helper_functions.jl")
 include("Utils/macros.jl")
 include("Utils/iterators.jl")

--- a/src/Utils/require.jl
+++ b/src/Utils/require.jl
@@ -1,0 +1,29 @@
+"""
+    require(package::Symbol; fun_name::String="", explanation::String="")
+
+Helper method to check for optional packages and printing an error message.
+
+### Input
+
+- `package`     -- symbol of the package name
+- `fun_name`    -- (optional; default: `""`) name of the function that requires
+                   the package
+- `explanation` -- (optional; default: `""`) additional explanation in the error
+                   message
+
+### Output
+
+If the package is loaded, this function has no effect.
+Otherwise it prints an error message.
+
+### Algorithm
+
+This function uses `@assert` and hence loses its ability to print an error
+message if assertions are deactivated.
+"""
+function require(package::Symbol; fun_name::String="", explanation::String="")
+    @assert isdefined(@__MODULE__, package) "package '$package' not loaded" *
+        (fun_name == "" ? "" :
+            " (it is required for executing `$fun_name`" *
+            (explanation == "" ? "" : " " * explanation) * ")")
+end

--- a/src/init.jl
+++ b/src/init.jl
@@ -11,33 +11,3 @@ function __init__()
     @require Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7" include("Initialization/init_Symbolics.jl")
     @require WriteVTK = "64499a7a-5c06-52f2-abe2-ccb03c286192" include("Initialization/init_WriteVTK.jl")
 end
-
-"""
-    require(package::Symbol; fun_name::String="", explanation::String="")
-
-Helper method to check for optional packages and printing an error message.
-
-### Input
-
-- `package`     -- symbol of the package name
-- `fun_name`    -- (optional; default: `""`) name of the function that requires
-                   the package
-- `explanation` -- (optional; default: `""`) additional explanation in the error
-                   message
-
-### Output
-
-If the package is loaded, this function has no effect.
-Otherwise it prints an error message.
-
-### Algorithm
-
-This function uses `@assert` and hence loses its ability to print an error
-message if assertions are deactivated.
-"""
-function require(package::Symbol; fun_name::String="", explanation::String="")
-    @assert isdefined(@__MODULE__, package) "package '$package' not loaded" *
-        (fun_name == "" ? "" :
-            " (it is required for executing `$fun_name`" *
-            (explanation == "" ? "" : " " * explanation) * ")")
-end

--- a/test/Approximations/symmetric_interval_hull.jl
+++ b/test/Approximations/symmetric_interval_hull.jl
@@ -18,3 +18,23 @@ for N in [Float64, Rational{Int}, Float32]
     H2 = Hyperrectangle(zeros(N, 4), N[6, 7, 16, 18])
     @test symmetric_interval_hull(M * H1) == H2
 end
+
+# tests that only work with Float64 and Float32
+for N in [Float64, Float32]
+    # exponential map of singleton
+    M = sparse(diagm(N[1, 1, 1]))
+    E = SparseMatrixExp(M) * Singleton(N[1, 2, 3])
+    H = Hyperrectangle(zeros(N, 3), N[ℯ, 2ℯ, 3ℯ])
+    @test symmetric_interval_hull(E) ≈ H
+
+    # exponential map of hyperrectangle
+    M = sparse(diagm(N[1, 1, 1]))
+    E = SparseMatrixExp(M) * Hyperrectangle(N[1, 2, 3], N[1, 2, 3])
+    H = symmetric_interval_hull(E)
+    @test H ≈ Hyperrectangle(zeros(N, 3), N[2ℯ, 4ℯ, 6ℯ])
+    # matrix with negative entries
+    M = sparse(diagm(N[1, -1]))
+    E = SparseMatrixExp(M) * Hyperrectangle(N[1, 1], N[1, 1])
+    H = symmetric_interval_hull(E)
+    @test H ≈ Hyperrectangle(zeros(N, 2), N[2ℯ, 2ℯ^(-1)])
+end


### PR DESCRIPTION
Using `Expokit` in `Approximations` required a small refactoring.

```julia
using LazySets, SparseArrays, Expokit, Test

for n in [1, 10, 100, 200]
    A = sparse(rand(n, n) .- rand(n, n));
    δ = 0.1;
    M = SparseMatrixExp(A * δ);

    println("n = $n\nSingleton")

    X = rand(Singleton, dim=n);
    EX = ExponentialMap(M, X);
    @time SX = symmetric_interval_hull(EX);  # master
    @time SX2 = LazySets.Approximations.symmetric_interval_hull2(EX);  # this branch
    @test isequivalent(SX, SX2)

    println("Hyperrectangle")

    Y = rand(Hyperrectangle, dim=n);
    EY = ExponentialMap(M, Y);
    @time SY = symmetric_interval_hull(EY);  # master
    @time SY2 = LazySets.Approximations._symmetric_interval_hull_krylov(EY);  # this branch
    @time SY3 = LazySets.Approximations._symmetric_interval_hull_exp(EY);  # this branch
    @test isequivalent(SY, SY2)
    @test isequivalent(SY, SY3)
end
```
---
```julia
n = 1
Singleton
  0.000094 seconds (119 allocations: 15.000 KiB)
  0.000028 seconds (57 allocations: 7.344 KiB)
Hyperrectangle
  0.000047 seconds (119 allocations: 15.000 KiB)
  0.000043 seconds (113 allocations: 14.594 KiB)
  0.000020 seconds (26 allocations: 2.281 KiB)
n = 10
Singleton
  0.002171 seconds (1.54 k allocations: 1.191 MiB)
  0.000106 seconds (78 allocations: 61.234 KiB)
Hyperrectangle
  0.002242 seconds (1.54 k allocations: 1.191 MiB)
  0.001896 seconds (839 allocations: 670.609 KiB)
  0.000102 seconds (37 allocations: 23.969 KiB)
n = 100
Singleton
  0.284080 seconds (14.01 k allocations: 53.663 MiB, 5.15% gc time)
  0.001111 seconds (71 allocations: 276.438 KiB)
Hyperrectangle
  0.300344 seconds (14.01 k allocations: 53.663 MiB, 2.81% gc time)
  0.120292 seconds (6.97 k allocations: 27.096 MiB)
  0.001231 seconds (43 allocations: 1.227 MiB)
n = 200
Singleton
  3.501998 seconds (32.97 k allocations: 149.301 MiB, 0.58% gc time)
  0.006972 seconds (83 allocations: 382.453 KiB)
Hyperrectangle
  4.091444 seconds (32.97 k allocations: 149.301 MiB, 0.45% gc time)
  1.412295 seconds (15.62 k allocations: 69.847 MiB, 0.50% gc time)
  0.006196 seconds (47 allocations: 5.505 MiB)
```

The first output is `master`. The second output is the Krylov approach. For hyperrectangles the direct computation of the matrix exponential (third output) is much faster (as long that is possible), so I used this one by default.