### PR TITLE
#2080 - Pull out documentation from requires blocks

### DIFF
--- a/src/Approximations/overapproximate.jl
+++ b/src/Approximations/overapproximate.jl
@@ -596,7 +596,6 @@ return quote
 
 using .IntervalConstraintProgramming: Paving
 
-
 """
     overapproximate(p::Paving{L, N}, dirs::AbstractDirections{N, VN})
         where {L, N, VN}
@@ -635,5 +634,4 @@ function overapproximate(p::Paving{L, N}, ::Type{<:HPolyhedron},
     return overapproximate(p, dirs)
 end
 
-end # quote
-end # load_paving_overapproximation
+end end  # quote / load_paving_overapproximation

--- a/src/Approximations/overapproximate_zonotope.jl
+++ b/src/Approximations/overapproximate_zonotope.jl
@@ -338,7 +338,6 @@ end
 
 # function to be loaded by Requires
 function load_taylormodels_overapproximation()
-
 return quote
 
 using .TaylorModels: Taylor1, TaylorN, TaylorModel1, TaylorModelN,
@@ -665,8 +664,7 @@ function _overapproximate_vTM_zonotope(vTM, n, N;
     return Z
 end
 
-end # quote
-end # load_taylormodels_overapproximation
+end end  # quote / load_taylormodels_overapproximation
 
 function load_intervalmatrices_overapproximation()
 return quote

--- a/src/Interfaces/LazySet.jl
+++ b/src/Interfaces/LazySet.jl
@@ -1677,5 +1677,4 @@ function polyhedron(P::LazySet; backend=default_polyhedra_backend(P))
     return polyhedron(Q; backend=backend)
 end
 
-end # quote
-end # function load_polyhedra_lazyset()
+end end  # quote / load_polyhedra_lazyset()

--- a/src/LazyOperations/Intersection.jl
+++ b/src/LazyOperations/Intersection.jl
@@ -727,9 +727,6 @@ function concretize(cap::Intersection)
     return intersection(concretize(cap.X), concretize(cap.Y))
 end
 
-function load_optim_intersection()
-return quote
-
 """
     _line_search(ℓ, X, H::Union{<:HalfSpace, <:Hyperplane, <:Line2D}; [kwargs...])
 
@@ -799,6 +796,14 @@ julia> v[1]
 """
 function _line_search(ℓ, X::S, H::Union{<:HalfSpace, <:Hyperplane, <:Line2D};
                       kwargs...) where {S<:LazySet}
+    return _line_search_optim(ℓ, X, H; kwargs...)
+end
+
+function load_optim_intersection()
+return quote
+
+function _line_search_optim(ℓ, X::S, H::Union{<:HalfSpace, <:Hyperplane, <:Line2D};
+                            kwargs...) where {S<:LazySet}
     if !isconvextype(S)
         raise(ArgumentError("the first set in the intersection must be convex"))
     end
@@ -837,9 +842,9 @@ function _line_search(ℓ, X::S, H::Union{<:HalfSpace, <:Hyperplane, <:Line2D};
     # Recover results
     fmin, λmin = sol.minimum, sol.minimizer
     return (fmin, λmin)
-end # _line_search
-end # quote
-end # load_optim
+end
+
+end end  # quote / load_optim_intersection
 
 """
     _projection(ℓ, X, H::Union{Hyperplane{N}, Line2D{N}};

--- a/src/Plotting/mesh.jl
+++ b/src/Plotting/mesh.jl
@@ -1,13 +1,11 @@
 export plot3d, plot3d!
 
-
 function load_polyhedra_mesh()
 return quote
 
 using .Polyhedra: Mesh
 
 end end  # quote / function load_polyhedra_mesh()
-
 
 function load_makie()
 return quote
@@ -16,7 +14,6 @@ using .Makie: mesh, mesh!
 using .Makie: Automatic
 
 end end  # quote / function load_makie()
-
 
 # helper function for 3D plotting; converts S to a polytope in H-representation
 function _plot3d_helper(S::LazySet, backend)

--- a/src/Sets/BallInf.jl
+++ b/src/Sets/BallInf.jl
@@ -121,19 +121,20 @@ end
 
 function load_genmat_ballinf_static()
 return quote
-    function genmat(B::BallInf{N, SVector{L, N}}) where {L, N}
-        if isflat(B)
-            return SMatrix{L, 0, N, 0}()
-        else
-            gens = zeros(MMatrix{L, L})
-            @inbounds for i in 1:L
-                gens[i, i] = B.radius
-            end
-            return SMatrix(gens)
+
+function genmat(B::BallInf{N, SVector{L, N}}) where {L, N}
+    if isflat(B)
+        return SMatrix{L, 0, N, 0}()
+    else
+        gens = zeros(MMatrix{L, L})
+        @inbounds for i in 1:L
+            gens[i, i] = B.radius
         end
+        return SMatrix(gens)
     end
 end
-end
+
+end end  # quote / load_genmat_ballinf_static()
 
 """
     center(B::BallInf)

--- a/src/Sets/HPolygon.jl
+++ b/src/Sets/HPolygon.jl
@@ -10,8 +10,8 @@ are sorted in counter-clockwise fashion with respect to their normal directions.
 
 ### Fields
 
-- `constraints`       -- list of linear constraints, sorted by the normal
-                         direction in counter-clockwise fashion
+- `constraints` -- list of linear constraints, sorted by the normal direction in
+                   counter-clockwise fashion
 
 ### Notes
 

--- a/src/Sets/HPolygonOpt.jl
+++ b/src/Sets/HPolygonOpt.jl
@@ -11,10 +11,10 @@ This implementation is a refined version of [`HPolygon`](@ref).
 
 ### Fields
 
-- `constraints`       -- list of linear constraints, sorted by the normal
-                         direction in counter-clockwise fashion
-- `ind`               -- index in the list of constraints to begin the search
-                         to evaluate the support vector/function
+- `constraints` -- list of linear constraints, sorted by the normal direction in
+                   counter-clockwise fashion
+- `ind`         -- index in the list of constraints to begin the search to
+                   evaluate the support vector/function
 
 ### Notes
 

--- a/src/Sets/HPolyhedron.jl
+++ b/src/Sets/HPolyhedron.jl
@@ -636,8 +636,7 @@ function triangulate(X::LazySet)
     return points, connec_tup
 end
 
-end # quote
-end # function load_polyhedra_hpolyhedron()
+end end  # quote / load_polyhedra_hpolyhedron()
 
 function is_hyperplanar(P::HPolyhedron)
     clist = P.constraints

--- a/src/Sets/HPolytope.jl
+++ b/src/Sets/HPolytope.jl
@@ -191,8 +191,7 @@ function HPolytope(P::HRep)
     convert(HPolytope, P)
 end
 
-end # quote
-end # function load_polyhedra_hpolytope()
+end end  # quote / load_polyhedra_hpolytope()
 
 """
     vertices_list(P::HPolytope; [backend]=nothing, [prune]::Bool=true)

--- a/src/Sets/Hyperrectangle.jl
+++ b/src/Sets/Hyperrectangle.jl
@@ -143,32 +143,33 @@ end
 
 function load_genmat_hyperrectangle_static()
 return quote
-    function genmat(H::Hyperrectangle{N, SVector{L, N}, SVector{L, N}}) where {L, N}
-        gens = zeros(MMatrix{L, L, N})
-        nzcol = Vector{Int}()
-        @inbounds for i in 1:L
-            r = H.radius[i]
-            if !isapproxzero(r)
-                gens[i, i] = r
-                push!(nzcol, i)
-            end
-        end
-        m = length(nzcol)
-        return SMatrix{L, m}(view(gens, :, nzcol))
-    end
 
-    # this function is type stable, but it does not prune the generators
-    # according to flat dimensions of H
-    function _genmat_static(H::Hyperrectangle{N, SVector{L, N}, SVector{L, N}}) where {L, N}
-        gens = zeros(MMatrix{L, L, N})
-        @inbounds for i in 1:L
-            r = H.radius[i]
+function genmat(H::Hyperrectangle{N, SVector{L, N}, SVector{L, N}}) where {L, N}
+    gens = zeros(MMatrix{L, L, N})
+    nzcol = Vector{Int}()
+    @inbounds for i in 1:L
+        r = H.radius[i]
+        if !isapproxzero(r)
             gens[i, i] = r
+            push!(nzcol, i)
         end
-        return SMatrix{L, L}(gens)
     end
+    m = length(nzcol)
+    return SMatrix{L, m}(view(gens, :, nzcol))
 end
+
+# this function is type stable, but it does not prune the generators
+# according to flat dimensions of H
+function _genmat_static(H::Hyperrectangle{N, SVector{L, N}, SVector{L, N}}) where {L, N}
+    gens = zeros(MMatrix{L, L, N})
+    @inbounds for i in 1:L
+        r = H.radius[i]
+        gens[i, i] = r
+    end
+    return SMatrix{L, L}(gens)
 end
+
+end end  # quote / load_genmat_hyperrectangle_static()
 
 function genmat(H::Hyperrectangle{N, <:AbstractVector, <:SparseVector{N}}) where {N}
     n = dim(H)

--- a/src/Sets/Universe.jl
+++ b/src/Sets/Universe.jl
@@ -421,5 +421,4 @@ function polyhedron(U::Universe; backend=default_polyhedra_backend(U))
     return Polyhedra.polyhedron(Polyhedra.hrep(A, b), backend)
 end
 
-end # quote
-end # function load_polyhedra_universe()
+end end  # quote / load_polyhedra_universe()

--- a/src/Sets/VPolytope.jl
+++ b/src/Sets/VPolytope.jl
@@ -567,8 +567,7 @@ function polyhedron(P::VPolytope;
     return polyhedron(Polyhedra.vrep(P.vertices), backend)
 end
 
-end # quote
-end # function load_polyhedra_vpolytope()
+end end  # quote / load_polyhedra_vpolytope()
 
 function project(P::VPolytope, block::AbstractVector{Int}; kwargs...)
     if isempty(P.vertices)

--- a/src/Utils/matrix_exponential.jl
+++ b/src/Utils/matrix_exponential.jl
@@ -30,7 +30,6 @@ end
 
 end end  # quote / load_exponentialutilities
 
-
 function _expmv(::Val{:ExponentialUtilities}, t, A, b)
     return ExponentialUtilities.expv(t, A, b)
 end

--- a/src/convert.jl
+++ b/src/convert.jl
@@ -214,34 +214,36 @@ end
 
 function load_genmat_2D_static()
 return quote
-    @inline function _genmat_2D(c::SVector{L, N}, rx, ry) where {L, N}
-        flat_x = isapproxzero(rx)
-        flat_y = isapproxzero(ry)
-        if !flat_x && !flat_y
-            G = SMatrix{2, 2, N, 4}(rx, zero(N), zero(N), ry)
-        elseif !flat_x && flat_y
-            G = SMatrix{2, 1, N, 2}(rx, zero(N))
-        elseif flat_x && !flat_y
-            G = SMatrix{2, 1, N, 2}(zero(N), ry)
-        else
-            G = SMatrix{2, 0, N, 0}()
-        end
-        return G
-    end
 
-    # this function is type-stable but doesn't prune the generators according
-    # to flat dimensions of H
-    function _convert_2D_static(::Type{Zonotope}, H::AbstractHyperrectangle{N}) where {N}
-        c = center(H)
-        rx = radius_hyperrectangle(H, 1)
-        ry = radius_hyperrectangle(H, 2)
+@inline function _genmat_2D(c::SVector{L, N}, rx, ry) where {L, N}
+    flat_x = isapproxzero(rx)
+    flat_y = isapproxzero(ry)
+    if !flat_x && !flat_y
         G = SMatrix{2, 2, N, 4}(rx, zero(N), zero(N), ry)
-        return Zonotope(c, G)
+    elseif !flat_x && flat_y
+        G = SMatrix{2, 1, N, 2}(rx, zero(N))
+    elseif flat_x && !flat_y
+        G = SMatrix{2, 1, N, 2}(zero(N), ry)
+    else
+        G = SMatrix{2, 0, N, 0}()
     end
+    return G
+end
 
-    function _convert_static(::Type{Zonotope}, H::Hyperrectangle{N, <:SVector, <:SVector}) where {N}
-        return Zonotope(center(H), _genmat_static(H))
-    end
+# this function is type-stable but doesn't prune the generators according
+# to flat dimensions of H
+function _convert_2D_static(::Type{Zonotope}, H::AbstractHyperrectangle{N}) where {N}
+    c = center(H)
+    rx = radius_hyperrectangle(H, 1)
+    ry = radius_hyperrectangle(H, 2)
+    G = SMatrix{2, 2, N, 4}(rx, zero(N), zero(N), ry)
+    return Zonotope(c, G)
+end
+
+function _convert_static(::Type{Zonotope}, H::Hyperrectangle{N, <:SVector, <:SVector}) where {N}
+    return Zonotope(center(H), _genmat_static(H))
+end
+
 end end  # quote / load_genmat_2D_static
 
 """


### PR DESCRIPTION
Closes #2080.

The remaining documentation only loaded inside `@requires` blocks uses package-specific types or extends a function that is only imported from the external package, so they cannot be moved.