### PR TITLE
#2823 - Change code examples to doctests

### DIFF
--- a/src/Approximations/overapproximate.jl
+++ b/src/Approximations/overapproximate.jl
@@ -726,7 +726,7 @@ using .TaylorModels: Taylor1, TaylorN, TaylorModelN, TaylorModel1,
     if p.order == 0
         return zeros(eltype(p), 1)
     end
-    return linear_polynomial(p).coeffs[2:end]
+    return linear_polynomial(p).coeffs[2:2]
 end
 
 @inline function get_linear_coeffs(p::TaylorN)
@@ -804,8 +804,6 @@ one variable (`TaylorModel1`). Using `overapproximate(vTM, Zonotope)` we can
 compute its associated zonotope in generator representation:
 
 ```julia
-julia> using LazySets.Approximations
-
 julia> Z = overapproximate(vTM, Zonotope);
 
 julia> center(Z)

--- a/src/Approximations/overapproximate.jl
+++ b/src/Approximations/overapproximate.jl
@@ -773,7 +773,7 @@ If the polynomials are linear, this functions exactly transforms to a zonotope.
 However, the nonlinear case necessarily introduces overapproximation error.
 Consider the linear case first:
 
-```julia
+```jldoctest oa_tm1
 julia> using LazySets, TaylorModels
 
 julia> const IA = IntervalArithmetic;
@@ -794,16 +794,16 @@ julia> p2 = Taylor1([0.9, 3.0], 2) # define another linear polynomial
  0.9 + 3.0 t + 𝒪(t³)
 
 julia> vTM = [TaylorModel1(pi, I, x₀, D) for pi in [p1, p2]]
-2-element Array{TaylorModel1{Float64,Float64},1}:
- 2.0 + 1.0 t + [-0.5, 0.5]
- 0.9 + 3.0 t + [-0.5, 0.5]
+2-element Vector{TaylorModel1{Float64, Float64}}:
+  2.0 + 1.0 t + [-0.5, 0.5]
+  0.9 + 3.0 t + [-0.5, 0.5]
 ```
 
 Here, `vTM` is a taylor model vector, since each component is a taylor model in
 one variable (`TaylorModel1`). Using `overapproximate(vTM, Zonotope)` we can
 compute its associated zonotope in generator representation:
 
-```julia
+```jldoctest oa_tm1
 julia> Z = overapproximate(vTM, Zonotope);
 
 julia> center(Z)
@@ -822,7 +822,7 @@ from the linear part of the polynomials, and another one that corresponds to the
 interval remainder. This conversion gives the same upper and lower bounds as the
 range evaluation using interval arithmetic:
 
-```julia
+```jldoctest oa_tm1
 julia> X = box_approximation(Z)
 Hyperrectangle{Float64, Vector{Float64}, Vector{Float64}}([1.0, -2.1], [2.5, 6.5])
 
@@ -830,13 +830,12 @@ julia> Y = evaluate(vTM[1], vTM[1].dom) × evaluate(vTM[2], vTM[2].dom)
 [-1.5, 3.5] × [-8.60001, 4.40001]
 
 julia> H = convert(Hyperrectangle, Y) # this IntevalBox is the same as X
-Hyperrectangle{Float64,StaticArrays.SArray{Tuple{2},Float64,1,2},
-               StaticArrays.SArray{Tuple{2},Float64,1,2}}([1.0, -2.1000000000000005], [2.5, 6.500000000000001])
+Hyperrectangle{Float64, StaticArrays.SVector{2, Float64}, StaticArrays.SVector{2, Float64}}([1.0, -2.1000000000000005], [2.5, 6.500000000000001])
 ```
 However, the zonotope returns better results if we want to approximate the `TM`,
 since it is not axis-aligned:
 
-```julia
+```jldoctest oa_tm1
 julia> d = [-0.35, 0.93];
 
 julia> ρ(d, Z) < ρ(d, X)
@@ -846,12 +845,12 @@ true
 This function also works if the polynomials are non-linear; for example suppose
 that we add a third polynomial with a quadratic term:
 
-```julia
+```jldoctest oa_tm1
 julia> p3 = Taylor1([0.9, 3.0, 1.0], 3)
  0.9 + 3.0 t + 1.0 t² + 𝒪(t⁴)
 
 julia> vTM = [TaylorModel1(pi, I, x₀, D) for pi in [p1, p2, p3]]
-3-element Array{TaylorModel1{Float64,Float64},1}:
+3-element Vector{TaylorModel1{Float64, Float64}}:
            2.0 + 1.0 t + [-0.5, 0.5]
            0.9 + 3.0 t + [-0.5, 0.5]
   0.9 + 3.0 t + 1.0 t² + [-0.5, 0.5]
@@ -868,9 +867,9 @@ julia> Matrix(genmat(Z))
 3×4 Matrix{Float64}:
  2.0  0.5  0.0  0.0
  6.0  0.0  0.5  0.0
- 6.0  0.0  0.0  6.5
+ 6.0  0.0  0.0  5.0
 ```
-The fourth and last generator corresponds to the addition between the interval
+The fourth and last generator corresponds to the addition of the interval
 remainder and the box overapproximation of the nonlinear part of `p3` over the
 domain.
 
@@ -931,7 +930,7 @@ A zonotope that overapproximates the range of the given taylor model.
 Consider a vector of two 2-dimensional taylor models of order 2 and 4
 respectively.
 
-```julia
+```jldoctest
 julia> using LazySets, TaylorModels
 
 julia> const IA = IntervalArithmetic;
@@ -963,9 +962,9 @@ julia> p2 = x₂^3 + 3x₁^4 + x₁ + 1
  1.0 + 1.0 x₁ + 1.0 x₂³ + 3.0 x₁⁴ + 𝒪(‖x‖⁹)
 
 julia> vTM = [TaylorModelN(pi, r, x₀, D) for pi in [p1, p2]]
-2-element Array{TaylorModelN{2,Float64,Float64},1}:
-             1.0 - 1.0 x₂ + 1.0 x₁² + [-0.5, 0.5]
-   1.0 + 1.0 x₁ + 1.0 x₂³ + 3.0 x₁⁴ + [-0.5, 0.5]
+2-element Vector{TaylorModelN{2, Float64, Float64}}:
+            1.0 - 1.0 x₂ + 1.0 x₁² + [-0.5, 0.5]
+  1.0 + 1.0 x₁ + 1.0 x₂³ + 3.0 x₁⁴ + [-0.5, 0.5]
 
 julia> Z = overapproximate(vTM, Zonotope);
 

--- a/src/Approximations/overapproximate.jl
+++ b/src/Approximations/overapproximate.jl
@@ -932,7 +932,7 @@ Consider a vector of two 2-dimensional taylor models of order 2 and 4
 respectively.
 
 ```julia
-julia> using LazySets, LazySets.Approximations, TaylorModels
+julia> using LazySets, TaylorModels
 
 julia> const IA = IntervalArithmetic;
 

--- a/src/ConcreteOperations/difference.jl
+++ b/src/ConcreteOperations/difference.jl
@@ -25,11 +25,11 @@ If `X` and `Y` are intervals, `X \\ Y` is used in some libraries to denote
 the left division, as the example below shows. However, it should not be
 confused with the *set difference*. For example,
 
-```julia
+```jldoctest
 julia> X = Interval(0, 2); Y = Interval(1, 4);
 
 julia> X \\ Y   # computing the set difference
-LazySets.Interval{Float64,IntervalArithmetic.Interval{Float64}}([0, 1])
+Interval{Float64, IntervalArithmetic.Interval{Float64}}([0, 1])
 
 julia> X.dat \\ Y.dat  # computing the left division
 [0.5, ∞]

--- a/src/ConcreteOperations/minkowski_sum.jl
+++ b/src/ConcreteOperations/minkowski_sum.jl
@@ -32,7 +32,7 @@ This function requires that the list of constraints of both lazy sets `P` and
 `minkowski_sum` function for polyhedral sets is used. For details see
 [`minkowski_sum(::VPolytope, ::VPolytope)`](@ref).
 
-This method requires `Polyhedra` and `CDDLib`, so you have to do:
+This method requires to load the packages `Polyhedra` and `CDDLib`, like so:
 
 ```julia
 julia> using LazySets, Polyhedra, CDDLib
@@ -103,7 +103,7 @@ A polyhedron in H-representation that corresponds to the Minkowski sum of `P` an
 
 ### Notes
 
-This method requires `Polyhedra` and `CDDLib`, so you have to do:
+This method requires to load the packages `Polyhedra` and `CDDLib`, like so:
 
 ```julia
 julia> using LazySets, Polyhedra, CDDLib

--- a/src/LazyOperations/Intersection.jl
+++ b/src/LazyOperations/Intersection.jl
@@ -783,7 +783,7 @@ julia> v[1]
 
 We can specify the upper bound in Brent's method:
 
-```julia _line_search
+```jldoctest _line_search
 julia> v = _line_search([1.0, 0.0], X, H, upper=1e3);
 
 julia> v[1]
@@ -792,7 +792,7 @@ julia> v[1]
 
 Instead of Brent's method we can use the Golden Section method:
 
-```julia _line_search
+```jldoctest _line_search
 julia> v = _line_search([1.0, 0.0], X, H, upper=1e3, method=GoldenSection());
 
 julia> v[1]

--- a/src/Plotting/mesh.jl
+++ b/src/Plotting/mesh.jl
@@ -85,8 +85,6 @@ If the function `constraints_list` is not applicable to your set `S`, try
 overapproximation first; e.g. via
 
 ```julia
-julia> using LazySets.Approximations
-
 julia> Sapprox = overapproximate(S, SphericalDirections(10))
 
 julia> plot3d(Sapprox)

--- a/src/Plotting/plot_recipes.jl
+++ b/src/Plotting/plot_recipes.jl
@@ -1,8 +1,6 @@
 using RecipesBase
 import RecipesBase.apply_recipe
 
-using LazySets.Approximations: overapproximate, PolarDirections
-
 # global values
 DEFAULT_COLOR = :auto
 DEFAULT_ALPHA = 0.5
@@ -447,14 +445,11 @@ vector (but see
 [#1187](https://github.com/JuliaReach/LazySets.jl/issues/1187))).
 
 Also note that if the set is a *nested* intersection, you may have to manually
-overapproximate this set before plotting (see
-`LazySets.Approximations.overapproximate` for details).
+overapproximate this set before plotting (see `overapproximate` for details).
 
 ### Examples
 
 ```julia
-julia> using LazySets.Approximations
-
 julia> X = Ball2(zeros(2), 1.) ∩ Ball2(ones(2), 1.5);  # lazy intersection
 
 julia> plot(X)

--- a/src/Utils/comparisons.jl
+++ b/src/Utils/comparisons.jl
@@ -37,7 +37,7 @@ for that numeric type is used. For floating-point types, a default value has bee
 defined through `default_tolerance` as follows:
 
 ```julia
-default_tolerance(N::Type{<:AbstractFloat}) = Tolerance(Base.rtoldefault(N), sqrt(eps(N)), zero(N))
+default_tolerance(N::Type{<:AbstractFloat}) = Tolerance(Base.rtoldefault(N), N(10) * sqrt(eps(N)), zero(N))
 ```
 Hence to set a single tolerance (either `rtol`, `ztol` or `atol`) for a given
 floating-point type, use the corresponding `set_rtol` function, while the values


### PR DESCRIPTION
Closes #2823.

This branch is based on #2822.

I did not turn the `Symbolics` examples into doctests because they use an old syntax. We should fix that once we use the new version in #2825.