### PR TITLE
#2845 - More efficient box_approximation of CHull and MSum

### DIFF
--- a/docs/src/lib/interfaces.md
+++ b/docs/src/lib/interfaces.md
@@ -73,8 +73,10 @@ isequivalent(::LazySet, ::LazySet)
 isconvextype(::Type{<:LazySet})
 low(::LazySet{N}, ::Int) where {N}
 high(::LazySet{N}, ::Int) where {N}
+low_high(::LazySet, ::Int)
 low(::LazySet)
 high(::LazySet)
+low_high(::LazySet)
 surface(::LazySet{N}) where {N}
 area(::LazySet{N}) where {N}
 concretize(::LazySet)

--- a/docs/src/lib/interfaces.md
+++ b/docs/src/lib/interfaces.md
@@ -73,10 +73,10 @@ isequivalent(::LazySet, ::LazySet)
 isconvextype(::Type{<:LazySet})
 low(::LazySet{N}, ::Int) where {N}
 high(::LazySet{N}, ::Int) where {N}
-low_high(::LazySet, ::Int)
+extrema(::LazySet, ::Int)
 low(::LazySet)
 high(::LazySet)
-low_high(::LazySet)
+extrema(::LazySet)
 surface(::LazySet{N}) where {N}
 area(::LazySet{N}) where {N}
 concretize(::LazySet)

--- a/src/Approximations/box_approximation.jl
+++ b/src/Approximations/box_approximation.jl
@@ -391,3 +391,9 @@ function _box_approximation_chull_twobox(X, Y)
     r = h - ci
     return Hyperrectangle(c, r)
 end
+
+function box_approximation(ms::MinkowskiSum)
+    H1 = box_approximation(ms.X)
+    H2 = box_approximation(ms.Y)
+    return minkowski_sum(H1, H2)
+end

--- a/src/Interfaces/AbstractCentrallySymmetric.jl
+++ b/src/Interfaces/AbstractCentrallySymmetric.jl
@@ -150,7 +150,7 @@ The center along a given dimension of the centrally symmetric set.
     return center(S)[i]
 end
 
-function low_high(S::AbstractCentrallySymmetric, i::Int)
+function extrema(S::AbstractCentrallySymmetric, i::Int)
     # h = c + r
     h = high(S, i)
     # l = c - r = -c - r + 2 * c = -h + 2 * c

--- a/src/Interfaces/AbstractCentrallySymmetric.jl
+++ b/src/Interfaces/AbstractCentrallySymmetric.jl
@@ -149,3 +149,11 @@ The center along a given dimension of the centrally symmetric set.
 @inline function center(S::AbstractCentrallySymmetric, i::Int)
     return center(S)[i]
 end
+
+function low_high(S::AbstractCentrallySymmetric, i::Int)
+    # h = c + r
+    h = high(S, i)
+    # l = c - r = -c - r + 2 * c = -h + 2 * c
+    l = - h + 2 * center(S, i)
+    return (l, h)
+end

--- a/src/Interfaces/AbstractHyperrectangle.jl
+++ b/src/Interfaces/AbstractHyperrectangle.jl
@@ -520,7 +520,7 @@ function low(H::AbstractHyperrectangle, i::Int)
     return center(H, i) - radius_hyperrectangle(H, i)
 end
 
-function low_high(H::AbstractHyperrectangle)
+function extrema(H::AbstractHyperrectangle)
     c = center(H)
     r = radius_hyperrectangle(H)
     l = c .- r
@@ -528,7 +528,7 @@ function low_high(H::AbstractHyperrectangle)
     return (l, h)
 end
 
-function low_high(H::AbstractHyperrectangle, i::Int)
+function extrema(H::AbstractHyperrectangle, i::Int)
     c = center(H, i)
     r = radius_hyperrectangle(H, i)
     l = c - r

--- a/src/Interfaces/AbstractHyperrectangle.jl
+++ b/src/Interfaces/AbstractHyperrectangle.jl
@@ -520,6 +520,22 @@ function low(H::AbstractHyperrectangle, i::Int)
     return center(H, i) - radius_hyperrectangle(H, i)
 end
 
+function low_high(H::AbstractHyperrectangle)
+    c = center(H)
+    r = radius_hyperrectangle(H)
+    l = c .- r
+    h = c .+ r
+    return (l, h)
+end
+
+function low_high(H::AbstractHyperrectangle, i::Int)
+    c = center(H, i)
+    r = radius_hyperrectangle(H, i)
+    l = c - r
+    h = c + r
+    return (l, h)
+end
+
 """
     isflat(H::AbstractHyperrectangle)
 

--- a/src/Interfaces/LazySet.jl
+++ b/src/Interfaces/LazySet.jl
@@ -33,7 +33,8 @@ export LazySet,
        vertices,
        project,
        rectify,
-       permute
+       permute,
+       low_high
 
 """
     LazySet{N}
@@ -1393,7 +1394,7 @@ Return the lower coordinate of a set in a given dimension.
 
 ### Input
 
-- `H` -- set
+- `X` -- set
 - `i` -- dimension of interest
 
 ### Output
@@ -1413,7 +1414,7 @@ Return a vector with the lowest coordinates of the set for each canonical direct
 
 ### Input
 
-- `H` -- set
+- `X` -- set
 
 ### Output
 
@@ -1435,7 +1436,7 @@ Return the higher coordinate of a set in a given dimension.
 
 ### Input
 
-- `H` -- set
+- `X` -- set
 - `i` -- dimension of interest
 
 ### Output
@@ -1455,7 +1456,7 @@ Return a vector with the highest coordinate of the set for each canonical direct
 
 ### Input
 
-- `H` -- set
+- `X` -- set
 
 ### Output
 
@@ -1468,6 +1469,58 @@ See also [`high(X::LazySet, i::Int)`](@ref).
 function high(X::LazySet)
     n = dim(X)
     return [high(X, i) for i in 1:n]
+end
+
+"""
+    low_high(X::LazySet)
+
+Return two vectors with the lowest and highest coordinate of the set for each
+canonical direction.
+
+### Input
+
+- `X` -- set
+- `i` -- dimension of interest
+
+### Output
+
+Two vectors with the lowest and highest coordinates of the set for each
+dimension.
+
+### Notes
+
+The result is equivalent to `(low(X), high(X))`, but sometimes it can be
+computed more efficiently.
+"""
+function low_high(X::LazySet)
+    l = low(X)
+    h = high(X)
+    return (l, h)
+end
+
+"""
+    low_high(X::LazySet, i::Int)
+
+Return the lower and higher coordinate of a set in a given dimension.
+
+### Input
+
+- `X` -- set
+- `i` -- dimension of interest
+
+### Output
+
+The lower and higher coordinate of the set in the given dimension.
+
+### Notes
+
+The result is equivalent to `(low(X, i), high(X, i))`, but sometimes it can be
+computed more efficiently.
+"""
+function low_high(X::LazySet, i::Int)
+    l = low(X, i)
+    h = high(X, i)
+    return (l, h)
 end
 
 """

--- a/src/Interfaces/LazySet.jl
+++ b/src/Interfaces/LazySet.jl
@@ -1,4 +1,4 @@
-import Base: ==, ≈, copy, eltype, rationalize
+import Base: ==, ≈, copy, eltype, rationalize, extrema
 import Random.rand
 
 export LazySet,
@@ -33,8 +33,7 @@ export LazySet,
        vertices,
        project,
        rectify,
-       permute,
-       low_high
+       permute
 
 """
     LazySet{N}
@@ -1472,34 +1471,32 @@ function high(X::LazySet)
 end
 
 """
-    low_high(X::LazySet)
+    extrema(X::LazySet)
 
-Return two vectors with the lowest and highest coordinate of the set for each
-canonical direction.
+Return two vectors with the lowest and highest coordinate of `X` for each
+dimension.
 
 ### Input
 
 - `X` -- set
-- `i` -- dimension of interest
 
 ### Output
 
-Two vectors with the lowest and highest coordinates of the set for each
-dimension.
+Two vectors with the lowest and highest coordinates of `X` for each dimension.
 
 ### Notes
 
 The result is equivalent to `(low(X), high(X))`, but sometimes it can be
 computed more efficiently.
 """
-function low_high(X::LazySet)
+function extrema(X::LazySet)
     l = low(X)
     h = high(X)
     return (l, h)
 end
 
 """
-    low_high(X::LazySet, i::Int)
+    extrema(X::LazySet, i::Int)
 
 Return the lower and higher coordinate of a set in a given dimension.
 
@@ -1517,7 +1514,7 @@ The lower and higher coordinate of the set in the given dimension.
 The result is equivalent to `(low(X, i), high(X, i))`, but sometimes it can be
 computed more efficiently.
 """
-function low_high(X::LazySet, i::Int)
+function extrema(X::LazySet, i::Int)
     l = low(X, i)
     h = high(X, i)
     return (l, h)


### PR DESCRIPTION
Closes #2845.

I added a new function `extrema`, which computes `low` and `high`. For certain set types this is faster than computing them individually.

With that, there are two similar implementations for `ConvexHull`: using `box_approximation` and using `extrema`. I tried both and sometimes the `box_approximation` implementation is orders of magnitude faster, while in other cases it is slightly slower due to additional allocations (I marked those cases below). This is mainly because we do not have efficient methods of `extrema` for certain set combinations yet. I kept both implementations but made the `box_approximation` one the default.

```julia
julia> H1 = rand(Hyperrectangle, dim=1000);

julia> H2 = rand(Hyperrectangle, dim=1000);

julia> C = CH(H1, H2);

julia> M = H1 + H2;

julia> @time box_approximation(C);
  0.000052 seconds (3 allocations: 15.906 KiB)  # master
  0.000037 seconds (3 allocations: 15.906 KiB)  # this branch extrema
  0.000039 seconds (6 allocations: 39.719 KiB)  # this branch twobox (-)
  0.000032 seconds (3 allocations: 15.906 KiB)  # this branch twobox new

julia> @time box_approximation(M);
  0.000054 seconds (3 allocations: 15.906 KiB)  # master
  0.000014 seconds (3 allocations: 15.906 KiB)  # this branch extrema
  0.000014 seconds (3 allocations: 15.906 KiB)  # this branch twobox
  0.000014 seconds (3 allocations: 15.906 KiB)  # this branch twobox new

# ---

julia> B1 = rand(Ball2, dim=1000);

julia> B2 = rand(Ball2, dim=1000);

julia> C = CH(B1, B2);

julia> M = B1 + B2;

julia> @time box_approximation(C);
  0.006140 seconds (3 allocations: 15.906 KiB)  # master
  0.002763 seconds (3 allocations: 15.906 KiB)  # this branch extrema
  0.000035 seconds (8 allocations: 55.594 KiB)  # this branch twobox (+)
  0.000029 seconds (5 allocations: 31.781 KiB)  # this branch twobox new (+)

julia> @time box_approximation(M);
  0.004947 seconds (3 allocations: 15.906 KiB)  # master
  0.000016 seconds (5 allocations: 31.781 KiB)  # this branch extrema
  0.000025 seconds (5 allocations: 31.781 KiB)  # this branch twobox
  0.000020 seconds (5 allocations: 31.781 KiB)  # this branch twobox new

# ---

julia> A = rand(1000, 1000);

julia> X = CH(H1, A * H1 + H2);

julia> Y = CH(B1, A * B1 + B2);

julia> @time box_approximation(X);
  2.471455 seconds (2.00 k allocations: 15.518 MiB)  # master
  2.439210 seconds (2.00 k allocations: 15.518 MiB)  # this branch extrema
  0.004456 seconds (12 allocations: 7.699 MiB)  # this branch twobox (+)
  0.007700 seconds (9 allocations: 7.676 MiB)  # this branch twobox new (+)

julia> @time box_approximation(Y);
  2.546049 seconds (2.00 k allocations: 15.518 MiB)  # master
  2.437563 seconds (2.00 k allocations: 15.518 MiB)  # this branch extrema
  2.505903 seconds (2.02 k allocations: 15.589 MiB)  # this branch twobox (-)
  2.597207 seconds (2.01 k allocations: 15.565 MiB)  # this branch twobox new (-)
```