### PR TITLE
operations on simple sparse polynomial zonotopes

### DIFF
--- a/docs/src/lib/sets/SimpleSparsePolynomialZonotope.md
+++ b/docs/src/lib/sets/SimpleSparsePolynomialZonotope.md
@@ -13,4 +13,7 @@ dim(::SimpleSparsePolynomialZonotope)
 ngens(::SimpleSparsePolynomialZonotope)
 nparams(::SimpleSparsePolynomialZonotope)
 order(::SimpleSparsePolynomialZonotope)
+linear_map(::AbstractMatrix, ::SimpleSparsePolynomialZonotope)
+minkowski_sum(::SimpleSparsePolynomialZonotope, ::SimpleSparsePolynomialZonotope)
+cartesian_product(::SimpleSparsePolynomialZonotope, ::SimpleSparsePolynomialZonotope)
 ```

--- a/src/ConcreteOperations/cartesian_product.jl
+++ b/src/ConcreteOperations/cartesian_product.jl
@@ -195,3 +195,24 @@ end
 function cartesian_product(U::Universe, H::HalfSpace)
     return HalfSpace(prepend_zeros(H.a, dim(U)), H.b)
 end
+
+"""
+    cartesian_product(P1::SimpleSparsePolynomialZonotope, P2::SimpleSparsePolynomialZonotope)
+
+computes the cartesian product of the simple sparse polynomial zonotopes `P1` and `P2`.
+
+### Input
+
+- `P1` -- simple sparse polynomial zonotope
+- `P2` -- simple sparse polynomial zonotope
+
+### Output
+
+The cartesian product of `P1` and `P2`
+"""
+function cartesian_product(P1::SimpleSparsePolynomialZonotope, P2::SimpleSparsePolynomialZonotope)
+    c = vcat(center(P1), center(P2))
+    G = cat(genmat(P1), genmat(P2), dims=(1, 2))
+    E = cat(expmat(P1), expmat(P2), dims=(1, 2))
+    return SimpleSparsePolynomialZonotope(c, G, E)
+end

--- a/src/ConcreteOperations/minkowski_sum.jl
+++ b/src/ConcreteOperations/minkowski_sum.jl
@@ -509,3 +509,24 @@ end
 @commutative minkowski_sum(::ZeroSet, H::AbstractHyperrectangle) = H
 @commutative minkowski_sum(::ZeroSet, X::AbstractSingleton) = X
 minkowski_sum(Z::ZeroSet, ::ZeroSet) = Z
+
+"""
+    minkowski_sum(P1::SimpleSparsePolynomialZonotope, P2::SimpleSparsePolynomialZonotope)
+
+computes the Minkowski sum of the simple sparse polynomial zonotopes `P1` and `P2`.
+
+### Input
+
+- `P1` -- simple sparse polynomial zonotope
+- `P2` -- simple sparse polynomial zonotope
+
+### Output
+
+The Minkowski sum of `P1` and `P2`
+"""
+function minkowski_sum(P1::SimpleSparsePolynomialZonotope, P2::SimpleSparsePolynomialZonotope)
+    c = center(P1) + center(P2)
+    G = hcat(genmat(P1), genmat(P2))
+    E = cat(expmat(P1), expmat(P2), dims=(1, 2))
+    return SimpleSparsePolynomialZonotope(c, G, E)
+end

--- a/src/Sets/SimpleSparsePolynomialZonotope.jl
+++ b/src/Sets/SimpleSparsePolynomialZonotope.jl
@@ -1,5 +1,5 @@
 export SimpleSparsePolynomialZonotope, expmat, nparams,
-       linear_map, minkowski_sum, cartesian_product
+       linear_map
 
 """
     SimpleSparsePolynomialZonotope{N, VN<:AbstractVector{N}, MN<:AbstractMatrix{N}, ME<:AbstractMatrix{<:Integer}} <: AbstractPolynomialZonotope{N}
@@ -143,46 +143,4 @@ The set resulting from applying the linear map `M` to `P`.
 """
 function linear_map(M::AbstractMatrix, P::SSPZ)
     return SimpleSparsePolynomialZonotope(M * center(P), M * genmat(P), expmat(P))
-end
-
-"""
-    minkowski_sum(P1::SimpleSparsePolynomialZonotope, P2::SimpleSparsePolynomialZonotope)
-
-computes the Minkowski sum of the simple sparse polynomial zonotopes `P1` and `P2`.
-
-### Input
-
-- `P1` -- simple sparse polynomial zonotope
-- `P2` -- simple sparse polynomial zonotope
-
-### Output
-
-The Minkowski sum of `P1` and `P2`
-"""
-function minkowski_sum(P1::SimpleSparsePolynomialZonotope, P2::SimpleSparsePolynomialZonotope)
-    c = center(P1) + center(P2)
-    G = hcat(genmat(P1), genmat(P2))
-    E = cat(expmat(P1), expmat(P2), dims=(1, 2))
-    return SimpleSparsePolynomialZonotope(c, G, E)
-end
-
-"""
-    cartesian_product(P1::SimpleSparsePolynomialZonotope, P2::SimpleSparsePolynomialZonotope)
-
-computes the cartesian product of the simple sparse polynomial zonotopes `P1` and `P2`.
-
-### Input
-
-- `P1` -- simple sparse polynomial zonotope
-- `P2` -- simple sparse polynomial zonotope
-
-### Output
-
-The cartesian product of `P1` and `P2`
-"""
-function cartesian_product(P1::SimpleSparsePolynomialZonotope, P2::SimpleSparsePolynomialZonotope)
-    c = vcat(center(P1), center(P2))
-    G = cat(genmat(P1), genmat(P2), dims=(1, 2))
-    E = cat(expmat(P1), expmat(P2), dims=(1, 2))
-    return SimpleSparsePolynomialZonotope(c, G, E)
 end

--- a/src/Sets/SimpleSparsePolynomialZonotope.jl
+++ b/src/Sets/SimpleSparsePolynomialZonotope.jl
@@ -131,6 +131,15 @@ expmat(P::SSPZ) = P.E
     linear_map(M::AbstractMatrix, P::SimpleSparsePolynomialZonotope)
 
 applies the linear mapping `M` to the simple sparse polynomial zonotope `P`.
+
+### Input
+
+- `M` -- square matrix with size(M) == dim(P)
+- `P` -- simple sparse polynomial zonotope
+
+### Output
+
+The set resulting from applying the linear map `M` to `P`.
 """
 function linear_map(M::AbstractMatrix, P::SSPZ)
     return SimpleSparsePolynomialZonotope(M * center(P), M * genmat(P), expmat(P))
@@ -140,11 +149,20 @@ end
     minkowski_sum(P1::SimpleSparsePolynomialZonotope, P2::SimpleSparsePolynomialZonotope)
 
 computes the Minkowski sum of the simple sparse polynomial zonotopes `P1` and `P2`.
+
+### Input
+
+- `P1` -- simple sparse polynomial zonotope
+- `P2` -- simple sparse polynomial zonotope
+
+### Output
+
+The Minkowski sum of `P1` and `P2`
 """
 function minkowski_sum(P1::SimpleSparsePolynomialZonotope, P2::SimpleSparsePolynomialZonotope)
     c = center(P1) + center(P2)
     G = hcat(genmat(P1), genmat(P2))
-    E = cat(expmat(P1), expmat(P2), dims=(1, 2)) # ? maybe using sparse arrays might be better?
+    E = cat(expmat(P1), expmat(P2), dims=(1, 2))
     return SimpleSparsePolynomialZonotope(c, G, E)
 end
 
@@ -152,6 +170,15 @@ end
     cartesian_product(P1::SimpleSparsePolynomialZonotope, P2::SimpleSparsePolynomialZonotope)
 
 computes the cartesian product of the simple sparse polynomial zonotopes `P1` and `P2`.
+
+### Input
+
+- `P1` -- simple sparse polynomial zonotope
+- `P2` -- simple sparse polynomial zonotope
+
+### Output
+
+The cartesian product of `P1` and `P2`
 """
 function cartesian_product(P1::SimpleSparsePolynomialZonotope, P2::SimpleSparsePolynomialZonotope)
     c = vcat(center(P1), center(P2))

--- a/src/Sets/SimpleSparsePolynomialZonotope.jl
+++ b/src/Sets/SimpleSparsePolynomialZonotope.jl
@@ -1,4 +1,5 @@
-export SimpleSparsePolynomialZonotope, expmat, nparams
+export SimpleSparsePolynomialZonotope, expmat, nparams,
+       linear_map, minkowski_sum, cartesian_product
 
 """
     SimpleSparsePolynomialZonotope{N, VN<:AbstractVector{N}, MN<:AbstractMatrix{N}, ME<:AbstractMatrix{<:Integer}} <: AbstractPolynomialZonotope{N}
@@ -125,3 +126,36 @@ julia> expmat(S)
 ```
 """
 expmat(P::SSPZ) = P.E
+
+"""
+    linear_map(M::AbstractMatrix, P::SimpleSparsePolynomialZonotope)
+
+applies the linear mapping `M` to the simple sparse polynomial zonotope `P`.
+"""
+function linear_map(M::AbstractMatrix, P::SSPZ)
+    return SimpleSparsePolynomialZonotope(M * center(P), M * genmat(P), expmat(P))
+end
+
+"""
+    minkowski_sum(P1::SimpleSparsePolynomialZonotope, P2::SimpleSparsePolynomialZonotope)
+
+computes the Minkowski sum of the simple sparse polynomial zonotopes `P1` and `P2`.
+"""
+function minkowski_sum(P1::SimpleSparsePolynomialZonotope, P2::SimpleSparsePolynomialZonotope)
+    c = center(P1) + center(P2)
+    G = hcat(genmat(P1), genmat(P2))
+    E = cat(expmat(P1), expmat(P2), dims=(1, 2)) # ? maybe using sparse arrays might be better?
+    return SimpleSparsePolynomialZonotope(c, G, E)
+end
+
+"""
+    cartesian_product(P1::SimpleSparsePolynomialZonotope, P2::SimpleSparsePolynomialZonotope)
+
+computes the cartesian product of the simple sparse polynomial zonotopes `P1` and `P2`.
+"""
+function cartesian_product(P1::SimpleSparsePolynomialZonotope, P2::SimpleSparsePolynomialZonotope)
+    c = vcat(center(P1), center(P2))
+    G = cat(genmat(P1), genmat(P2), dims=(1, 2))
+    E = cat(expmat(P1), expmat(P2), dims=(1, 2))
+    return SimpleSparsePolynomialZonotope(c, G, E)
+end

--- a/test/Sets/SimpleSparsePolynomialZonotope.jl
+++ b/test/Sets/SimpleSparsePolynomialZonotope.jl
@@ -16,4 +16,20 @@ for N in [Float64, Float32, Rational{Int}]
     @test overapproximate(S, Zonotope) == Zonotope(N[3., 1], N[1 1;2 1.])
     @test length(overapproximate(S, Zonotope; nsdiv=3)) == 9
     @test length(overapproximate(S, Zonotope; partition=(2, 3))) == 6
+
+    LMS = linear_map([1.0 2.0;3.0 4.0], S);
+    @test center(LMS) == [2.0, 6.0]
+    @test genmat(LMS) == [5.0 6.0;11.0 14.0]
+    @test expmat(LMS) == expmat(S)
+
+    MSS = minkowski_sum(S, S)
+    @test center(MSS) == [4.0, 0.0]
+    @test genmat(MSS) == [1 2 1 2;2 2 2 2.]
+    @test expmat(MSS) == [1 4 0 0;1 2 0 0;0 0 1 4;0 0 1 2]
+
+    CPS = cartesian_product(S, S)
+    @test center(CPS) == [2, 0, 2.0, 0]
+    @test genmat(CPS) == [1 2 0 0;2 2 0 0;0 0 1 2;0 0 2 2.]
+    @test expmat(CPS) == [1 4 0 0;1 2 0 0;0 0 1 4;0 0 1 2]
+
 end


### PR DESCRIPTION
This PR adds the operations on SSPZ described in Niklas presentation. Currently I added those into the same file of SSPZ, but maybe we want to move those in the corresponding files in `concrete_operations`?

### TODO

- [x] ~~linear combination~~ in future PR
- [x] ~~quadratic map~~ in future PR
- [x] ~~convex hull~~ in future PR
- [x] tests

