### PR TITLE
cartesian_product not requiring Polyhedra

### DIFF
--- a/docs/src/lib/binary_functions.md
+++ b/docs/src/lib/binary_functions.md
@@ -14,7 +14,6 @@ CurrentModule = LazySets
 ## Cartesian product
 
 ```@docs
-cartesian_product(::HPoly, ::HPoly)
 cartesian_product(::VPolytope, ::VPolytope)
 cartesian_product(::LazySet, ::LazySet)
 ```

--- a/src/Sets/HPolygon.jl
+++ b/src/Sets/HPolygon.jl
@@ -83,6 +83,11 @@ function HPolygon()
     HPolygon{Float64}()
 end
 
+# constructor for an HPolyhedron with constraints of mixed type
+function HPolygon(constraints::Vector{<:LinearConstraint})
+    HPolygon(_normal_Vector(constraints))
+end
+
 # constructor from a simple H-representation
 HPolygon(A::AbstractMatrix,
          b::AbstractVector;

--- a/src/Sets/HPolygonOpt.jl
+++ b/src/Sets/HPolygonOpt.jl
@@ -92,6 +92,11 @@ function HPolygonOpt()
     HPolygonOpt{Float64}()
 end
 
+# constructor for an HPolyhedron with constraints of mixed type
+function HPolygonOpt(constraints::Vector{<:LinearConstraint})
+    HPolygonOpt(_normal_Vector(constraints))
+end
+
 # constructor from a simple H-representation
 HPolygonOpt(A::AbstractMatrix,
             b::AbstractVector;

--- a/src/Sets/HPolyhedron.jl
+++ b/src/Sets/HPolyhedron.jl
@@ -57,6 +57,11 @@ function HPolyhedron()
     HPolyhedron{Float64}()
 end
 
+# constructor for an HPolyhedron with constraints of mixed type
+function HPolyhedron(constraints::Vector{<:LinearConstraint})
+    HPolyhedron(_normal_Vector(constraints))
+end
+
 # constructor from a simple H-representation
 HPolyhedron(A::AbstractMatrix, b::AbstractVector) =
     HPolyhedron(constraints_list(A, b))

--- a/src/Sets/HPolytope.jl
+++ b/src/Sets/HPolytope.jl
@@ -59,6 +59,11 @@ function HPolytope()
     HPolytope{Float64}()
 end
 
+# constructor for an HPolytope with constraints of mixed type
+function HPolytope(constraints::Vector{<:LinearConstraint})
+    HPolytope(_normal_Vector(constraints))
+end
+
 # constructor from a simple H-representation
 HPolytope(A::AbstractMatrix, b::AbstractVector;
           check_boundedness::Bool=false) =

--- a/src/Sets/HalfSpace.jl
+++ b/src/Sets/HalfSpace.jl
@@ -520,9 +520,9 @@ function _linear_map_hrep_helper(M::AbstractMatrix, hs::HalfSpace,
 end
 
 # TODO: after #2032, #2041 remove use of this function
-_normal_Vector(P::LazySet) = [LinearConstraint(convert(Vector, c.a), c.b) for c in constraints_list(P)]
 _normal_Vector(c::LinearConstraint) = LinearConstraint(convert(Vector, c.a), c.b)
-
+_normal_Vector(C::Vector{<:LinearConstraint}) = [_normal_Vector(c) for c in C]
+_normal_Vector(P::LazySet) = _normal_Vector(constraints_list(P))
 
 # ============================================
 # Functionality that requires Symbolics

--- a/test/ConcreteOperations/cartesian_product.jl
+++ b/test/ConcreteOperations/cartesian_product.jl
@@ -68,4 +68,14 @@ for N in [Float64, Float32, Rational{Int}]
     @test isequivalent(PU, HPolyhedron([HalfSpace(N[1, 0, 0], N(2))]))
     UP = cartesian_product(U, P)
     @test isequivalent(UP, HPolyhedron([HalfSpace(N[0, 0, 1], N(2))]))
+
+    # polytopes and polyhedra
+    X = Interval(N(1), N(3))
+    XX = BallInf(N[2, 2], N(1))
+    P = convert(HPolytope, X)
+    Q = convert(HPolyhedron, X)
+    PP = cartesian_product(P, P)
+    @test PP isa HPolytope{N} && isequivalent(PP, XX)
+    QQ = cartesian_product(Q, Q)
+    @test QQ isa HPolyhedron{N} && isequivalent(QQ, XX)
 end

--- a/test/LazyOperations/MinkowskiSum.jl
+++ b/test/LazyOperations/MinkowskiSum.jl
@@ -218,7 +218,7 @@ for N in [Float64]
         X = BallInf(N[0, 0], N(1)) ⊕ Singleton(N[1, 2])
         Y = Ball1(N[1, 1], N(1))
         A = cartesian_product(X, Y, algorithm="vrep")
-        Ah = tohrep(A, backend=CDDLib.Library());
+        Ah = tohrep(A, backend=CDDLib.Library())
         B = cartesian_product(X, Y, algorithm="hrep")
         @test Ah ⊆ B && B ⊆ Ah
     end


### PR DESCRIPTION
(The first commit is required but independent. I outsourced it to #2815.)

The Cartesian product in H-rep is simple, so I added it as a native method which is now the default. The old implementation via `Polyhedra` can be used with the new algorithm `"hrep_polyhedra"` (not sure about the name).