### PR TITLE
Remove unused type parameters

### DIFF
--- a/src/ConcreteOperations/issubset.jl
+++ b/src/ConcreteOperations/issubset.jl
@@ -606,7 +606,7 @@ function _issubset_interval(x::Interval{N}, a::Interval, b::Interval,
     end
 end
 
-function ⊆(x::Interval, U::UnionSetArray, witness::Bool=false) where {N}
+function ⊆(x::Interval, U::UnionSetArray, witness::Bool=false)
     @assert dim(U) == 1 "an interval is incompatible with a set of dimension " *
         "$(dim(U))"
     V = _get_interval_array_copy(U)

--- a/src/LazyOperations/Complement.jl
+++ b/src/LazyOperations/Complement.jl
@@ -50,7 +50,7 @@ isoperationtype(::Type{<:Complement}) = true
 # special cases for which the complement is always convex
 isconvextype(::Type{<:Complement{N, <:Union{EmptySet, HalfSpace, Universe}}}) where {N} = true
 
-is_polyhedral(::Complement) where {N} = false
+is_polyhedral(::Complement) = false
 is_polyhedral(::Complement{N, <:Union{EmptySet, HalfSpace}}) where {N} = true
 
 # the complement of the complement is the original set again

--- a/src/convert.jl
+++ b/src/convert.jl
@@ -176,7 +176,7 @@ function convert(::Type{HPolyhedron}, P::AbstractPolytope)
     return HPolyhedron(constraints_list(P))
 end
 
-function convert(::Type{HPolyhedron}, X::AbstractPolyhedron) where {N}
+function convert(::Type{HPolyhedron}, X::AbstractPolyhedron)
     return HPolyhedron(constraints_list(X))
 end
 


### PR DESCRIPTION
This actually produced warnings in the CI runs (but not locally, at least for me).