### PR TITLE
#230 - Overapproximate DensePolynomialZonotope with Zonotope

### DIFF
--- a/docs/src/lib/interfaces.md
+++ b/docs/src/lib/interfaces.md
@@ -539,6 +539,7 @@ linear_map(::AbstractMatrix, ::AbstractAffineMap)
 
 ```@docs
 AbstractPolynomialZonotope
+dim(::AbstractPolynomialZonotope)
 ```
 
 ### Implementations

--- a/docs/src/lib/sets/DensePolynomialZonotope.md
+++ b/docs/src/lib/sets/DensePolynomialZonotope.md
@@ -6,11 +6,13 @@ CurrentModule = LazySets
 
 ```@docs
 DensePolynomialZonotope
-dim(::DensePolynomialZonotope)
-σ(::AbstractVector, ::DensePolynomialZonotope)
-ρ(::AbstractVector, ::DensePolynomialZonotope)
-polynomial_order(pz::DensePolynomialZonotope)
+center(::DensePolynomialZonotope)
+ngens_dep(::DensePolynomialZonotope)
+ngens_indep(::DensePolynomialZonotope)
+polynomial_order(::DensePolynomialZonotope)
 order(::DensePolynomialZonotope)
 linear_map(::AbstractMatrix, ::DensePolynomialZonotope)
 scale(::Number, ::DensePolynomialZonotope)
 ```
+Inherited from [`AbstractPolynomialZonotope`](@ref):
+* [`dim`](@ref dim(::AbstractPolynomialZonotope))

--- a/docs/src/lib/sets/SimpleSparsePolynomialZonotope.md
+++ b/docs/src/lib/sets/SimpleSparsePolynomialZonotope.md
@@ -11,7 +11,6 @@ rand(::Type{SimpleSparsePolynomialZonotope})
 center(::SimpleSparsePolynomialZonotope)
 genmat(::SimpleSparsePolynomialZonotope)
 expmat(::SimpleSparsePolynomialZonotope)
-dim(::SimpleSparsePolynomialZonotope)
 ngens(::SimpleSparsePolynomialZonotope)
 nparams(::SimpleSparsePolynomialZonotope)
 order(::SimpleSparsePolynomialZonotope)
@@ -21,3 +20,5 @@ quadratic_map(::Vector{MT}, ::SimpleSparsePolynomialZonotope) where {N, MT<:Abst
 quadratic_map(Q::Vector{MT}, S1::SimpleSparsePolynomialZonotope, S2::SimpleSparsePolynomialZonotope) where {N, MT<:AbstractMatrix{N}}
 remove_redundant_generators(::SimpleSparsePolynomialZonotope)
 ```
+Inherited from [`AbstractPolynomialZonotope`](@ref):
+* [`dim`](@ref dim(::AbstractPolynomialZonotope))

--- a/docs/src/lib/sets/SparsePolynomialZonotope.md
+++ b/docs/src/lib/sets/SparsePolynomialZonotope.md
@@ -13,7 +13,6 @@ genmat_indep(::SparsePolynomialZonotope)
 expmat(::SparsePolynomialZonotope)
 indexvector(P::SparsePolynomialZonotope)
 uniqueID(::Int)
-dim(::SparsePolynomialZonotope)
 ngens_dep(::SparsePolynomialZonotope)
 ngens_indep(::SparsePolynomialZonotope)
 nparams(::SparsePolynomialZonotope)
@@ -23,3 +22,5 @@ translate(::SparsePolynomialZonotope, ::AbstractVector)
 remove_redundant_generators(::SparsePolynomialZonotope)
 reduce_order(::SparsePolynomialZonotope, ::Real, ::AbstractReductionMethod=GIR05())
 ```
+Inherited from [`AbstractPolynomialZonotope`](@ref):
+* [`dim`](@ref dim(::AbstractPolynomialZonotope))

--- a/src/Approximations/overapproximate_zonotope.jl
+++ b/src/Approximations/overapproximate_zonotope.jl
@@ -247,8 +247,7 @@ function _zonotope_overapprox(c, G, E)
 end
 
 """
-    overapproximate(P::SimpleSparsePolynomialZonotope, ::Type{<:Zonotope};
-                    [nsdiv]=1, [partition]=nothing)
+    overapproximate(P::SimpleSparsePolynomialZonotope, ::Type{<:Zonotope})
 
 Overapproximate a simple sparse polynomial zonotope with a zonotope.
 
@@ -256,22 +255,12 @@ Overapproximate a simple sparse polynomial zonotope with a zonotope.
 
 - `P`         -- simple sparse polynomial zonotope
 - `Zonotope`  -- target set type
-- `nsdiv`     -- (optional, default: `1`) size of uniform partitioning grid
-- `partition` -- (optional, default: `nothing`) tuple of integers indicating the
-                 number of blocks in each dimensino; the length should match
-                 `nparams(P)`
 
 ### Output
 
 A zonotope.
 """
-function overapproximate(P::SimpleSparsePolynomialZonotope, ::Type{<:Zonotope};
-                         nsdiv=1, partition=nothing)
-    if !isnothing(partition) || nsdiv != 1
-        return overapproximate(P, UnionSetArray{Zonotope}; nsdiv=nsdiv,
-                               partition=partition)
-    end
-
+function overapproximate(P::SimpleSparsePolynomialZonotope, ::Type{<:Zonotope})
     cnew, Gnew = _zonotope_overapprox(center(P), genmat(P), expmat(P))
     return Zonotope(cnew, Gnew)
 end

--- a/src/Approximations/overapproximate_zonotope.jl
+++ b/src/Approximations/overapproximate_zonotope.jl
@@ -313,8 +313,8 @@ Overapproximate a sparse polynomial zonotope with a zonotope.
 
 ### Input
 
-- `P`         -- sparse polynomial zonotope
-- `Zonotope`  -- target set type
+- `P`        -- sparse polynomial zonotope
+- `Zonotope` -- target set type
 
 ### Output
 
@@ -323,6 +323,35 @@ A zonotope.
 function overapproximate(P::SparsePolynomialZonotope, ::Type{<:Zonotope})
     cnew, Gnew = _zonotope_overapprox(center(P), genmat_dep(P), expmat(P))
     return Zonotope(cnew, hcat(Gnew, genmat_indep(P)))
+end
+
+"""
+    overapproximate(P::DensePolynomialZonotope, ::Type{<:Zonotope})
+
+Overapproximate a polynomial zonotope with a zonotope.
+
+### Input
+
+- `P`        -- polynomial zonotope
+- `Zonotope` -- target set type
+
+### Output
+
+A zonotope.
+
+### Algorithm
+
+This method implements Proposition 1 in [1].
+
+[1] M. Althoff in *Reachability analysis of nonlinear systems using conservative
+    polynomialization and non-convex sets*, Hybrid Systems: Computation and
+    Control, 2013, pp. 173-182.
+"""
+function overapproximate(P::DensePolynomialZonotope, ::Type{<:Zonotope})
+    η = polynomial_order(P)
+    cnew = center(P) + 1/2 * vec(sum(i -> sum(P.E[2i], dims=2), 1:floor(Int, η / 2)))
+    Gnew = hcat([iseven(i) ? 1/2 * P.E[i] : P.E[i] for i in 1:η]..., P.F..., P.G)
+    return Zonotope(cnew, Gnew)
 end
 
 # function to be loaded by Requires

--- a/src/Interfaces/AbstractPolynomialZonotope.jl
+++ b/src/Interfaces/AbstractPolynomialZonotope.jl
@@ -9,6 +9,12 @@ Abstract type for polynomial zonotope sets.
 
 Polynomial zonotopes are in general non-convex. They are always bounded.
 
+Every concrete `AbstractPolynomialZonotope` must define the following functions:
+
+- `center(::AbstractPolynomialZonotope)` -- return the center
+
+- `order(::AbstractPolynomialZonotope)` -- return the order
+
 ```jldoctest; setup = :(using LazySets: subtypes)
 julia> subtypes(AbstractPolynomialZonotope)
 3-element Vector{Any}:
@@ -21,3 +27,18 @@ abstract type AbstractPolynomialZonotope{N} <: LazySet{N} end
 
 isconvextype(::Type{<:AbstractPolynomialZonotope}) = false
 isboundedtype(::Type{<:AbstractPolynomialZonotope}) = true
+
+"""
+    dim(PZ::AbstractPolynomialZonotope)
+
+Return the ambient dimension of a polynomial zonotope.
+
+### Input
+
+- `PZ` -- polynomial zonotope
+
+### Output
+
+An integer representing the ambient dimension of the polynomial zonotope.
+"""
+dim(PZ::AbstractPolynomialZonotope) = length(center(PZ))

--- a/src/Sets/DensePolynomialZonotope.jl
+++ b/src/Sets/DensePolynomialZonotope.jl
@@ -31,7 +31,7 @@ where:
 - ``c ∈ \\mathbb{R}^n`` is the starting point (in some particular cases it
   corresponds to the center of a usual zonotope),
 
-- ``E = [E^{[1]} ⋯ E^{[η]}]`` is an ``n × p × η(η+1)/2`` matrix with column
+- ``E = [E^{[1]} ⋯ E^{[η]}]`` is an ``n × p × η`` matrix with column
   blocks
 
 ```math

--- a/src/Sets/SimpleSparsePolynomialZonotope.jl
+++ b/src/Sets/SimpleSparsePolynomialZonotope.jl
@@ -68,34 +68,12 @@ Another shorthand is `SSPZ`.
 """
 const PolynomialZonotope = SimpleSparsePolynomialZonotope
 
+# short-hand
 const SSPZ = SimpleSparsePolynomialZonotope
 
 function isoperationtype(P::Type{<:SimpleSparsePolynomialZonotope})
     return false
 end
-
-function isconvextype(P::Type{<:SimpleSparsePolynomialZonotope})
-    return false
-end
-
-function isboundedtype(P::Type{<:SimpleSparsePolynomialZonotope})
-    return true
-end
-
-"""
-    dim(P::SimpleSparsePolynomialZonotope)
-
-Return the dimension of a simple sparse polynomial zonotope.
-
-### Input
-
-- `P` -- simple sparse polynomial zonotope
-
-### Output
-
-The ambient dimension of `P`.
-"""
-dim(P::SSPZ) = length(P.c)
 
 """
     ngens(P::SimpleSparsePolynomialZonotope)

--- a/src/Sets/SparsePolynomialZonotope.jl
+++ b/src/Sets/SparsePolynomialZonotope.jl
@@ -79,29 +79,6 @@ function isoperationtype(P::Type{<:SparsePolynomialZonotope})
     return false
 end
 
-function isconvextype(P::Type{<:SparsePolynomialZonotope})
-    return false
-end
-
-function isboundedtype(P::Type{<:SparsePolynomialZonotope})
-    return true
-end
-
-"""
-    dim(P::SparsePolynomialZonotope)
-
-Return the dimension of a sparse polynomial zonotope.
-
-### Input
-
-- `P` -- sparse polynomial zonotope
-
-### Output
-
-The ambient dimension of `P`.
-"""
-dim(P::SPZ) = length(P.c)
-
 """
     ngens_dep(P::SparsePolynomialZonotope)
 

--- a/src/Utils/helper_functions.jl
+++ b/src/Utils/helper_functions.jl
@@ -62,8 +62,9 @@ Every convex set type implements the function `σ`.
 julia> dict = implementing_sets(σ; signature=Type[AbstractVector], index=2);
 
 julia> dict["missing"]
-5-element Vector{Type}:
+6-element Vector{Type}:
  Complement
+ DensePolynomialZonotope
  Polygon
  QuadraticMap
  SimpleSparsePolynomialZonotope

--- a/test/Interfaces/interfaces.jl
+++ b/test/Interfaces/interfaces.jl
@@ -92,3 +92,10 @@
 # set
 @test check_method_implementation(AbstractAffineMap, set,
                                   Function[S -> (S{Float64},)])
+
+# --- AbstractPolynomialZonotope ---
+
+@test check_method_implementation(AbstractPolynomialZonotope, center,
+                                  Function[S -> (S{Float64},)])
+@test check_method_implementation(AbstractPolynomialZonotope, order,
+                                  Function[S -> (S{Float64},)])

--- a/test/Sets/DensePolynomialZonotope.jl
+++ b/test/Sets/DensePolynomialZonotope.jl
@@ -1,25 +1,25 @@
 for N in [Float64, Float32, Rational{Int}]
-
+    # example set from Figure 2 in original paper
     c = zeros(N, 2)
     E1 = Matrix(Diagonal(N[-1, 0.5]))
     E2 = N[1 1; 0.5 0.3]
     E = [E1, E2]
     F2 = hcat(N[-0.5, 1])
     F = [F2]
-    G = Matrix(N(0.3)I, 2, 2)
-    p = DensePolynomialZonotope(c, E, F, G)
+    G = hcat(N[0.3, 0.3])
+    P = DensePolynomialZonotope(c, E, F, G)
 
-    @test dim(p) == 2
-    @test polynomial_order(p) == 2
-    @test center(p) == c
-    @test ngens_dep(p) == 5
-    @test ngens_indep(p) == 2
-    @test order(p) == 7//2
+    @test dim(P) == 2
+    @test polynomial_order(P) == 2
+    @test center(P) == c
+    @test ngens_dep(P) == 5
+    @test ngens_indep(P) == 1
+    @test order(P) == 3//1
 
     # type-specific concrete methods
-    scale(N(0.5), p)
-    linear_map(N[1.0 2.0; 2.0 5.0], p)
+    scale(N(0.5), P)
+    linear_map(N[1.0 2.0; 2.0 5.0], P)
     z = Zonotope(N[1., 2.], Matrix(N(1)I, 2, 2))
-    minkowski_sum(p, z)
-    minkowski_sum(z, p)
+    minkowski_sum(P, z)
+    minkowski_sum(z, P)
 end

--- a/test/Sets/DensePolynomialZonotope.jl
+++ b/test/Sets/DensePolynomialZonotope.jl
@@ -10,8 +10,11 @@ for N in [Float64, Float32, Rational{Int}]
     p = DensePolynomialZonotope(c, E, F, G)
 
     @test dim(p) == 2
-    @test order(p) == 7//2
     @test polynomial_order(p) == 2
+    @test center(p) == c
+    @test ngens_dep(p) == 5
+    @test ngens_indep(p) == 2
+    @test order(p) == 7//2
 
     # type-specific concrete methods
     scale(N(0.5), p)

--- a/test/Sets/SimpleSparsePolynomialZonotope.jl
+++ b/test/Sets/SimpleSparsePolynomialZonotope.jl
@@ -16,8 +16,8 @@ for N in [Float64, Float32, Rational{Int}]
     @test order(S) == 1 // 1
 
     @test overapproximate(S, Zonotope) == Zonotope(N[3., 1], N[1 1; 2 1.])
-    @test length(overapproximate(S, Zonotope; nsdiv=3)) == 9
-    @test length(overapproximate(S, Zonotope; partition=(2, 3))) == 6
+    @test length(overapproximate(S, UnionSetArray{Zonotope}; nsdiv=3)) == 9
+    @test length(overapproximate(S, UnionSetArray{Zonotope}; partition=(2, 3))) == 6
 
     LMS = linear_map(N[1 2; 3 4], S);
     @test center(LMS) == N[2, 6]


### PR DESCRIPTION
Closes #230.

- The first commit shifts some code from the three implementations to the interface and adds some simple methods for `DensePolynomialZonotope`.
- The second commit removes some arguments to a method that made the method confusing (and type unstable).
- The third commit fixes an error in the docstring of `DensePolynomialZonotope`.
- The fourth commit adds a method for `overapproximate` of a `DensePolynomialZonotope` with a `Zonotope`.

EDIT: I implemented a sampler for polynomial zonotopes (currently in a branch that depends on some changes here). Below is the sampling of the set in the paper, and in blue you see the zonotope approximation from this branch.

![zonotope_sample](https://user-images.githubusercontent.com/9656686/230108741-f0ad9f7f-38a6-4edc-a315-bcb63c14f038.png)