### PR TITLE
Revise HPolytope code and generalize isbounded to list of constraints

### DIFF
--- a/docs/src/lib/interfaces.md
+++ b/docs/src/lib/interfaces.md
@@ -225,6 +225,7 @@ an_element(::AbstractPolyhedron{N}) where {N}
 isbounded(::AbstractPolyhedron{N}) where {N}
 vertices_list(::AbstractPolyhedron)
 project(::AbstractPolyhedron{N}, ::AbstractVector{Int}) where {N}
+LazySets._isbounded_stiemke
 ```
 
 Some common functions to work with linear constraints:

--- a/docs/src/lib/sets/HPolyhedron.md
+++ b/docs/src/lib/sets/HPolyhedron.md
@@ -24,8 +24,10 @@ translate(::HPoly, ::AbstractVector)
 polyhedron(::HPoly)
 remove_redundant_constraints(::HPoly)
 remove_redundant_constraints!(::HPoly)
-LazySets._isbounded_stiemke(::HPolyhedron{N}) where {N}
 ```
+Inherited from [`LazySet`](@ref):
+* [`high`](@ref high(::LazySet))
+* [`low`](@ref low(::LazySet))
 
 Inherited from [`ConvexSet`](@ref):
 * [`norm`](@ref norm(::ConvexSet, ::Real))
@@ -35,6 +37,7 @@ Inherited from [`ConvexSet`](@ref):
 
 Inherited from [`AbstractPolyhedron`](@ref):
 * [`∈`](@ref ∈(::AbstractVector, ::AbstractPolyhedron))
+* [`an_element`](@ref an_element(::AbstractPolyhedron))
 * [`constrained_dimensions`](@ref constrained_dimensions(::AbstractPolyhedron)
 * [`linear_map`](@ref linear_map(::AbstractMatrix{NM}, ::AbstractPolyhedron{NP}) where {NM, NP})
 

--- a/docs/src/lib/sets/HPolytope.md
+++ b/docs/src/lib/sets/HPolytope.md
@@ -6,19 +6,19 @@ CurrentModule = LazySets
 
 [Convex polytopes](https://en.wikipedia.org/wiki/Polytope) are bounded polyhedra.
 The type `HPolytope` represents polytopes.
-While identical to [`HPolyhedron`](@ref) in implementation, `HPolytope`
+While identical to [`HPolyhedron`](@ref) in its representation, `HPolytope`
 instances are assumed to be bounded.
 
 ```@docs
 HPolytope
 ```
 
-Some functionality is shared with [`HPolyhedron`](@ref).
-Below follows the additional functionality specific to `HPolytope`.
+Most functionality is shared with [`HPolyhedron`](@ref).
+Additional functionality specific to `HPolytope` is listed below.
 
 ```@docs
 rand(::Type{HPolytope})
-vertices_list(::HPolytope{N}) where {N}
+vertices_list(::HPolytope)
 isbounded(::HPolytope, ::Bool=true)
 ```
 

--- a/src/Approximations/overapproximate.jl
+++ b/src/Approximations/overapproximate.jl
@@ -375,7 +375,7 @@ function overapproximate(X::LazySet{N}, dir::AbstractDirections{N, VN}; prune::B
 
     # if the input is bounded and the directions are bounding => output is bounded
     # otherwise, check boundedness of the output
-    if (isbounded(X) && isbounding(dir)) || _isbounded_stiemke(HPolyhedron(H))
+    if (isbounded(X) && isbounding(dir)) || _isbounded_stiemke(H)
         return HPolytope(H, check_boundedness=false)
     else
         return HPolyhedron(H)

--- a/src/Interfaces/ConvexSet.jl
+++ b/src/Interfaces/ConvexSet.jl
@@ -229,7 +229,7 @@ function isbounded(S::ConvexSet; algorithm="support_function")
     if algorithm == "support_function"
         return _isbounded_unit_dimensions(S)
     elseif algorithm == "stiemke"
-        return _isbounded_stiemke(S)
+        return _isbounded_stiemke(constraints_list(S))
     else
         throw(ArgumentError("unknown algorithm $algorithm"))
     end

--- a/src/Sets/HPolyhedron.jl
+++ b/src/Sets/HPolyhedron.jl
@@ -639,64 +639,6 @@ end
 end # quote
 end # function load_polyhedra_hpolyhedron()
 
-"""
-    _isbounded_stiemke(P::HPolyhedron{N}; solver=LazySets.default_lp_solver(N),
-                       check_nonempty::Bool=true) where {N}
-
-Determine whether a polyhedron is bounded using Stiemke's theorem of alternatives.
-
-### Input
-
-- `P`       -- polyhedron
-- `backend` -- (optional, default: `default_lp_solver(N)`) the backend used
-               to solve the linear program
-- `check_nonempty` -- (optional, default: `true`) if `true`, check the
-                      precondition to this algorithm that `P` is non-empty
-
-### Output
-
-`true` iff the polyhedron is bounded
-
-### Notes
-
-The algorithm internally calls `isempty` to check whether the polyhedron is empty.
-This computation can be avoided using the `check_nonempty` flag.
-
-### Algorithm
-
-The algorithm is based on Stiemke's theorem of alternatives, see e.g. [1].
-
-Let the polyhedron ``P`` be given in constraint form ``Ax ≤ b``. We assume that
-the polyhedron is not empty.
-
-Proposition 1. If ``\\ker(A)≠\\{0\\}``, then ``P`` is unbounded.
-
-Proposition 2. Assume that ``ker(A)={0}`` and ``P`` is non-empty.
-Then ``P`` is bounded if and only if the following linear
-program admits a feasible solution: ``\\min∥y∥_1`` subject to ``A^Ty=0`` and ``y≥1``.
-
-[1] Mangasarian, Olvi L. *Nonlinear programming.*
-    Society for Industrial and Applied Mathematics, 1994.
-"""
-function _isbounded_stiemke(P::HPolyhedron{N}; solver=LazySets.default_lp_solver(N),
-                            check_nonempty::Bool=true) where {N}
-    if check_nonempty && isempty(P)
-        return true
-    end
-
-    A, b = tosimplehrep(P)
-    m, n = size(A)
-
-    if !isempty(nullspace(A))
-        return false
-    end
-
-    At = copy(transpose(A))
-    c = ones(N, m)
-    lp = linprog(c, At, '=', zeros(n), one(N), Inf, solver)
-    return is_lp_optimal(lp.status)
-end
-
 function is_hyperplanar(P::HPolyhedron)
     clist = P.constraints
     m = length(clist)

--- a/src/Sets/HPolytope.jl
+++ b/src/Sets/HPolytope.jl
@@ -8,31 +8,48 @@ export HPolytope,
 """
     HPolytope{N, VN<:AbstractVector{N}} <: AbstractPolytope{N}
 
-Type that represents a convex polytope in H-representation, that is a finite intersection of half-spaces,
+Type that represents a convex polytope in constraint representation, i.e., a
+bounded set characterized by a finite intersection of half-spaces,
 
 ```math
 P = \\bigcap_{i = 1}^m H_i,
 ```
-where each ``H_i = \\{x \\in \\mathbb{R}^n : a_i^T x \\leq b_i \\}`` is a half-space,
-``a_i \\in \\mathbb{R}^n`` is the normal vector of the ``i``-th half-space and ``b_i`` is the displacement.
-It is assumed that ``P`` is bounded (see also [`HPolyhedron`](@ref) which does not make such assumption).
+
+where each ``H_i = \\{x \\in \\mathbb{R}^n : a_i^T x \\leq b_i \\}`` is a
+half-space, ``a_i \\in \\mathbb{R}^n`` is the normal vector of the ``i``-th
+half-space and ``b_i`` is the displacement.
+It is assumed that ``P`` is bounded (see also [`HPolyhedron`](@ref), which does
+not make such an assumption).
 
 ### Fields
 
 - `constraints`       -- vector of linear constraints
 - `check_boundedness` -- (optional, default: `false`) flag for checking if the
                          constraints make the polytope bounded; (boundedness is
-                         a running assumption of this type)
+                         a running assumption for this type)
 
-### Note
+### Notes
 
-Recall that a polytope is a bounded polyhedron. Boundedness is a running
-assumption in this type.
+A polytope is a bounded polyhedron.
+
+Boundedness is a running assumption for this type. For performance reasons,
+boundedness is not checked in the constructor by default. We also exploit this
+assumption, so a boundedness check may not return the answer you would expect.
+
+```jldoctest isbounded
+julia> P = HPolytope([HalfSpace([1.0], 1.0)]);  # x <= 1
+
+julia> isbounded(P)  # uses the type assumption and does not actually check
+true
+
+julia> isbounded(P, false)  # performs a real boundedness check
+false
+```
 """
 struct HPolytope{N, VN<:AbstractVector{N}} <: AbstractPolytope{N}
-    constraints::Vector{LinearConstraint{N, VN}}
+    constraints::Vector{HalfSpace{N, VN}}
 
-    function HPolytope(constraints::Vector{LinearConstraint{N, VN}};
+    function HPolytope(constraints::Vector{HalfSpace{N, VN}};
                        check_boundedness::Bool=false) where {N, VN<:AbstractVector{N}}
         P = new{N, VN}(constraints)
         @assert (!check_boundedness ||
@@ -42,36 +59,32 @@ struct HPolytope{N, VN<:AbstractVector{N}} <: AbstractPolytope{N}
 end
 
 isoperationtype(::Type{<:HPolytope}) = false
-isconvextype(::Type{<:HPolytope}) = true
 
-# constructor for an HPolyhedron with no constraints
+# constructor with no constraints
 function HPolytope{N, VN}() where {N, VN<:AbstractVector{N}}
-    HPolytope(Vector{LinearConstraint{N, VN}}())
+    return HPolytope(Vector{HalfSpace{N, VN}}())
 end
 
-# constructor for an HPolygon with no constraints and given numeric type
+# constructor with no constraints, given only the numeric type
 function HPolytope{N}() where {N}
-    HPolytope(Vector{LinearConstraint{N, Vector{N}}}())
+    return HPolytope{N, Vector{N}}()
 end
 
-# constructor for an HPolytope without explicit numeric type, defaults to Float64
+# constructor without explicit numeric type, defaults to Float64
 function HPolytope()
-    HPolytope{Float64}()
+    return HPolytope{Float64}()
 end
 
-# constructor for an HPolytope with constraints of mixed type
-function HPolytope(constraints::Vector{<:LinearConstraint})
-    HPolytope(_normal_Vector(constraints))
+# constructor with constraints of mixed type
+function HPolytope(constraints::Vector{<:HalfSpace})
+    return HPolytope(_normal_Vector(constraints))
 end
 
-# constructor from a simple H-representation
-HPolytope(A::AbstractMatrix, b::AbstractVector;
-          check_boundedness::Bool=false) =
-    HPolytope(constraints_list(A, b); check_boundedness=check_boundedness)
-
-
-# --- ConvexSet interface functions ---
-
+# constructor from a simple constraint representation
+function HPolytope(A::AbstractMatrix, b::AbstractVector;
+                   check_boundedness::Bool=false)
+    return HPolytope(constraints_list(A, b); check_boundedness=check_boundedness)
+end
 
 """
     rand(::Type{HPolytope}; [N]::Type{<:Real}=Float64, [dim]::Int=2,
@@ -127,17 +140,12 @@ Determine whether a polytope in constraint representation is bounded.
 
 `true` if `use_type_assumption` is activated.
 Otherwise, `true` iff `P` is bounded.
-
-### Algorithm
-
-If `!use_type_assumption`, we convert `P` to an `HPolyhedron` `P2` and then use
-`isbounded(P2)`.
 """
 function isbounded(P::HPolytope, use_type_assumption::Bool=true)
     if use_type_assumption
         return true
     end
-    return isbounded(HPolyhedron(P.constraints))
+    return isbounded(P.constraints)
 end
 
 function _linear_map_hrep_helper(M::AbstractMatrix, P::HPolytope,
@@ -146,22 +154,18 @@ function _linear_map_hrep_helper(M::AbstractMatrix, P::HPolytope,
     return HPolytope(constraints)
 end
 
-
-# --- functions that use Polyhedra.jl ---
-
-
 function load_polyhedra_hpolytope() # function to be loaded by Requires
 return quote
-# see the interface file AbstractPolytope.jl for the imports
+# see the file init_Polyhedra.jl for the imports
 
 function convert(::Type{HPolytope}, P::HRep{N}) where {N}
     VT = Polyhedra.hvectortype(P)
-    constraints = Vector{LinearConstraint{N, VT}}()
+    constraints = Vector{HalfSpace{N, VT}}()
     for hi in Polyhedra.allhalfspaces(P)
         a, b = hi.a, hi.β
         if isapproxzero(norm(a))
-            @assert b >= zero(N) "the half-space is inconsistent since it has a " *
-                "zero normal direction but the constraint is negative"
+            @assert b >= zero(N) "the half-space is inconsistent since it " *
+                "has a zero normal direction but the constraint is negative"
             continue
         end
         push!(constraints, HalfSpace(hi.a, hi.β))
@@ -172,8 +176,8 @@ end
 """
     HPolytope(P::HRep)
 
-Return a polytope in H-representation given a `HRep` polyhedron
-from `Polyhedra.jl`.
+Return a polytope in constraint representation given an `HRep` polyhedron from
+`Polyhedra.jl`.
 
 ### Input
 
@@ -191,43 +195,44 @@ end # quote
 end # function load_polyhedra_hpolytope()
 
 """
-    vertices_list(P::HPolytope{N};
-                  [backend]=nothing, [prune]::Bool=true) where {N}
+    vertices_list(P::HPolytope; [backend]=nothing, [prune]::Bool=true)
 
-Return the list of vertices of a polytope in constraint representation.
+Return a list of the vertices of a polytope in constraint representation.
 
 ### Input
 
 - `P`       -- polytope in constraint representation
-- `backend` -- (optional, default: `nothing`) the polyhedral computations backend
+- `backend` -- (optional, default: `nothing`) the backend for polyhedral
+               computations
 - `prune`   -- (optional, default: `true`) flag to remove redundant vertices
 
 ### Output
 
-List of vertices.
+A list of the vertices.
 
 ### Algorithm
 
 If the polytope is two-dimensional, the polytope is converted to a polygon in
-H-representation and then its `vertices_list` function is used. This ensures
-that, by default, the optimized two-dimensional methods are used.
+constraint representation and then its `vertices_list` implementation is used.
+This ensures that, by default, the optimized two-dimensional methods are used.
 
 It is possible to use the `Polyhedra` backend in two-dimensions as well
-by passing, e.g. `backend=CDDLib.Library()`.
+by passing a `backend`.
 
-If the polytope is not two-dimensional, the concrete polyhedra manipulation
+If the polytope is not two-dimensional, the concrete polyhedra-manipulation
 library `Polyhedra` is used. The actual computation is performed by a given
-backend; for the default backend used in `LazySets` see `default_polyhedra_backend(P)`.
-For further information on the supported backends see
+backend; for the default backend used in `LazySets` see
+`default_polyhedra_backend(P)`. For further information on the supported
+backends see
 [Polyhedra's documentation](https://juliapolyhedra.github.io/Polyhedra.jl/).
 """
-function vertices_list(P::HPolytope{N};
-                       backend=nothing, prune::Bool=true) where {N}
-    if length(P.constraints) == 0
-        return Vector{N}(Vector{N}(undef, 0))
-    end
-
-    if dim(P) == 2 && backend == nothing
+function vertices_list(P::HPolytope;
+                       backend=nothing, prune::Bool=true)
+    N = eltype(P)
+    if isempty(P.constraints)
+        return Vector{N}(Vector{N}(undef, 0))  # illegal polytope
+    elseif dim(P) == 2 && backend == nothing
+        # use efficient 2D implementation
         return vertices_list(convert(HPolygon, P, prune=prune))
     else
         require(@__MODULE__, :Polyhedra; fun_name="vertices_list")
@@ -242,32 +247,31 @@ function vertices_list(P::HPolytope{N};
     end
 end
 
-# used for dispatch, see minkowski_sum(::AbstractPolytope{N}, ::AbstractPolytope{N}; ...)
 function _vertices_list(P::HPolytope, backend)
-    return vertices_list(P, backend=backend)
+    return vertices_list(P; backend=backend)
 end
 
-# ============================================
-# Functionality that requires Symbolics
-# ============================================
 function load_symbolics_hpolytope()
-
 return quote
 
 """
-    HPolytope(expr::Vector{<:Num}, vars=_get_variables(expr); [N]::Type{<:Real}=Float64, [check_boundedness]::Bool=false)
+    HPolytope(expr::Vector{<:Num}, vars=_get_variables(expr);
+              [N]::Type{<:Real}=Float64, [check_boundedness]::Bool=false)
 
-Return the polytope in half-space representation given by a list of symbolic expressions.
+Return the polytope in constraint representation given by a list of symbolic
+expressions.
 
 ### Input
 
-- `expr` -- vector of symbolic expressions that describes each half-space
-- `vars` -- (optional, default: `_get_variables(expr)`), if an array of variables is given,
-            use those as the ambient variables in the set with respect to which derivations
-            take place; otherwise, use only the variables which appear in the given
-            expression (but be careful because the order may be incorrect; it is advised
-            to always pass `vars` explicitly)
-- `N`    -- (optional, default: `Float64`) the numeric type of the returned half-space
+- `expr` -- vector of symbolic expressions that describes each constraint
+- `vars` -- (optional, default: `_get_variables(expr)`) if an array of variables
+            is given, use those as the ambient variables in the set with respect
+            to which derivations take place; otherwise, use only the variables
+            that appear in the given expression (but be careful because the
+            order may be incorrect; it is advised to always pass `vars`
+            explicitly)
+- `N`    -- (optional, default: `Float64`) the numeric type of the returned
+            polytope
 - `check_boundedness` -- (optional, default: `false`) flag to check boundedness
 
 ### Output
@@ -294,7 +298,15 @@ function HPolytope(expr::Vector{<:Num}, vars::AbstractVector{Num};
                      check_boundedness=check_boundedness)
 end
 
-HPolytope(expr::Vector{<:Num}; N::Type{<:Real}=Float64, check_boundedness::Bool=false) = HPolytope(expr, _get_variables(expr); N=N, check_boundedness=check_boundedness)
-HPolytope(expr::Vector{<:Num}, vars; N::Type{<:Real}=Float64, check_boundedness::Bool=false) = HPolytope(expr, _vec(vars); N=N, check_boundedness=check_boundedness)
+function HPolytope(expr::Vector{<:Num}; N::Type{<:Real}=Float64,
+                   check_boundedness::Bool=false)
+    return HPolytope(expr, _get_variables(expr); N=N,
+                     check_boundedness=check_boundedness)
+end
+
+function HPolytope(expr::Vector{<:Num}, vars; N::Type{<:Real}=Float64,
+                   check_boundedness::Bool=false)
+    return HPolytope(expr, _vec(vars); N=N, check_boundedness=check_boundedness)
+end
 
 end end  # quote / load_modeling_toolkit_hpolytope()

--- a/test/Sets/Polyhedron.jl
+++ b/test/Sets/Polyhedron.jl
@@ -168,9 +168,9 @@ for N in [Float64, Float32]
     @test isbounded(p)
     @test !isbounded(HPolyhedron([HalfSpace(N[1, 0], N(1))]))
 
-    @test _isbounded_stiemke(p_univ)
-    @test _isbounded_stiemke(p)
-    @test !_isbounded_stiemke(HPolyhedron([HalfSpace(N[1, 0], N(1))]))
+    @test _isbounded_stiemke(constraints_list(p_univ))
+    @test _isbounded_stiemke(constraints_list(p))
+    @test !_isbounded_stiemke([HalfSpace(N[1, 0], N(1))])
 
     @test _isbounded_unit_dimensions(p_univ)
     @test _isbounded_unit_dimensions(p)


### PR DESCRIPTION
The first commit adds an `isbounded` method for a list of constraints and generalizes `_isbounded_stiemke` to a list of constraints (hence moved to a different file).

The second commit revises `HPolytope` with  no essential code changes. I added a new note on how `isbounded` behaves in the type documentation because this may be confusing.