### PR TITLE
#1348 - Improved bound for line search

### DIFF
--- a/src/LazyOperations/Intersection.jl
+++ b/src/LazyOperations/Intersection.jl
@@ -807,7 +807,8 @@ function _line_search(ℓ, X::S, H::Union{<:HalfSpace, <:Hyperplane, <:Line2D};
 
     # Initialization
     a, b = H.a, H.b
-    f(λ) = ρ(ℓ - λ[1] * a, X) + λ[1] * b
+    m = -ρ(-ℓ, X)  # `m` is a known lower bound for `f` below (Lemma 3 in paper)
+    f(λ) = max(ρ(ℓ - λ[1] * a, X) + λ[1] * b, m)
 
     if haskey(options, :lower)
         lower = pop!(options, :lower)

--- a/test/LazyOperations/Intersection.jl
+++ b/test/LazyOperations/Intersection.jl
@@ -170,9 +170,13 @@ for N in [Float64]
     # default algorithm
     @test ρ(d, X ∩ H) < 1e-6 && ρ(d, H ∩ X) < 1e-6
 
-    # specify  line search algorithm
+    # specify line-search algorithm
     @test ρ(d, X ∩ H, algorithm="line_search") < 1e-6 &&
         ρ(d, H ∩ X, algorithm="line_search") < 1e-6
+    # test approximation errors (see #1144)
+    B = Hyperrectangle(N[0.009231278330571413, 0], N[0.009231221669425305, 1])
+    H = HalfSpace(N[1, 0], N(0))
+    @test ρ([1.0, 0], B ∩ H) >= 0
 
     # boundedness
     @test isbounded(HalfSpace(N[1], N(1)) ∩ HalfSpace(N[-1], N(1)))


### PR DESCRIPTION
Closes #1348.
This also improves https://github.com/JuliaReach/LazySets.jl/issues/1144#issuecomment-1341598035, but it is a workaround rather than a complete solution to #1144.