### PR TITLE
Fix support vector of unbounded HPolyhedron

### DIFF
--- a/test/Sets/Polyhedron.jl
+++ b/test/Sets/Polyhedron.jl
@@ -219,7 +219,7 @@ for N in [Float64]
     @test isbounded(p)
 
     if test_suite_polyhedra
-        p_unbounded = HPolyhedron([LinearConstraint(N[-1, 0], N(0))])
+        p_unbounded = HPolyhedron([LinearConstraint(N[-1, 0], N(-1))])
         p_infeasible = HPolyhedron([LinearConstraint(N[1], N(0)),
                                     LinearConstraint(N[-1], N(-1))])
 
@@ -228,6 +228,9 @@ for N in [Float64]
         @test σ(d, p_unbounded)[1] == N(Inf)
         @test ρ(d, p_unbounded) == N(Inf)
         @test_throws ErrorException σ(N[1], p_infeasible)
+        d = N[-1, 1]  # unbounded in y direction, but x value matters
+        @test σ(d, p_unbounded) == N[1, Inf]
+        @test ρ(d, p_unbounded) == N(Inf)
 
         # isempty
         @test !isempty(p_unbounded)


### PR DESCRIPTION
```julia
julia> P = HPolyhedron([HalfSpace([0, -1.0], -1.0)]);

julia> x = σ([1.0, 0], P)  # the result is not a feasible solution because y should be >= 1
2-element Vector{Float64}:
 Inf
  0.0
```

The ray from the LP solver cannot simply be translated into a feasible solution (ignoring `Inf` entries). I am not 100% sure the new version does either (the new version takes a feasible point and replaces all directions of the ray by `±Inf`), but at least it improves the situation.

I also outsourced the code so it is easier to reuse the code.