### PR TITLE
#1758 - faster support function/vector for CartesianProduct/CartesianProductArray

### DIFF
--- a/src/LazyOperations/CartesianProduct.jl
+++ b/src/LazyOperations/CartesianProduct.jl
@@ -151,6 +151,18 @@ function σ(d::AbstractVector, cp::CartesianProduct)
     return [σ(d[1:n1], cp.X); σ(d[n1+1:length(d)], cp.Y)]
 end
 
+# faster version for single-entry vectors
+function σ(d::SingleEntryVector, cp::CartesianProduct)
+    n1 = dim(cp.X)
+    idx = d.i
+    if idx <= n1
+        return [σ(SingleEntryVector(idx, n1, d.v), cp.X); an_element(cp.Y)]
+    else
+        n2 = length(d) - n1
+        return [an_element(cp.X); σ(SingleEntryVector(idx - n1, n2, d.v), cp.Y)]
+    end
+end
+
 """
     ρ(d::AbstractVector, cp::CartesianProduct)
 
@@ -169,6 +181,18 @@ If the direction has norm zero, the result depends on the wrapped sets.
 function ρ(d::AbstractVector, cp::CartesianProduct)
     n1 = dim(cp.X)
     return ρ(d[1:n1], cp.X) + ρ(d[n1+1:length(d)], cp.Y)
+end
+
+# faster version for single-entry vectors
+function ρ(d::SingleEntryVector, cp::CartesianProduct)
+    n1 = dim(cp.X)
+    idx = d.i
+    if idx <= n1
+        return ρ(SingleEntryVector(idx, n1, d.v), cp.X)
+    else
+        n2 = length(d) - n1
+        return ρ(SingleEntryVector(idx - n1, n2, d.v), cp.Y)
+    end
 end
 
 """

--- a/src/LazyOperations/CartesianProductArray.jl
+++ b/src/LazyOperations/CartesianProductArray.jl
@@ -28,14 +28,14 @@ Constructors:
  -- constructor for an empty product with optional size hint and numeric type
 """
 struct CartesianProductArray{N, S<:LazySet{N}} <: LazySet{N}
-   array::Vector{S}
+    array::Vector{S}
 end
 
 # constructor for an empty product with optional size hint and numeric type
 function CartesianProductArray(n::Int=0, N::Type=Float64)
-   arr = Vector{LazySet{N}}()
-   sizehint!(arr, n)
-   return CartesianProductArray(arr)
+    arr = Vector{LazySet{N}}()
+    sizehint!(arr, n)
+    return CartesianProductArray(arr)
 end
 
 isoperationtype(::Type{<:CartesianProductArray}) = true
@@ -61,7 +61,7 @@ Return the array of a Cartesian product of a finite number of sets.
 The array of a Cartesian product of a finite number of sets.
 """
 function array(cpa::CartesianProductArray)
-   return cpa.array
+    return cpa.array
 end
 
 """
@@ -79,7 +79,7 @@ The ambient dimension of the Cartesian product of a finite number of sets, or
 `0` if there is no set in the array.
 """
 function dim(cpa::CartesianProductArray)
-   return length(cpa.array) == 0 ? 0 : sum(dim(Xi) for Xi in cpa.array)
+    return length(cpa.array) == 0 ? 0 : sum(dim(Xi) for Xi in cpa.array)
 end
 
 """
@@ -98,53 +98,53 @@ A support vector in the given direction.
 If the direction has norm zero, the result depends on the product sets.
 """
 function σ(d::AbstractVector, cpa::CartesianProductArray)
-   svec = similar(d)
-   i0 = 1
-   for Xi in cpa.array
-       i1 = i0 + dim(Xi) - 1
-       svec[i0:i1] = σ(d[i0:i1], Xi)
-       i0 = i1 + 1
-   end
-   return svec
+    svec = similar(d)
+    i0 = 1
+    for Xi in cpa.array
+        i1 = i0 + dim(Xi) - 1
+        svec[i0:i1] = σ(d[i0:i1], Xi)
+        i0 = i1 + 1
+    end
+    return svec
 end
 
 # faster version for sparse vectors
 function σ(d::AbstractSparseVector, cpa::CartesianProductArray)
-   # idea: We walk through the blocks of `cpa` (i.e., the sets `Xi`) and search
-   # for corresponding non-zero entries in `d` (stored in `indices`).
-   # `next_idx` is the next index of `indices` such that
-   # `next_dim = indices[next_idx]` lies in the next block to consider
-   # (potentially skipping some blocks).
-   svec = similar(d)
-   indices, _ = SparseArrays.findnz(d)
-   if isempty(indices)
-       # direction is the zero vector
-       return an_element(cpa)
-   end
-   next_idx = 1
-   next_dim = indices[next_idx]
-   m = length(indices)
-   i0 = 1
-   for Xi in cpa.array
-       i1 = i0 + dim(Xi) - 1
-       if next_dim <= i1
-           # there is a non-zero entry in this block
-           svec[i0:i1] = σ(d[i0:i1], Xi)
+    # idea: We walk through the blocks of `cpa` (i.e., the sets `Xi`) and search
+    # for corresponding non-zero entries in `d` (stored in `indices`).
+    # `next_idx` is the next index of `indices` such that
+    # `next_dim = indices[next_idx]` lies in the next block to consider
+    # (potentially skipping some blocks).
+    svec = similar(d)
+    indices, _ = SparseArrays.findnz(d)
+    if isempty(indices)
+        # direction is the zero vector
+        return an_element(cpa)
+    end
+    next_idx = 1
+    next_dim = indices[next_idx]
+    m = length(indices)
+    i0 = 1
+    for Xi in cpa.array
+        i1 = i0 + dim(Xi) - 1
+        if next_dim <= i1
+            # there is a non-zero entry in this block
+            svec[i0:i1] = σ(d[i0:i1], Xi)
 
-           # find next index outside the current block
-           next_idx += 1
-           while next_idx <= m && indices[next_idx] <= i1
-               next_idx += 1
-           end
-           if next_idx <= m
-               next_dim = indices[next_idx]
-           end
-       else
-           svec[i0:i1] = an_element(Xi)
-       end
-       i0 = i1 + 1
-   end
-   return svec
+            # find next index outside the current block
+            next_idx += 1
+            while next_idx <= m && indices[next_idx] <= i1
+                next_idx += 1
+            end
+            if next_idx <= m
+                next_dim = indices[next_idx]
+            end
+        else
+            svec[i0:i1] = an_element(Xi)
+        end
+        i0 = i1 + 1
+    end
+    return svec
 end
 
 """
@@ -163,51 +163,51 @@ The evaluation of the support function in the given direction.
 If the direction has norm zero, the result depends on the wrapped sets.
 """
 function ρ(d::AbstractVector, cpa::CartesianProductArray)
-   N = promote_type(eltype(d), eltype(cpa))
-   sfun = zero(N)
-   i0 = 1
-   for Xi in cpa.array
-       i1 = i0 + dim(Xi) - 1
-       sfun += ρ(d[i0:i1], Xi)
-       i0 = i1 + 1
-   end
-   return sfun
+    N = promote_type(eltype(d), eltype(cpa))
+    sfun = zero(N)
+    i0 = 1
+    for Xi in cpa.array
+        i1 = i0 + dim(Xi) - 1
+        sfun += ρ(d[i0:i1], Xi)
+        i0 = i1 + 1
+    end
+    return sfun
 end
 
 # faster version for sparse vectors
 function ρ(d::AbstractSparseVector, cpa::CartesianProductArray)
-   N = promote_type(eltype(d), eltype(cpa))
-   # idea: see the σ method for AbstractSparseVector
-   sfun = zero(N)
-   indices, _ = SparseArrays.findnz(d)
-   if isempty(indices)
-       # direction is the zero vector
-       return sfun
-   end
-   next_idx = 1
-   next_dim = indices[next_idx]
-   m = length(indices)
-   i0 = 1
-   for Xi in cpa.array
-       i1 = i0 + dim(Xi) - 1
-       if next_dim <= i1
-           # there is a non-zero entry in this block
-           sfun += ρ(d[i0:i1], Xi)
+    N = promote_type(eltype(d), eltype(cpa))
+    # idea: see the σ method for AbstractSparseVector
+    sfun = zero(N)
+    indices, _ = SparseArrays.findnz(d)
+    if isempty(indices)
+        # direction is the zero vector
+        return sfun
+    end
+    next_idx = 1
+    next_dim = indices[next_idx]
+    m = length(indices)
+    i0 = 1
+    for Xi in cpa.array
+        i1 = i0 + dim(Xi) - 1
+        if next_dim <= i1
+            # there is a non-zero entry in this block
+            sfun += ρ(d[i0:i1], Xi)
 
-           # find next index outside the current block
-           next_idx += 1
-           while next_idx <= m && indices[next_idx] <= i1
-               next_idx += 1
-           end
-           if next_idx > m
-               # no more non-zero entries
-               break
-           end
-           next_dim = indices[next_idx]
-       end
-       i0 = i1 + 1
-   end
-   return sfun
+            # find next index outside the current block
+            next_idx += 1
+            while next_idx <= m && indices[next_idx] <= i1
+                next_idx += 1
+            end
+            if next_idx > m
+                # no more non-zero entries
+                break
+            end
+            next_dim = indices[next_idx]
+        end
+        i0 = i1 + 1
+    end
+    return sfun
 end
 
 """
@@ -224,7 +224,7 @@ Check whether a Cartesian product of a finite number of sets is bounded.
 `true` iff all wrapped sets are bounded.
 """
 function isbounded(cpa::CartesianProductArray)
-   return all(isbounded, cpa.array)
+    return all(isbounded, cpa.array)
 end
 
 function isboundedtype(::Type{<:CartesianProductArray{N, S}}) where {N, S}
@@ -247,17 +247,17 @@ number of sets.
 `true` iff ``x ∈ \\text{cpa}``.
 """
 function ∈(x::AbstractVector, cpa::CartesianProductArray)
-   @assert length(x) == dim(cpa)
+    @assert length(x) == dim(cpa)
 
-   i0 = 1
-   for Xi in cpa.array
-       i1 = i0 + dim(Xi) - 1
-       if x[i0:i1] ∉ Xi
-           return false
-       end
-       i0 = i1 + 1
-   end
-   return true
+    i0 = 1
+    for Xi in cpa.array
+        i1 = i0 + dim(Xi) - 1
+        if x[i0:i1] ∉ Xi
+            return false
+        end
+        i0 = i1 + 1
+    end
+    return true
 end
 
 """
@@ -274,7 +274,7 @@ Check whether a Cartesian product of a finite number of sets is empty.
 `true` iff any of the sub-blocks is empty.
 """
 function isempty(cpa::CartesianProductArray)
-   return any(isempty, array(cpa))
+    return any(isempty, array(cpa))
 end
 
 """
@@ -322,7 +322,7 @@ function constraints_list(cpa::CartesianProductArray)
             n_low = dim(c_low)
         else
             n_low = dim(c_low_list[1])
-            indices = prev_step : (prev_step + n_low - 1)
+            indices = prev_step:(prev_step+n_low-1)
         end
         for constr in c_low_list
             new_constr = HalfSpace(sparsevec(indices, constr.a, n), constr.b)
@@ -557,7 +557,7 @@ end
 """
     substitute_blocks(low_dim_cpa::CartesianProductArray{N},
                       orig_cpa::CartesianProductArray{N},
-                      blocks::Vector{Tuple{Int,Int}}) where {N}
+                      blocks::Vector{Tuple{Int, Int}}) where {N}
 
 Return a Cartesian product of a finite number of sets (CPA) obtained by merging
 an original CPA with a low-dimensional CPA, which represents the updated subset
@@ -576,7 +576,7 @@ The merged Cartesian product.
 """
 function substitute_blocks(low_dim_cpa::CartesianProductArray{N},
                            orig_cpa::CartesianProductArray{N},
-                           blocks::Vector{Tuple{Int,Int}}) where {N}
+                           blocks::Vector{Tuple{Int, Int}}) where {N}
 
     array = Vector{LazySet{N}}(undef, length(orig_cpa.array))
     index = 1

--- a/src/LazyOperations/CartesianProductArray.jl
+++ b/src/LazyOperations/CartesianProductArray.jl
@@ -147,6 +147,24 @@ function σ(d::AbstractSparseVector, cpa::CartesianProductArray)
     return svec
 end
 
+# faster version for single-entry vectors
+function σ(d::SingleEntryVector, cpa::CartesianProductArray)
+    svec = similar(d)
+    i0 = 1
+    idx = d.i
+    for Xi in cpa.array
+        ni = dim(Xi)
+        i1 = i0 + ni - 1
+        if i0 <= idx && idx <= i1
+            svec[i0:i1] = σ(SingleEntryVector(d.i - i0 + 1, ni, d.v), Xi)
+        else
+            svec[i0:i1] = an_element(Xi)
+        end
+        i0 = i1 + 1
+    end
+    return svec
+end
+
 """
     ρ(d::AbstractVector, cpa::CartesianProductArray)
 
@@ -204,6 +222,21 @@ function ρ(d::AbstractSparseVector, cpa::CartesianProductArray)
                 break
             end
             next_dim = indices[next_idx]
+        end
+        i0 = i1 + 1
+    end
+    return sfun
+end
+
+# faster version for single-entry vectors
+function ρ(d::SingleEntryVector, cpa::CartesianProductArray)
+    i0 = 1
+    idx = d.i
+    for Xi in cpa.array
+        ni = dim(Xi)
+        i1 = i0 + ni - 1
+        if i0 <= idx && idx <= i1
+            return ρ(SingleEntryVector(d.i - i0 + 1, ni, d.v), Xi)
         end
         i0 = i1 + 1
     end


### PR DESCRIPTION
Closes #1758.

The first commit is just formatting (4 spaces instead of 3).

```julia
julia> d = SingleEntryVector(10, 100, 1.0)
julia> X = CartesianProductArray([rand(Ball2, dim=10) for _ in 1:10])
julia> Y = CartesianProduct(rand(Ball2, dim=50), rand(Ball2, dim=50))

julia> @time σ(d, X)
  0.000013 seconds (21 allocations: 3.688 KiB)  # master
  0.000010 seconds (2 allocations: 1.016 KiB)  # this branch

julia> @time ρ(d, X)
  0.000018 seconds (11 allocations: 1.422 KiB)  # master
  0.000010 seconds (1 allocation: 16 bytes)  # this branch

julia> @time σ(d, Y)
  0.000013 seconds (5 allocations: 2.812 KiB)  # master
  0.000013 seconds (2 allocations: 1.359 KiB)  # this branch

julia> @time ρ(d, Y)
  0.000011 seconds (3 allocations: 1008 bytes)  # master
  0.000005 seconds (1 allocation: 16 bytes)  # this branch
```