### PR TITLE
Let generators of LineSegment return an iterator

### DIFF
--- a/src/Sets/LineSegment.jl
+++ b/src/Sets/LineSegment.jl
@@ -232,7 +232,7 @@ function generators(L::LineSegment)
         N = eltype(L)
         return EmptyIterator{Vector{N}}()
     end
-    return [(L.p - L.q) / 2]
+    return SingletonIterator((L.p - L.q) / 2)
 end
 
 """


### PR DESCRIPTION
This is slightly more efficient because it does not allocate a `Vector`.