### PR TITLE
Sampling from HalfSpace

### DIFF
--- a/docs/src/lib/sets/Hyperplane.md
+++ b/docs/src/lib/sets/Hyperplane.md
@@ -20,6 +20,7 @@ constraints_list(::Hyperplane)
 translate(::Hyperplane, ::AbstractVector)
 normalize(::Hyperplane{N}, p=N(2)) where {N}
 distance(::AbstractVector, ::Hyperplane{N}) where {N}
+reflect(::AbstractVector, ::Hyperplane)
 ```
 Inherited from [`LazySet`](@ref):
 * [`norm`](@ref norm(::LazySet, ::Real))

--- a/docs/src/lib/utils.md
+++ b/docs/src/lib/utils.md
@@ -98,6 +98,7 @@ sample
 LazySets.AbstractSampler
 LazySets.CombinedSampler
 LazySets.FaceSampler
+LazySets.HalfSpaceSampler
 LazySets.RejectionSampler
 LazySets.RandomWalkSampler
 ```

--- a/src/Sets/Hyperplane.jl
+++ b/src/Sets/Hyperplane.jl
@@ -622,3 +622,35 @@ function distance(x::AbstractVector, H::Hyperplane{N}) where {N}
 end
 
 distance(H::Hyperplane, x::AbstractVector) = distance(x, H)
+
+"""
+    reflect(x::AbstractVector, H::Hyperplane)
+
+Reflect (mirror) a vector in a hyperplane.
+
+### Input
+
+- `x` -- vector
+- `H` -- hyperplane
+
+### Output
+
+The reflection of `x` in `H`.
+
+### Algorithm
+
+The reflection of a point ``p`` in the hyperplane ``a ⋅ x = b`` is
+
+```math
+    p − 2 \frac{p ⋅ a − c}{a ⋅ a} a
+```
+
+where ``x · y`` denotes the dot product.
+"""
+function reflect(x::AbstractVector, H::Hyperplane)
+    return _reflect_point_hyperplane(x, H.a, H.b)
+end
+
+function _reflect_point_hyperplane(x, a, b)
+    return x - 2 * (dot(x, a) - b) / dot(a, a) * a
+end

--- a/test/Sets/HalfSpace.jl
+++ b/test/Sets/HalfSpace.jl
@@ -147,6 +147,11 @@ for N in [Float64, Rational{Int}, Float32]
            ]
         @test LazySets.iscomplement(h1, h2) == eq
     end
+
+    # sampling
+    for x in sample(H, 10)
+        @test x ∈ H
+    end
 end
 
 # tests that only work with Float64 and Float32

--- a/test/Sets/Hyperplane.jl
+++ b/test/Sets/Hyperplane.jl
@@ -135,6 +135,11 @@ for N in [Float64, Rational{Int}, Float32]
             @test_throws ArgumentError convert(Hyperplane, P)
         end
     end
+
+    # reflection
+    H = Hyperplane(N[1, 1], N(1))
+    p = N[0, 0]
+    @test reflect(p, H) == N[1, 1]
 end
 
 # tests that only work with Float64 and Float32


### PR DESCRIPTION
See #2734.

The idea is to take a random point from some distribution. If it is not in the half-space, reflect the point in the hyperplane.

The only tricky question is what to choose as the distribution. I think the user has to help here. I set the default to [0, 1]^n.

See the example for the blue and the (dual) red half-space below. The green points are samples from blue (taken from [0, 1]^2 and all inside). The purple points are samples from red (taken from [0, 1]^2 and then reflected).

![sample_halfspace](https://user-images.githubusercontent.com/9656686/144131991-285c4573-3d86-4d2e-8f80-6c7cec73541c.png)
