### PR TITLE
`Pkg.checkout()` is not supported anymore

### DIFF
--- a/docs/src/man/getting_started.md
+++ b/docs/src/man/getting_started.md
@@ -55,7 +55,7 @@ After working with `LazySets` for some time, you may want to get the newest
 version.
 For this you can use the following command (e.g., from the REPL):
 ```julia
-Pkg.checkout("LazySets")
+Pkg.update("LazySets")
 ```
 That will check out the latest version in the `master` branch, and precompile it
 the next time you enter a session and execute `using LazySets`.


### PR DESCRIPTION
In the **Updating** section the code snipped 
```julia
Pkg.checkout("LazySets")
```
Does not work anymore, it creates this error
```julia
Pkg.checkout("LazySets")
ERROR: UndefVarError: checkout not defined
Stacktrace:
 [1] getproperty(x::Module, f::Symbol)
   @ Base .\Base.jl:31
 [2] top-level scope
   @ REPL[7]:1
```

One possible solution is to change `Pkg.checkout("LazySets")` for `Pkg.update("LazySets")`