### PR TITLE
Fix and generalize norm for a set

### DIFF
--- a/src/Interfaces/LazySet.jl
+++ b/src/Interfaces/LazySet.jl
@@ -380,6 +380,8 @@ A real number representing the norm.
 function norm(S::LazySet, p::Real=Inf)
     if p == Inf
         return norm(box_approximation(S), p)
+    elseif applicable(vertices_list, S)
+        return maximum(norm(v, p) for v in vertices_list(S))
     else
         error("the norm for this value of p=$p is not implemented")
     end

--- a/test/Approximations/radiusdiameter.jl
+++ b/test/Approximations/radiusdiameter.jl
@@ -56,12 +56,14 @@ for N in [Float64, Rational{Int}, Float32]
     @test radius(p, Inf) ≈ N(3//10)
     @test diameter(p, Inf) ≈ N(6//10)
 
+    # metrics in the 2-norm
+    @test norm(p, 2) ≈ norm(high(p), 2)
+
     # ====================================
     #  failing case (not implemented yet)
     # ====================================
 
     s = MinkowskiSum(b, b)
-    @test_throws ErrorException norm(s, 2)
     @test_throws ErrorException radius(s, 2)
     @test_throws ErrorException diameter(s, 2)
 end


### PR DESCRIPTION
First commit: The infinity norm of a set was pessimistic. The correct result can be smaller.

Second commit: Generalize `norm` to polytopic sets by taking the maximum of the norm in every vertex.