### PR TITLE
Revise ZeroSet code

### DIFF
--- a/docs/src/lib/interfaces.md
+++ b/docs/src/lib/interfaces.md
@@ -465,6 +465,7 @@ This interface defines the following functions:
 ρ(::AbstractVector, ::AbstractSingleton)
 ∈(::AbstractVector, ::AbstractSingleton)
 center(::AbstractSingleton)
+center(::AbstractSingleton, ::Int)
 vertices(::AbstractSingleton{N}) where {N}
 vertices_list(::AbstractSingleton)
 radius_hyperrectangle(::AbstractSingleton{N}) where {N}

--- a/docs/src/lib/sets/ZeroSet.md
+++ b/docs/src/lib/sets/ZeroSet.md
@@ -7,7 +7,6 @@ CurrentModule = LazySets
 ```@docs
 ZeroSet
 dim(::ZeroSet)
-σ(::AbstractVector, ::ZeroSet)
 ρ(::AbstractVector, ::ZeroSet)
 ∈(::AbstractVector, ::ZeroSet)
 rand(::Type{ZeroSet})
@@ -15,7 +14,6 @@ element(::ZeroSet{N}) where {N}
 element(::ZeroSet{N}, ::Int) where {N}
 linear_map(::AbstractMatrix, ::ZeroSet)
 translate(::ZeroSet, ::AbstractVector)
-center(::ZeroSet{N}, ::Int) where {N}
 rectify(Z::ZeroSet)
 ```
 Inherited from [`ConvexSet`](@ref):
@@ -31,18 +29,16 @@ Inherited from [`AbstractCentrallySymmetricPolytope`](@ref):
 * [`an_element`](@ref an_element(::AbstractCentrallySymmetricPolytope))
 
 Inherited from [`AbstractZonotope`](@ref):
-* [`ngens`](@ref ngens(::AbstractZonotope))
 * [`order`](@ref order(::AbstractZonotope))
 * [`togrep`](@ref togrep(::AbstractZonotope))
 
 Inherited from [`AbstractHyperrectangle`](@ref):
 * [`norm`](@ref norm(::AbstractHyperrectangle, ::Real))
 * [`radius`](@ref radius(::AbstractHyperrectangle, ::Real))
-* [`high`](@ref high(::AbstractHyperrectangle))
-* [`low`](@ref low(::AbstractHyperrectangle))
 * [`constraints_list`](@ref constraints_list(::AbstractHyperrectangle{N}) where {N})
 
 Inherited from [`AbstractSingleton`](@ref):
+* [`σ`](@ref σ(::AbstractVector, ::AbstractSingleton))
 * [`radius_hyperrectangle`](@ref radius_hyperrectangle(::AbstractSingleton{N}) where {N})
 * [`radius_hyperrectangle`](@ref radius_hyperrectangle(::AbstractSingleton{N}, ::Int) where {N})
 * [`vertices`](@ref vertices(::AbstractSingleton{N}) where {N})
@@ -50,3 +46,6 @@ Inherited from [`AbstractSingleton`](@ref):
 * [`center`](@ref center(::AbstractSingleton))
 * [`generators`](@ref generators(::AbstractSingleton{N}) where {N})
 * [`genmat`](@ref genmat(::AbstractSingleton{N}) where {N})
+* [`ngens`](@ref ngens(::AbstractSingleton))
+* [`high`](@ref high(::AbstractSingleton))
+* [`low`](@ref low(::AbstractSingleton))

--- a/src/Interfaces/AbstractSingleton.jl
+++ b/src/Interfaces/AbstractSingleton.jl
@@ -220,6 +220,25 @@ function center(S::AbstractSingleton)
     return element(S)
 end
 
+"""
+    center(S::AbstractSingleton, i::Int)
+
+Return the center of a set with a single value in a given dimension.
+
+### Input
+
+- `S` -- set with a single value
+- `i` -- dimension of interest
+
+### Output
+
+The `i`-th entry of the only element of the set.
+"""
+function center(S::AbstractSingleton, i::Int)
+    @boundscheck _check_bounds(S, i)
+    return element(S, i)
+end
+
 
 # --- AbstractPolytope interface functions ---
 

--- a/src/Sets/ZeroSet.jl
+++ b/src/Sets/ZeroSet.jl
@@ -11,69 +11,60 @@ Type that represents the zero set, i.e., the set that only contains the origin.
 
 ### Fields
 
-- `dim` -- the ambient dimension of this zero set
+- `dim` -- the ambient dimension of the set
 """
 struct ZeroSet{N} <: AbstractSingleton{N}
     dim::Int
 end
 
 isoperationtype(::Type{<:ZeroSet}) = false
-isconvextype(::Type{<:ZeroSet}) = true
 
 # default constructor of type Float64
 ZeroSet(dim::Int) = ZeroSet{Float64}(dim)
 
-
-# --- AbstractSingleton interface functions ---
-
-
 """
-    element(S::ZeroSet{N}) where {N}
+    element(Z::ZeroSet{N}) where {N}
 
 Return the element of a zero set.
 
 ### Input
 
-- `S` -- zero set
+- `Z` -- zero set
 
 ### Output
 
 The element of the zero set, i.e., a zero vector.
 """
-function element(S::ZeroSet{N}) where {N}
-    return zeros(N, S.dim)
+function element(Z::ZeroSet{N}) where {N}
+    return zeros(N, Z.dim)
 end
 
 """
-    element(S::ZeroSet{N}, ::Int) where {N}
+    element(Z::ZeroSet{N}, ::Int) where {N}
 
 Return the i-th entry of the element of a zero set.
 
 ### Input
 
-- `S` -- zero set
+- `Z` -- zero set
 - `i` -- dimension
 
 ### Output
 
 The i-th entry of the element of the zero set, i.e., 0.
 """
-function element(S::ZeroSet{N}, ::Int) where {N}
+function element(Z::ZeroSet{N}, ::Int) where {N}
     return zero(N)
 end
-
-
-# --- ConvexSet interface functions ---
-
 
 """
     dim(Z::ZeroSet)
 
-Return the ambient dimension of this zero set.
+Return the ambient dimension of a zero set.
 
 ### Input
 
-- `Z` -- a zero set, i.e., a set that only contains the origin
+- `Z` -- zero set
 
 ### Output
 
@@ -84,26 +75,6 @@ function dim(Z::ZeroSet)
 end
 
 """
-    σ(d::AbstractVector, Z::ZeroSet)
-
-Return the support vector of a zero set.
-
-### Input
-
-- `d` -- direction
-- `Z` -- a zero set, i.e., a set that only contains the origin
-
-### Output
-
-The returned value is the origin since it is the only point that belongs to this
-set.
-"""
-function σ(d::AbstractVector, Z::ZeroSet)
-    @assert length(d) == dim(Z) "the direction has the wrong dimension"
-    return element(Z)
-end
-
-"""
     ρ(d::AbstractVector, Z::ZeroSet)
 
 Evaluate the support function of a zero set in a given direction.
@@ -111,14 +82,15 @@ Evaluate the support function of a zero set in a given direction.
 ### Input
 
 - `d` -- direction
-- `Z` -- a zero set, i.e., a set that only contains the origin
+- `Z` -- zero set
 
 ### Output
 
 `0`.
 """
 function ρ(d::AbstractVector, Z::ZeroSet)
-    @assert length(d) == dim(Z) "the direction has the wrong dimension"
+    @assert length(d) == dim(Z) "a $(length(d))-dimensional vector is " *
+                                "incompatible with a $(dim(Z))-dimensional set"
     N = promote_type(eltype(d), eltype(Z))
     return zero(N)
 end
@@ -149,10 +121,9 @@ true
 ```
 """
 function ∈(x::AbstractVector, Z::ZeroSet)
-    @assert length(x) == dim(Z)
-
-    N = promote_type(eltype(x), eltype(Z))
-    return all(==(zero(N)), x)
+    @assert length(x) == dim(Z) "a $(length(x))-dimensional vector is " *
+                                "incompatible with a $(dim(Z))-dimensional set"
+    return iszero(x)
 end
 
 """
@@ -200,7 +171,8 @@ function linear_map(M::AbstractMatrix, Z::ZeroSet)
     @assert dim(Z) == size(M, 2) "a linear map of size $(size(M)) cannot be " *
                                  "applied to a set of dimension $(dim(Z))"
 
-    return ZeroSet(size(M, 1))
+    N = promote_type(eltype(M), eltype(Z))
+    return ZeroSet{N}(size(M, 1))
 end
 
 """
@@ -221,29 +193,6 @@ function translate(Z::ZeroSet, v::AbstractVector)
     @assert length(v) == dim(Z) "cannot translate a $(dim(Z))-dimensional " *
                                 "set by a $(length(v))-dimensional vector"
     return Singleton(v)
-end
-
-
-# --- AbstractCentrallySymmetric interface functions ---
-
-
-"""
-    center(Z::ZeroSet{N}, i::Int) where {N}
-
-Return the center along a given dimension of a zero set.
-
-### Input
-
-- `Z` -- zero set
-- `i` -- dimension of interest
-
-### Output
-
-The center along a given dimension of the zero set.
-"""
-@inline function center(Z::ZeroSet{N}, i::Int) where {N}
-    @boundscheck _check_bounds(Z, i)
-    return zero(N)
 end
 
 """

--- a/test/Sets/ZeroSet.jl
+++ b/test/Sets/ZeroSet.jl
@@ -52,11 +52,11 @@ for N in [Float64, Rational{Int}, Float32]
     # linear map (concrete)
     M = hcat(N[1])
     Mz = linear_map(M, z)
-    @test Mz isa ZeroSet && dim(Mz) == 1
+    @test Mz isa ZeroSet{N} && dim(Mz) == 1
 
     M = N[-1 -2;]
     MZ = linear_map(M, Z)
-    @test MZ isa ZeroSet && dim(MZ) == 1
+    @test MZ isa ZeroSet{N} && dim(MZ) == 1
 
     # translation
     @test translate(Z, N[1, 2]) == Singleton(N[1, 2])


### PR DESCRIPTION
Code changes:
- Fix: `linear_map` did not preserve the numeric type.
- The `center(X, i)` method was generalized to `AbstractSingleton`.
- `σ` was redundant (identical to the implementation for `AbstractSingleton`).