### PR TITLE
Generalize low, high, extrema to LazySet

### DIFF
--- a/docs/src/lib/interfaces.md
+++ b/docs/src/lib/interfaces.md
@@ -40,6 +40,18 @@ LazySet
 
 ```@docs
 isconvextype(::Type{<:LazySet})
+low(::LazySet)
+high(::LazySet)
+extrema(::LazySet, ::Int)
+extrema(::LazySet)
+```
+
+The following methods are also defined for `LazySet` but cannot be documented
+due to a bug.
+
+```@docs
+low(::ConvexSet{N}, ::Int) where {N}
+high(::ConvexSet{N}, ::Int) where {N}
 ```
 
 ## [General sets (ConvexSet)](@id def_ConvexSet)
@@ -84,12 +96,6 @@ is_interior_point(::AbstractVector{N}, ::ConvexSet{N}; p=Inf, ε=_rtol(N)) where
 isoperationtype(::Type{<:ConvexSet})
 isoperation(::ConvexSet)
 isequivalent(::ConvexSet, ::ConvexSet)
-low(::ConvexSet{N}, ::Int) where {N}
-high(::ConvexSet{N}, ::Int) where {N}
-extrema(::ConvexSet, ::Int)
-low(::ConvexSet)
-high(::ConvexSet)
-extrema(::ConvexSet)
 surface(::ConvexSet{N}) where {N}
 area(::ConvexSet{N}) where {N}
 concretize(::ConvexSet)

--- a/src/Interfaces/ConvexSet.jl
+++ b/src/Interfaces/ConvexSet.jl
@@ -1,4 +1,4 @@
-import Base: ==, ≈, copy, eltype, rationalize, extrema
+import Base: ==, ≈, copy, eltype, rationalize
 import Random.rand
 
 export ConvexSet,
@@ -1311,13 +1311,13 @@ function rectify(X::ConvexSet, concrete_intersection::Bool=false)
 end
 
 """
-    low(X::ConvexSet, i::Int)
+    low(X::ConvexSet{N}, i::Int) where {N}
 
-Return the lower coordinate of a set in a given dimension.
+Return the lower coordinate of a convex set in a given dimension.
 
 ### Input
 
-- `X` -- set
+- `X` -- convex set
 - `i` -- dimension of interest
 
 ### Output
@@ -1325,41 +1325,19 @@ Return the lower coordinate of a set in a given dimension.
 The lower coordinate of the set in the given dimension.
 """
 function low(X::ConvexSet{N}, i::Int) where {N}
-    n = dim(X)
-    d = SingleEntryVector(i, n, -one(N))
-    return -ρ(d, X)
+    # Note: this method is needed for documentation reasons
+    # (see the method for LazySet)
+    return _low(X, i)
 end
 
 """
-    low(X::ConvexSet)
+    high(X::ConvexSet{N}, i::Int) where {N}
 
-Return a vector with the lowest coordinates of the set for each canonical direction.
-
-### Input
-
-- `X` -- set
-
-### Output
-
-A vector with the lower coordinate of the set for each dimension.
-
-### Notes
-
-See also [`low(X::ConvexSet, i::Int)`](@ref).
-"""
-function low(X::ConvexSet)
-    n = dim(X)
-    return [low(X, i) for i in 1:n]
-end
-
-"""
-    high(X::ConvexSet, i::Int)
-
-Return the higher coordinate of a set in a given dimension.
+Return the higher coordinate of a convex set in a given dimension.
 
 ### Input
 
-- `X` -- set
+- `X` -- convex set
 - `i` -- dimension of interest
 
 ### Output
@@ -1367,81 +1345,9 @@ Return the higher coordinate of a set in a given dimension.
 The higher coordinate of the set in the given dimension.
 """
 function high(X::ConvexSet{N}, i::Int) where {N}
-    n = dim(X)
-    d = SingleEntryVector(i, n, one(N))
-    return ρ(d, X)
-end
-
-"""
-    high(X::ConvexSet)
-
-Return a vector with the highest coordinate of the set for each canonical direction.
-
-### Input
-
-- `X` -- set
-
-### Output
-
-A vector with the highest coordinate of the set for each dimension.
-
-### Notes
-
-See also [`high(X::ConvexSet, i::Int)`](@ref).
-"""
-function high(X::ConvexSet)
-    n = dim(X)
-    return [high(X, i) for i in 1:n]
-end
-
-"""
-    extrema(X::ConvexSet)
-
-Return two vectors with the lowest and highest coordinate of `X` for each
-dimension.
-
-### Input
-
-- `X` -- set
-
-### Output
-
-Two vectors with the lowest and highest coordinates of `X` for each dimension.
-
-### Notes
-
-The result is equivalent to `(low(X), high(X))`, but sometimes it can be
-computed more efficiently.
-"""
-function extrema(X::ConvexSet)
-    l = low(X)
-    h = high(X)
-    return (l, h)
-end
-
-"""
-    extrema(X::ConvexSet, i::Int)
-
-Return the lower and higher coordinate of a set in a given dimension.
-
-### Input
-
-- `X` -- set
-- `i` -- dimension of interest
-
-### Output
-
-The lower and higher coordinate of the set in the given dimension.
-
-### Notes
-
-The result is equivalent to `(low(X, i), high(X, i))`, but sometimes it can be
-computed more efficiently.
-"""
-function extrema(X::ConvexSet, i::Int)
-    l = low(X, i)
-    h = high(X, i)
-    return (l, h)
+    # Note: this method is needed for documentation reasons
+    # (see the method for LazySet)
+    return _high(X, i)
 end
 
 """

--- a/src/Interfaces/LazySet.jl
+++ b/src/Interfaces/LazySet.jl
@@ -1,4 +1,8 @@
-export LazySet
+import Base: extrema
+
+export LazySet,
+       low,
+       high
 
 """
     LazySet{N}
@@ -144,3 +148,138 @@ true
 ```
 """
 isconvextype(X::Type{<:LazySet}) = false
+
+# Note: this method cannot be documented due to a bug in Julia
+function low(X::LazySet, i::Int)
+    return _low(X, i)
+end
+
+function _low(X::LazySet{N}, i::Int) where {N}
+    n = dim(X)
+    d = SingleEntryVector(i, n, -one(N))
+    return -ρ(d, X)
+end
+
+"""
+    low(X::LazySet)
+
+Return a vector with the lowest coordinates of the set in each canonical
+direction.
+
+### Input
+
+- `X` -- set
+
+### Output
+
+A vector with the lower coordinate of the set in each dimension.
+
+### Notes
+
+See also [`low(X::LazySet, i::Int)`](@ref).
+
+The result is the lowermost corner of the box approximation, so it is not
+necessarily contained in `X`.
+"""
+function low(X::LazySet)
+    n = dim(X)
+    return [low(X, i) for i in 1:n]
+end
+
+# Note: this method cannot be documented due to a bug in Julia
+function high(X::LazySet, i::Int)
+    return _high(X, i)
+end
+
+function _high(X::LazySet{N}, i::Int) where {N}
+    n = dim(X)
+    d = SingleEntryVector(i, n, one(N))
+    return ρ(d, X)
+end
+
+"""
+    high(X::LazySet)
+
+Return a vector with the highest coordinate of the set in each canonical
+direction.
+
+### Input
+
+- `X` -- set
+
+### Output
+
+A vector with the highest coordinate of the set in each dimension.
+
+### Notes
+
+See also [`high(X::LazySet, i::Int)`](@ref).
+
+The result is the uppermost corner of the box approximation, so it is not
+necessarily contained in `X`.
+"""
+function high(X::LazySet)
+    n = dim(X)
+    return [high(X, i) for i in 1:n]
+end
+
+"""
+    extrema(X::LazySet, i::Int)
+
+Return the lower and higher coordinate of a set in a given dimension.
+
+### Input
+
+- `X` -- set
+- `i` -- dimension of interest
+
+### Output
+
+The lower and higher coordinate of the set in the given dimension.
+
+### Notes
+
+The result is equivalent to `(low(X, i), high(X, i))`, but sometimes it can be
+computed more efficiently.
+
+### Algorithm
+
+The bounds are computed with `low` and `high`.
+"""
+function extrema(X::LazySet, i::Int)
+    l = low(X, i)
+    h = high(X, i)
+    return (l, h)
+end
+
+"""
+    extrema(X::LazySet)
+
+Return two vectors with the lowest and highest coordinate of `X` in each
+canonical direction.
+
+### Input
+
+- `X` -- set
+
+### Output
+
+Two vectors with the lowest and highest coordinates of `X` in each dimension.
+
+### Notes
+
+The result is equivalent to `(low(X), high(X))`, but sometimes it can be
+computed more efficiently.
+
+The resulting points are the lowermost and uppermost corners of the box
+approximation, so they are not necessarily contained in `X`.
+
+### Algorithm
+
+The bounds are computed with `low` and `high`.
+"""
+function extrema(X::LazySet)
+    l = low(X)
+    h = high(X)
+    return (l, h)
+end


### PR DESCRIPTION
Also extend the docstrings a bit to clarify that the results are not necessarily contained.

There is a really weird (Julia?) bug when removing the method for `ConvexSet`. I tried many different combinations, to no avail. What I ended up with was to keep the methods for `ConvexSet` but also to define undocumented methods for `LazySet`. So the functionality is there, just not directly visible in the documentation (I added a line about this in the online documentation).