### PR TITLE
#3194 - Remove AbstractStar interface

### DIFF
--- a/docs/src/lib/interfaces.md
+++ b/docs/src/lib/interfaces.md
@@ -259,6 +259,7 @@ plot_recipe(::AbstractPolyhedron{N}, ::Any=zero(N)) where {N}
 * [Line2D](@ref def_Line2D)
 * [Line](@ref def_Line)
 * [Universe](@ref def_Universe)
+* [Star](@ref def_Star)
 
 ## [Polytopes (AbstractPolytope)](@id def_AbstractPolytope)
 
@@ -530,16 +531,6 @@ linear_map(::AbstractMatrix, ::AbstractAffineMap)
 * [Linear map (LinearMap)](@ref def_LinearMap)
 * [Reset map (ResetMap)](@ref def_ResetMap)
 * [Translation](@ref def_Translation)
-
-## [Star sets (AbstractStar)](@id def_AbstractStar)
-
-```@docs
-AbstractStar
-```
-
-### Implementations
-
-* [Star](@ref def_Star)
 
 ## [Polynomial zonotope sets (AbstractPolynomialZonotope)](@id def_AbstractPolynomialZonotope)
 

--- a/src/Interfaces/LazySet.jl
+++ b/src/Interfaces/LazySet.jl
@@ -74,7 +74,7 @@ The subtypes of `LazySet` (including abstract interfaces):
 
 ```jldoctest; setup = :(using LazySets: subtypes)
 julia> subtypes(LazySet, false)
-18-element Vector{Any}:
+17-element Vector{Any}:
  AbstractAffineMap
  AbstractPolynomialZonotope
  Bloating
@@ -85,7 +85,6 @@ julia> subtypes(LazySet, false)
  ConvexSet
  Intersection
  IntersectionArray
- LazySets.AbstractStar
  MinkowskiSum
  MinkowskiSumArray
  Polygon
@@ -101,7 +100,7 @@ If we only consider *concrete* subtypes, then:
 julia> concrete_subtypes = subtypes(LazySet, true);
 
 julia> length(concrete_subtypes)
-54
+53
 
 julia> println.(concrete_subtypes);
 AffineMap
@@ -133,7 +132,6 @@ Intersection
 IntersectionArray
 Interval
 InverseLinearMap
-LazySets.AbstractStar
 Line
 Line2D
 LineSegment

--- a/src/LazySets.jl
+++ b/src/LazySets.jl
@@ -59,7 +59,7 @@ include("Utils/file_formats.jl")
 # ==================
 include("Interfaces/LazySet.jl")
 include("Interfaces/ConvexSet.jl")
-include("Interfaces/AbstractStar.jl")
+# include("Interfaces/AbstractStar.jl")
 include("Interfaces/AbstractPolynomialZonotope.jl")
 include("Interfaces/AbstractPolyhedron.jl")
 include("Sets/HalfSpace.jl")  # must come before AbstractPolyhedron_functions

--- a/src/Utils/helper_functions.jl
+++ b/src/Utils/helper_functions.jl
@@ -62,9 +62,8 @@ Every convex set type implements the function `σ`.
 julia> dict = implementing_sets(σ; signature=Type[AbstractVector], index=2);
 
 julia> dict["missing"]
-6-element Vector{Type}:
+5-element Vector{Type}:
  Complement
- LazySets.AbstractStar
  Polygon
  QuadraticMap
  SimpleSparsePolynomialZonotope

--- a/test/Interfaces/interfaces.jl
+++ b/test/Interfaces/interfaces.jl
@@ -2,11 +2,14 @@
 
 # --- LazySet ---
 
+# dimension
+@test check_method_implementation(LazySet, dim, Function[S -> (S{Float64},)])
+
+# --- ConvexSet ---
+
 # support vector
 @test check_method_implementation(ConvexSet, σ,
                                   Function[S -> (Vector{Float64}, S{Float64})])
-# dimension
-check_method_implementation(LazySet, dim, Function[S -> (S{Float64},)])
 
 # --- AbstractPolyhedron ---
 

--- a/test/Sets/EmptySet.jl
+++ b/test/Sets/EmptySet.jl
@@ -79,8 +79,7 @@ end
 # intersection
 for X in filter(!isoperationtype, LazySets.subtypes(LazySet, true))
     if X ∈ [RotatedHyperrectangle, Star, Polygon, DensePolynomialZonotope,
-            SparsePolynomialZonotope, SimpleSparsePolynomialZonotope,
-            LazySets.AbstractStar]
+            SparsePolynomialZonotope, SimpleSparsePolynomialZonotope]
         # missing rand()
         continue
     end

--- a/test/Utils/check_method_implementation.jl
+++ b/test/Utils/check_method_implementation.jl
@@ -33,7 +33,7 @@ This function can also print all intermediate results to STDOUT.
 ### Examples
 
 ```jldoctest
-julia> check_method_implementation(LazySet, σ,
+julia> check_method_implementation(ConvexSet, σ,
         Function[S -> (AbstractVector{Float64}, S)])
 true
 ```


### PR DESCRIPTION
Closes #3194.

Once we have an implementation, we can easily add it again. But for now this just breaks some assumptions.