### PR TITLE
Revise convex_hull code and generalize to LazySet

### DIFF
--- a/docs/src/lib/binary_functions.md
+++ b/docs/src/lib/binary_functions.md
@@ -52,14 +52,13 @@ isdisjoint(::Line2D, ::Line2D, ::Bool=false)
 ## Convex hull
 
 ```@docs
-convex_hull(::ConvexSet{N}, ::ConvexSet{N}) where {N}
+convex_hull(::LazySet, ::LazySet)
 convex_hull(::HPoly, ::HPoly)
 convex_hull(::VPolytope, ::VPolytope)
 convex_hull(::VPolygon, ::VPolygon)
 convex_hull(::Vector{VN}) where {N, VN<:AbstractVector{N}}
-convex_hull(::UnionSetArray{N, PT}; kwargs...) where {N, PT<:AbstractPolytope{N}}
-monotone_chain!
 convex_hull(::SimpleSparsePolynomialZonotope, ::SimpleSparsePolynomialZonotope)
+monotone_chain!
 ```
 ## Exact sum
 

--- a/docs/src/lib/interfaces.md
+++ b/docs/src/lib/interfaces.md
@@ -67,6 +67,7 @@ low(::LazySet)
 high(::LazySet)
 extrema(::LazySet, ::Int)
 extrema(::LazySet)
+convex_hull(::LazySet; kwargs...)
 ```
 
 The following methods are also defined for `LazySet` but cannot be documented

--- a/src/ConcreteOperations/convex_hull.jl
+++ b/src/ConcreteOperations/convex_hull.jl
@@ -43,7 +43,7 @@ function convex_hull(X::LazySet, Y::LazySet; algorithm=nothing,
     @assert n == dim(Y) "the convex hull requires two sets of the same " *
                         "dimension, but they have dimension $n and $(dim(Y))"
 
-    vlist = convex_hull!([copy(vertices_list(X)); copy(vertices_list(Y))];
+    vlist = convex_hull!([vertices_list(X); vertices_list(Y)];
                          algorithm=algorithm, backend=backend, solver=solver)
     return _convex_hull_set(vlist; n=n)
 end

--- a/src/ConcreteOperations/convex_hull.jl
+++ b/src/ConcreteOperations/convex_hull.jl
@@ -9,15 +9,15 @@ function default_convex_hull_algorithm(points)
 end
 
 """
-    convex_hull(X::ConvexSet{N}, Y::ConvexSet{N}; [algorithm]=nothing,
-                [backend]=nothing, [solver]=nothing) where {N}
+    convex_hull(X::LazySet, Y::LazySet; [algorithm]=nothing,
+                [backend]=nothing, [solver]=nothing)
 
-Compute the convex hull of the given convex sets.
+Compute the convex hull of two polytopic sets.
 
 ### Input
 
-- `X`         -- convex set
-- `Y`         -- convex set
+- `X`         -- polytopic set
+- `Y`         -- polytopic set
 - `algorithm` -- (optional, default: `nothing`) the convex-hull algorithm
 - `backend`   -- (optional, default: `nothing`) backend for polyhedral
                  computations (used for higher-dimensional sets)
@@ -26,61 +26,56 @@ Compute the convex hull of the given convex sets.
 
 ### Output
 
+If the sets are empty, the result is an `EmptySet`.
+If the convex hull consists of a single point, the result is a `Singleton`.
 If the input sets are one-dimensional, the result is an `Interval`.
 If the input sets are two-dimensional, the result is a `VPolygon`.
 Otherwise the result is a `VPolytope`.
 
 ### Algorithm
 
-One-dimensional sets are resolved by using `overapproximate` with an `Interval`
-(which is exact).
-For higher-dimensional sets, we compute the vertices of both `X` and `Y` using
-`vertices_list` and then compute the convex hull of the union of those vertices.
+We compute the vertices of both `X` and `Y` using `vertices_list` and then
+compute the convex hull of the union of those vertices.
 """
-function convex_hull(X::ConvexSet{N}, Y::ConvexSet{N};
-                     algorithm=nothing,
-                     backend=nothing,
-                     solver=nothing
-                    ) where {N}
+function convex_hull(X::LazySet, Y::LazySet; algorithm=nothing,
+                     backend=nothing, solver=nothing)
     n = dim(X)
     @assert n == dim(Y) "the convex hull requires two sets of the same " *
-                        "dimension, but the sets had dimension $n and $(dim(Y))"
+                        "dimension, but they have dimension $n and $(dim(Y))"
 
-    chull = convex_hull!([vertices_list(X); vertices_list(Y)];
+    vlist = convex_hull!([copy(vertices_list(X)); copy(vertices_list(Y))];
                          algorithm=algorithm, backend=backend, solver=solver)
-    m = length(chull)
+    return _convex_hull_set(vlist; n=n)
+end
+
+# turn a list of points describing the convex hull into an appropriate set
+function _convex_hull_set(vlist; n::Int=(isempty(vlist) ? -1 : length(vlist[1])))
+    m = length(vlist)
     if m == 0
+        N = eltype(vlist)
         return EmptySet{N}(n)
     elseif m == 1
-            return Singleton(chull[1])
+            return Singleton(vlist[1])
     elseif n == 1
-        @assert m == 2
-        low = chull[1][1]
-        high = chull[2][1]
-        if low > high
-            tmp = low
-            low = high
-            high = tmp
-        end
-        return Interval(low, high)
+        @assert m == 2 "a convex hull in 1D can have at most two vertices"
+        # points are sorted
+        return Interval(vlist[1][1], vlist[end][1])
     elseif n == 2
-        return VPolygon(chull)
+        # points are sorted
+        return VPolygon(vlist)
     end
-    return VPolytope(chull)
+    return VPolytope(vlist)
 end
 
 """
-    convex_hull(points::Vector{VN};
-                [algorithm]=nothing,
-                [backend]=nothing,
-                [solver]=nothing
-                ) where {N, VN<:AbstractVector{N}}
+    convex_hull(points::Vector{VN}; [algorithm]=nothing, [backend]=nothing,
+                [solver]=nothing) where {N, VN<:AbstractVector{N}}
 
-Compute the convex hull of the given points.
+Compute the convex hull of a list of points.
 
 ### Input
 
-- `points`    -- list of vectors
+- `points`    -- list of points
 - `algorithm` -- (optional, default: `nothing`) the convex-hull algorithm; see
                  below for valid options
 - `backend`   -- (optional, default: `nothing`) polyhedral computation backend
@@ -90,7 +85,7 @@ Compute the convex hull of the given points.
 
 ### Output
 
-The convex hull as a list of vectors with the coordinates of the points.
+The convex hull as a list of points.
 
 ### Algorithm
 
@@ -98,22 +93,23 @@ A pre-processing step treats the cases with up to two points for one dimension
 and up to four points for two dimensions.
 For more points in one resp. two dimensions, we use more general algorithms.
 
-For the one-dimensional case we return the minimum and maximum points, in that order.
+For the one-dimensional case, we return the minimum and maximum points, in that
+order.
 
-The two-dimensional case is handled with a planar convex hull algorithm. The
+The two-dimensional case is handled with a planar convex-hull algorithm. The
 following algorithms are available:
 
 * `"monotone_chain"`        -- compute the convex hull of points in the plane
-                               using Andrew's monotone chain method
+                               using Andrew's monotone-chain method
 * `"monotone_chain_sorted"` -- the same as `"monotone_chain"` but assuming that
-                               the points are already sorted in counter-clockwise
-                               fashion
+                               the points are already sorted in
+                               counter-clockwise fashion
 
 See the reference docstring of each of those algorithms for details.
 
-The higher dimensional case is treated using the concrete polyhedra library
-`Polyhedra`, that gives access to libraries such as `CDDLib` and `ConvexHull.jl`.
-These libraries can be chosen from the `backend` argument.
+The higher-dimensional case is treated using the concrete polyhedra library
+`Polyhedra`, which gives access to libraries such as `CDDLib` and
+`ConvexHull.jl`. These libraries can be chosen via the `backend` argument.
 
 ### Notes
 
@@ -132,24 +128,16 @@ julia> typeof(hull)
 Vector{Vector{Float64}} (alias for Array{Array{Float64, 1}, 1})
 ```
 """
-function convex_hull(points::Vector{VN};
-                     algorithm=nothing,
-                     backend=nothing,
-                     solver=nothing
-                     ) where {N, VN<:AbstractVector{N}}
-    return convex_hull!(copy(points), algorithm=algorithm, backend=backend, solver=solver)
+function convex_hull(points::Vector{VN}; algorithm=nothing, backend=nothing,
+                     solver=nothing) where {N, VN<:AbstractVector{N}}
+    return convex_hull!(copy(points), algorithm=algorithm, backend=backend,
+                        solver=solver)
 end
 
-function convex_hull!(points::Vector{VN};
-                      algorithm=nothing,
-                      backend=nothing,
+function convex_hull!(points::Vector{VN}; algorithm=nothing, backend=nothing,
                       solver=nothing) where {N, VN<:AbstractVector{N}}
 
     m = length(points)
-
-    # =====================
-    # Treat special cases
-    # =====================
 
     # zero or one point
     if m == 0 || m == 1
@@ -196,6 +184,10 @@ function _two_points_1d!(points)
     p1, p2 = points[1], points[2]
     if  _isapprox(p1[1], p2[1]) # check for redundancy
         pop!(points)
+    elseif p1[1] > p2[1]
+        tmp = p1[1]
+        p1[1] = p2[1]
+        p2[1] = tmp
     end
     return points
 end
@@ -209,13 +201,14 @@ function _two_points_2d!(points)
 end
 
 function _three_points_2d!(points::AbstractVector{<:AbstractVector{N}}) where {N}
-    # Algorithm: the function takes three points and uses the formula
-    #            from here: https://stackoverflow.com/questions/2122305/convex-hull-of-4-points/2122620#2122620
-    #            to decide if the points are ordered in a counter-clockwise fashion or not, the result is saved
-    #            in the 'turn' boolean, then returns the points in ccw fashion acting according to 'turn'. For the
-    #            cases where the points are collinear we pass the points with the minimum and maximum first
-    #            component to the function for two points in 2d(_two_points_2d), if those are equal, we do the same
-    #            but with the second component.
+    # Algorithm: the function takes three points and uses the formula from here:
+    # https://stackoverflow.com/questions/2122305/convex-hull-of-4-points/2122620#2122620
+    # to decide if the points are ordered in counter-clockwise order. The result
+    # is saved in the 'turn' flag and returned in ccw fashion acting according
+    # to 'turn'. For the cases where the points are collinear, we pass the
+    # points with the minimum and maximum first component to the function for
+    # two points in 2d(_two_points_2d). If those are equal, we do the same but
+    # with the second component.
     A, B, C = points[1], points[2], points[3]
     turn = right_turn(A, B, C)
 
@@ -229,10 +222,12 @@ function _three_points_2d!(points::AbstractVector{<:AbstractVector{N}}) where {N
                 pop!(points)
                 return points
             else
-                points[1], points[2] = points[argmin([A[2], B[2], C[2]])], points[argmax([A[2], B[2], C[2]])]
+                points[1] = points[argmin([A[2], B[2], C[2]])]
+                points[2] = points[argmax([A[2], B[2], C[2]])]
             end
         else
-            points[1], points[2] = points[argmin([A[1], B[1], C[1]])], points[argmax([A[1], B[1], C[1]])]
+            points[1] = points[argmin([A[1], B[1], C[1]])]
+            points[2] = points[argmax([A[1], B[1], C[1]])]
         end
         pop!(points)
         _two_points_2d!(points)
@@ -244,7 +239,8 @@ function _three_points_2d!(points::AbstractVector{<:AbstractVector{N}}) where {N
     return points
 end
 
-# given an index i in {1, 2, 3} return the element among (A, B, C) in the i-th position
+# given an index i in {1, 2, 3}, return the element among (A, B, C) in the i-th
+# position
 @inline function _get_i(i, A, B, C)
     return i == 1 ? A : i == 2 ? B : C
 end
@@ -260,8 +256,9 @@ function _collinear_case!(points, A, B, C, D)
             pop!(points)
             return _two_points_2d!(points)
         else
-            # assign the points with max and min value in their second component to the
-            # firsts points and the extra point to the third place, then pop the point that was in the middle
+            # assign the points with max and min value in their second component
+            # to the firsts points and the extra point to the third place, then
+            # pop the point that was in the middle
             min_y, max_y = arg_minmax(A[2], B[2], C[2])
             points[1] = _get_i(min_y, A, B, C)
             points[2] = _get_i(max_y, A, B, C)
@@ -269,8 +266,9 @@ function _collinear_case!(points, A, B, C, D)
             pop!(points)
         end
     else
-        # assign the points with max and min value in their first component to the
-        # firsts points and the extra point to the third place, then pop the point that was in the middle
+        # assign the points with max and min value in their first component to
+        # the firsts points and the extra point to the third place, then pop the
+        # point that was in the middle
         min_x, max_x = arg_minmax(A[1], B[1], C[1])
         points[1] = _get_i(min_x, A, B, C)
         points[2] = _get_i(max_x, A, B, C)
@@ -329,43 +327,43 @@ function _four_points_2d!(points::AbstractVector{<:AbstractVector{N}}) where {N}
     #  -    -    -    +   ADCB
     #  -    -    -    -   ACB
     if key == 1111
-        points[1], points[2], points[3] = A, B, C # +    +    +    +   ABC
+        points[1], points[2], points[3] = A, B, C #  +    +    +    +   ABC
         pop!(points)
     elseif key == 1110
-        points[1], points[2], points[3], points[4] = A, B, C, D # +    +    +    -   ABCD
+        points[1], points[2], points[3], points[4] = A, B, C, D #  +    +    +    -   ABCD
     elseif key == 1101
         points[1], points[2], points[3], points[4] = A, B, D, C #  +    +    -    +   ABDC
     elseif key == 1100
-        points[1], points[2], points[3] = A, B, D #  +    +    -    -   ABD
+        points[1], points[2], points[3] = A, B, D               #  +    +    -    -   ABD
         pop!(points)
     elseif key == 1011
         points[1], points[2], points[3], points[4] = A, D, B, C #  +    -    +    +   ADBC
     elseif key == 1010
-        points[1], points[2], points[3] = B, C, D #  +    -    +    -   BCD
+        points[1], points[2], points[3] = B, C, D               #  +    -    +    -   BCD
         pop!(points)
     elseif key == 1001
-        points[1], points[2], points[3] = C, A, D #  +    -    -    +    CAD
+        points[1], points[2], points[3] = C, A, D               #  +    -    -    +    CAD
         pop!(points)
     elseif key == 0110
-        points[1], points[2], points[3] = A, C, D #  -    +    +    -   ACD
+        points[1], points[2], points[3] = A, C, D               #  -    +    +    -   ACD
         pop!(points)
     elseif key == 0101
-        points[1], points[2], points[3] = D, C, B #  -    +    -    +   DCB
+        points[1], points[2], points[3] = D, C, B               #  -    +    -    +   DCB
         pop!(points)
     elseif key == 0100
         points[1], points[2], points[3], points[4] = D, A, C, B #  -    +    -    -   DACB
     elseif key == 0011
-        points[1], points[2], points[3] = A, D, B #  -    -    +    +   ADB
+        points[1], points[2], points[3] = A, D, B               #  -    -    +    +   ADB
         pop!(points)
     elseif key == 0010
         points[1], points[2], points[3], points[4] = A, C, D, B #  -    -    +    -   ACDB
     elseif key == 0001
         points[1], points[2], points[3], points[4] = A, D, C, B #  -    -    -    +   ADCB
     elseif key == 0000
-        points[1], points[2], points[3] = A, C, B #  -    -    -    -   ACB
+        points[1], points[2], points[3] = A, C, B               #  -    -    -    -   ACB
         pop!(points)
     else
-        @assert false "unexpected case in convex_hull"
+        error("unexpected case in convex-hull algorithm")
     end
     return points
 end
@@ -405,12 +403,12 @@ end
     monotone_chain!(points::Vector{VN}; sort::Bool=true
                    ) where {N, VN<:AbstractVector{N}}
 
-Compute the convex hull of points in the plane using Andrew's monotone chain
-method.
+Compute the convex hull of a list of points in the plane using Andrew's
+monotone-chain method.
 
 ### Input
 
-- `points` -- list of 2D vectors; is sorted in-place inside this function
+- `points` -- list of 2D vectors; will be sorted in-place inside this method
 - `sort`   -- (optional, default: `true`) flag for sorting the vertices
               lexicographically; sortedness is required for correctness
 
@@ -421,18 +419,17 @@ convex hull.
 
 ### Notes
 
-For large sets of points, it is convenient to use static vectors to get
-maximum performance. For information on how to convert usual vectors
-into static vectors, see the type `SVector` provided by the
+For large sets of points, it is convenient to use static vectors to get maximum
+performance. For information on how to convert usual vectors into static
+vectors, see the type `SVector` provided by the
 [StaticArrays](http://juliaarrays.github.io/StaticArrays.jl/stable/)
 package.
 
 ### Algorithm
 
-This function implements Andrew's monotone chain convex hull algorithm to
+This method implements Andrew's monotone-chain convex hull algorithm to
 construct the convex hull of a set of ``n`` points in the plane in
-``O(n \\log n)`` time.
-For further details see
+``O(n \\log n)`` time. For further details see
 [Monotone chain](https://en.wikibooks.org/wiki/Algorithm_Implementation/Geometry/Convex_hull/Monotone_chain)
 """
 function monotone_chain!(points::Vector{VN}; sort::Bool=true
@@ -476,24 +473,6 @@ function monotone_chain!(points::Vector{VN}; sort::Bool=true
 end
 
 """
-    convex_hull(U::UnionSetArray{N, PT}; kwargs...) where {N, PT<:AbstractPolytope{N}}
-
-Compute the convex hull of a union of a finite number of polytopes.
-
-### Input
-
-- `U` -- UnionSetArray of polytopes
-
-### Output
-
-A list of the vertices of the convex hull.
-"""
-function convex_hull(U::UnionSetArray{N, PT}; kwargs...) where {N, PT<:AbstractPolytope{N}}
-    vlist = mapreduce(vertices_list, vcat, U.array)
-    return convex_hull(vlist; kwargs...)
-end
-
-"""
     convex_hull(P::VPolygon, Q::VPolygon; [algorithm]::String="monotone_chain")
 
 Return the convex hull of two polygons in vertex representation.
@@ -501,20 +480,17 @@ Return the convex hull of two polygons in vertex representation.
 ### Input
 
 - `P`         -- polygon in vertex representation
-- `Q`         -- another polygon in vertex representation
+- `Q`         -- polygon in vertex representation
 - `algorithm` -- (optional, default: "monotone_chain") the algorithm used to
                  compute the convex hull
 
 ### Output
 
-A new polygon such that its vertices are the convex hull of the given two polygons.
+A new polygon such that its vertices are the convex hull of the two polygons.
 
-### Algorithm
+### Notes
 
-A convex hull algorithm is used to compute the convex hull of the vertices of the
-given input polygons `P` and `Q`; see `?convex_hull` for details on the available
-algorithms. The vertices of the output polygon are sorted in counter-clockwise
-fashion.
+The vertices of the output polygon are sorted in counter-clockwise fashion.
 """
 function convex_hull(P::VPolygon, Q::VPolygon;
                      algorithm::String="monotone_chain")
@@ -526,14 +502,13 @@ end
 """
     convex_hull(P1::VPolytope, P2::VPolytope; [backend]=nothing)
 
-Compute the convex hull of the set union of two polytopes in V-representation.
+Compute the convex hull of two polytopes in vertex representation.
 
 ### Input
 
-- `P1`         -- polytope
-- `P2`         -- another polytope
-- `backend`    -- (optional, default: `nothing`) the polyhedral
-                  computations backend
+- `P1`      -- polytope in vertex representation
+- `P2`      -- polytope in vertex representation
+- `backend` -- (optional, default: `nothing`) the polyhedral computation backend
 
 ### Output
 
@@ -542,7 +517,7 @@ The `VPolytope` obtained by the concrete convex hull of `P1` and `P2`.
 ### Notes
 
 This function takes the union of the vertices of each polytope and then relies
-on a concrete convex hull algorithm.
+on a concrete convex-hull algorithm.
 For low dimensions, a specialized implementation for polygons is used.
 For higher dimensions, `convex_hull` relies on the polyhedral backend that can
 be specified using the `backend` keyword argument.
@@ -559,14 +534,15 @@ end
     convex_hull(P1::HPoly, P2::HPoly;
                [backend]=default_polyhedra_backend(P1))
 
-Compute the convex hull of the set union of two polyhedra in H-representation.
+Compute the convex hull of the set union of two polyhedra in constraint
+representation.
 
 ### Input
 
-- `P1`         -- polyhedron
-- `P2`         -- another polyhedron
-- `backend`    -- (optional, default: `default_polyhedra_backend(P1)`)
-                  the polyhedral computations backend
+- `P1`      -- polyhedron
+- `P2`      -- polyhedron
+- `backend` -- (optional, default: `default_polyhedra_backend(P1)`) the
+               backend for polyhedral computations
 
 ### Output
 
@@ -594,14 +570,19 @@ function convex_hull(X::UnionSet)
     return convex_hull(X.X, X.Y)
 end
 
-convex_hull(X::ConvexSet, ::EmptySet) = X
-convex_hull(::EmptySet, X::ConvexSet) = X
+@commutative function convex_hull(X::LazySet, ::EmptySet)
+    @assert isconvextype(typeof(X)) "this implementation requires a convex " *
+        "set as input"
+    return X
+end
+
 convex_hull(∅::EmptySet, ::EmptySet) = ∅
 
 """
-    convex_hull(P1::SimpleSparsePolynomialZonotope, P2::SimpleSparsePolynomialZonotope)
+    convex_hull(P1::SimpleSparsePolynomialZonotope,
+                P2::SimpleSparsePolynomialZonotope)
 
-Computes the convex hull of the simple sparse polynomial zonotopes `P1` and `P2`.
+Compute the convex hull of two simple sparse polynomial zonotopes.
 
 ### Input
 
@@ -614,21 +595,4 @@ Tightest convex simple sparse polynomial zonotope containing `P1` and `P2`.
 """
 function convex_hull(P1::SimpleSparsePolynomialZonotope, P2::SimpleSparsePolynomialZonotope)
     return linear_combination(linear_combination(P1, P1), linear_combination(P2, P2))
-end
-
-"""
-    convex_hull(P::SimpleSparsePolynomialZonotope)
-
-Computes the convex hull of the simple sparse polynomial zonotope `P`.
-
-### Input
-
-- `P` -- simple sparse polynomial zonotopes
-
-### Output
-
-Tightest convex simple sparse polynomial zonotope containing `P`.
-"""
-function convex_hull(P::SimpleSparsePolynomialZonotope)
-    return linear_combination(P, P)
 end

--- a/src/Interfaces/AbstractPolytope.jl
+++ b/src/Interfaces/AbstractPolytope.jl
@@ -120,6 +120,7 @@ end
     m = size(M, 1) # output dimension
     if m == 1
         convex_hull!(vlist)
+        # points are sorted
         return Interval(vlist[1][1], vlist[end][1])
     elseif m == 2
         return VPolygon(vlist)

--- a/src/Interfaces/LazySet.jl
+++ b/src/Interfaces/LazySet.jl
@@ -308,3 +308,30 @@ function plot_vlist(X::S, ε::Real) where {S<:LazySet}
     P = overapproximate(X, ε)
     return convex_hull(vertices_list(P))
 end
+
+"""
+    convex_hull(X::LazySet; kwargs...)
+
+Compute the convex hull of a polytopic set.
+
+### Input
+
+- `X` -- polytopic set
+
+### Output
+
+The set `X` itself if its type indicates that it is convex, or a new set with
+the list of the vertices describing the convex hull.
+
+### Algorithm
+
+For non-convex sets, this method relies on the `vertices_list` method.
+"""
+function convex_hull(X::LazySet; kwargs...)
+    if isconvextype(typeof(X))
+        return X
+    end
+
+    vlist = convex_hull(vertices_list(X); kwargs...)
+    return _convex_hull_set(vlist; n=dim(X))
+end

--- a/src/Sets/SimpleSparsePolynomialZonotope.jl
+++ b/src/Sets/SimpleSparsePolynomialZonotope.jl
@@ -414,3 +414,20 @@ function rand(::Type{SimpleSparsePolynomialZonotope};
     SSPZ = SimpleSparsePolynomialZonotope(center, generators, expmat)
     return remove_redundant_generators(SSPZ)
 end
+
+"""
+    convex_hull(P::SimpleSparsePolynomialZonotope)
+
+Computes the convex hull of a simple sparse polynomial zonotope.
+
+### Input
+
+- `P` -- simple sparse polynomial zonotope
+
+### Output
+
+The tightest convex simple sparse polynomial zonotope containing `P`.
+"""
+function convex_hull(P::SimpleSparsePolynomialZonotope)
+    return linear_combination(P, P)
+end

--- a/test/ConcreteOperations/convex_hull.jl
+++ b/test/ConcreteOperations/convex_hull.jl
@@ -159,5 +159,6 @@ for N in [Float64, Rational{Int}]
     V1 = VPolytope([N[0, 0], N[1, 0], N[0, 1]])
     V2 = VPolytope([N[1, 1], N[1, 0], N[0, 1]])
     U = UnionSetArray([V1, V2]);
-    @test ispermutation(convex_hull(U), [N[0, 0], N[1, 0], N[0, 1], N[1, 1]])
+    chull = convex_hull(U)
+    @test isequivalent(chull, VPolygon([N[0, 0], N[1, 0], N[0, 1], N[1, 1]]))
 end


### PR DESCRIPTION
Closes #2755.

The code changes are:
- ~Copy the vertices before calling `convex_hull!`.~
- Also sort the vertices in the 1D case (actually one other method relied on that).
- Unary convex hull of general sets (but currently only works for convex sets and unions). This made the old implementation for `UnionSetArray` redundant (which however returned the vertices instead of a set; I think this was a mistake).
- Outsource the unary convex hull of `SSPZ` to the corresponding file.