### PR TITLE
Revise box-/ballinf-approximation and sih code

### DIFF
--- a/docs/src/lib/approximations.md
+++ b/docs/src/lib/approximations.md
@@ -51,12 +51,11 @@ approximate
 ## Box Approximations
 
 ```@docs
-ballinf_approximation
 box_approximation
 interval_hull
 symmetric_interval_hull
 box_approximation_symmetric
-box_approximation_helper
+ballinf_approximation
 ```
 
 ## Iterative refinement

--- a/src/Approximations/box_approximation.jl
+++ b/src/Approximations/box_approximation.jl
@@ -27,10 +27,6 @@ dir_south(N, ::SVector) = DIR_SOUTH_STATIC(N)
 
 end end  # quote / load_staticarrays_directions
 
-# ================================================
-# Concrete overapproximation with a hyperrectangle
-# ================================================
-
 """
     box_approximation(S::LazySet{N}) where {N}
 
@@ -44,16 +40,33 @@ Overapproximate a set by a tight hyperrectangle.
 
 A tight hyperrectangle.
 
+### Notes
+
+An alias for this function is `interval_hull`.
+
 ### Algorithm
 
-The center of the hyperrectangle is obtained by averaging the support function
-of the given set in the canonical directions, and the lengths of the sides can
-be recovered from the distance among support functions in the same directions.
+The center and radius of the hyperrectangle are obtained by averaging the low
+and high coordinates of `S` computed with the `extrema` function.
 """
 function box_approximation(S::LazySet{N}) where {N}
-    c, r = box_approximation_helper(S)
-    if r[1] < zero(N)
-        return EmptySet{N}(dim(S))
+    n = dim(S)
+    c = Vector{N}(undef, n)
+    r = Vector{N}(undef, n)
+    @inbounds for i in 1:n
+        lo, hi = extrema(S, i)
+        ri = (hi - lo) / 2
+        if ri < zero(N)
+            if !_geq(ri, zero(N))
+                # contradicting bounds => set is empty
+                return EmptySet{N}(n)
+            else
+                # assume this is a precision error with flat sets
+                ri = zero(N)
+            end
+        end
+        c[i] = (hi + lo) / 2
+        r[i] = ri
     end
     return Hyperrectangle(c, r)
 end
@@ -65,52 +78,7 @@ Alias for `box_approximation`.
 """
 interval_hull = box_approximation
 
-"""
-    box_approximation_helper(S::LazySet{N}) where {N}
-
-Common code of `box_approximation` and `box_approximation_symmetric`.
-
-### Input
-
-- `S` -- set
-
-### Output
-
-A tuple containing the data that is needed to construct a tightly
-overapproximating hyperrectangle.
-
-- `c` -- center
-- `r` -- radius
-
-### Algorithm
-
-The center of the hyperrectangle is obtained by averaging the low and high coordinates of `S` obtained via `extrema`.
-The lengths of the sides can be recovered from the distance among support
-functions in the same directions.
-"""
-@inline function box_approximation_helper(S::LazySet{N}) where {N}
-    n = dim(S)
-    c = Vector{N}(undef, n)
-    r = Vector{N}(undef, n)
-    @inbounds for i in 1:n
-        hbottom, htop = extrema(S, i)
-        r[i] = (htop - hbottom) / 2
-        if r[i] < 0
-            # contradicting bounds => set is empty
-            # terminate with first radius entry being negative
-            r[1] = r[i]
-            break
-        end
-        c[i] = (htop + hbottom) / 2
-    end
-    return c, r
-end
-
-# ===============
-# Specializations
-# ===============
-
-# hyperrectangle specialization
+# AbstractHyperrectangle specialization
 function box_approximation(S::AbstractHyperrectangle)
     return Hyperrectangle(center(S), radius_hyperrectangle(S))
 end
@@ -121,12 +89,12 @@ box_approximation(∅::EmptySet) = ∅
 """
     box_approximation(S::CartesianProductArray{N, <:AbstractHyperrectangle}) where {N}
 
-Return a tight overapproximation of the Cartesian product array of a finite
-number of convex sets with and hyperrectangle.
+Overapproximate the Cartesian product of a finite number of hyperrectangular
+sets by a tight hyperrectangle.
 
 ### Input
 
-- `S`              -- Cartesian product array of a finite number of convex set
+- `S`-- Cartesian product of a finite number of hyperrectangular sets
 
 ### Output
 
@@ -134,9 +102,9 @@ A hyperrectangle.
 
 ### Algorithm
 
-This method falls back to the corresponding `convert` method. Since the sets wrapped
-by the Cartesian product array are hyperrectangles, it can be done efficiently
-without overapproximation.
+This method falls back to the `convert` method. Since the sets wrapped by the
+Cartesian product array are hyperrectangles, this can be done without
+overapproximation.
 """
 function box_approximation(S::CartesianProductArray{N, <:AbstractHyperrectangle}) where {N}
     return convert(Hyperrectangle, S)
@@ -145,12 +113,12 @@ end
 """
     box_approximation(S::CartesianProduct{N, <:AbstractHyperrectangle, <:AbstractHyperrectangle}) where {N}
 
-Return a tight overapproximation of the Cartesian product of two
-hyperrectangles by a new hyperrectangle.
+Overapproximate the Cartesian product of two hyperrectangular sets by a tight
+hyperrectangle.
 
 ### Input
 
-- `S`              -- Cartesian product of two hyperrectangular sets
+- `S`-- Cartesian product of two hyperrectangular sets
 
 ### Output
 
@@ -158,9 +126,9 @@ A hyperrectangle.
 
 ### Algorithm
 
-This method falls back to the corresponding `convert` method. Since the sets wrapped
-by the Cartesian product are hyperrectangles, it can be done efficiently
-without overapproximation.
+This method falls back to the `convert` method. Since the sets wrapped by the
+Cartesian product array are hyperrectangles, this can be done without
+overapproximation.
 """
 function box_approximation(S::CartesianProduct{N, <:AbstractHyperrectangle, <:AbstractHyperrectangle}) where {N}
     return convert(Hyperrectangle, S)
@@ -174,7 +142,7 @@ using a hyperrectangle.
 
 ### Input
 
-- `S`              -- linear map of a hyperrectangular set
+- `lm`-- linear map of a hyperrectangular set
 
 ### Output
 
@@ -183,25 +151,25 @@ A hyperrectangle.
 ### Algorithm
 
 If `c` and `r` denote the center and vector radius of a hyperrectangle `H`,
-a tight hyperrectangular overapproximation of `M * H` is obtained by transforming
-`c ↦ M*c` and `r ↦ abs.(M) * r`, where `abs.(⋅)` denotes the element-wise absolute
-value operator.
+a tight hyperrectangular overapproximation of `M * H` is obtained by
+transforming `c ↦ M*c` and `r ↦ abs.(M) * r`, where `abs.(⋅)` denotes the
+element-wise absolute-value operator.
 """
 function box_approximation(lm::LinearMap{N, <:AbstractHyperrectangle}) where {N}
     M, X = lm.M, lm.X
-    center_MX = M * center(X)
-    radius_MX = abs.(M) * radius_hyperrectangle(X)
-    return Hyperrectangle(center_MX, radius_MX)
+    c = M * center(X)
+    r = abs.(M) * radius_hyperrectangle(X)
+    return Hyperrectangle(c, r)
 end
 
 """
-    box_approximation(r::Rectification{N}) where {N}
+    box_approximation(R::Rectification{N}) where {N}
 
-Overapproximate the rectification of a convex set by a tight hyperrectangle.
+Overapproximate the rectification of a set by a tight hyperrectangle.
 
 ### Input
 
-- `r`              -- rectification of a convex set
+- `R`-- rectification of a set
 
 ### Output
 
@@ -209,17 +177,16 @@ A hyperrectangle.
 
 ### Algorithm
 
-Box approximation and rectification distribute.
-Hence we first check whether the wrapped set is empty.
-If so, we return the empty set.
-Otherwise, we compute the box approximation of the wrapped set, rectify the
-resulting box (which is simple), and finally convert the resulting set to a box.
+Box approximation and rectification distribute. We first check whether the
+wrapped set is empty. If so, we return the empty set. Otherwise, we compute the
+box approximation of the wrapped set, rectify the resulting box (which is
+simple), and finally convert the resulting set to a box.
 """
-function box_approximation(r::Rectification{N}) where {N}
-    if isempty(r.X)
-        return EmptySet{N}(dim(r))
+function box_approximation(R::Rectification{N}) where {N}
+    if isempty(R.X)
+        return EmptySet{N}(dim(R))
     end
-    return convert(Hyperrectangle, Rectification(box_approximation(r.X)))
+    return convert(Hyperrectangle, Rectification(box_approximation(R.X)))
 end
 
 """
@@ -238,14 +205,14 @@ A hyperrectangle.
 ### Algorithm
 
 This function implements the method in [Section 5.1.2, 1]. A zonotope
-``Z = ⟨c, G⟩`` can be overapproximated tightly by an axis-aligned box
-(i.e. a `Hyperrectangle`) such that its center is ``c`` and the radius along
-dimension ``i`` is the column-sum of the absolute values of the ``i``-th row
-of ``G`` for ``i = 1,…, p``, where ``p`` is the number of generators of ``Z``.
+``Z = ⟨c, G⟩`` can be tightly overapproximated by an axis-aligned hyperrectangle
+such that its center is ``c`` and the radius along dimension ``i`` is the
+column-sum of the absolute values of the ``i``-th row of ``G`` for
+``i = 1,…, p``, where ``p`` is the number of generators of ``Z``.
 
-[1] *Althoff, M., Stursberg, O., & Buss, M. (2010). Computing reachable sets of
-hybrid systems using a combination of zonotopes and polytopes. Nonlinear analysis:
-hybrid systems, 4(2), 233-249.*
+[1] Althoff, M., Stursberg, O., & Buss, M. (2010). *Computing reachable sets of
+hybrid systems using a combination of zonotopes and polytopes.* Nonlinear
+analysis: hybrid systems, 4(2), 233-249.
 """
 function box_approximation(Z::AbstractZonotope)
     r = sum(abs, genmat(Z), dims=2)[:]
@@ -255,12 +222,12 @@ end
 """
     box_approximation(am::AbstractAffineMap{N, <:AbstractHyperrectangle}) where {N}
 
-Overapproximate the affine map of a hyperrectangular set
-using a hyperrectangle.
+Overapproximate the affine map of a hyperrectangular set by a tight
+hyperrectangle.
 
 ### Input
 
-- `am`             -- affine map of a hyperrectangular set
+- `am` -- affine map of a hyperrectangular set
 
 ### Output
 
@@ -269,15 +236,15 @@ A hyperrectangle.
 ### Algorithm
 
 If `c` and `r` denote the center and vector radius of a hyperrectangle `H`
-and `v` the translation vector, a tight hyperrectangular overapproximation of
+and `v` is the translation vector, a tight hyperrectangular overapproximation of
 `M * H + v` is obtained by transforming `c ↦ M*c+v` and `r ↦ abs.(M) * r`, where
-`abs.(⋅)` denotes the element-wise absolute value operator.
+`abs.(⋅)` denotes the element-wise absolute-value operator.
 """
 function box_approximation(am::AbstractAffineMap{N, <:AbstractHyperrectangle}) where {N}
     M, X, v = matrix(am), set(am), vector(am)
-    center_MXv = M * center(X) + v
-    radius_MX = abs.(M) * radius_hyperrectangle(X)
-    return Hyperrectangle(center_MXv, radius_MX)
+    c = M * center(X) + v
+    r = abs.(M) * radius_hyperrectangle(X)
+    return Hyperrectangle(c, r)
 end
 
 function box_approximation(P::Union{VPolytope, VPolygon})
@@ -286,8 +253,8 @@ function box_approximation(P::Union{VPolytope, VPolygon})
     @assert !isempty(vlist) "cannot overapproximate an empty polytope"
 
     @inbounds v1 = vlist[1]
-    center = similar(v1)
-    radius = similar(v1)
+    c = similar(v1)
+    r = similar(v1)
 
     @inbounds for i in 1:n
         low_i = v1[i]
@@ -299,20 +266,20 @@ function box_approximation(P::Union{VPolytope, VPolygon})
                 low_i = v[i]
             end
         end
-        radius_i = (high_i - low_i) / 2
-        center[i] = low_i + radius_i
-        radius[i] = radius_i
+        ri = (high_i - low_i) / 2
+        c[i] = low_i + ri
+        r[i] = ri
     end
-    return Hyperrectangle(center, radius)
+    return Hyperrectangle(c, r)
 end
 
-# centrally symmetric sets only require n support-function evaluations
+# centrally-symmetric sets only require n support-function evaluations
 function box_approximation(X::AbstractCentrallySymmetric{N}) where {N}
     n = dim(X)
     c = center(X)
     r = Vector{N}(undef, n)
     @inbounds for i in 1:n
-        r[i] = ρ(SingleEntryVector(i, n, one(N)), X) - c[i]
+        r[i] = high(X, i) - c[i]
     end
     return Hyperrectangle(c, r)
 end
@@ -403,7 +370,7 @@ end
 """
     box_approximation(ms::MinkowskiSum)
 
-Compute the box approximation of the Minkowski sum of two sets.
+Overapproximate the Minkowski sum of two sets with a tight hyperrectangle.
 
 ### Input
 
@@ -411,7 +378,7 @@ Compute the box approximation of the Minkowski sum of two sets.
 
 ### Output
 
-A hyperrectangle representing the box approximation of `ms`.
+A hyperrectangle.
 
 ### Algorithm
 

--- a/test/Approximations/box_approximation.jl
+++ b/test/Approximations/box_approximation.jl
@@ -79,7 +79,7 @@ for N in [Float64, Rational{Int}, Float32]
 end
 
 for N in [Float64]
-    # empty intersection due to line search
+    # slightly contradicting bounds are interpreted as a flat set
     X = HalfSpace(N[-1], N(0)) ∩ HalfSpace(N[1], N(-1e-15))
-    @test box_approximation(X) isa EmptySet{N}
+    @test box_approximation(X) == Hyperrectangle(N[-5.0e-16], N[0])
 end


### PR DESCRIPTION
Relevant code changes:
- `symmetric_interval_hull` of an `Interval` now also returns a `Hyperrectangle` (makes the function type stable)
- `box_approximation_helper` was inlined resp. replaced by more efficient code
- `concretize(SymmetricIntervalHull)` does not call `concretize` recursively anymore, which is better

The `Expokit` code was not generalized (I opened an issue instead).