### PR TITLE
Revise convert code and generalize to LazySet

### DIFF
--- a/docs/src/lib/conversion.md
+++ b/docs/src/lib/conversion.md
@@ -13,49 +13,39 @@ CurrentModule = LazySets
 ```
 
 ```@docs
-convert(::Type{HPOLYGON}, ::VPolygon) where {HPOLYGON<:AbstractHPolygon}
-convert(::Type{Hyperrectangle}, ::AbstractHyperrectangle)
-convert(::Type{Interval}, ::AbstractHyperrectangle)
-convert(::Type{Interval}, ::ConvexSet{N}) where {N<:Real}
-convert(::Type{Hyperrectangle}, cpa::CartesianProductArray{N, HN}) where {N<:Real, HN<:AbstractHyperrectangle{N}}
-convert(::Type{Hyperrectangle}, cpa::CartesianProductArray{N, Interval{N}}) where {N<:Real}
-convert(::Type{HPOLYGON}, ::AbstractHyperrectangle) where {HPOLYGON<:AbstractHPolygon}
-convert(::Type{HPOLYGON}, ::HPolytope{N, VN}) where {N<:Real, VN<:AbstractVector{N}, HPOLYGON<:AbstractHPolygon}
-convert(::Type{HPOLYGON}, ::AbstractSingleton{N}) where {N<:Real, HPOLYGON<:AbstractHPolygon}
-convert(::Type{HPOLYGON}, ::LineSegment{N}) where {N<:Real, HPOLYGON<:AbstractHPolygon}
-convert(::Type{HPOLYGON}, ::ConvexSet) where {HPOLYGON<:AbstractHPolygon}
-convert(::Type{HPolyhedron}, ::AbstractPolytope)
-convert(::Type{HPolytope}, ::AbstractHPolygon)
-convert(::Type{HPolytope}, ::AbstractHyperrectangle)
-convert(::Type{HPolytope}, ::AbstractPolytope)
-convert(::Type{HPolytope}, ::VPolytope)
-convert(::Type{VPolygon}, ::AbstractHPolygon)
-convert(::Type{VPolytope}, ::ConvexSet)
-convert(::Type{VPolytope}, ::AbstractPolytope)
-convert(::Type{VPolytope}, ::HPolytope)
-convert(::Type{Zonotope}, ::AbstractZonotope)
+convert(::Type{Interval}, ::LazySet)
+convert(::Type{Interval}, ::Rectification{N, IN}) where {N, IN<:Interval}
+convert(::Type{Interval}, ::MinkowskiSum{N, IT, IT}) where {N, IT<:Interval}
+convert(::Type{Interval}, ::IntervalArithmetic.Interval)
+convert(::Type{IntervalArithmetic.Interval}, ::LazySet)
 convert(::Type{IntervalArithmetic.IntervalBox}, ::AbstractHyperrectangle)
 convert(::Type{Hyperrectangle}, ::IntervalArithmetic.IntervalBox)
-convert(::Type{Zonotope}, ::CartesianProduct{N, ZN1, ZN2}) where {N<:Real, ZN1<:AbstractZonotope{N}, ZN2<:AbstractZonotope{N}}
-convert(::Type{Hyperrectangle}, ::CartesianProduct{N, HN1, HN2}) where {N<:Real, HN1<:AbstractHyperrectangle{N}, HN2<:AbstractHyperrectangle{N}}
-convert(::Type{Zonotope}, ::CartesianProduct{N, HN1, HN2}) where {N<:Real, HN1<:AbstractHyperrectangle{N}, HN2<:AbstractHyperrectangle{N}}
-convert(::Type{Zonotope}, ::CartesianProductArray{N, HN}) where {N<:Real, HN<:AbstractHyperrectangle{N}}
-convert(::Type{Zonotope}, ::LinearMap{N, ZN}) where {N, ZN<:AbstractZonotope{N}}
-convert(::Type{Zonotope}, ::LinearMap{N, CartesianProduct{N, HN1, HN2}}) where {N, HN1<:AbstractHyperrectangle{N}, HN2<:AbstractHyperrectangle{N}}
-convert(::Type{Zonotope}, ::LinearMap{N, CartesianProductArray{N, HN}}) where {N, HN<:AbstractHyperrectangle{N}}
-convert(::Type{CartesianProduct{N, Interval{N}, Interval{N}}}, ::AbstractHyperrectangle{N}) where {N<:Real}
-convert(::Type{CartesianProductArray{N, Interval{N}}}, ::AbstractHyperrectangle{N}) where {N<:Real}
-convert(::Type{Hyperrectangle}, ::Rectification{N, AH}) where {N<:Real, AH<:AbstractHyperrectangle{N}}
-convert(::Type{Interval}, ::Rectification{N, IN}) where {N<:Real, IN<:Interval{N}}
-convert(::Type{IntervalArithmetic.Interval}, ::ConvexSet)
-convert(::Type{Interval}, ::IntervalArithmetic.Interval)
-convert(::Type{VPolytope}, ::ConvexHullArray{N, Singleton{N, VT}}) where {N, VT}
-convert(::Type{VPolygon}, ::ConvexSet)
+convert(::Type{Hyperrectangle}, ::AbstractHyperrectangle)
+convert(::Type{Hyperrectangle}, ::CartesianProduct{N, HN1, HN2}) where {N, HN1<:AbstractHyperrectangle, HN2<:AbstractHyperrectangle}
+convert(::Type{Hyperrectangle}, ::CartesianProductArray{N, HN}) where {N, HN<:AbstractHyperrectangle}
+convert(::Type{Hyperrectangle}, ::CartesianProductArray{N, IN}) where {N, IN<:Interval}
+convert(::Type{Hyperrectangle}, ::Rectification{N, AH}) where {N, AH<:AbstractHyperrectangle}
+convert(::Type{HPOLYGON}, ::LazySet) where {HPOLYGON<:AbstractHPolygon}
+convert(::Type{HPOLYGON}, ::VPolygon) where {HPOLYGON<:AbstractHPolygon}
+convert(::Type{HPOLYGON}, ::LineSegment{N}) where {N, HPOLYGON<:AbstractHPolygon}
+convert(::Type{HPOLYGON}, ::AbstractSingleton{N}) where {N, HPOLYGON<:AbstractHPolygon}
+convert(::Type{HPolyhedron}, ::LazySet)
+convert(::Type{HPolytope}, ::LazySet)
+convert(::Type{VPolygon}, ::LazySet)
+convert(::Type{VPolygon}, ::AbstractHPolygon)
+convert(::Type{VPolytope}, ::LazySet)
+convert(::Type{Zonotope}, ::AbstractZonotope)
+convert(::Type{Zonotope}, ::LinearMap{N, ZN}) where {N, ZN<:AbstractZonotope}
+convert(::Type{Zonotope}, ::LinearMap{N, CartesianProduct{N, HN1, HN2}}) where {N, HN1<:AbstractHyperrectangle, HN2<:AbstractHyperrectangle}
+convert(::Type{Zonotope}, ::LinearMap{N, CartesianProductArray{N, HN}}) where {N, HN<:AbstractHyperrectangle}
+convert(::Type{Zonotope}, ::CartesianProduct{N, ZN1, ZN2}) where {N, ZN1<:AbstractZonotope, ZN2<:AbstractZonotope}
+convert(::Type{Zonotope}, ::CartesianProduct{N, HN1, HN2}) where {N, HN1<:AbstractHyperrectangle, HN2<:AbstractHyperrectangle}
+convert(::Type{Zonotope}, ::CartesianProductArray{N, AZ}) where {N, AZ<:AbstractZonotope}
+convert(::Type{Zonotope}, ::CartesianProductArray{N, HN}) where {N, HN<:AbstractHyperrectangle}
+convert(::Type{CartesianProduct{N, Interval{N}, Interval{N}}}, ::AbstractHyperrectangle{N}) where {N}
+convert(::Type{CartesianProductArray{N, Interval{N}}}, ::AbstractHyperrectangle{N}) where {N}
 convert(::Type{MinkowskiSumArray}, ::MinkowskiSum{N, ST, MinkowskiSumArray{N, ST}}) where {N, ST}
-convert(::Type{Interval}, ::MinkowskiSum{N, IT, IT}) where {N, IT<:Interval{N}}
 convert(::Type{HParallelotope}, Z::AbstractZonotope{N}) where {N}
-convert(::Type{Zonotope}, ::CartesianProduct{N, AZ1, AZ2}) where {N, AZ1<:AbstractZonotope{N}, AZ2<:AbstractZonotope{N}}
-convert(::Type{Zonotope}, ::CartesianProductArray{N, AZ}) where {N, AZ<:AbstractZonotope{N}}
 convert(::Type{STAR}, ::AbstractPolyhedron{N}) where {N}
 convert(::Type{STAR}, ::Star)
 convert(::Type{Star}, ::AbstractPolyhedron{N}) where {N}

--- a/src/Interfaces/AbstractHyperrectangle.jl
+++ b/src/Interfaces/AbstractHyperrectangle.jl
@@ -153,7 +153,7 @@ end
 
 
 """
-    vertices_list(H::AbstractHyperrectangle)
+    vertices_list(H::AbstractHyperrectangle; kwargs...)
 
 Return the list of vertices of a hyperrectangular set.
 
@@ -192,7 +192,7 @@ entry `1` (but changing it to `-1`).
 This way we only need to change the vertex in those dimensions where `v` has
 changed, which usually is a smaller number than `n`.
 """
-function vertices_list(H::AbstractHyperrectangle)
+function vertices_list(H::AbstractHyperrectangle; kwargs...)
     n = dim(H)
 
     # identify flat dimensions and store them in a binary vector whose entry in

--- a/src/Interfaces/AbstractZonotope.jl
+++ b/src/Interfaces/AbstractZonotope.jl
@@ -520,7 +520,7 @@ Return the list of constraints defining a zonotopic set.
 
 ### Input
 
-- `Z`               -- zonotopic set
+- `Z` -- zonotopic set
 
 ### Output
 
@@ -546,6 +546,10 @@ The one-dimensional case is not covered by that algorithm; we manually handle
 this case.
 """
 function constraints_list(Z::AbstractZonotope{N}) where {N<:AbstractFloat}
+    return _constraints_list_zonotope(Z)
+end
+
+function _constraints_list_zonotope(Z::AbstractZonotope{N}) where {N<:AbstractFloat}
     n = dim(Z)
 
     # special handling of the 1D case

--- a/src/LazyOperations/ConvexHullArray.jl
+++ b/src/LazyOperations/ConvexHullArray.jl
@@ -190,8 +190,8 @@ function isempty(cha::ConvexHullArray)
 end
 
 """
-    vertices_list(cha::ConvexHullArray; apply_convex_hull::Bool=true,
-                  backend=nothing)
+    vertices_list(cha::ConvexHullArray; [apply_convex_hull]::Bool=true,
+                  [backend]=nothing, [prune]::Bool=apply_convex_hull)
 
 Return the list of vertices of the convex hull of a finite number of sets.
 
@@ -202,6 +202,8 @@ Return the list of vertices of the convex hull of a finite number of sets.
                          vertices using a convex-hull algorithm
 - `backend`           -- (optional, default: `nothing`) backend for computing
                          the convex hull (see argument `apply_convex_hull`)
+- `prune`             -- (optional, default: `apply_convex_hull`) alias for
+                         `apply_convex_hull`
 
 ### Output
 
@@ -209,9 +211,10 @@ The list of vertices.
 """
 function vertices_list(cha::ConvexHullArray;
                        apply_convex_hull::Bool=true,
-                       backend=nothing)
+                       backend=nothing,
+                       prune::Bool=apply_convex_hull)
     vlist = vcat([vertices_list(Xi) for Xi in array(cha)]...)
-    if apply_convex_hull
+    if apply_convex_hull || prune
         convex_hull!(vlist, backend=backend)
     end
     return vlist

--- a/src/Sets/Interval.jl
+++ b/src/Sets/Interval.jl
@@ -401,7 +401,7 @@ function rand(::Type{Interval};
 end
 
 """
-    vertices_list(x::Interval)
+    vertices_list(x::Interval; kwargs...)
 
 Return the list of vertices of an interval.
 
@@ -415,7 +415,7 @@ The list of vertices of the interval, which are two one-dimensional vectors,
 or just one if the interval is degenerate (the endpoints match within the
 working tolerance).
 """
-function vertices_list(x::Interval)
+function vertices_list(x::Interval; kwargs...)
     a = min(x)
     b = max(x)
     return _isapprox(a, b) ? [[a]] : [[a], [b]]

--- a/src/Sets/VPolygon.jl
+++ b/src/Sets/VPolygon.jl
@@ -259,7 +259,7 @@ function tohrep(P::VPolygon{N}, ::Type{HPOLYGON}=HPolygon
 end
 
 """
-    vertices_list(P::VPolygon)
+    vertices_list(P::VPolygon; kwargs...)
 
 Return the list of vertices of a polygon in vertex representation.
 
@@ -271,7 +271,7 @@ Return the list of vertices of a polygon in vertex representation.
 
 The list of vertices.
 """
-function vertices_list(P::VPolygon)
+function vertices_list(P::VPolygon; kwargs...)
     return P.vertices
 end
 


### PR DESCRIPTION
The first commit adds a method `_constraints_list_zonotope` to resolve a TODO.
The second commit contains the main changes. It mainly removes some implementations that are redundant because of an identical implementation of the supertype.
The remaining commits add kwargs to some `vertices_list` methods to make the above removal work.