### PR TITLE
Revise issubset code and generalize to LazySet

### DIFF
--- a/docs/src/lib/binary_functions.md
+++ b/docs/src/lib/binary_functions.md
@@ -126,33 +126,33 @@ pontryagin_difference
 
 ```@docs
 issubset
-⊆(::ConvexSet, ::ConvexSet, ::Bool=false)
-⊆(::ConvexSet, ::AbstractHyperrectangle, ::Bool=false)
-⊆(::AbstractPolytope, ::ConvexSet, ::Bool=false)
+⊆(::LazySet, ::LazySet, ::Bool=false)
+⊆(::LazySet, ::AbstractHyperrectangle, ::Bool=false)
+⊆(::AbstractPolytope, ::LazySet, ::Bool=false)
 ⊆(::AbstractPolytope, ::AbstractHyperrectangle, ::Bool=false)
 ⊆(::AbstractZonotope, ::AbstractHyperrectangle)
 ⊆(::AbstractHyperrectangle, ::AbstractHyperrectangle, ::Bool=false)
-⊆(::ConvexSet, ::AbstractPolyhedron, ::Bool=false)
-⊆(::AbstractSingleton, ::ConvexSet, ::Bool=false)
+⊆(::LazySet, ::AbstractPolyhedron, ::Bool=false)
+⊆(::AbstractSingleton, ::LazySet, ::Bool=false)
 ⊆(::AbstractSingleton, ::AbstractHyperrectangle, ::Bool=false)
 ⊆(::AbstractSingleton, ::AbstractSingleton, ::Bool=false)
 ⊆(::Ball2, ::Ball2, ::Bool=false)
 ⊆(::Union{Ball2, Ballp}, ::AbstractSingleton, ::Bool=false)
-⊆(::LineSegment, ::ConvexSet, ::Bool=false)
+⊆(::LineSegment, ::LazySet, ::Bool=false)
 ⊆(::LineSegment, ::AbstractHyperrectangle, ::Bool=false)
-⊆(::Interval{N}, ::Interval, ::Bool=false) where {N}
+⊆(::Interval, ::Interval, ::Bool=false)
 ⊆(::Interval, ::UnionSet, ::Bool=false)
-⊆(::EmptySet, ::ConvexSet, ::Bool=false)
-⊆(::ConvexSet, ::EmptySet, ::Bool=false)
-⊆(::UnionSet, ::ConvexSet, ::Bool=false)
-⊆(::UnionSetArray, ::ConvexSet, ::Bool=false)
-⊆(::ConvexSet, ::Universe, ::Bool=false)
-⊆(::Universe, ::ConvexSet, ::Bool=false)
-⊆(::ConvexSet, ::Complement, ::Bool=false)
+⊆(::EmptySet, ::LazySet, ::Bool=false)
+⊆(::LazySet, ::EmptySet, ::Bool=false)
+⊆(::UnionSet, ::LazySet, ::Bool=false)
+⊆(::UnionSetArray, ::LazySet, ::Bool=false)
+⊆(::LazySet, ::Universe, ::Bool=false)
+⊆(::Universe, ::LazySet, ::Bool=false)
+⊆(::LazySet, ::Complement, ::Bool=false)
 ⊆(::CartesianProduct, ::CartesianProduct, ::Bool=false)
 ⊆(::CartesianProductArray, ::CartesianProductArray, ::Bool=false)
 ⊆(::AbstractZonotope, ::AbstractHyperrectangle, ::Bool=false)
-⊆(::LazySet{N}, ::UnionSetArray, ::Bool=false; ::Bool=true) where {N}
+⊆(::LazySet, ::UnionSetArray, ::Bool=false; ::Bool=true)
 ⊂
 ```
 

--- a/docs/src/lib/lazy_operations/Bloating.md
+++ b/docs/src/lib/lazy_operations/Bloating.md
@@ -14,6 +14,7 @@ isempty(::Bloating)
 an_element(::Bloating)
 constraints_list(::Bloating)
 center(::Bloating)
+is_polyhedral(::Bloating)
 ```
 
 Inherited from [`ConvexSet`](@ref):

--- a/src/LazyOperations/Bloating.jl
+++ b/src/LazyOperations/Bloating.jl
@@ -183,8 +183,9 @@ set.
 We call `constraints_list` on the lazy Minkowski sum.
 """
 function constraints_list(B::Bloating)
-    @assert (B.p == 1 || B.p == Inf) "the constraints list is only available " *
-        "for bloating in the 1-norm or in the infinity norm"
+    @assert is_polyhedral(B) "the constraints list is only available for " *
+        "polyhedral bloating (which requires a polyhedral base set and the " *
+        "1-norm or the infinity norm)"
     if B.ε < 0
         throw(ArgumentError("computing the constraints list of a negatively " *
                             "bloated set is not supported yet"))
@@ -208,4 +209,26 @@ The center of the wrapped set.
 """
 function center(B::Bloating)
     center(B.X)
+end
+
+"""
+    is_polyhedral(B::Bloating)
+
+Check whether a bloated set is polyhedral.
+
+### Input
+
+- `B` -- bloated set
+
+### Output
+
+`true` if the set is polyhedral.
+
+### Algorithm
+
+We check the sufficient condition that the base set is polyhedral and that the
+norm for bloating is either 1-norm or the infinity norm.
+"""
+function is_polyhedral(B::Bloating)
+    return (B.p == 1 || B.p == Inf) && is_polyhedral(B.X)
 end


### PR DESCRIPTION
Closes #1856.

The main code changes are:
- `_issubset_in_hyperrectangle` now does not require `interval_hull` anymore (and is also more efficient)
- I inlined the `_default_issubset` function because it was only used by one method.
- I used some approximate equality checks.
- I fixed a crash in `⊆(::LazySet, ::UnionSetArray)`.

The second commit adds `is_polyhedral` for `Bloating` to make an old test pass.