### PR TITLE
Revise Line2D code

### DIFF
--- a/docs/src/lib/sets/Line2D.md
+++ b/docs/src/lib/sets/Line2D.md
@@ -9,7 +9,7 @@ Line2D
 dim(::Line2D)
 σ(::AbstractVector, ::Line2D)
 ∈(::AbstractVector, ::Line2D)
-an_element(::Line2D{N}) where {N}
+an_element(::Line2D)
 rand(::Type{Line2D})
 isbounded(::Line2D)
 isuniversal(::Line2D, ::Bool=false)
@@ -19,7 +19,16 @@ constraints_list(::Line2D)
 translate(::Line2D, ::AbstractVector)
 project(::AbstractVector, ::Line2D)
 ```
+Inherited from [`LazySet`](@ref):
+* [`high`](@ref high(::LazySet))
+* [`low`](@ref low(::LazySet))
+
 Inherited from [`ConvexSet`](@ref):
 * [`norm`](@ref norm(::ConvexSet, ::Real))
 * [`radius`](@ref radius(::ConvexSet, ::Real))
 * [`diameter`](@ref diameter(::ConvexSet, ::Real))
+* [`low`](@ref low(::ConvexSet, ::Int))
+* [`high`](@ref high(::ConvexSet, ::Int))
+
+Inherited from [`AbstractPolyhedron`](@ref):
+* [`linear_map`](@ref linear_map(::AbstractMatrix, ::AbstractPolyhedron))


### PR DESCRIPTION
Main changes:
- catch invalid inputs (two identical points) in the constructor
- use `σ` for `Hyperplane`s
- cheaper witness construction for `isuniversal`
- slightly change `an_element` implementation to be consistent with the `Hyperplane` implementation
- fix `project` for block `[2, 1]` (which swaps dimensions)