### PR TITLE
Faster concrete intersection of mixed polygons

### DIFF
--- a/docs/src/lib/binary_functions.md
+++ b/docs/src/lib/binary_functions.md
@@ -70,7 +70,7 @@ intersection(::Interval, ::Interval)
 intersection(::Interval, ::HalfSpace)
 intersection(::Interval, ::Hyperplane)
 intersection(::Interval, ::LazySet)
-intersection(::AbstractHPolygon, ::AbstractHPolygon, ::Bool=true)
+intersection(::AbstractHPolygon, ::AbstractHPolygon)
 intersection(::AbstractPolyhedron{N}, ::AbstractPolyhedron{N}) where {N}
 intersection(::Union{VPolytope, VPolygon}, ::Union{VPolytope, VPolygon})
 intersection(::VPolygon, ::VPolygon; ::Bool=true)

--- a/src/ConcreteOperations/intersection.jl
+++ b/src/ConcreteOperations/intersection.jl
@@ -457,7 +457,7 @@ end
     _intersection_singleton(S, H)
 
 """
-    intersection(P1::AbstractHPolygon, P2::AbstractHPolygon, [prune]::Bool=true)
+    intersection(P1::AbstractHPolygon, P2::AbstractHPolygon; [prune]::Bool=true)
 
 Return the intersection of two polygons in constraint representation.
 
@@ -482,7 +482,7 @@ one.
 Redundancy of constraints is checked with
 [`remove_redundant_constraints!(::AbstractHPolygon)`](@ref).
 """
-function intersection(P1::AbstractHPolygon, P2::AbstractHPolygon, prune::Bool=true)
+function intersection(P1::AbstractHPolygon, P2::AbstractHPolygon; prune::Bool=true)
 
     # all constraints of one polygon are processed; now add the other polygon's
     # constraints

--- a/src/ConcreteOperations/intersection.jl
+++ b/src/ConcreteOperations/intersection.jl
@@ -578,6 +578,11 @@ function intersection(P1::AbstractHPolygon, P2::AbstractHPolygon; prune::Bool=tr
     return P
 end
 
+# use H-rep algorithm for mixed polygons
+function intersection(P::AbstractPolygon, Q::AbstractPolygon; prune::Bool=true)
+    return intersection(tohrep(P), tohrep(Q); prune=prune)
+end
+
 """
     intersection(P1::AbstractPolyhedron{N},
                  P2::AbstractPolyhedron{N};

--- a/test/Sets/Polygon.jl
+++ b/test/Sets/Polygon.jl
@@ -224,6 +224,13 @@ for N in [Float64, Float32, Rational{Int}]
     @test xaux ⊆ oaux && oaux ⊆ xaux # TODO use isequivalent
     @test LazySets._intersection_vrep_2d(paux.vertices, qaux.vertices) == xaux.vertices
 
+    # concrete intersection of H-rep and V-rep
+    q1 = intersection(paux, p)
+    q2 = intersection(p, paux)
+    @test isequivalent(q1, q2)
+    # HPolygons have the same constraints in the same order
+    @test q1 isa HPolygon && q2 isa HPolygon && q1 == q2
+
     # check that tighter constraints are used in intersection (#883)
     h1 = HalfSpace([N(1), N(0)], N(3))
     h2 = HalfSpace([N(-1), N(0)], N(-3))


### PR DESCRIPTION
This also fixes the problem in #2934.

```julia
julia> p = rand(HPolygon; seed=0);
julia> q = rand(VPolygon);

julia> @time intersection(p, q);  # master
  0.000727 seconds (3.11 k allocations: 173.297 KiB)

julia> @time intersection(p, q);  # this branch
  0.000038 seconds (112 allocations: 7.750 KiB)
```

I also changed the `prune` argument of one method to a keyword argument for consistency, which makes this a _breaking change_.