### PR TITLE
Escape inverse slash in docstring.

### DIFF
--- a/src/LazyOperations/CartesianProduct.jl
+++ b/src/LazyOperations/CartesianProduct.jl
@@ -38,7 +38,7 @@ the second block is `cp.Y`.
 
 The Cartesian product between two sets `X` and `Y` can be constructed either
 using `CartesianProduct(X, Y)` or the short-cut notation `X × Y` (to enter the times
-symbol, write `\times[TAB]`).
+symbol, write `\\times[TAB]`).
 
 ```jldoctest cartesianproduct_constructor
 julia> I1 = Interval(0, 1);


### PR DESCRIPTION
Hi, just noticed this typo in the docs:
![image](https://user-images.githubusercontent.com/33068707/159431259-4ea455e6-dc69-4e2a-8a61-a48c47959b73.png)
and thought, *oh this smells like a great first contribution*

Have a nice day