### PR TITLE
Revise plot_recipes code and overapproximation of SPZ

### DIFF
--- a/docs/src/lib/interfaces.md
+++ b/docs/src/lib/interfaces.md
@@ -47,8 +47,8 @@ implementation below internally relies on the function `plot_recipe`. For some
 set types (e.g., `Intersection`), the default implementation is overridden.
 
 ```@docs
-RecipesBase.apply_recipe(::AbstractDict{Symbol,Any}, ::LazySet{N}, ::N=N(1e-3)) where {N}
-RecipesBase.apply_recipe(::AbstractDict{Symbol,Any}, ::AbstractVector{VN}, ::N=N(1e-3), ::Int=40; ::Bool=false) where {N, VN<:LazySet{N}}
+RecipesBase.apply_recipe(::AbstractDict{Symbol,Any}, ::LazySet{N}, ::Real=N(1e-3)) where {N}
+RecipesBase.apply_recipe(::AbstractDict{Symbol,Any}, ::AbstractVector{VN}, ::Real=N(1e-3), ::Int=40; ::Bool=false) where {N, VN<:LazySet{N}}
 plot_vlist(::S, ::Real) where {S<:LazySet}
 ```
 
@@ -489,7 +489,7 @@ generators(::AbstractSingleton{N}) where {N}
 genmat(::AbstractSingleton{N}) where {N}
 ngens(::AbstractSingleton)
 plot_recipe(::AbstractSingleton{N}, ::Any=zero(N)) where {N}
-RecipesBase.apply_recipe(::AbstractDict{Symbol,Any}, ::AbstractSingleton{N}, ::N=zero(N)) where {N}
+RecipesBase.apply_recipe(::AbstractDict{Symbol,Any}, ::AbstractSingleton{N}, ::Real=zero(N)) where {N}
 ```
 
 ### Implementations

--- a/docs/src/lib/interfaces.md
+++ b/docs/src/lib/interfaces.md
@@ -49,6 +49,7 @@ set types (e.g., `Intersection`), the default implementation is overridden.
 ```@docs
 RecipesBase.apply_recipe(::AbstractDict{Symbol,Any}, ::LazySet{N}, ::N=N(1e-3)) where {N}
 RecipesBase.apply_recipe(::AbstractDict{Symbol,Any}, ::AbstractVector{VN}, ::N=N(1e-3), ::Int=40; ::Bool=false) where {N, VN<:LazySet{N}}
+plot_vlist(::S, ::Real) where {S<:LazySet}
 ```
 
 For three-dimensional sets, we support `Makie`:

--- a/docs/src/lib/lazy_operations/Intersection.md
+++ b/docs/src/lib/lazy_operations/Intersection.md
@@ -28,7 +28,7 @@ _line_search
 _projection
 linear_map(::AbstractMatrix, ::Intersection)
 plot_recipe(::Intersection{N}, ::N=zero(N), ::Int=40) where {N<:Real}
-RecipesBase.apply_recipe(::AbstractDict{Symbol,Any}, ::Intersection{N}, ::N=zero(N), ::Int=40) where {N}
+RecipesBase.apply_recipe(::AbstractDict{Symbol,Any}, ::Intersection{N}, ::Real=zero(N), ::Int=40) where {N}
 ```
 
 Inherited from [`ConvexSet`](@ref):

--- a/docs/src/lib/sets/EmptySet.md
+++ b/docs/src/lib/sets/EmptySet.md
@@ -24,7 +24,7 @@ diameter(::EmptySet, ::Real=Inf)
 linear_map(::AbstractMatrix{N}, ::EmptySet{N}) where {N}
 translate(::EmptySet, ::AbstractVector)
 plot_recipe(::EmptySet{N}, ::Any=zero(N)) where {N}
-RecipesBase.apply_recipe(::AbstractDict{Symbol,Any}, ::EmptySet{N}, ::N=zero(N)) where {N}
+RecipesBase.apply_recipe(::AbstractDict{Symbol,Any}, ::EmptySet{N}, ::Real=zero(N)) where {N}
 area(::EmptySet)
 volume(::EmptySet{N}) where {N}
 chebyshev_center_radius(::EmptySet; kwargs...)

--- a/src/Approximations/overapproximate.jl
+++ b/src/Approximations/overapproximate.jl
@@ -692,7 +692,7 @@ function overapproximate(P::SimpleSparsePolynomialZonotope, ::Type{Zonotope}, do
 end
 
 function overapproximate(P::SimpleSparsePolynomialZonotope, ::Type{UnionSetArray{Zonotope}};
-                         nsdiv=100, partition=nothing)
+                         nsdiv=10, partition=nothing)
     q = nparams(P)
     dom = IA.IntervalBox(IA.Interval(-1, 1), q)
     cells = IA.mince(dom, isnothing(partition) ? nsdiv : partition)

--- a/src/Interfaces/LazySet.jl
+++ b/src/Interfaces/LazySet.jl
@@ -285,3 +285,26 @@ function extrema(X::LazySet)
     h = high(X)
     return (l, h)
 end
+
+"""
+    plot_vlist(X::S, ε::Real) where {S<:LazySet}
+
+Return a list of vertices used for plotting a two-dimensional set.
+
+### Input
+
+- `X` -- two-dimensional set
+- `ε` -- precision parameter
+
+### Output
+
+A list of vertices of a polygon `P`.
+For convex `X`, `P` usually satisfies that the Hausdorff distance to `X` is less
+than `ε`.
+"""
+function plot_vlist(X::S, ε::Real) where {S<:LazySet}
+    @assert isconvextype(S) "can only plot convex sets"
+
+    P = overapproximate(X, ε)
+    return convex_hull(vertices_list(P))
+end

--- a/src/Plotting/plot_recipes.jl
+++ b/src/Plotting/plot_recipes.jl
@@ -96,7 +96,7 @@ function _bounding_hyperrectangle(lims, N)
 end
 
 """
-    plot_list(list::AbstractVector{VN}, [ε]::N=N(PLOT_PRECISION),
+    plot_list(list::AbstractVector{VN}, [ε]::Real=N(PLOT_PRECISION),
               [Nφ]::Int=PLOT_POLAR_DIRECTIONS; [same_recipe]=false; ...)
         where {N, VN<:LazySet{N}}
 
@@ -145,7 +145,7 @@ julia> plot(Bs, 1e-3)  # default accuracy value (explicitly given for clarity)
 julia> plot(Bs, 1e-2)  # faster but less accurate than the previous call
 ```
 """
-@recipe function plot_list(list::AbstractVector{VN}, ε::N=N(PLOT_PRECISION),
+@recipe function plot_list(list::AbstractVector{VN}, ε::Real=N(PLOT_PRECISION),
                            Nφ::Int=PLOT_POLAR_DIRECTIONS; same_recipe=false
                           ) where {N, VN<:LazySet{N}}
     if same_recipe
@@ -169,7 +169,7 @@ julia> plot(Bs, 1e-2)  # faster but less accurate than the previous call
     end
 end
 
-function _plot_list_same_recipe(list::AbstractVector{VN}, ε::N=N(PLOT_PRECISION),
+function _plot_list_same_recipe(list::AbstractVector{VN}, ε::Real=N(PLOT_PRECISION),
                                 Nφ::Int=PLOT_POLAR_DIRECTIONS) where {N, VN<:LazySet{N}}
     first = true
     x = Vector{N}()
@@ -248,8 +248,8 @@ function _plot_singleton_list(list)
     elseif n == 2
         _plot_singleton_list_2D(list)
     else
-        throw(ArgumentError("plotting a vector of singletons is only available for dimensions " *
-             "one or two, got dimension $n"))
+        throw(ArgumentError("plotting singletons is only available for " *
+            "dimensions one or two, but got dimension $n"))
     end
 end
 
@@ -280,7 +280,7 @@ function _plot_singleton_list_2D(list::AbstractVector{SN}) where {N, SN<:Abstrac
 end
 
 """
-    plot_lazyset(X::LazySet{N}, [ε]::N=N(PLOT_PRECISION); ...) where {N}
+    plot_lazyset(X::LazySet{N}, [ε]::Real=N(PLOT_PRECISION); ...) where {N}
 
 Plot a set.
 
@@ -307,7 +307,7 @@ julia> plot(B, 1e-3)  # default accuracy value (explicitly given for clarity her
 julia> plot(B, 1e-2)  # faster but less accurate than the previous call
 ```
 """
-@recipe function plot_lazyset(X::LazySet{N}, ε::N=N(PLOT_PRECISION)) where {N}
+@recipe function plot_lazyset(X::LazySet{N}, ε::Real=N(PLOT_PRECISION)) where {N}
     label --> DEFAULT_LABEL
     grid --> DEFAULT_GRID
     if DEFAULT_ASPECT_RATIO != :none
@@ -365,7 +365,7 @@ julia> plot(B, 1e-2)  # faster but less accurate than the previous call
 end
 
 """
-    plot_singleton(S::AbstractSingleton{N}, [ε]::N=zero(N); ...) where {N}
+    plot_singleton(S::AbstractSingleton{N}, [ε]::Real=zero(N); ...) where {N}
 
 Plot a singleton.
 
@@ -380,7 +380,7 @@ Plot a singleton.
 julia> plot(Singleton([0.5, 1.0]))
 ```
 """
-@recipe function plot_singleton(S::AbstractSingleton{N}, ε::N=zero(N)) where {N}
+@recipe function plot_singleton(S::AbstractSingleton{N}, ε::Real=zero(N)) where {N}
     label --> DEFAULT_LABEL
     grid --> DEFAULT_GRID
     if DEFAULT_ASPECT_RATIO != :none
@@ -403,7 +403,7 @@ julia> plot(Singleton([0.5, 1.0]))
 end
 
 """
-    plot_emptyset(∅::EmptySet, [ε]::N=zero(N); ...)
+    plot_emptyset(∅::EmptySet, [ε]::Real=zero(N); ...)
 
 Plot an empty set.
 
@@ -412,7 +412,7 @@ Plot an empty set.
 - `∅` -- empty set
 - `ε` -- (optional, default: `0`) ignored, used for dispatch
 """
-@recipe function plot_emptyset(∅::EmptySet{N}, ε::N=zero(N)) where {N}
+@recipe function plot_emptyset(∅::EmptySet{N}, ε::Real=zero(N)) where {N}
     label --> DEFAULT_LABEL
     grid --> DEFAULT_GRID
     if DEFAULT_ASPECT_RATIO != :none
@@ -423,7 +423,7 @@ Plot an empty set.
 end
 
 """
-    plot_intersection(cap::Intersection{N}, [ε]::N=zero(N),
+    plot_intersection(cap::Intersection{N}, [ε]::Real=zero(N),
                       [Nφ]::Int=PLOT_POLAR_DIRECTIONS) where {N}
 
 Plot a lazy intersection.
@@ -454,18 +454,18 @@ julia> plot(X)
 ```
 
 You can specify the accuracy of the overapproximation of the lazy intersection
-by passing a higher value for `Nφ`, which stands for the number of polar
+by passing an explicit value for `Nφ`, which stands for the number of polar
 directions used in the overapproximation.
 This number can also be passed to the `plot` function directly.
 
 ```julia
 julia> plot(overapproximate(X, PolarDirections(100)))
 
-julia> plot(X, -1., 100)  # equivalent to the above line
+julia> plot(X, 0.0, 100)  # equivalent to the above line
 ```
 """
 @recipe function plot_intersection(cap::Intersection{N},
-                                   ε::N=zero(N),
+                                   ε::Real=zero(N),
                                    Nφ::Int=PLOT_POLAR_DIRECTIONS
                                   ) where {N}
     label --> DEFAULT_LABEL
@@ -506,7 +506,7 @@ end
 
 # non-convex sets
 
-@recipe function plot_union(cup::UnionSet{N}, ε::N=N(PLOT_PRECISION)) where {N}
+@recipe function plot_union(cup::UnionSet{N}, ε::Real=N(PLOT_PRECISION)) where {N}
     label --> DEFAULT_LABEL
     grid --> DEFAULT_GRID
     if DEFAULT_ASPECT_RATIO != :none
@@ -519,7 +519,7 @@ end
     return _plot_list_same_recipe([cup.X, cup.Y], ε)
 end
 
-@recipe function plot_union(cup::UnionSetArray{N}, ε::N=N(PLOT_PRECISION)) where {N}
+@recipe function plot_union(cup::UnionSetArray{N}, ε::Real=N(PLOT_PRECISION)) where {N}
     label --> DEFAULT_LABEL
     grid --> DEFAULT_GRID
     if DEFAULT_ASPECT_RATIO != :none
@@ -533,7 +533,7 @@ end
 end
 
 @recipe function plot_polyzono(P::AbstractPolynomialZonotope{N},
-                               ε::N=N(PLOT_PRECISION); nsdiv=10,
+                               ε::Real=N(PLOT_PRECISION); nsdiv=10,
                                partition=nothing) where {N}
     label --> DEFAULT_LABEL
     grid --> DEFAULT_GRID

--- a/src/Plotting/plot_recipes.jl
+++ b/src/Plotting/plot_recipes.jl
@@ -532,7 +532,9 @@ end
     return _plot_list_same_recipe(array(cup), ε)
 end
 
-@recipe function plot_polyzono(P::SimpleSparsePolynomialZonotope{N}, ε::N=N(PLOT_PRECISION); nsdiv=100, partition=nothing) where {N}
+@recipe function plot_polyzono(P::AbstractPolynomialZonotope{N},
+                               ε::N=N(PLOT_PRECISION); nsdiv=10,
+                               partition=nothing) where {N}
     label --> DEFAULT_LABEL
     grid --> DEFAULT_GRID
     if DEFAULT_ASPECT_RATIO != :none

--- a/src/Plotting/plot_recipes.jl
+++ b/src/Plotting/plot_recipes.jl
@@ -170,7 +170,7 @@ julia> plot(Bs, 1e-2)  # faster but less accurate than the previous call
 end
 
 function _plot_list_same_recipe(list::AbstractVector{VN}, ε::N=N(PLOT_PRECISION),
-                               Nφ::Int=PLOT_POLAR_DIRECTIONS) where {N, VN<:LazySet{N}}
+                                Nφ::Int=PLOT_POLAR_DIRECTIONS) where {N, VN<:LazySet{N}}
     first = true
     x = Vector{N}()
     y = Vector{N}()
@@ -180,12 +180,12 @@ function _plot_list_same_recipe(list::AbstractVector{VN}, ε::N=N(PLOT_PRECISION
         else
             # hard-code overapproximation here to avoid individual
             # compilations for mixed sets
-            Pi = overapproximate(Xi, ε)
-            vlist = transpose(hcat(convex_hull(vertices_list(Pi))...))
+            vlist = plot_vlist(Xi, ε)
             if isempty(vlist)
                 @warn "overapproximation during plotting was empty"
                 continue
             end
+            vlist = transpose(hcat(vlist...))  # transpose vertices
             res = vlist[:, 1], vlist[:, 2]
             if length(res[1]) > 2
                 # add first vertex to "close" the polygon


### PR DESCRIPTION
The first commit adds a `plot_vlist` function for simplification and later extension.
The second commit changes the default value of SPZ overapproximation to 10 splits per dimension. This uncovered a potential bug (see below). I still kept the changes here because the old code base is also affected (one just does not see it so obviously).
The third commit removes the restriction that epsilon needs to have the same numeric type.

### Old
![old](https://user-images.githubusercontent.com/9656686/196281480-c79aa1e1-baad-4bc6-89f6-69fc8407902c.png)

### New
![new](https://user-images.githubusercontent.com/9656686/196281494-0ae300ef-c62f-4f0c-8271-e7fdd7025273.png)