### PR TITLE
Revise RotatedHyperrectangle code

### DIFF
--- a/docs/src/lib/sets/RotatedHyperrectangle.md
+++ b/docs/src/lib/sets/RotatedHyperrectangle.md
@@ -16,12 +16,17 @@ linear_map(::AbstractMatrix, ::RotatedHyperrectangle)
 vertices_list(::RotatedHyperrectangle)
 constraints_list(::RotatedHyperrectangle)
 ```
+Inherited from [`LazySet`](@ref):
+* [`high`](@ref high(::LazySet))
+* [`low`](@ref low(::LazySet))
 
 Inherited from [`ConvexSet`](@ref):
 * [`norm`](@ref norm(::ConvexSet, ::Real))
 * [`radius`](@ref radius(::ConvexSet, ::Real))
 * [`diameter`](@ref diameter(::ConvexSet, ::Real))
 * [`singleton_list`](@ref singleton_list(::ConvexSet))
+* [`area`](@ref area(::ConvexSet))
+* [`rectify`](@ref rectify(::ConvexSet))
 
 Inherited from [`AbstractPolytope`](@ref):
 * [`isbounded`](@ref isbounded(::AbstractPolytope))

--- a/src/Sets/RotatedHyperrectangle.jl
+++ b/src/Sets/RotatedHyperrectangle.jl
@@ -24,14 +24,13 @@ struct RotatedHyperrectangle{N, MN<:AbstractMatrix{N},
 
     function RotatedHyperrectangle(M::MN, box::HT) where {N,
             MN<:AbstractMatrix{N}, HT<:AbstractHyperrectangle{N}}
-        @assert size(M, 2) == dim(box) "a rotated hyperrectangle of dimension " *
+        @assert size(M, 2) == dim(box) "a hyperrectangle of dimension " *
             "$(dim(box)) is incompatible with a matrix of dimension $(size(M))"
         return new{N, MN, HT}(M, box)
     end
 end
 
 isoperationtype(::Type{RotatedHyperrectangle}) = false
-isconvextype(::Type{RotatedHyperrectangle}) = true
 
 """
     dim(R::RotatedHyperrectangle)
@@ -71,7 +70,7 @@ end
 """
     σ(d::AbstractVector, R::RotatedHyperrectangle)
 
-Return the support vector of a rotated hyperrectangle in a given direction.
+Return a support vector of a rotated hyperrectangle in a given direction.
 
 ### Input
 
@@ -80,7 +79,7 @@ Return the support vector of a rotated hyperrectangle in a given direction.
 
 ### Output
 
-The support vector in the given direction.
+A support vector in the given direction.
 """
 function σ(d::AbstractVector, R::RotatedHyperrectangle)
     return _σ_linear_map(d, R.M, R.box)
@@ -196,5 +195,5 @@ Return the list of constraints of a rotated hyperrectangle.
 A list of the linear constraints.
 """
 function constraints_list(R::RotatedHyperrectangle)
-    return constraints_list(convert(VPolytope, R))
+    return constraints_list(convert(Zonotope, R))
 end


### PR DESCRIPTION
The only code change is in `constraints_list`: converting to a `Zonotope` is much more efficient.