### PR TITLE
New algorithm to compute support vectors for HPoly

### DIFF
--- a/benchmark/supports.jl
+++ b/benchmark/supports.jl
@@ -1,3 +1,5 @@
+using Polyhedra
+
 # generate a tridiagonal matrix
 function tridiagm(a, b, c, n)
     dd, du = ones(n), ones(n - 1)
@@ -22,5 +24,19 @@ for set_type in (Ball1, BallInf, Hyperrectangle)
         Y = A * X
         SUITE["ρ"]["LinearMap of $(string(set_type))", "dense", n] = @benchmarkable ρ($d, $Y)
         SUITE["σ"]["LinearMap of $(string(set_type))", "dense", n] = @benchmarkable σ($d, $Y)
+    end
+end
+
+
+N = Float64
+for set_type in (HPolytope, HPolyhedron)
+    for n in (2, 5, 10)
+        rng = MersenneTwister(n)
+        d = rand(rng, n)
+        X = rand(set_type, dim=n, rng=rng)
+        SUITE["ρ"]["LP $(string(set_type))", "dense", n] = @benchmarkable ρ($d, $X)
+        SUITE["σ"]["LP $(string(set_type))", "dense", n] = @benchmarkable σ($d, $X)
+        SUITE["ρ"]["Halfspace dir $(string(set_type))", "dense", n] = @benchmarkable ρ($d, $X; algorithm=$("halfspace_direction"))
+        SUITE["σ"]["Halfspace dir $(string(set_type))", "dense", n] = @benchmarkable σ($d, $X; algorithm=$("halfspace_direction"))
     end
 end

--- a/src/Sets/HPolyhedron.jl
+++ b/src/Sets/HPolyhedron.jl
@@ -165,11 +165,9 @@ entries.
 
 ### Algorithm
 
-This method applies either a LP-based approach or an approach based on direction of
-halfspaces. The default is to apply the LP-based approach. This is the safer algorithm
-as it works correctly for `HPoly` with redundant constraints, i.e. if `P` is empty or
-has redudant constraints, then the approach based on halfspace directions is not
-guaranteed to produce a correct result. 
+This method applies either an LP-based approach or an approach based on direction of
+half-spaces. The default is to apply the LP-based approach. This is the safer algorithm,
+as it works correctly for `HPoly` with redundant constraints or if `P` is empty.
 
 #### LP
 
@@ -182,17 +180,16 @@ resuling vector of `±Inf`.
 
 #### Halfspace normal vector directions
 
-Note: This algorithm only applies if the `P` contains no redundant constraints. If not,
-this algorithm is not guaranteed to produce a correct result.
+Note: This algorithm only applies if `P` contains no redundant constraints.
 
-This algorithm is solves the problem of finding support vectors by analyzing the normal
-vectors of halfspace constraints. The algorithm relies on the following three key insights:
+This algorithm analyzes the normal vectors of the half-space constraints and
+relies on the following three key insights:
 
 1. The support vector will always be a vertex or unbounded.
-2. The `dim(P)` constraints with the smallest angle to `d` will constraint the vertex ``x``
-   maximizing ``d^\\mathrm{T}x``.
-3. If the angle between `d` and the normal vector of a halfspace is greater than 
-   ``90^{\\circ}``, then that halfspace cannot constraint the optimal vertex ``x``.
+2. The `dim(P)` constraints with the smallest angle to `d` will constrain the
+   vertex ``x`` maximizing ``d^\\mathrm{T}x``.
+3. If the angle between `d` and the normal vector of a half-space is greater than 
+   ``90^{\\circ}``, then that half-space cannot constrain the optimal vertex ``x``.
 
 Following this train of thought, the algorithm finds the `dim(P)` constraints with the
 largest  ``\\cos(\\theta) = \\frac{\\langle a, d \\rangle}{\\lVert a \\rVert \\lVert d \\rVert}``

--- a/src/Sets/HPolyhedron.jl
+++ b/src/Sets/HPolyhedron.jl
@@ -178,7 +178,7 @@ infeasible, then the primal is unbounded meaning that the polyhedron is unbounde
 the given direction. An infeasibility certificate is used to find the sign of the
 resuling vector of `±Inf`.
 
-#### Halfspace normal vector directions
+#### Half-space normal vector directions
 
 Note: This algorithm only applies if `P` contains no redundant constraints.
 
@@ -192,13 +192,18 @@ relies on the following three key insights:
    ``90^{\\circ}``, then that half-space cannot constrain the optimal vertex ``x``.
 
 Following this train of thought, the algorithm finds the `dim(P)` constraints with the
-largest  ``\\cos(\\theta) = \\frac{\\langle a, d \\rangle}{\\lVert a \\rVert \\lVert d \\rVert}``
+smallestabsolute angle to `d`. To avoid computations, observe that for an angle
+``-\\pi <= \\theta <= \\pi``, the mapping from ``|\\theta|`` to ``\\cos(\\theta)`` is
+monotone decreasing. Hence, the algorithm instead finds the `dim(P)` constraints with the
+largest ``\\cos(\\theta) = \\frac{\\langle a, d \\rangle}{\\lVert a \\rVert \\lVert d \\rVert}``
 where ``a`` is the normal vector. Let ``A x \\leq b`` be the system of linear inequalities
 representing the selected constraints. Then only one ``x`` satisfying ``A x = b`` exists,
 which is the support vector and can be found efficently using 
 [factorization](https://docs.julialang.org/en/v1/stdlib/LinearAlgebra/#man-linalg-factorizations).
 If fewer than `dim(P)` constraints have a positive ``\\cos(\\theta)``, then the polyhedron is
-unbounded in the given direction.
+unbounded in the given direction. To determine for each dimension whether to return `+Inf` or 
+`-Inf`, `d` is projected onto the polyhedral cone ``A x \\leq 0`` iteratively over constraints
+(at most `dim(P)` iterations).
 """
 function σ(d::AbstractVector{M}, P::HPoly{N};
            algorithm::String="lp",

--- a/test/Sets/Polyhedron.jl
+++ b/test/Sets/Polyhedron.jl
@@ -242,6 +242,13 @@ for N in [Float64]
         @test ρ(d, p_unbounded) == N(Inf)
         @test σ(d, p_unbounded; algorithm="halfspace_direction")[1] == N(Inf)
         @test ρ(d, p_unbounded; algorithm="halfspace_direction") == N(Inf)
+
+        d = N[-1, 1]
+        @test σ(d, p_unbounded)[2] == N(Inf)
+        @test ρ(d, p_unbounded) == N(Inf)
+        @test σ(d, p_unbounded; algorithm="halfspace_direction")[2] == N(Inf)
+        @test ρ(d, p_unbounded; algorithm="halfspace_direction") == N(Inf)
+
         @test_throws ErrorException σ(N[1], p_infeasible)
 
         # isempty

--- a/test/Sets/Polyhedron.jl
+++ b/test/Sets/Polyhedron.jl
@@ -41,6 +41,7 @@ for N in [Float64, Rational{Int}, Float32]
 
     # support vector of polyhedron with no constraints
     @test σ(N[1], p_univ) == N[Inf]
+    @test σ(N[1], p_univ; algorithm="halfspace_direction") == N[Inf]
 
     # is_polyhedral
     @test is_polyhedral(p)
@@ -192,12 +193,24 @@ for N in [Float64]
     # support vector
     d = N[1, 0]
     @test σ(d, p) == N[4, 2]
+    @test σ(d, p; algorithm="halfspace_direction") == N[4, 2]
+    @test ρ(d, p) == 4.0
+    @test ρ(d, p; algorithm="halfspace_direction") == 4.0
     d = N[0, 1]
     @test σ(d, p) == N[2, 4]
+    @test σ(d, p; algorithm="halfspace_direction") == N[2, 4]
+    @test ρ(d, p) == 4.0
+    @test ρ(d, p; algorithm="halfspace_direction") == 4.0
     d = N[-1, 0]
     @test σ(d, p) == N[-1, 1]
+    @test σ(d, p; algorithm="halfspace_direction") == N[-1, 1]
+    @test ρ(d, p) == 1.0
+    @test ρ(d, p; algorithm="halfspace_direction") == 1.0
     d = N[0, -1]
     @test σ(d, p) == N[0, 0]
+    @test σ(d, p; algorithm="halfspace_direction") == N[0, 0]
+    @test ρ(d, p) == 0.0
+    @test ρ(d, p; algorithm="halfspace_direction") == 0.0
 
     # membership
     @test [Inf, Inf] ∉ p
@@ -227,6 +240,8 @@ for N in [Float64]
         d = N[1, 0]
         @test σ(d, p_unbounded)[1] == N(Inf)
         @test ρ(d, p_unbounded) == N(Inf)
+        @test σ(d, p_unbounded; algorithm="halfspace_direction")[1] == N(Inf)
+        @test ρ(d, p_unbounded; algorithm="halfspace_direction") == N(Inf)
         @test_throws ErrorException σ(N[1], p_infeasible)
 
         # isempty


### PR DESCRIPTION
 New algorithm to compute support vectors for HPoly based on direction of normal vectors of halfspaces. The observed speed-up has been anywhere from 60x to 200x depending on the dimensionality. The limitation of this algorithm is that it only works if there are no redundant constraints.

It should be possible to achieve higher speed-ups by considering a spatial index such as an R-tree of the normal vectors projected onto the n-dimensional unit sphere, to search fewer constraints. A similar approach with spatial indexing could be applied to VPolytopes for all non-interior points to accelerate the computation of support vectors. 