### PR TITLE
Bring back fixed test

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -57,6 +57,7 @@ Javis = "78b212ba-a7f9-42d4-b726-60726080707e"
 Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
 MiniQhull = "978d7f02-9e05-4691-894f-ae31a51d76ca"
 Optim = "429524aa-4258-5aef-a3af-852621145aeb"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Polyhedra = "67491407-f73d-577b-9b50-8179a7c68029"
 RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
@@ -67,4 +68,5 @@ WriteVTK = "64499a7a-5c06-52f2-abe2-ccb03c286192"
 
 [targets]
 test = ["CDDLib", "Distributions", "Documenter", "Expokit", "ExponentialUtilities", "GR", "IntervalConstraintProgramming",
-        "IntervalMatrices", "Makie", "Optim", "Polyhedra", "RecipesBase", "StaticArrays", "Symbolics", "TaylorModels", "Test"]
+        "IntervalMatrices", "Makie", "Optim", "Pkg", "Polyhedra", "RecipesBase", "StaticArrays", "Symbolics", "TaylorModels",
+        "Test"]

--- a/test/LazyOperations/Intersection.jl
+++ b/test/LazyOperations/Intersection.jl
@@ -24,10 +24,14 @@ for N in [Float64, Rational{Int}, Float32]
     I2 = Singleton(N[1]) ∩ HalfSpace(N[1], N(1))
     @test isbounded(I2) && isboundedtype(typeof(I2))
     I2 = Hyperplane(ones(N, 2), N(1)) ∩ HalfSpace(ones(N, 2), N(1))
-    if N != Rational{Int}
-        # Julia crashes if GLPK is used with rationals here, see https://github.com/jump-dev/GLPK.jl/issues/207
+    # the next test fails with the "EXACT" solver GLPK older than v0.15.3
+    # see https://github.com/jump-dev/GLPK.jl/issues/207
+    mf = Pkg.Operations.Context().env.manifest
+    ver = mf[findfirst(v -> v.name == "GLPK", mf)].version
+    if N != Rational{Int} || ver >= v"0.15.3"
         @test !isbounded(I2) && !isboundedtype(typeof(I2))
     end
+
     # is_polyhedral
     @test is_polyhedral(I)
     if N isa AbstractFloat

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,7 +10,7 @@ Random.seed!(1234)
 # Optional dependencies
 # ========================
 import Distributions, ExponentialUtilities, Expokit, IntervalArithmetic,
-       IntervalMatrices, Optim, TaylorModels, IntervalConstraintProgramming
+       IntervalMatrices, Optim, Pkg, TaylorModels, IntervalConstraintProgramming
 const IA = IntervalArithmetic
 using IntervalArithmetic: IntervalBox
 using IntervalMatrices: ±, IntervalMatrix


### PR DESCRIPTION
This test was temporarily deactivated in #2923.

I suggest to include a check based on the version of `GLPK` since at least for now some package(s) in my default Manifest hold(s) the new `GLPK` version with the fix back and hence tests would fail locally.