### PR TITLE
Add order-reduction method with parallelotope

### DIFF
--- a/docs/src/lib/interfaces.md
+++ b/docs/src/lib/interfaces.md
@@ -402,6 +402,7 @@ reduce_order(::AbstractZonotope, ::Real, ::AbstractReductionMethod=GIR05())
 
 ```@docs
 LazySets.AbstractReductionMethod
+LazySets.ASB10
 LazySets.COMB03
 LazySets.GIR05
 ```

--- a/test/Sets/Zonotope.jl
+++ b/test/Sets/Zonotope.jl
@@ -124,22 +124,28 @@ for N in [Float64, Rational{Int}, Float32]
     @test ispermutation(collect(generators(Z)), [genmat(Z)[:, j] for j in 1:ngens(Z)])
 
     # test order reduction
-    Zred1 = reduce_order(Z, 1)
-    @test ngens(Zred1) == 2
-    @test order(Zred1) == 1
-    Zred2 = reduce_order(Z, 2)
-    @test ngens(Zred2) == 4
-    @test order(Zred2) == 2
-    Z = Zonotope(N[2, 1], N[-1//2 3//2 1//2 1 0 1; 1//2 3//2 1 1//2 1 0])
-    Zred3 = reduce_order(Z, 2)
-    @test ngens(Zred3) == 4
-    @test order(Zred3) == 2
-    Znogen = Zonotope(N[1, 2], Matrix{N}(undef, 2, 0))
-    @test ngens(Znogen) == 0
-    @test genmat(Znogen) == Matrix{N}(undef, 2, 0)
-    @test collect(generators(Znogen)) == Vector{N}()
-    Zs = Zonotope(SVector{2}(Z.center), SMatrix{2, 6}(Z.generators))
-    @test reduce_order(Zs, 2) isa Zonotope{N, SVector{2, N}, SMatrix{2, 4, N, 8}}
+    for method in [LazySets.ASB10(), LazySets.COMB03(), LazySets.GIR05()]
+        Z = Zonotope(N[2, 1], N[-1//2 3//2 1//2 1; 1//2 3//2 1 1//2])
+        Zred1 = reduce_order(Z, 1, method)
+        @test ngens(Zred1) == 2
+        @test order(Zred1) == 1
+        Zred2 = reduce_order(Z, 2, method)
+        @test ngens(Zred2) == 4
+        @test order(Zred2) == 2
+        Z = Zonotope(N[2, 1], N[-1//2 3//2 1//2 1 0 1; 1//2 3//2 1 1//2 1 0])
+        Zred3 = reduce_order(Z, 2, method)
+        @test ngens(Zred3) == 4
+        @test order(Zred3) == 2
+        Znogen = Zonotope(N[1, 2], Matrix{N}(undef, 2, 0))
+        @test ngens(Znogen) == 0
+        @test genmat(Znogen) == Matrix{N}(undef, 2, 0)
+        @test collect(generators(Znogen)) == Vector{N}()
+    end
+    # order reduction with static arrays
+    for method in [LazySets.COMB03(), LazySets.GIR05()]
+        Zs = Zonotope(SVector{2}(Z.center), SMatrix{2, 6}(Z.generators))
+        @test reduce_order(Zs, 2, method) isa Zonotope{N, SVector{2, N}, SMatrix{2, 4, N, 8}}
+    end
 
     # conversion from zonotopic sets
     Z = Zonotope(N[0, 0], hcat(N[1, 1]))


### PR DESCRIPTION
I tried several examples and sometimes this approximation is really not good. But other times it can be useful.

```julia
julia> Z = rand(Zonotope, num_generators=10); Z.generators
2×10 Matrix{Float64}:
 -1.97436   -0.00678346  -1.04514   0.527674  0.949779   0.537129  -1.14433   -0.0677212  1.03545  -1.46856
  0.915773   0.459995     0.773422  1.39259   0.763097  -0.796472  -0.223115  -0.606334   0.55431   0.510208

julia> Z1 = reduce_order(Z, 2, LazySets.GIR05());
julia> Z2 = reduce_order(Z, 2, LazySets.COMB03());
julia> Z3 = reduce_order(Z, 2, LazySets.ASB10());  # new method

julia> plot(Z1, lab="GIR05", leg=:outerleft)
julia> plot!(Z2, lab="COMB03")
julia> plot!(Z3, lab="ASB10")
julia> plot!(Z, lab="original")
```

![reduce_order](https://user-images.githubusercontent.com/9656686/204387211-891aa10a-50df-4b6d-8298-7e78e4f452ff.png)