### PR TITLE
Revise CartesianProduct code

### DIFF
--- a/docs/src/lib/lazy_operations/CartesianProduct.md
+++ b/docs/src/lib/lazy_operations/CartesianProduct.md
@@ -19,8 +19,9 @@ isbounded(::CartesianProduct)
 isempty(::CartesianProduct)
 center(::CartesianProduct)
 constraints_list(::CartesianProduct)
-vertices_list(cp::CartesianProduct{N}) where {N}
-linear_map(M::AbstractMatrix, cp::CartesianProduct)
+vertices_list(::CartesianProduct)
+linear_map(::AbstractMatrix, ::CartesianProduct)
+volume(::CartesianProduct)
 project(::CartesianProduct{N, IT, HT}, ::AbstractVector{Int}) where {N, IT<:Interval, HT<:AbstractHyperrectangle{N}}
 project(::CartesianProduct{N, IT, ZT}, ::AbstractVector{Int}) where {N, IT<:Interval, ZT<:AbstractZonotope{N}}
 project(::CartesianProduct{N, IT, Union{VP1, VP2}}, ::AbstractVector{Int}) where {N, IT<:Interval, VP1<:VPolygon{N}, VP2<:VPolytope{N}}

--- a/src/LazyOperations/CartesianProduct.jl
+++ b/src/LazyOperations/CartesianProduct.jl
@@ -7,12 +7,13 @@ export CartesianProduct,
 """
     CartesianProduct{N, S1<:ConvexSet{N}, S2<:ConvexSet{N}} <: ConvexSet{N}
 
-Type that represents the Cartesian product of two sets, that is the set
+Type that represents the Cartesian product of two sets, i.e., the set
 
 ```math
 Z = \\{ z ∈ \\mathbb{R}^{n + m} : z = (x, y),\\qquad x ∈ X, y ∈ Y \\}.
 ```
-If ``X ⊆ \\mathbb{R}^n`` and ``Y ⊆ \\mathbb{R}^m``, then ``Z`` is ``n+m``-dimensional.
+If ``X ⊆ \\mathbb{R}^n`` and ``Y ⊆ \\mathbb{R}^m``, then ``Z`` is
+``n+m``-dimensional.
 
 ### Fields
 
@@ -21,23 +22,22 @@ If ``X ⊆ \\mathbb{R}^n`` and ``Y ⊆ \\mathbb{R}^m``, then ``Z`` is ``n+m``-di
 
 ### Notes
 
-The Cartesian product of three elements is obtained recursively.
-See also [`CartesianProductArray`](@ref) for an implementation of a Cartesian product of
-many sets without recursion, instead using an array, making the operations more efficient.
+See also [`CartesianProductArray`](@ref) for an implementation of a Cartesian
+product of more than two sets.
 
 The `EmptySet` is the absorbing element for `CartesianProduct`.
 
 The Cartesian product preserves convexity: if the set arguments are convex, then
 their Cartesian product is convex as well.
 
-In some docstrings the word "block" is used to denote each wrapped set, with the natural
-order, i.e. we say that the first block of a Cartesian product `cp` is `cp.X` and
-the second block is `cp.Y`.
+In some docstrings the word "block" is used to denote each wrapped set, with the
+natural order, i.e. we say that the first block of a Cartesian product `cp` is
+`cp.X` and the second block is `cp.Y`.
 
 ### Examples
 
-The Cartesian product between two sets `X` and `Y` can be constructed either
-using `CartesianProduct(X, Y)` or the short-cut notation `X × Y` (to enter the times
+The Cartesian product of two sets `X` and `Y` can be constructed either using
+`CartesianProduct(X, Y)` or the short-cut notation `X × Y` (to enter the *times*
 symbol, write `\\times[TAB]`).
 
 ```jldoctest cartesianproduct_constructor
@@ -50,8 +50,8 @@ julia> I12 = I1 × I2;
 julia> typeof(I12)
 CartesianProduct{Float64, Interval{Float64, IntervalArithmetic.Interval{Float64}}, Interval{Float64, IntervalArithmetic.Interval{Float64}}}
 ```
-A hyperrectangle is the cartesian product of intervals, so we can convert `I12`
-exactly to a `Hyperrectangle` type:
+A hyperrectangle is the Cartesian product of intervals, so we can convert `I12`
+to a `Hyperrectangle` type:
 
 ```jldoctest cartesianproduct_constructor
 julia> convert(Hyperrectangle, I12)
@@ -61,13 +61,17 @@ Hyperrectangle{Float64, Vector{Float64}, Vector{Float64}}([0.5, 3.0], [0.5, 1.0]
 struct CartesianProduct{N, S1<:ConvexSet{N}, S2<:ConvexSet{N}} <: ConvexSet{N}
     X::S1
     Y::S2
+
     function CartesianProduct(X::ConvexSet{N}, Y::ConvexSet{N}) where {N}
         return new{N, typeof(X), typeof(Y)}(X, Y)
     end
 end
 
 isoperationtype(::Type{<:CartesianProduct}) = true
-isconvextype(::Type{CartesianProduct{N, S1, S2}}) where {N, S1, S2} = isconvextype(S1) && isconvextype(S2)
+
+isconvextype(::Type{CartesianProduct{N, S1, S2}}) where {N, S1, S2} =
+    isconvextype(S1) && isconvextype(S2)
+
 is_polyhedral(cp::CartesianProduct) = is_polyhedral(cp.X) && is_polyhedral(cp.Y)
 
 # EmptySet is the absorbing element for CartesianProduct
@@ -85,7 +89,7 @@ Alias for the binary Cartesian product.
 """
     ×
 
-Unicode alias constructor × (`times`) for the binary Cartesian product operator.
+Unicode alias (`times`) for the binary Cartesian product operator.
 
 ### Notes
 
@@ -100,7 +104,7 @@ Return a new `CartesianProduct` object with the arguments swapped.
 
 ### Input
 
-- `cp` -- Cartesian product of two sets
+- `cp` -- Cartesian product
 
 ### Output
 
@@ -130,7 +134,7 @@ end
 """
     σ(d::AbstractVector, cp::CartesianProduct)
 
-Return the support vector of a Cartesian product.
+Return a support vector of a Cartesian product.
 
 ### Input
 
@@ -139,7 +143,7 @@ Return the support vector of a Cartesian product.
 
 ### Output
 
-The support vector in the given direction.
+A support vector in the given direction.
 If the direction has norm zero, the result depends on the wrapped sets.
 """
 function σ(d::AbstractVector, cp::CartesianProduct)
@@ -150,7 +154,7 @@ end
 """
     ρ(d::AbstractVector, cp::CartesianProduct)
 
-Return the support function of a Cartesian product.
+Evaluate the support function of a Cartesian product.
 
 ### Input
 
@@ -159,7 +163,7 @@ Return the support function of a Cartesian product.
 
 ### Output
 
-The support function in the given direction.
+The evaluation of the support function in the given direction.
 If the direction has norm zero, the result depends on the wrapped sets.
 """
 function ρ(d::AbstractVector, cp::CartesianProduct)
@@ -170,7 +174,7 @@ end
 """
     isbounded(cp::CartesianProduct)
 
-Determine whether a Cartesian product is bounded.
+Check whether a Cartesian product is bounded.
 
 ### Input
 
@@ -213,7 +217,7 @@ end
 """
     isempty(cp::CartesianProduct)
 
-Return if a Cartesian product is empty or not.
+Check whether a Cartesian product is empty.
 
 ### Input
 
@@ -251,7 +255,7 @@ Return the list of constraints of a (polyhedral) Cartesian product.
 
 ### Input
 
-- `cp` -- Cartesian product
+- `cp` -- polyhedral Cartesian product
 
 ### Output
 
@@ -262,13 +266,13 @@ function constraints_list(cp::CartesianProduct)
 end
 
 """
-    vertices_list(cp::CartesianProduct{N}) where {N}
+    vertices_list(cp::CartesianProduct)
 
 Return the list of vertices of a (polytopic) Cartesian product.
 
 ### Input
 
-- `cp` -- Cartesian product
+- `cp` -- polytopic Cartesian product
 
 ### Output
 
@@ -280,16 +284,18 @@ We assume that the underlying sets are polytopic.
 Then the high-dimensional set of vertices is just the Cartesian product of the
 low-dimensional sets of vertices.
 """
-function vertices_list(cp::CartesianProduct{N}) where {N}
+function vertices_list(cp::CartesianProduct)
     # collect low-dimensional vertices lists
-    vlist_low = (vertices_list(cp.X), vertices_list(cp.Y))
+    vlist1 = vertices_list(cp.X)
+    vlist2 = vertices_list(cp.Y)
 
     # create high-dimensional vertices list
+    N = eltype(cp)
     vlist = Vector{Vector{N}}()
-    m = length(vlist_low[1]) * length(vlist_low[2])
+    m = length(vlist1) * length(vlist2)
     sizehint!(vlist, m)
-    for v1 in vlist_low[1]
-        for v2 in vlist_low[2]
+    for v1 in vlist1
+        for v2 in vlist2
             push!(vlist, vcat(v1, v2))
         end
     end
@@ -305,7 +311,7 @@ Concrete linear map of a (polyhedral) Cartesian product.
 ### Input
 
 - `M`  -- matrix
-- `cp` -- Cartesian product of two sets
+- `cp` -- Cartesian product
 
 ### Output
 
@@ -316,7 +322,8 @@ A polytope if `cp` is bounded and a polyhedron otherwise.
 We convert the Cartesian product to constraint representation and then call
 `linear_map` on the corresponding polyhedron.
 
-This is a fallback implementation and it will fail if the wrapped sets are not polyhedral.
+This is a fallback implementation and will fail if the wrapped sets are not
+polyhedral.
 """
 function linear_map(M::AbstractMatrix, cp::CartesianProduct)
     return linear_map_cartesian_product(M, cp)
@@ -359,17 +366,18 @@ end
     project(cp::CartesianProduct{N, IT, HT}, block::AbstractVector{Int};
             [kwargs...]) where {N, IT<:Interval, HT<:AbstractHyperrectangle{N}}
 
-Concrete projection of a Cartesian product between an interval and a hyperrectangle.
+Concrete projection of the Cartesian product of an interval and a
+hyperrectangular set.
 
 ### Input
 
-- `cp`       -- Cartesian product between an interval and a hyperrectangle
-- `block`    -- block structure, a vector with the dimensions of interest
+- `cp`    -- Cartesian product of an interval and a hyperrectangle
+- `block` -- block structure, a vector with the dimensions of interest
 
 ### Output
 
-A hyperrectangle representing the projection of the cartesian product `cp` on the
-dimensions specified by `block`.
+A hyperrectangle representing the projection of the Cartesian product `cp` on
+the dimensions specified by `block`.
 """
 function project(cp::CartesianProduct{N, IT, HT}, block::AbstractVector{Int};
                  kwargs...) where {N, IT<:Interval, HT<:AbstractHyperrectangle{N}}
@@ -391,16 +399,16 @@ end
     project(cp::CartesianProduct{N, IT, ZT}, block::AbstractVector{Int};
             [kwargs...]) where {N, IT<:Interval, ZT<:AbstractZonotope{N}}
 
-Concrete projection of the Cartesian product between an interval and a zonotopic set.
+Concrete projection of the Cartesian product of an interval and a zonotopic set.
 
 ### Input
 
-- `cp`       -- Cartesian product between an interval and a zonotopic set
-- `block`    -- block structure, a vector with the dimensions of interest
+- `cp`    -- Cartesian product of an interval and a zonotopic set
+- `block` -- block structure, a vector with the dimensions of interest
 
 ### Output
 
-A zonotope representing the projection of the cartesian product `cp` on the
+A zonotope representing the projection of the Cartesian product `cp` on the
 dimensions specified by `block`.
 """
 function project(cp::CartesianProduct{N, IT, ZT}, block::AbstractVector{Int};
@@ -421,16 +429,17 @@ end
             block::AbstractVector{Int};
             [kwargs...]) where {N, IT<:Interval, VP1<:VPolygon{N}, VP2<:VPolytope{N}}
 
-Concrete projection of the Cartesian product between an interval and a set in vertex representation.
+Concrete projection of the Cartesian product of an interval and a set in vertex
+representation.
 
 ### Input
 
-- `cp`       -- Cartesian product between an interval and a `VPolygon` or a `VPolytope`
-- `block`    -- block structure, a vector with the dimensions of interest
+- `cp`    -- Cartesian product of an interval and a `VPolygon` or a `VPolytope`
+- `block` -- block structure, a vector with the dimensions of interest
 
 ### Output
 
-A `VPolytope` representing the projection of the cartesian product `cp` on the
+A `VPolytope` representing the projection of the Cartesian product `cp` on the
 dimensions specified by `block`.
 """
 function project(cp::CartesianProduct{N, IT, Union{VP1, VP2}},
@@ -448,6 +457,19 @@ function project(cp::CartesianProduct{N, IT, Union{VP1, VP2}},
     return Pout
 end
 
+"""
+    volume(cp::CartesianProduct)
+
+Compute the volume of a Cartesian product.
+
+### Input
+
+- `cp` -- Cartesian product
+
+### Output
+
+The volume.
+"""
 function volume(cp::CartesianProduct)
     return volume(cp.X) * volume(cp.Y)
 end


### PR DESCRIPTION
The removal of the type parameter in `vertices_list` is to fix the docs entry.