### PR TITLE
#600 - Specialized support function for VPolytope

### DIFF
--- a/docs/src/lib/sets/VPolytope.md
+++ b/docs/src/lib/sets/VPolytope.md
@@ -8,6 +8,7 @@ CurrentModule = LazySets
 VPolytope
 dim(::VPolytope)
 σ(::AbstractVector, ::VPolytope)
+ρ(::AbstractVector, ::VPolytope)
 ∈(::AbstractVector{N}, ::VPolytope{N}) where {N}
 rand(::Type{VPolytope})
 translate(::VPolytope, ::AbstractVector)
@@ -24,7 +25,6 @@ reflect(::VPolytope)
 Inherited from [`LazySet`](@ref):
 * [`high`](@ref high(::LazySet))
 * [`low`](@ref low(::LazySet))
-* [`ρ`](@ref ρ(::AbstractVector, ::LazySet))
 * [`norm`](@ref norm(::LazySet, ::Real))
 * [`radius`](@ref radius(::LazySet, ::Real))
 * [`diameter`](@ref diameter(::LazySet, ::Real))

--- a/src/Sets/VPolytope.jl
+++ b/src/Sets/VPolytope.jl
@@ -135,7 +135,7 @@ function σ(d::AbstractVector, P::VPolytope)
     # base cases
     m = length(P.vertices)
     if m == 0
-        error("the support function of an empty polytope is undefined")
+        error("the support vector of an empty polytope is undefined")
     elseif m == 1
         @inbounds return P.vertices[1]
     end
@@ -152,6 +152,29 @@ function σ(d::AbstractVector, P::VPolytope)
         end
     end
     @inbounds return P.vertices[max_idx]
+end
+
+"""
+    ρ(d::AbstractVector, P::VPolytope)
+
+Evaluate the support function of a polytope in vertex representation in a given
+direction.
+
+### Input
+
+- `d` -- direction
+- `P` -- polytope in vertex representation
+
+### Output
+
+Evaluation of the support function in the given direction.
+"""
+function ρ(d::AbstractVector, P::VPolytope)
+    if isempty(P.vertices)
+        error("the support function of an empty polytope is undefined")
+    end
+    # evaluate support function in every vertex
+    return maximum(v -> dot(d, v), P.vertices)
 end
 
 """


### PR DESCRIPTION
See #600.

There is essentially no difference, but the generated code is a bit shorter.

```julia
julia> L = rand(VPolytope, dim=50, num_vertices=100); d = rand(50);

julia> @time ρ_old(d, V)
  0.000015 seconds (1 allocation: 16 bytes)
15.335757954706304

julia> @time ρ_new(d, V)
  0.000021 seconds (1 allocation: 16 bytes)
15.335757954706304
```