### PR TITLE
#3012 - Generalize code for inclusion in union

### DIFF
--- a/docs/src/lib/binary_functions.md
+++ b/docs/src/lib/binary_functions.md
@@ -136,6 +136,7 @@ issubset
 ⊆(::CartesianProduct, ::CartesianProduct, ::Bool=false)
 ⊆(::CartesianProductArray, ::CartesianProductArray, ::Bool=false)
 ⊆(::AbstractZonotope, ::AbstractHyperrectangle, ::Bool=false)
+⊆(::LazySet{N}, ::UnionSetArray, ::Bool=false; ::Bool=true) where {N}
 ⊂
 ```
 


### PR DESCRIPTION
Closes #3012.

The previous code for hyperrectangles was already general, so this PR mainly renames the variables.