### PR TITLE
Hotfix for Revise/Require bug

### DIFF
--- a/src/init.jl
+++ b/src/init.jl
@@ -3,7 +3,7 @@ function __init__()
     @require Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f" include("Initialization/init_Distributions.jl")
     @require Expokit = "a1e7a1ef-7a5d-5822-a38c-be74e1bb89f4" include("Initialization/init_Expokit.jl")
     @require ExponentialUtilities = "d4d017d3-3776-5f7e-afef-a10c40355c18" include("Initialization/init_ExponentialUtilities.jl")
-    @require Ipopt = "b6b21f68-93f8-5de0-b562-5493be1d77c9" nothing
+    @require Ipopt = "b6b21f68-93f8-5de0-b562-5493be1d77c9" (nothing,)
     @require Javis = "78b212ba-a7f9-42d4-b726-60726080707e" include("Initialization/init_Javis.jl")
     @require Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a" include("Initialization/init_Makie.jl")
     @require MiniQhull = "978d7f02-9e05-4691-894f-ae31a51d76ca" include("Initialization/init_MiniQhull.jl")


### PR DESCRIPTION
Fixes #3040 

Context: The problem seems to be that `Revise.add_require` dispatches on `Expr` for it's last argument but the `@require ... nothing` statement parses `nothing` as a `Symbol`. Thus, we never hit that dispatch. I'll make a PR to Revise to fix it over there but, for now, this workaround should do and should have no undesired side effects.