### PR TITLE
Revise minkowski_sum code and generalize to LazySet

### DIFF
--- a/docs/src/lib/binary_functions.md
+++ b/docs/src/lib/binary_functions.md
@@ -103,7 +103,7 @@ linear_combination(::SimpleSparsePolynomialZonotope, ::SimpleSparsePolynomialZon
 ## Minkowski sum
 
 ```@docs
-minkowski_sum(::ConvexSet, ::ConvexSet)
+minkowski_sum(::LazySet, ::LazySet)
 minkowski_sum(::AbstractPolyhedron, ::AbstractPolyhedron)
 minkowski_sum(::VPolytope, ::VPolytope)
 minkowski_sum(::AbstractHyperrectangle, ::AbstractHyperrectangle)

--- a/src/ConcreteOperations/convex_hull.jl
+++ b/src/ConcreteOperations/convex_hull.jl
@@ -175,7 +175,9 @@ function convex_hull!(points::Vector{VN};
 end
 
 function _convex_hull_2d_preprocess!(points, m=length(points); algorithm=nothing)
-    if m == 2
+    if m == 1
+        return points
+    elseif m == 2
         # two points case in 2d
         return _two_points_2d!(points)
     elseif m == 3


### PR DESCRIPTION
The only code changes are in `function minkowski_sum(P::LazySet, Q::LazySet ...)` (formerly `function minkowski_sum(P::ConvexSet, Q::ConvexSet ...)`):
1. Instead of `isapplicable`, which does not help with lazy operations, and the potentially expensive `isbounded`, I used traits.
2. I added a case in `_convex_hull_2d_preprocess!` and only apply it if the `prune` argument is `true` (because it is also correct to return more vertices and often there are no redundant vertices).