### PR TITLE
#993 - More efficient support vector for UnionSet and UnionSetArray

### DIFF
--- a/src/LazyOperations/ConvexHullArray.jl
+++ b/src/LazyOperations/ConvexHullArray.jl
@@ -110,18 +110,7 @@ A support vector in the given direction.
 """
 function σ(d::AbstractVector, cha::ConvexHullArray)
     @assert !isempty(cha.array) "an empty convex hull is not allowed"
-    svec = d
-    N = eltype(d)
-    rmax = N(-Inf)
-    for chi in cha.array
-        si = σ(d, chi)
-        ri = dot(d, si)
-        if ri > rmax
-            rmax = ri
-            svec = si
-        end
-    end
-    return svec
+    return _σ_union(d, array(cha))
 end
 
 """

--- a/src/LazyOperations/UnionSet.jl
+++ b/src/LazyOperations/UnionSet.jl
@@ -124,8 +124,8 @@ function σ(d::AbstractVector, cup::UnionSet; algorithm="support_vector")
         return dot(d, σX) > dot(d, σY) ? σX : σY
 
     elseif algorithm == "support_function"
-        m = argmax([ρ(d, X), ρ(d, Y)])
-        return m == 1 ? σ(d, X) : σ(d, Y)
+        ρX, ρY = ρ(d, X), ρ(d, Y)
+        return ρX > ρY ? σ(d, X) : σ(d, Y)
 
     else
         error("algorithm $algorithm for the support vector of a `UnionSet` is" *


### PR DESCRIPTION
Closes #993.

```julia
julia> cup = UnionSet(rand(Ball2), rand(Ball1)); d = rand(2);

julia> @time σ(d, cup; algorithm="support_function");  # master
  0.000011 seconds (4 allocations: 256 bytes)

julia> @time σ(d, cup; algorithm="support_function");  # this branch
  0.000011 seconds (3 allocations: 176 bytes)

###

julia> cup = UnionSetArray([rand(Ball2) for _ in 1:20]); d = rand(2);

julia> @time σ(d, cup; algorithm="support_vector");  # master
  0.000018 seconds (23 allocations: 2.000 KiB)

julia> @time σ(d, cup; algorithm="support_function");  # master
  0.000030 seconds (3 allocations: 320 bytes)

julia> @time σ(d, cup; algorithm="support_vector");  # this branch
  0.000015 seconds (21 allocations: 1.578 KiB)

julia> @time σ(d, cup; algorithm="support_function");  # this branch
  0.000022 seconds (2 allocations: 96 bytes)
```