### PR TITLE
Fix check for elimination algorithm type in _minkowski_sum_hrep

### DIFF
--- a/src/ConcreteOperations/minkowski_sum.jl
+++ b/src/ConcreteOperations/minkowski_sum.jl
@@ -168,7 +168,7 @@ function _minkowski_sum_hrep(A::AbstractMatrix, b::AbstractVector,
 
     if algorithm == nothing
         algorithm = Polyhedra.FourierMotzkin()
-    elseif !(algorithm <: EliminationAlgorithm)
+    elseif !(algorithm isa Polyhedra.EliminationAlgorithm)
         error("algorithm $algorithm is not a valid elimination algorithm; " *
               "choose among any of $(subtypes(Polyhedra.EliminationAlgorithm))")
     end


### PR DESCRIPTION
This fixes two issues in `_minkowski_sum_hrep`:
1. EliminationAlgorithm results in an UndefVarError without the Polyhedra quantifier.
2. `algorithm` is a value, not a type. Hence `algorithm <: EliminationAlgorithm` results in a TypeError.