### PR TITLE
Fix variable naming error in overapproximate to HPolyhedron

### DIFF
--- a/src/Approximations/overapproximate.jl
+++ b/src/Approximations/overapproximate.jl
@@ -195,7 +195,7 @@ end
 # alias with HPolyhedron type as second argument
 function overapproximate(X::LazySet, ::Type{<:HPolyhedron},
                          dirs::AbstractDirections; prune::Bool=true)
-    H = _overapproximate_directions(X, dir, prune)
+    H = _overapproximate_directions(X, dirs, prune)
     return HPolyhedron(H)
 end
 


### PR DESCRIPTION
Fixes wrong name in overapproximate for HPolyhedron, resulting in an UndefVarError.