### PR TITLE
Update refs to MathOptInterface

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -20,7 +20,7 @@ StaticArraysCore = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
 [compat]
 GLPK = "0.11 - 0.15, 1"
 IntervalArithmetic = "0.15 - 0.20"
-JuMP = "0.21 - 0.23, 1"
+JuMP = "1.8"
 ReachabilityBase = "0.1.5"
 RecipesBase = "0.6 - 0.8, 1"
 Reexport = "0.2, 1"

--- a/src/Initialization/init_JuMP.jl
+++ b/src/Initialization/init_JuMP.jl
@@ -1,34 +1,34 @@
-using JuMP.MathOptInterface: AbstractOptimizer, OptimizerWithAttributes
+using JuMP.MOI: AbstractOptimizer, OptimizerWithAttributes
 using JuMP: Model, @variable, @objective, @constraint, optimize!,
             termination_status, objective_value, value, primal_status
 
 # solver status
 function is_lp_optimal(status)
-    return status == JuMP.MathOptInterface.OPTIMAL
+    return status == JuMP.MOI.OPTIMAL
 end
 
 function is_lp_infeasible(status; strict::Bool=false)
-    if status == JuMP.MathOptInterface.INFEASIBLE
+    if status == JuMP.MOI.INFEASIBLE
         return true
     end
     if strict
         return false
     end
-    return status == JuMP.MathOptInterface.INFEASIBLE_OR_UNBOUNDED
+    return status == JuMP.MOI.INFEASIBLE_OR_UNBOUNDED
 end
 
 function is_lp_unbounded(status; strict::Bool=false)
-    if status == JuMP.MathOptInterface.DUAL_INFEASIBLE
+    if status == JuMP.MOI.DUAL_INFEASIBLE
         return true
     end
     if strict
         return false
     end
-    return status == JuMP.MathOptInterface.INFEASIBLE_OR_UNBOUNDED
+    return status == JuMP.MOI.INFEASIBLE_OR_UNBOUNDED
 end
 
 function has_lp_infeasibility_ray(model)
-    return primal_status(model) == JuMP.MathOptInterface.INFEASIBILITY_CERTIFICATE
+    return primal_status(model) == JuMP.MOI.INFEASIBILITY_CERTIFICATE
 end
 
 # solve a linear program (in the old MathProgBase interface)


### PR DESCRIPTION
Hi,
I've noticed that since `JuMP.jl` updated to v1.8, they reference `MathOptInterface.jl` as `MOI`, so anytime we call out to `JuMP.MathOptInterface` we get an `UndefVarError`. This means that currently we can't load `LazySets.jl` without restricting the `JuMP` version. I've proposed here to reference `MathOptInterface` as `MOI` to fix this. 

Example of breakage: 
```julia
using Pkg
Pkg.add("LazySets")
using LazySets
```
Gives
```julia
julia> using LazySets
[ Info: Precompiling LazySets [b4f0291d-fe17-52bc-9479-3d1a343d9043]
ERROR: LoadError: LoadError: UndefVarError: MathOptInterface not defined
Stacktrace:
 [1] include(mod::Module, _path::String)
   @ Base ./Base.jl:386
 [2] include(x::String)
   @ LazySets ~/.julia/packages/LazySets/qrmge/src/LazySets.jl:4
 [3] top-level scope
   @ ~/.julia/packages/LazySets/qrmge/src/LazySets.jl:46
 [4] include
   @ ./Base.jl:386 [inlined]
 [5] include_package_for_output(pkg::Base.PkgId, input::String, depot_path::Vector{String}, dl_load_path::Vector{String}, load_path::Vector{String}, concrete_deps::Vector{Pair{Base.PkgId, UInt64}}, source::Nothing)
   @ Base ./loading.jl:1235
 [6] top-level scope
   @ none:1
 [7] eval
   @ ./boot.jl:360 [inlined]
 [8] eval(x::Expr)
   @ Base.MainInclude ./client.jl:446
 [9] top-level scope
   @ none:1
in expression starting at /home/ben/.julia/packages/LazySets/qrmge/src/Initialization/init_JuMP.jl:1
in expression starting at /home/ben/.julia/packages/LazySets/qrmge/src/LazySets.jl:4
ERROR: Failed to precompile LazySets [b4f0291d-fe17-52bc-9479-3d1a343d9043] to /home/ben/.julia/compiled/v1.6/LazySets/jl_DFAOff.
Stacktrace:
 [1] error(s::String)
   @ Base ./error.jl:33
 [2] compilecache(pkg::Base.PkgId, path::String, internal_stderr::Base.TTY, internal_stdout::Base.TTY, ignore_loaded_modules::Bool)
   @ Base ./loading.jl:1385
 [3] compilecache(pkg::Base.PkgId, path::String)
   @ Base ./loading.jl:1329
 [4] _require(pkg::Base.PkgId)
   @ Base ./loading.jl:1043
 [5] require(uuidkey::Base.PkgId)
   @ Base ./loading.jl:936
 [6] require(into::Module, mod::Symbol)
   @ Base ./loading.jl:923

```