### PR TITLE
Fix remove_redundant_constraints! output

### DIFF
--- a/src/Interfaces/AbstractPolyhedron_functions.jl
+++ b/src/Interfaces/AbstractPolyhedron_functions.jl
@@ -259,8 +259,13 @@ function remove_redundant_constraints!(constraints::AbstractVector{S};
         end
     end
 
-    deleteat!(constraints, setdiff(1:m, non_redundant_indices))
-    return true
+    idx_delete = setdiff(1:m, non_redundant_indices)
+    if !isempty(idx_delete)
+        deleteat!(constraints, idx_delete)
+        return true
+    else
+        return false
+    end
 end
 
 """


### PR DESCRIPTION
~The implementation could return `true` even if no constraint was removed.~

This was intended. The comment is a bit confusing, but the function should return `false` if and only if the constraints are infeasible.