### PR TITLE
Add option to get 2D Delaunay triangulation for 3D sets

### DIFF
--- a/src/Interfaces/LazySet.jl
+++ b/src/Interfaces/LazySet.jl
@@ -1348,7 +1348,9 @@ Compute the Delaunay triangulation of the given polytopic set.
 
 ### Input
 
-- `X` -- polytopic set
+- `X`                    -- polytopic set
+- `compute_triangles_3d` -- (optional; default: `false`) flag to compute the 2D
+                            triangulation of a 3D set
 
 ### Output
 
@@ -1356,22 +1358,40 @@ A union of polytopes in vertex representation.
 
 ### Notes
 
-This function requires that you have properly installed the package
-[MiniQhull.jl](https://github.com/gridap/MiniQhull.jl), including the library
+This implementation requires the package
+[MiniQhull.jl](https://github.com/gridap/MiniQhull.jl), which uses the library
 [Qhull](http://www.qhull.org/).
 
 The method works in arbitrary dimension and the requirement is that the list of
 vertices of `X` can be obtained.
 """
-function delaunay(X::LazySet)
+function delaunay(X::LazySet; compute_triangles_3d::Bool=false)
+    vlist, connect_mat = delaunay_vlist_connectivity(X;
+        compute_triangles_3d=compute_triangles_3d)
+    nsimplices = size(connect_mat, 2)
+    if compute_triangles_3d
+        simplices = [VPolytope(vlist[connect_mat[1:3, j]]) for j in 1:nsimplices]
+    else
+        simplices = [VPolytope(vlist[connect_mat[:, j]]) for j in 1:nsimplices]
+    end
+    return UnionSetArray(simplices)
+end
+
+# compute the vertices and the connectivity matrix of the Delaunay triangulation
+#
+# if the flag `compute_triangles_3d` is set, the resulting matrix still has four
+# rows, but the last row has no meaning
+function delaunay_vlist_connectivity(X::LazySet;
+                                     compute_triangles_3d::Bool=false)
     n = dim(X)
-    v = vertices_list(X)
-    m = length(v)
-    coordinates = vcat(v...)
-    connectivity_matrix = delaunay(n, m, coordinates)
-    nelements = size(connectivity_matrix, 2)
-    elements = [VPolytope(v[connectivity_matrix[:, i]]) for i in 1:nelements]
-    return UnionSetArray(elements)
+    @assert !compute_triangles_3d || n == 3 "the `compute_triangles_3d` " *
+                                            "option requires 3D inputs"
+    vlist=vertices_list(X)
+    m = length(vlist)
+    coordinates = vcat(vlist...)
+    flags = compute_triangles_3d ? "qhull Qt" : nothing
+    connectivity_matrix = delaunay(n, m, coordinates, flags)
+    return vlist, connectivity_matrix
 end
 
 end end  # load_delaunay_MiniQhull

--- a/test/Sets/Polytope.jl
+++ b/test/Sets/Polytope.jl
@@ -588,3 +588,19 @@ for N in [Float64]
         @test ispermutation(vertices_list(overapproximate(Projection(X, [1, 2]), 1e-3)), v12)
     end
 end
+
+for N in [Float64, Rational{Int}]
+    # delaunay triangulation
+    vlist = [N[0, 0, 0], N[0, 0, 1], N[0, 1, 0], N[1, 0, 0]]  # tetrahedron
+    V = VPolytope(vlist)
+    D = delaunay(V)
+    @test length(D) == 1 && isequivalent(array(D)[1], V)
+    D = delaunay(V; compute_triangles_3d=true)
+    @test length(D) == 4
+    for P in array(D)
+        @test isequivalent(P, VPolytope(vlist[[1, 2, 3]])) ||
+              isequivalent(P, VPolytope(vlist[[1, 2, 4]])) ||
+              isequivalent(P, VPolytope(vlist[[1, 3, 4]])) ||
+              isequivalent(P, VPolytope(vlist[[2, 3, 4]]))
+    end
+end


### PR DESCRIPTION
With this new option we can easily add a 3D plot recipe with `Plots` (#35):

```julia
using LazySets, Plots
import MiniQhull

B = BallInf(zeros(3), 1.0)

V, C = LazySets.delaunay_vlist_connectivity(B; compute_triangles_3d=true)
C = Matrix{Int}(C .- 1)  # -1 for zero indexing; convert to Int64 on 64-bit systems

x = [v[1] for v in V]
y = [v[2] for v in V]
z = [v[3] for v in V]

i = [C[1, j] for j in 1:size(C, 2)]
j = [C[2, j] for j in 1:size(C, 2)]
k = [C[3, j] for j in 1:size(C, 2)]

plot(x, y, z, seriestype=:mesh3d; connections=(i, j, k))
```

![3d](https://user-images.githubusercontent.com/9656686/229616389-7baa1826-7b8e-4008-bf94-da47f3e6a1db.png)