### PR TITLE
Revise VPolytope code

### DIFF
--- a/docs/src/lib/sets/VPolytope.md
+++ b/docs/src/lib/sets/VPolytope.md
@@ -20,14 +20,19 @@ tovrep(::VPolytope)
 polyhedron(::VPolytope)
 linear_map(::AbstractMatrix, ::VPolytope)
 ```
+Inherited from [`LazySet`](@ref):
+* [`high`](@ref high(::LazySet))
+* [`low`](@ref low(::LazySet))
+
 Inherited from [`ConvexSet`](@ref):
+* [`ρ`](@ref ρ(::AbstractVector, ::ConvexSet))
 * [`norm`](@ref norm(::ConvexSet, ::Real))
 * [`radius`](@ref radius(::ConvexSet, ::Real))
 * [`diameter`](@ref diameter(::ConvexSet, ::Real))
 * [`singleton_list`](@ref singleton_list(::ConvexSet))
 
 Inherited from [`AbstractPolyhedron`](@ref):
-* [`linear_map`](@ref linear_map(::AbstractMatrix{NM}, ::AbstractPolyhedron{NP}) where {NM, NP})
+* [`an_element`](@ref an_element(::AbstractPolyhedron))
 
 Inherited from [`AbstractPolytope`](@ref):
 * [`isbounded`](@ref isbounded(::AbstractPolytope))


### PR DESCRIPTION
Changes:
- Fix `translate!` and `project` for empty polytope
- Fix `tohrep` for empty polytope (created an `EmptySet` of dimension -1)
- Better conversion from `VRep`
- Better `project` in 1D

```julia
julia> P = VPolytope([[-0.15330599660046973, -0.5838096094570292], [-0.7591127909105239, -1.192999658387627], [0.7380486638517654, -1.3390682799566664], [-1.0158204730815894, -0.008656516404044098], [0.6470895258893331, -0.11120778290971557], [-1.27356201159646, 0.2040335091701241], [0.026857226377266084, -1.2352895693477395]]);

julia> Q = polyhedron(P);
julia> @time VPolytope(Q);  # master
  0.000008 seconds (3 allocations: 144 bytes)
julia> @time VPolytope(Q);  # this branch
  0.000009 seconds (2 allocations: 128 bytes)

julia> @time project(P, [1])  # master
  0.000019 seconds (24 allocations: 1.594 KiB)
julia> @time project(P, [1])  # this branch
  0.000011 seconds (2 allocations: 96 bytes)
```

This PR requires #3106.