### PR TITLE
Revise HPolyhedron code

### DIFF
--- a/docs/src/lib/conversion.md
+++ b/docs/src/lib/conversion.md
@@ -30,6 +30,7 @@ convert(::Type{HPOLYGON}, ::VPolygon) where {HPOLYGON<:AbstractHPolygon}
 convert(::Type{HPOLYGON}, ::LineSegment{N}) where {N, HPOLYGON<:AbstractHPolygon}
 convert(::Type{HPOLYGON}, ::AbstractSingleton{N}) where {N, HPOLYGON<:AbstractHPolygon}
 convert(::Type{HPolyhedron}, ::LazySet)
+convert(::Type{HPolyhedron}, ::HRep{N}) where {N}
 convert(::Type{HPolytope}, ::LazySet)
 convert(::Type{VPolygon}, ::LazySet)
 convert(::Type{VPolygon}, ::AbstractHPolygon)

--- a/docs/src/lib/interfaces.md
+++ b/docs/src/lib/interfaces.md
@@ -68,6 +68,7 @@ high(::LazySet)
 extrema(::LazySet, ::Int)
 extrema(::LazySet)
 convex_hull(::LazySet; kwargs...)
+triangulate(::LazySet)
 ```
 
 The following methods are also defined for `LazySet` but cannot be documented

--- a/docs/src/lib/sets/HPolyhedron.md
+++ b/docs/src/lib/sets/HPolyhedron.md
@@ -14,7 +14,7 @@ The following methods are shared between `HPolytope` and `HPolyhedron`.
 dim(::HPoly)
 ρ(::AbstractVector{M}, ::HPoly{N}) where {M, N}
 σ(::AbstractVector{M}, ::HPoly{N}) where {M, N}
-addconstraint!(::HPoly, ::LinearConstraint)
+addconstraint!(::HPoly, ::HalfSpace)
 constraints_list(::HPoly)
 tohrep(::HPoly)
 tovrep(::HPoly)
@@ -38,17 +38,16 @@ Inherited from [`ConvexSet`](@ref):
 Inherited from [`AbstractPolyhedron`](@ref):
 * [`∈`](@ref ∈(::AbstractVector, ::AbstractPolyhedron))
 * [`an_element`](@ref an_element(::AbstractPolyhedron))
-* [`constrained_dimensions`](@ref constrained_dimensions(::AbstractPolyhedron)
+* [`constrained_dimensions`](@ref constrained_dimensions(::AbstractPolyhedron))
 * [`linear_map`](@ref linear_map(::AbstractMatrix{NM}, ::AbstractPolyhedron{NP}) where {NM, NP})
 
 The following methods are specific to `HPolyhedron`.
 
 ```@docs
 rand(::Type{HPolyhedron})
-isbounded(::HPolyhedron)
 ```
 
 Inherited from [`AbstractPolyhedron`](@ref):
-
+* [`isbounded`](@ref isbounded(::AbstractPolyhedron{N}) where {N})
 * [`isuniversal`](@ref isuniversal(::AbstractPolyhedron{N}, ::Bool=false) where {N})
 * [`vertices_list`](@ref vertices_list(::AbstractPolyhedron, ::Bool=false))

--- a/src/Initialization/init_Polyhedra.jl
+++ b/src/Initialization/init_Polyhedra.jl
@@ -1,6 +1,6 @@
 eval(quote
     import .Polyhedra: polyhedron
-    export polyhedron
+    export polyhedron, triangulate
     using .Polyhedra: HRep, VRep,
                       removehredundancy!, removevredundancy!
 

--- a/src/Sets/HPolyhedron.jl
+++ b/src/Sets/HPolyhedron.jl
@@ -18,73 +18,70 @@ export HPolyhedron,
 """
     HPolyhedron{N, VN<:AbstractVector{N}} <: AbstractPolyhedron{N}
 
-Type that represents a convex polyhedron in H-representation, that is a finite intersection of half-spaces,
+Type that represents a convex polyhedron in constraint representation, that is,
+a finite intersection of half-spaces,
 ```math
 P = \\bigcap_{i = 1}^m H_i,
 ```
-where each ``H_i = \\{x \\in \\mathbb{R}^n : a_i^T x \\leq b_i \\}`` is a half-space,
-``a_i \\in \\mathbb{R}^n`` is the normal vector of the ``i``-th half-space and ``b_i`` is the displacement.
-The set ``P`` may or may not be bounded (see also [`HPolytope`](@ref), which assumes boundedness).
+where each ``H_i = \\{x \\in \\mathbb{R}^n : a_i^T x \\leq b_i \\}`` is a
+half-space, ``a_i \\in \\mathbb{R}^n`` is the normal vector of the ``i``-th
+half-space and ``b_i`` is the displacement. The set ``P`` may or may not be
+bounded (see also [`HPolytope`](@ref), which assumes boundedness).
 
 ### Fields
 
 - `constraints` -- vector of linear constraints
 """
 struct HPolyhedron{N, VN<:AbstractVector{N}} <: AbstractPolyhedron{N}
-    constraints::Vector{LinearConstraint{N, VN}}
+    constraints::Vector{HalfSpace{N, VN}}
 
-    function HPolyhedron(constraints::Vector{LinearConstraint{N, VN}}) where {N,
-                                                                              VN<:AbstractVector{N}}
+    function HPolyhedron(constraints::Vector{HalfSpace{N, VN}}) where {N, VN<:AbstractVector{N}}
         return new{N, VN}(constraints)
     end
 end
 
 isoperationtype(::Type{<:HPolyhedron}) = false
-isconvextype(::Type{<:HPolyhedron}) = true
 
-# constructor for an HPolyhedron with no constraints
+# constructor with no constraints
 function HPolyhedron{N, VN}() where {N, VN<:AbstractVector{N}}
-    HPolyhedron(Vector{LinearConstraint{N, VN}}())
+    HPolyhedron(Vector{HalfSpace{N, VN}}())
 end
 
-# constructor for an HPolyhedron with no constraints and given numeric type
+# constructor with no constraints, given only the numeric type
 function HPolyhedron{N}() where {N}
-    HPolyhedron(Vector{LinearConstraint{N, Vector{N}}}())
+    HPolyhedron(Vector{HalfSpace{N, Vector{N}}}())
 end
 
-# constructor for an HPolyhedron without explicit numeric type, defaults to Float64
+# constructor without explicit numeric type, defaults to Float64
 function HPolyhedron()
     HPolyhedron{Float64}()
 end
 
-# constructor for an HPolyhedron with constraints of mixed type
-function HPolyhedron(constraints::Vector{<:LinearConstraint})
+# constructor with constraints of mixed type
+function HPolyhedron(constraints::Vector{<:HalfSpace})
     HPolyhedron(_normal_Vector(constraints))
 end
 
-# constructor from a simple H-representation
-HPolyhedron(A::AbstractMatrix, b::AbstractVector) =
-    HPolyhedron(constraints_list(A, b))
+# constructor from a simple constraint representation
+function HPolyhedron(A::AbstractMatrix, b::AbstractVector)
+    return HPolyhedron(constraints_list(A, b))
+end
 
 # convenience union type
 const HPoly{N} = Union{HPolytope{N}, HPolyhedron{N}}
 
-
-# --- ConvexSet interface functions ---
-
-
 """
     dim(P::HPoly)
 
-Return the dimension of a polyhedron in H-representation.
+Return the dimension of a polyhedron in constraint representation.
 
 ### Input
 
-- `P`  -- polyhedron in H-representation
+- `P`  -- polyhedron in constraint representation
 
 ### Output
 
-The ambient dimension of the polyhedron in H-representation.
+The ambient dimension of the polyhedron in constraint representation.
 If it has no constraints, the result is ``-1``.
 """
 function dim(P::HPoly)
@@ -95,19 +92,19 @@ end
     ρ(d::AbstractVector{M}, P::HPoly{N};
       solver=default_lp_solver(M, N)) where {M, N}
 
-Evaluate the support function of a polyhedron (in H-representation) in a given
-direction.
+Evaluate the support function of a polyhedron in constraint representation in a
+given direction.
 
 ### Input
 
 - `d`      -- direction
-- `P`      -- polyhedron in H-representation
+- `P`      -- polyhedron in constraint representation
 - `solver` -- (optional, default: `default_lp_solver(M, N)`) the backend used to
               solve the linear program
 
 ### Output
 
-The support function of the polyhedron.
+The evaluation of the support function for the polyhedron.
 If a polytope is unbounded in the given direction, we throw an error.
 If a polyhedron is unbounded in the given direction, the result is `Inf`.
 """
@@ -128,19 +125,22 @@ end
     σ(d::AbstractVector{M}, P::HPoly{N};
       solver=default_lp_solver(M, N) where {M, N}
 
-Return the support vector of a polyhedron (in H-representation) in a given
+Return a support vector of a polyhedron in constraint representation in a given
 direction.
 
 ### Input
 
 - `d`      -- direction
-- `P`      -- polyhedron in H-representation
+- `P`      -- polyhedron in constraint representation
 - `solver` -- (optional, default: `default_lp_solver(M, N)`) the backend used to
               solve the linear program
 
 ### Output
 
 The support vector in the given direction.
+If a polytope is unbounded in the given direction, we throw an error.
+If a polyhedron is unbounded in the given direction, the result contains `±Inf`
+entries.
 """
 function σ(d::AbstractVector{M}, P::HPoly{N};
            solver=default_lp_solver(M, N)) where {M, N}
@@ -175,7 +175,7 @@ function σ(d::AbstractVector{M}, P::HPoly{N};
 end
 
 function σ_helper(d::AbstractVector, P::HPoly, solver)
-    # let c = -d as a Vector since GLPK does not accept sparse vectors
+    # represent c = -d as a Vector since GLPK does not accept sparse vectors
     # (see #1011)
     c = to_negative_vector(d)
 
@@ -206,7 +206,7 @@ end
     rand(::Type{HPolyhedron}; [N]::Type{<:Real}=Float64, [dim]::Int=2,
          [rng]::AbstractRNG=GLOBAL_RNG, [seed]::Union{Int, Nothing}=nothing)
 
-Create a polyhedron.
+Create a random polyhedron.
 
 ### Input
 
@@ -218,12 +218,12 @@ Create a polyhedron.
 
 ### Output
 
-A polyhedron.
+A random polyhedron.
 
 ### Algorithm
 
-We first create a random polytope and then randomly remove some of the
-constraints.
+We first create a random polytope and then for each constraint randomly (50%)
+decide whether to include it.
 """
 function rand(::Type{HPolyhedron};
               N::Type{<:Real}=Float64,
@@ -242,20 +242,14 @@ function rand(::Type{HPolyhedron};
     return HPolyhedron(constraints_Q)
 end
 
-
-# ===========================================
-# HPolyhedron and HPolytope's shared methods
-# ===========================================
-
-
 """
-    addconstraint!(P::HPoly, constraint::LinearConstraint)
+    addconstraint!(P::HPoly, constraint::HalfSpace)
 
-Add a linear constraint to a polyhedron in H-representation.
+Add a linear constraint to a polyhedron in constraint representation.
 
 ### Input
 
-- `P`          -- polyhedron in H-representation
+- `P`          -- polyhedron in constraint representation
 - `constraint` -- linear constraint to add
 
 ### Notes
@@ -263,7 +257,7 @@ Add a linear constraint to a polyhedron in H-representation.
 It is left to the user to guarantee that the dimension of all linear constraints
 is the same.
 """
-function addconstraint!(P::HPoly, constraint::LinearConstraint)
+function addconstraint!(P::HPoly, constraint::HalfSpace)
     push!(P.constraints, constraint)
     return nothing
 end
@@ -271,11 +265,12 @@ end
 """
     constraints_list(P::HPoly)
 
-Return the list of constraints defining a polyhedron in H-representation.
+Return the list of constraints defining a polyhedron in constraint
+representation.
 
 ### Input
 
-- `P` -- polyhedron in H-representation
+- `P` -- polyhedron in constraint representation
 
 ### Output
 
@@ -325,10 +320,9 @@ function normalize(P::HPoly{N}, p=N(2)) where {N}
 end
 
 """
-    remove_redundant_constraints(P::HPoly{N};
-                                 backend=nothing) where {N}
+    remove_redundant_constraints(P::HPoly{N}; [backend]=nothing) where {N}
 
-Remove the redundant constraints in a polyhedron in H-representation.
+Remove the redundant constraints in a polyhedron in constraint representation.
 
 ### Input
 
@@ -361,11 +355,10 @@ function remove_redundant_constraints(P::HPoly; backend=nothing)
 end
 
 """
-    remove_redundant_constraints!(P::HPoly{N};
-                                  backend=nothing) where {N}
+    remove_redundant_constraints!(P::HPoly{N}; [backend]=nothing) where {N}
 
-Remove the redundant constraints in a polyhedron in H-representation; the
-polyhedron is updated in-place.
+Remove the redundant constraints of a polyhedron in constraint representation;
+the polyhedron is updated in-place.
 
 ### Input
 
@@ -425,26 +418,22 @@ function translate(P::HPoly, v::AbstractVector; share::Bool=false)
     return T(constraints)
 end
 
-# ========================================================
-# External methods that require Polyhedra.jl to be loaded
-# ========================================================
-
 """
-    tovrep(P::HPoly;
-          [backend]=default_polyhedra_backend(P))
+    tovrep(P::HPoly; [backend]=default_polyhedra_backend(P))
 
-Transform a polyhedron in H-representation to a polytope in V-representation.
+Transform a polytope in constraint representation to a polytope in vertex
+representation.
 
 ### Input
 
-- `P`       -- polyhedron in constraint representation
+- `P`       -- polytope in constraint representation
 - `backend` -- (optional, default: `default_polyhedra_backend(P)`) the
                backend for polyhedral computations
 
 ### Output
 
-The `VPolytope` which is the vertex representation of the given polyhedron
-in constraint representation.
+A `VPolytope` which is a vertex representation of the given polytope in
+constraint representation.
 
 ### Notes
 
@@ -453,8 +442,7 @@ depending on the backend.
 For further information on the supported backends see [Polyhedra's
 documentation](https://juliapolyhedra.github.io/).
 """
-function tovrep(P::HPoly;
-                backend=default_polyhedra_backend(P))
+function tovrep(P::HPoly; backend=default_polyhedra_backend(P))
     require(@__MODULE__, :Polyhedra; fun_name="tovrep")
     P = polyhedron(P; backend=backend)
     return VPolytope(P)
@@ -465,19 +453,19 @@ end
             [use_polyhedra_interface]::Bool=false, [solver]=nothing,
             [backend]=nothing) where {N}
 
-Determine whether a polyhedron is empty.
+Check whether a polyhedron in constraint representation is empty.
 
 ### Input
 
-- `P`       -- polyhedron
+- `P`       -- polyhedron in constraint representation
 - `witness` -- (optional, default: `false`) compute a witness if activated
 - `use_polyhedra_interface` -- (optional, default: `false`) if `true`, we use
                the `Polyhedra` interface for the emptiness test
-- `solver`  -- (optional, default: `nothing`) LP-solver backend, uses `default_lp_solver(N)`
-               if it is not provided
+- `solver`  -- (optional, default: `nothing`) LP-solver backend; uses
+               `default_lp_solver(N)` if not provided
 - `backend` -- (optional, default: `nothing`) backend for polyhedral
-               computations in `Polyhedra`, uses `default_polyhedra_backend(P)` if
-               it is not provided
+               computations in `Polyhedra`; uses `default_polyhedra_backend(P)`
+               if not provided
 
 ### Output
 
@@ -510,8 +498,8 @@ function isempty(P::HPoly{N},
         return witness ? (false, an_element(P)) : false
     end
     if use_polyhedra_interface
-        require(@__MODULE__, :Polyhedra; fun_name="isempty", explanation="with the active " *
-            "option `use_polyhedra_interface`")
+        require(@__MODULE__, :Polyhedra; fun_name="isempty",
+                explanation="with the active option `use_polyhedra_interface`")
 
         if backend == nothing
             backend = default_polyhedra_backend(P)
@@ -548,17 +536,28 @@ function isempty(P::HPoly{N},
     end
 end
 
-# ==================================
-# Methods that use Polyhedra.jl
-# ==================================
-
 function load_polyhedra_hpolyhedron() # function to be loaded by Requires
 return quote
 # see the interface file init_Polyhedra.jl for the imports
 
+"""
+     convert(::Type{HPolyhedron}, P::HRep{N}) where {N}
+
+Convert an `HRep` polyhedron from `Polyhedra.jl` to a polyhedron in constraint
+representation .
+
+### Input
+
+- `HPolyhedron` -- target type
+- `P`           -- `HRep` polyhedron
+
+### Output
+
+An `HPolyhedron`.
+"""
 function convert(::Type{HPolyhedron}, P::HRep{N}) where {N}
     VN = Polyhedra.hvectortype(P)
-    constraints = Vector{LinearConstraint{N, VN}}()
+    constraints = Vector{HalfSpace{N, VN}}()
     for hi in Polyhedra.allhalfspaces(P)
         a, b = hi.a, hi.β
         if isapproxzero(norm(a))
@@ -569,20 +568,7 @@ function convert(::Type{HPolyhedron}, P::HRep{N}) where {N}
     return HPolyhedron(constraints)
 end
 
-"""
-     HPolyhedron(P::HRep{N}) where {N}
-
-Return a polyhedron in H-representation given a `HRep` polyhedron
-from `Polyhedra.jl`.
-
-### Input
-
-- `P` -- `HRep` polyhedron
-
-### Output
-
-An `HPolyhedron`.
-"""
+# convenience conversion method
 function HPolyhedron(P::HRep{N}) where {N}
     convert(HPolyhedron, P)
 end
@@ -591,7 +577,7 @@ end
     polyhedron(P::HPoly; [backend]=default_polyhedra_backend(P))
 
 Return an `HRep` polyhedron from `Polyhedra.jl` given a polytope in
-H-representation.
+constraint representation.
 
 ### Input
 
@@ -608,23 +594,37 @@ An `HRep` polyhedron.
 For further information on the supported backends see
 [Polyhedra's documentation](https://juliapolyhedra.github.io/).
 """
-function polyhedron(P::HPoly;
-                    backend=default_polyhedra_backend(P))
+function polyhedron(P::HPoly; backend=default_polyhedra_backend(P))
     A, b = tosimplehrep(P)
     return Polyhedra.polyhedron(Polyhedra.hrep(A, b), backend)
 end
 
-function triangulate(X::ConvexSet)
+"""
+    triangulate(X::LazySet)
 
-    dim(X) == 3 || throw(ArgumentError("the dimension of the set should be three, got $(dim(X))"))
+Triangulate a three-dimensional polyhedral set.
 
-    poly = polyhedron(convert(HPolyhedron, X))
-    mes = Mesh(poly)
+### Input
+
+- `X` -- three-dimensional polyhedral set
+
+### Output
+
+A tuple `(p, c)` where `p` is a matrix, with each column containing a point, and
+`c` is a list of 3-tuples containing the indices of the points in each triangle.
+"""
+function triangulate(X::LazySet)
+    dim(X) == 3 || throw(ArgumentError("the dimension of the set should be " *
+        "three, got $(dim(X))"))
+
+    P = polyhedron(convert(HPolyhedron, X))
+    mes = Mesh(P)
     coords = Polyhedra.GeometryBasics.coordinates(mes)
     connec = Polyhedra.GeometryBasics.faces(mes)
 
     ntriangles = length(connec)
-    npoints = 3*ntriangles
+    npoints = length(coords)
+    @assert npoints == 3 * ntriangles
     points = Matrix{Float32}(undef, 3, npoints)
 
     for i in 1:npoints
@@ -657,27 +657,26 @@ function is_hyperplanar(P::HPolyhedron)
     return @inbounds iscomplement(clist[1], clist[2])
 end
 
-# ============================================
-# Functionality that requires Symbolics
-# ============================================
 function load_symbolics_hpolyhedron()
-
 return quote
 
 """
-    HPolyhedron(expr::Vector{<:Num}, vars=_get_variables(expr); N::Type{<:Real}=Float64)
+    HPolyhedron(expr::Vector{<:Num}, vars=_get_variables(expr);
+                N::Type{<:Real}=Float64)
 
-Return the polyhedron in half-space representation given by a list of symbolic expressions.
+Return a polyhedron in constraint representation given by a list of symbolic
+expressions.
 
 ### Input
 
 - `expr` -- vector of symbolic expressions that describes each half-space
-- `vars` -- (optional, default: `_get_variables(expr)`), if an array of variables is given,
-            use those as the ambient variables in the set with respect to which derivations
-            take place; otherwise, use only the variables which appear in the given
-            expression (but be careful because the order may be incorrect; it is advicsed to always
-            pass `vars` explicitly)
-- `N`    -- (optional, default: `Float64`) the numeric type of the returned half-space
+- `vars` -- (optional, default: `_get_variables(expr)`), if an array of
+            variables is given, use those as the ambient variables in the set
+            with respect to which derivations take place; otherwise, use only
+            the variables that appear in the given expression (but be careful
+            because the order may be incorrect; it is advised to always pass
+            `vars` explicitly)
+- `N`    -- (optional, default: `Float64`) the numeric type of the returned set
 
 ### Output
 
@@ -729,7 +728,9 @@ function HPolyhedron(expr::Vector{<:Num}, vars::AbstractVector{Num}; N::Type{<:R
     return HPolyhedron(clist)
 end
 
-HPolyhedron(expr::Vector{<:Num}; N::Type{<:Real}=Float64) = HPolyhedron(expr, _get_variables(expr); N=N)
-HPolyhedron(expr::Vector{<:Num}, vars; N::Type{<:Real}=Float64) = HPolyhedron(expr, _vec(vars); N=N)
+HPolyhedron(expr::Vector{<:Num}; N::Type{<:Real}=Float64) =
+    HPolyhedron(expr, _get_variables(expr); N=N)
+HPolyhedron(expr::Vector{<:Num}, vars; N::Type{<:Real}=Float64) =
+    HPolyhedron(expr, _vec(vars); N=N)
 
 end end  # quote / load_symbolics_hpolyhedron()


### PR DESCRIPTION
Main code changes:
- I documented the `convert` method from `HRep` rather than the `HPolyhedron(::HRep)` method because that is the standard Julia way to convert.
- I documented and exported `triangulate`.