### PR TITLE
Revise some Approximations code

### DIFF
--- a/src/Approximations/Approximations.jl
+++ b/src/Approximations/Approximations.jl
@@ -1,8 +1,7 @@
 __precompile__(true)
 
 """
-Module `Approximations.jl` -- polygonal approximation of convex sets through
-support vectors.
+Module `Approximations.jl` -- polygonal approximation of sets.
 """
 module Approximations
 

--- a/src/Approximations/approximate.jl
+++ b/src/Approximations/approximate.jl
@@ -5,13 +5,13 @@ Approximate a rectification of a polytopic set with a convex polytope.
 
 ### Input
 
-- `R`                 -- rectification
+- `R`                 -- rectification of a polytopic set
 - `apply_convex_hull` -- (optional; default: `false`) option to remove redundant
                          vertices
 
 ### Output
 
-A polytope in vertex representation.
+A polytope in vertex representation (`VPolygon` in 2D, `VPolytope` otherwise).
 There is no guarantee that the result over- or underapproximates `R`.
 
 ### Algorithm


### PR DESCRIPTION
Main code changes:
- fix `_underapproximate_box` (sometimes swapped low and high ends)
- generalize `underapproximate` with directions to unbounded sets

```julia
julia> clist = constraints_list(rand(BallInf));
julia> pop!(clist);
julia> X = HPolyhedron(clist);
julia> Y = underapproximate(X, BoxDirections(2));
```

![unbounded](https://user-images.githubusercontent.com/9656686/194949764-c3d6cb78-0c77-430c-8baf-0016d7993ac3.png)