### PR TITLE
Fix isempty(::HParallelotope)

### DIFF
--- a/src/Sets/HParallelotope.jl
+++ b/src/Sets/HParallelotope.jl
@@ -345,3 +345,7 @@ function rand(::Type{HParallelotope};
     offset = randn(N, 2 * dim)
     return HParallelotope(D, offset)
 end
+
+function isempty(P::HParallelotope)
+    return isempty(convert(HPolyhedron, P))
+end

--- a/test/Sets/HParallelotope.jl
+++ b/test/Sets/HParallelotope.jl
@@ -4,7 +4,7 @@ for N in [Float32, Float64, Rational{Int}]
     # [1] Tommaso Dreossi, Thao Dang, and Carla Piazza. *Reachability computation for polynomial dynamical systems.*
     #      Formal Methods in System Design 50.1 (2017): 1-38.
     D = N[-1 0 0; -1 -1 0; 0 0 -1]
-    c = N[-0.80, -0.95, 0.0, 0.85, 1.0, 0.0]
+    c = N[-0.80, -0.95, 0, 0.85, 1, 0]
     P = HParallelotope(D, c)
 
     # test getter functions
@@ -40,6 +40,12 @@ for N in [Float32, Float64, Rational{Int}]
 
     # random parallelotope
     rand(HParallelotope)
+
+    # emptiness
+    H = N[1 1; 0 1]
+    o = N[2, 2, -4, -1]
+    P2 = HParallelotope(H, o)
+    @test !isempty(P) && isempty(P2)
 end
 
 for N in [Float32, Float64]


### PR DESCRIPTION
See #2772 and #2786.

In fact, I would rather propose that we check for emptiness in the constructor. The fact that we can create an empty parallelotope creates several problems with the default definitions. And I think it is never intended to actually create an empty set this way. I proposed this alternative in #2876.