### PR TITLE
#2786 - Add consistency check to HParallelotope constructor and use cheap isempty method

### DIFF
--- a/docs/src/lib/sets/HParallelotope.md
+++ b/docs/src/lib/sets/HParallelotope.md
@@ -16,7 +16,6 @@ genmat(::HParallelotope)
 generators(::HParallelotope)
 constraints_list(::HParallelotope)
 rand(::Type{HParallelotope})
-isempty(::HParallelotope)
 volume(::HParallelotope)
 ```
 
@@ -45,4 +44,5 @@ Inherited from [`AbstractZonotope`](@ref):
 * [`linear_map`](@ref linear_map(::AbstractMatrix, ::AbstractZonotope))
 * [`translate`](@ref translate(::AbstractZonotope, ::AbstractVector))
 * [`vertices_list`](@ref vertices_list(::AbstractZonotope))
+* [`isempty`](@ref isempty(::AbstractZonotope))
 * [`order`](@ref order(::AbstractZonotope))

--- a/src/Sets/HParallelotope.jl
+++ b/src/Sets/HParallelotope.jl
@@ -389,12 +389,11 @@ function rand(::Type{HParallelotope};
             offset[i] = -offset[i-dim] + abs(offset[i])
         end
 
-        P = HParallelotope(D, offset)
-
         # convert to polyhedron to check boundedness
-        Q = HPolyhedron(vcat(P.directions, -P.directions), P.offset)
+        clist = _constraints_list_hparallelotope(D, offset, N, typeof(offset))
+        Q = HPolyhedron(clist)
         if isbounded(Q)
-            return P
+            return P = HParallelotope(D, offset; check_consistency=false)
         end
         # set is unbounded; sample a new set in the next iteration
     end

--- a/src/Sets/HParallelotope.jl
+++ b/src/Sets/HParallelotope.jl
@@ -400,28 +400,6 @@ function rand(::Type{HParallelotope};
 end
 
 """
-    isempty(P::HParallelotope)
-
-Check whether a parallelotope in constraint representation is empty.
-
-### Input
-
-- `P` -- parallelotope in constraint representation
-
-### Output
-
-`true` iff the constraints are consistent/feasible.
-
-### Algorithm
-
-We call `isempty` for an `HPolyhedron`. We do not assume `HPolytope` because the
-set may be wrongly represented and in fact be unbounded.
-"""
-function isempty(P::HParallelotope)
-    return isempty(convert(HPolyhedron, P))
-end
-
-"""
     volume(P::HParallelotope)
 
 Return the volume of a parallelotope in constraint representation.

--- a/src/Sets/HParallelotope.jl
+++ b/src/Sets/HParallelotope.jl
@@ -40,9 +40,11 @@ for ``i = 1, …, n``. Here ``D_i`` represents the ``i``-th row of ``D`` and
 ``c_i`` the ``i``-th component of ``c``.
 
 Note that, although representing a zonotopic set, an `HParallelotope` can be
-empty if the constraints are contradictory. This may cause problems with default
-methods because the library assumes that zonotopic sets are non-empty. Thus such
-instances are considered illegal.
+empty or unbounded if the constraints are unsuitably chosen. This may cause
+problems with default methods because the library assumes that zonotopic sets
+are non-empty and bounded. Thus such instances are considered illegal. The
+default constructor thus checks these conditions, which can be deactivated by
+passing the argument `check_consistency=false`.
 
 For details as well as applications of parallelotopes in reachability analysis
 we refer to [1] and [2]. For conversions between set representations we refer to
@@ -65,11 +67,22 @@ struct HParallelotope{N, VN<:AbstractVector{N}, MN<:AbstractMatrix{N}} <: Abstra
     directions::MN
     offset::VN
 
-    # default constructor with dimension check
-    function HParallelotope(D::MN, c::VN) where {N, VN<:AbstractVector{N}, MN<:AbstractMatrix{N}}
+    # default constructor with dimension and consistency check
+    function HParallelotope(D::MN, c::VN; check_consistency::Bool=true
+                           ) where {N, VN<:AbstractVector{N}, MN<:AbstractMatrix{N}}
         @assert length(c) == 2*checksquare(D) "the length of the offset " *
             "vector should be twice the size of the directions matrix, " *
             "but they have sizes $(length(c)) and $(size(D)) respectively"
+
+        if check_consistency
+            P = HPolyhedron(_constraints_list_hparallelotope(D, c, N, VN))
+            if isempty(P)
+                throw(ArgumentError("the constraints are contradictory"))
+            elseif !isbounded(P)
+                throw(ArgumentError("the constraints are not bounding"))
+            end
+        end
+
         return new{N, VN, MN}(D, c)
     end
 end
@@ -306,11 +319,15 @@ The list of constraints of `P`.
 """
 function constraints_list(P::HParallelotope)
     D, c = P.directions, P.offset
-    n = dim(P)
     N, VN = _parameters(P)
+    return _constraints_list_hparallelotope(D, c, N, VN)
+end
+
+function _constraints_list_hparallelotope(D, c, N, VN)
     if isempty(D)
         return Vector{HalfSpace{N, VN}}(undef, 0)
     end
+    n = size(D, 1)
     clist = Vector{HalfSpace{N, VN}}(undef, 2n)
     @inbounds for i in 1:n
         clist[i] = HalfSpace(D[i, :], c[i])
@@ -319,6 +336,7 @@ function constraints_list(P::HParallelotope)
     return clist
 end
 
+# reason: `Documenter` cannot annotate `constraints_list` with type parameters
 function _parameters(P::HParallelotope{N, VN}) where {N, VN}
     return (N, VN)
 end
@@ -385,7 +403,7 @@ end
 """
     isempty(P::HParallelotope)
 
-Check if a parallelotope in constraint representation is empty.
+Check whether a parallelotope in constraint representation is empty.
 
 ### Input
 
@@ -397,7 +415,8 @@ Check if a parallelotope in constraint representation is empty.
 
 ### Algorithm
 
-We call `isempty` for an `HPolyhedron`.
+We call `isempty` for an `HPolyhedron`. We do not assume `HPolytope` because the
+set may be wrongly represented and in fact be unbounded.
 """
 function isempty(P::HParallelotope)
     return isempty(convert(HPolyhedron, P))

--- a/src/convert.jl
+++ b/src/convert.jl
@@ -914,7 +914,7 @@ function convert(::Type{HParallelotope}, Z::AbstractZonotope{N}) where {N}
         c[i+n] = constraints[j+1].b
         j += 2
     end
-    return HParallelotope(D, c)
+    return HParallelotope(D, c; check_consistency=false)
 end
 
 """

--- a/test/Sets/HParallelotope.jl
+++ b/test/Sets/HParallelotope.jl
@@ -56,14 +56,10 @@ for N in [Float32, Float64, Rational{Int}]
     rand(HParallelotope)
 
     # emptiness
-    H = N[1 1; 0 1]
-    o = N[2, 2, -4, -1]
-    P2 = HParallelotope(H, o)
-    @test !isempty(P) && isempty(P2)
+    @test !isempty(P)
 
     # volume
     @test volume(P) == N(4)
-    @test volume(P2) == N(2)
 
     # vertices list
     @test ispermutation(vertices_list(P),

--- a/test/Sets/HParallelotope.jl
+++ b/test/Sets/HParallelotope.jl
@@ -7,6 +7,20 @@ for N in [Float32, Float64, Rational{Int}]
     c = N[-0.80, -0.95, 0, 0.85, 1, 0]
     P = HParallelotope(D, c)
 
+    # illegal input: empty set
+    D2 = N[1 1; 0 1]
+    c2 = N[5//2, 2, -4, -1]
+    @test_throws ArgumentError HParallelotope(D2, c2)
+    P2 = HParallelotope(D2, c2; check_consistency=false)
+    @test isempty(convert(HPolyhedron, P2))
+
+    # illegal input: unbounded set
+    D2 = N[1 1; 1 1]
+    c2 = N[1, 1, -1, -1]
+    @test_throws ArgumentError HParallelotope(D2, c2)
+    P2 = HParallelotope(D2, c2; check_consistency=false)
+    @test !isbounded(convert(HPolyhedron, P2))
+
     # test getter functions
     @test directions(P) == D
     @test offset(P) == c
@@ -50,6 +64,10 @@ for N in [Float32, Float64, Rational{Int}]
     # volume
     @test volume(P) == N(4)
     @test volume(P2) == N(2)
+
+    # vertices list
+    @test ispermutation(vertices_list(P),
+                        [N[1, 1], N[1, -1], N[-1, 1], N[-1, -1]])
 end
 
 for N in [Float32, Float64]


### PR DESCRIPTION
Closes #2786.

This PR adds a consistency check to the `HParallelotope` constructor. Thus we accept that `vertices_list` and `isempty` return wrong results for inconsistent sets.