### PR TITLE
#600 - Specialized support function for LineSegment

### DIFF
--- a/docs/src/lib/sets/LineSegment.md
+++ b/docs/src/lib/sets/LineSegment.md
@@ -8,6 +8,7 @@ CurrentModule = LazySets
 LineSegment
 dim(::LineSegment)
 σ(::AbstractVector, ::LineSegment)
+ρ(::AbstractVector, ::LineSegment)
 ∈(::AbstractVector, ::LineSegment)
 center(::LineSegment)
 an_element(::LineSegment)

--- a/src/Sets/LineSegment.jl
+++ b/src/Sets/LineSegment.jl
@@ -111,6 +111,24 @@ function σ(d::AbstractVector, L::LineSegment)
 end
 
 """
+    ρ(d::AbstractVector, L::LineSegment)
+
+Evaluate the support function of a 2D line segment in a given direction.
+
+### Input
+
+- `d` -- direction
+- `L` -- 2D line segment
+
+### Output
+
+Evaluation of the support function in the given direction.
+"""
+function ρ(d::AbstractVector, L::LineSegment)
+    return max(dot(L.p, d), dot(L.q, d))
+end
+
+"""
     an_element(L::LineSegment)
 
 Return some element of a 2D line segment.


### PR DESCRIPTION
See #600.

The version in `master` uses the default implementation for `AbstractZonotope`, which constructs the generator matrix.

```julia
julia> L = rand(LineSegment); d = rand(2);

julia> @time ρ_old(d, L)
  0.000012 seconds (7 allocations: 496 bytes)
-0.5400307176763027

julia> @time ρ_new(d, L)
  0.000009 seconds (1 allocation: 16 bytes)
-0.5400307176763026
```