### PR TITLE
#600 - Specialized support function for Ball1 and Ballp

### DIFF
--- a/docs/src/lib/sets/Ball1.md
+++ b/docs/src/lib/sets/Ball1.md
@@ -7,6 +7,7 @@ CurrentModule = LazySets
 ```@docs
 Ball1
 σ(::AbstractVector, ::Ball1)
+ρ(::AbstractVector, ::Ball1)
 ∈(::AbstractVector, ::Ball1, ::Bool=false)
 vertices_list(::Ball1)
 center(::Ball1)
@@ -18,7 +19,6 @@ reflect(::Ball1)
 ```
 
 Inherited from [`LazySet`](@ref):
-* [`ρ`](@ref ρ(::AbstractVector, ::LazySet))
 * [`norm`](@ref norm(::LazySet, ::Real))
 * [`radius`](@ref radius(::LazySet, ::Real))
 * [`diameter`](@ref diameter(::LazySet, ::Real))

--- a/docs/src/lib/sets/Ballp.md
+++ b/docs/src/lib/sets/Ballp.md
@@ -7,6 +7,7 @@ CurrentModule = LazySets
 ```@docs
 Ballp
 σ(::AbstractVector, ::Ballp)
+ρ(::AbstractVector, ::Ballp)
 ∈(::AbstractVector, ::Ballp)
 center(::Ballp)
 rand(::Type{Ballp})

--- a/src/Sets/Ball1.jl
+++ b/src/Sets/Ball1.jl
@@ -135,6 +135,33 @@ function σ(d::AbstractVector, B::Ball1)
 end
 
 """
+    ρ(d::AbstractVector, B::Ball1)
+
+Evaluate the support function of a ball in the 1-norm in the given direction.
+
+### Input
+
+- `d` -- direction
+- `B` -- ball in the 1-norm
+
+### Output
+
+Evaluation of the support function in the given direction.
+
+### Algorithm
+
+Let ``c`` and ``r`` be the center and radius of the ball ``B`` in the 1-norm,
+respectively. Then:
+
+```math
+ρ(d, B) = ⟨d, c⟩ + r ‖d‖_∞.
+```
+"""
+function ρ(d::AbstractVector, B::Ball1)
+    return dot(d, B.center) + B.radius * maximum(abs, d)
+end
+
+"""
     ∈(x::AbstractVector, B::Ball1, [failfast]::Bool=false)
 
 Check whether a given point is contained in a ball in the 1-norm.

--- a/src/Sets/Ball2.jl
+++ b/src/Sets/Ball2.jl
@@ -96,7 +96,7 @@ Return the support function of a 2-norm ball in the given direction.
 
 The support function in the given direction.
 
-### Notes
+### Algorithm
 
 Let ``c`` and ``r`` be the center and radius of the ball ``B`` in the 2-norm,
 respectively. Then:
@@ -106,10 +106,7 @@ respectively. Then:
 ```
 """
 function ρ(d::AbstractVector, B::Ball2)
-    c = B.center
-    r = B.radius
-    dnorm = norm(d, 2)
-    return dot(d, c) + dnorm * r
+    return dot(d, B.center) + B.radius * norm(d, 2)
 end
 
 """

--- a/src/Sets/Ballp.jl
+++ b/src/Sets/Ballp.jl
@@ -130,19 +130,47 @@ otherwise, for all ``i = 1, …, n``.
 """
 function σ(d::AbstractVector, B::Ballp)
     p = B.p
-    q = p/(p-1)
+    q = p / ( p - 1)
     v = similar(d)
     N = promote_type(eltype(d), eltype(B))
     @inbounds for (i, di) in enumerate(d)
         v[i] = di == zero(N) ? di : abs.(di).^q / di
     end
     vnorm = norm(v, p)
-    if iszero(vnorm)
+    if isapproxzero(vnorm)
         svec = B.center
     else
-        svec = @.(B.center + B.radius * (v/vnorm))
+        svec = @.(B.center + B.radius * (v / vnorm))
     end
     return svec
+end
+
+"""
+    ρ(d::AbstractVector, B::Ballp)
+
+Evaluate the support function of a ball in the p-norm in the given direction.
+
+### Input
+
+- `d` -- direction
+- `B` -- ball in the p-norm
+
+### Output
+
+Evaluation of the support function in the given direction.
+
+### Algorithm
+
+Let ``c`` and ``r`` be the center and radius of the ball ``B`` in the p-norm,
+respectively, and let ``q = \\frac{p}{p-1}``. Then:
+
+```math
+ρ(d, B) = ⟨d, c⟩ + r ‖d‖_q.
+```
+"""
+function ρ(d::AbstractVector, B::Ballp)
+    q = B.p / (B.p - 1)
+    return dot(d, B.center) + B.radius * norm(d, q)
 end
 
 """


### PR DESCRIPTION
See #600.

The default implementation needs to allocate the support vector, which can be avoided.

```julia
julia> B1 = rand(Ball1, dim=100); d = rand(100);

julia> @time ρ_old(d, B1)
  0.000010 seconds (2 allocations: 912 bytes)
8.280132936590725

julia> @time ρ_new(d, B1)
  0.000013 seconds (1 allocation: 16 bytes)
8.280132936590725

###

julia> Bp = rand(Ballp, dim=100); d = rand(100);

julia> @time ρ_old(d, Bp)
  0.000023 seconds (3 allocations: 1.766 KiB)
11.071392754318621

julia> @time ρ_new(d, Bp)
  0.000016 seconds (1 allocation: 16 bytes)
11.071392754318621
```