### PR TITLE
Revise iterative_refinement code

### DIFF
--- a/docs/src/lib/approximations.md
+++ b/docs/src/lib/approximations.md
@@ -61,15 +61,14 @@ ballinf_approximation
 ## Iterative refinement
 
 ```@docs
+overapproximate_hausdorff
 LocalApproximation
 PolygonalOverapproximation
-new_approx(S::ConvexSet, p1::VN, d1::VN,
-           p2::VN, d2::VN) where {N<:AbstractFloat, VN<:AbstractVector{N}}
-addapproximation!(Ω::PolygonalOverapproximation, p1::VN, d1::VN, p2::VN, d2::VN) where {N<:Real, VN<:AbstractVector{N}}
-refine(::LocalApproximation, ::ConvexSet)
+new_approx
+addapproximation!
+refine(::LocalApproximation, ::LazySet)
 tohrep(::PolygonalOverapproximation)
-_approximate(S::ConvexSet{N}, ε::Real) where {N<:AbstractFloat}
-constraint(::LocalApproximation)
+convert(::Type{HalfSpace}, ::LocalApproximation)
 ```
 
 ## Template directions

--- a/docs/src/man/iterative_refinement.md
+++ b/docs/src/man/iterative_refinement.md
@@ -68,7 +68,7 @@ Hausdorff distance.
 
 
 ```@example example_iterative_refinement
-import LazySets.Approximations:PolygonalOverapproximation, addapproximation!
+using LazySets.Approximations: PolygonalOverapproximation, addapproximation!
 
 Ω = PolygonalOverapproximation(b)
 p1, d1, p2, d2 = [1.0, 0.0], [1.0, 0.0], [0.0, 1.0], [0.0, 1.0]
@@ -98,7 +98,7 @@ To illustrate this, first let's add the remaining three approximations to `Ω`
 along the canonical directions, to build a box overapproximation of `b`.
 
 ```@example example_iterative_refinement
-import LazySets.Approximations: refine, tohrep
+using LazySets.Approximations: refine, tohrep
 
 plot(b, 1e-3, aspectratio=1, alpha=0.3)
 
@@ -161,7 +161,7 @@ point epsilon in the given numerical precision.
 ## Algorithm
 
 Having presented the individual steps, we give the pseudocode of the iterative
-refinement algorithm, see `_approximate(S, ε)`.
+refinement algorithm, see `overapproximate_hausdorff(S, ε)`.
 
 The algorithm consists of the following steps:
 
@@ -187,7 +187,7 @@ As a final example consider the iterative refinement of the ball `b` for
 different values of the approximation threshold `ε`.
 
 ```@example example_iterative_refinement
-import LazySets.Approximations:overapproximate, _approximate
+using LazySets.Approximations: overapproximate_hausdorff
 
 p0 = plot(b, 1e-6, aspectratio=1)
 p1 = plot!(p0, overapproximate(b, 1.), alpha=0.4, aspectratio=1)
@@ -205,15 +205,15 @@ Meanwhile, the number of constraints of the polygonal overapproximation
 increases, in this example by a power of 2 when the error is divided by a factor 10.
 
 ```@example example_iterative_refinement
-h = ε ->  length(_approximate(b, ε).constraints)
+h = ε ->  length(overapproximate_hausdorff(b, ε).constraints)
 h(1.), h(0.1), h(0.01)
 ```
 
 !!! note
-    Actually, the plotting function for an arbitrary `ConvexSet` `plot(...)`,
-    called *recipe* in the context of
-    [Plots.jl](https://github.com/JuliaPlots/Plots.jl), is such that it receives
-    a numeric argument `ε` and the routine itself calls `overapproximate`.
+    Actually, the plotting function for an arbitrary convex `LazySet`,
+    `plot(...)` (called *recipe* in the context of
+    [Plots.jl](https://github.com/JuliaPlots/Plots.jl)), receives a numeric
+    argument `ε` and the routine itself calls `overapproximate`.
     However, some sets such as abstract polygons have their own plotting recipe
     and hence do not require the error threshold, since they are plotted exactly
     as the convex hull of their vertices.

--- a/src/Approximations/Approximations.jl
+++ b/src/Approximations/Approximations.jl
@@ -5,6 +5,8 @@ Module `Approximations.jl` -- polygonal approximation of sets.
 """
 module Approximations
 
+import Base: convert
+
 import IntervalArithmetic
 const IA = IntervalArithmetic
 

--- a/src/Approximations/overapproximate.jl
+++ b/src/Approximations/overapproximate.jl
@@ -1,5 +1,3 @@
-import Base: convert
-
 using LazySets: block_to_dimension_indices,
                 substitute_blocks,
                 fast_interval_pow,
@@ -90,7 +88,7 @@ function overapproximate(S::LazySet{N},
         constraints[4] = LinearConstraint(DIR_SOUTH(N), ρ(DIR_SOUTH(N), S))
         return HPolygon(constraints, sort_constraints=false)
     else
-        P = tohrep(_approximate(S, ε))
+        P = overapproximate_hausdorff(S, ε)
         if prune
             remove_redundant_constraints!(P)
         end


### PR DESCRIPTION
Code changes:
- rename `_approximate` into `overapproximate_hausdorff` (open for other suggestions, but I wanted to remove the `_` and make clear that it is an overapproximation); this function now also returns a polygon immediately because there is no other use case; I also fixed a bug that could occur if the algorithm has not converged yet (could not happen through use of the main public API)
- change `constraint` method into a standard `convert` method