### PR TITLE
Undo #2900

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,12 @@
 name: CI
 
 on:
+  push:
+    paths-ignore:
+      - 'LICENSE.md'
+      - 'README.md'
+    branches:
+      - master
   pull_request:
     branches:
       - master


### PR DESCRIPTION
I realized that the change in #2900 means that there is no coverage running on `master` anymore. So I suggest to undo the change.