### PR TITLE
Fix isconvextype

### DIFF
--- a/docs/src/lib/interfaces.md
+++ b/docs/src/lib/interfaces.md
@@ -36,6 +36,12 @@ Every set in this library is a subtype of the abstract type `LazySet`.
 LazySet
 ```
 
+### Globally defined set functions
+
+```@docs
+isconvextype(::Type{<:LazySet})
+```
+
 ## [General sets (ConvexSet)](@id def_ConvexSet)
 
 Every convex set in this library implements this interface.
@@ -47,16 +53,14 @@ ConvexSet
 ### Support function and support vector
 
 Every `ConvexSet` type must define a function `σ` to compute the support vector.
+The support function, `ρ`, can optionally be defined; otherwise, a fallback
+definition based on `σ` is used.
 
 ```@docs
+σ
 support_vector
 ρ(::AbstractVector, ::ConvexSet)
 support_function
-σ
-singleton_list(::ConvexSet)
-constraints(::ConvexSet)
-vertices(::ConvexSet)
-delaunay
 ```
 
 ### Other globally defined set functions
@@ -80,7 +84,6 @@ is_interior_point(::AbstractVector{N}, ::ConvexSet{N}; p=Inf, ε=_rtol(N)) where
 isoperationtype(::Type{<:ConvexSet})
 isoperation(::ConvexSet)
 isequivalent(::ConvexSet, ::ConvexSet)
-isconvextype(::Type{<:ConvexSet})
 low(::ConvexSet{N}, ::Int) where {N}
 high(::ConvexSet{N}, ::Int) where {N}
 extrema(::ConvexSet, ::Int)
@@ -98,6 +101,10 @@ project(::ConvexSet, ::AbstractVector{Int}, ::Real, ::Int=dim(S))
 rectify(::ConvexSet, ::Bool=false)
 permute
 rationalize(::Type{T}, ::ConvexSet{N}, ::Real) where {T<:Integer, N<:AbstractFloat}
+singleton_list(::ConvexSet)
+constraints(::ConvexSet)
+vertices(::ConvexSet)
+delaunay
 ```
 
 Plotting is available for general one- or two-dimensional `ConvexSet`s, provided

--- a/src/Interfaces/AbstractCentrallySymmetric.jl
+++ b/src/Interfaces/AbstractCentrallySymmetric.jl
@@ -7,7 +7,7 @@ export AbstractCentrallySymmetric,
 """
     AbstractCentrallySymmetric{N} <: ConvexSet{N}
 
-Abstract type for centrally symmetric sets.
+Abstract type for centrally symmetric convex sets.
 
 ### Notes
 
@@ -26,7 +26,7 @@ julia> subtypes(AbstractCentrallySymmetric)
 """
 abstract type AbstractCentrallySymmetric{N} <: ConvexSet{N} end
 
-isconvextype(::Type{<:AbstractCentrallySymmetric}) = false
+isconvextype(::Type{<:AbstractCentrallySymmetric}) = true
 
 """
     dim(S::AbstractCentrallySymmetric)

--- a/src/Interfaces/ConvexSet.jl
+++ b/src/Interfaces/ConvexSet.jl
@@ -844,55 +844,7 @@ function _isequivalent_inclusion(X::ConvexSet, Y::ConvexSet)
     return X ⊆ Y && Y ⊆ X
 end
 
-"""
-    isconvextype(X::Type{<:ConvexSet})
-
-Check whether the given `ConvexSet` type is convex.
-
-### Input
-
-- `X` -- subtype of `ConvexSet`
-
-### Output
-
-`true` if the given set type is guaranteed to be convex by using only type
-information, and `false` otherwise.
-
-### Notes
-
-Since this operation only acts on types (not on values), it can return false
-negatives, i.e. there may be instances where the set is convex, even though the
-answer of this function is `false`. The examples below illustrate this point.
-
-### Examples
-
-A ball in the infinity norm is always convex, hence we get:
-
-```jldoctest convex_types
-julia> isconvextype(BallInf)
-true
-```
-
-For instance, the union (`UnionSet`) of two sets may in general be either convex
-or not, since convexity cannot be decided by just using type information.
-Hence, `isconvextype` returns `false` if `X` is `Type{<:UnionSet}`.
-
-```jldoctest convex_types
-julia> isconvextype(UnionSet)
-false
-```
-
-However, the type parameters from the set operations allow to decide convexity
-in some cases, by falling back to the convexity of the type of its arguments.
-Consider for instance the lazy intersection. The intersection of two convex sets
-is always convex, hence we can get:
-
-```jldoctest convex_types
-julia> isconvextype(Intersection{Float64, BallInf{Float64}, BallInf{Float64}})
-true
-```
-"""
-isconvextype(X::Type{<:ConvexSet}) = false
+isconvextype(X::Type{<:ConvexSet}) = true
 
 """
     surface(X::ConvexSet{N}) where {N}

--- a/src/Interfaces/LazySet.jl
+++ b/src/Interfaces/LazySet.jl
@@ -94,3 +94,53 @@ Zonotope
 ```
 """
 abstract type LazySet{N} end
+
+"""
+    isconvextype(X::Type{<:LazySet})
+
+Check whether the given `LazySet` type is convex.
+
+### Input
+
+- `X` -- subtype of `LazySet`
+
+### Output
+
+`true` if the given set type is guaranteed to be convex by using only type
+information, and `false` otherwise.
+
+### Notes
+
+Since this operation only acts on types (not on values), it can return false
+negatives, i.e. there may be instances where the set is convex, even though the
+answer of this function is `false`. The examples below illustrate this point.
+
+### Examples
+
+A ball in the infinity norm is always convex, hence we get:
+
+```jldoctest convex_types
+julia> isconvextype(BallInf)
+true
+```
+
+For instance, the union (`UnionSet`) of two sets may in general be either convex
+or not, since convexity cannot be decided by just using type information.
+Hence, `isconvextype` returns `false` if `X` is `Type{<:UnionSet}`.
+
+```jldoctest convex_types
+julia> isconvextype(UnionSet)
+false
+```
+
+However, the type parameters from the set operations allow to decide convexity
+in some cases, by falling back to the convexity of the type of its arguments.
+Consider for instance the lazy intersection. The intersection of two convex sets
+is always convex, hence we can get:
+
+```jldoctest convex_types
+julia> isconvextype(Intersection{Float64, BallInf{Float64}, BallInf{Float64}})
+true
+```
+"""
+isconvextype(X::Type{<:LazySet}) = false


### PR DESCRIPTION
- Redefine `isconvextype` of `ConvexSet` and `AbstractCentrallySymmetric` to `true`. The latter is debatable, but I do not see a use case for non-convex centrally symmetric sets. (This should have been done before when we introduced `ConvexSet`, but fortunately we redefined the function for all convex subtypes, so the answers were still correct.)
- Define `isconvextype` for `LazySet` as `false`.
- Fix some docs of `ConvexSet`.