### PR TITLE
#3203 - Make rand of HParallelotope return a nonempty set

### DIFF
--- a/src/Sets/HParallelotope.jl
+++ b/src/Sets/HParallelotope.jl
@@ -344,6 +344,15 @@ A random parallelotope.
 ### Notes
 
 All numbers are normally distributed with mean 0 and standard deviation 1.
+
+Technically there is a chance that the resulting set represents an unbounded
+set, but this case has not been observed in practice.
+
+### Algorithm
+
+The directions matrix and offset vector are created randomly. On average there
+is a good chance that this resulting set is empty. We then modify the offset to
+ensure non-emptiness.
 """
 function rand(::Type{HParallelotope};
               N::Type{<:Real}=Float64,
@@ -353,6 +362,13 @@ function rand(::Type{HParallelotope};
     rng = reseed(rng, seed)
     D = randn(rng, N, dim, dim)
     offset = randn(rng, N, 2 * dim)
+
+    # make sure that the set is not empty:
+    # `offset[i] >= -offset[i-dim]` for all `i ∈ dim+1:2*dim`
+    @inbounds for i in dim+1:2*dim
+        offset[i] = -offset[i-dim] + abs(offset[i])
+    end
+
     return HParallelotope(D, offset)
 end
 

--- a/src/Sets/HParallelotope.jl
+++ b/src/Sets/HParallelotope.jl
@@ -345,14 +345,14 @@ A random parallelotope.
 
 All numbers are normally distributed with mean 0 and standard deviation 1.
 
-Technically there is a chance that the resulting set represents an unbounded
-set, but this case has not been observed in practice.
-
 ### Algorithm
 
 The directions matrix and offset vector are created randomly. On average there
 is a good chance that this resulting set is empty. We then modify the offset to
 ensure non-emptiness.
+
+There is a chance that the resulting set represents an unbounded set. This
+implementation checks for that case and then samples a new set.
 """
 function rand(::Type{HParallelotope};
               N::Type{<:Real}=Float64,
@@ -360,16 +360,26 @@ function rand(::Type{HParallelotope};
               rng::AbstractRNG=GLOBAL_RNG,
               seed::Union{Int, Nothing}=nothing)
     rng = reseed(rng, seed)
-    D = randn(rng, N, dim, dim)
-    offset = randn(rng, N, 2 * dim)
 
-    # make sure that the set is not empty:
-    # `offset[i] >= -offset[i-dim]` for all `i ∈ dim+1:2*dim`
-    @inbounds for i in dim+1:2*dim
-        offset[i] = -offset[i-dim] + abs(offset[i])
+    while true
+        D = randn(rng, N, dim, dim)
+        offset = randn(rng, N, 2 * dim)
+
+        # make sure that the set is not empty:
+        # `offset[i] >= -offset[i-dim]` for all `i ∈ dim+1:2*dim`
+        @inbounds for i in dim+1:2*dim
+            offset[i] = -offset[i-dim] + abs(offset[i])
+        end
+
+        P = HParallelotope(D, offset)
+
+        # convert to polyhedron to check boundedness
+        Q = HPolyhedron(vcat(P.directions, -P.directions), P.offset)
+        if isbounded(Q)
+            return P
+        end
+        # set is unbounded; sample a new set in the next iteration
     end
-
-    return HParallelotope(D, offset)
 end
 
 """


### PR DESCRIPTION
Closes #3203.

There is a small chance that the result is unbounded (this was also possible before).

```julia
julia> D = [1. 1; 1 1];
julia> offset = [1., 1, -1, -1];
julia> Q = HParallelotope(D, offset);
julia> P = HPolyhedron(vcat(Q.directions, -Q.directions), Q.offset);  # convert to polyhedron
julia> isbounded(P)
false
```