### PR TITLE
remove trailing whitespace

### DIFF
--- a/docs/src/about.md
+++ b/docs/src/about.md
@@ -116,7 +116,7 @@ Here we list the names of the maintainers of the `LazySets.jl` library, as well 
 
 ### Acknowledgements
 
-We are grateful to the following persons for enlightening discussions: 
+We are grateful to the following persons for enlightening discussions:
 
 - [Sergiy Bogomolov](https://www.sergiybogomolov.com/)
-- [Goran Frehse](https://sites.google.com/site/frehseg/) 
+- [Goran Frehse](https://sites.google.com/site/frehseg/)

--- a/docs/src/man/getting_started.md
+++ b/docs/src/man/getting_started.md
@@ -38,7 +38,7 @@ This should precompile the package and make it available afterward.
 ## Optional dependencies
 
 An optional dependency is a package that is not required to compile and use `LazySets.jl`,
-although some extra functionality is available provided that you load that package. 
+although some extra functionality is available provided that you load that package.
 For example, if you want to work with sets defined using simple algebraic expressions you can install
 [Symbolics.jl](https://github.com/JuliaSymbolics/Symbolics.jl) as usual with the package manager,
 `] add Symbolics`, then load it together with `LazySets` to have new functionality.

--- a/docs/src/man/interval_hulls.md
+++ b/docs/src/man/interval_hulls.md
@@ -140,16 +140,16 @@ We can get the list of vertices using the `vertices_list` function:
 ```@example example_ih
 vertices_list(S)
 ```
- 
+
 For instance, compute the support vector in the south-east direction:
- 
+
 ```@example example_ih
 σ([1., -1.], S)
 ```
- 
+
 It is also possible to pass a sparse vector as direction, and the result is a
 sparse vector:
- 
+
  ```@example example_ih
 σ(sparsevec([1., -1.]), S)
 ```

--- a/docs/src/man/optional_dependencies.md
+++ b/docs/src/man/optional_dependencies.md
@@ -10,7 +10,7 @@ Pages = ["optional_dependencies.md"]
 ## Installing all dependencies
 
 Use the following command to install *all* optional dependencies. Installing all optional dependencies is required
-if you want to run the full test suite and build the documentation locally. 
+if you want to run the full test suite and build the documentation locally.
 
 ```julia
 julia> import Pkg; Pkg.add(["CDDLib",
@@ -64,7 +64,7 @@ Note: `IntervalConstraintProgramming` is currently not tested due to compatibili
 
 Some computations require use of external numerical optimization solvers. The modeling language [`JuMP`](https://github.com/jump-dev/JuMP.jl) is loaded by default, together with the [GLPK](https://en.wikipedia.org/wiki/GNU_Linear_Programming_Kit) solver for linear programs (LPs). Other solvers can be loaded on-demand, even commercial ones, provided that you have the appropriate license. See JuMP's [documentation page on supported solvers](https://jump.dev/JuMP.jl/stable/installation/#Supported-solvers) for further details.
 
-For other uses, such as line search methods to compute the support function of lazy intersections of certain sets, [`Optim`](https://github.com/JuliaNLSolvers/Optim.jl) can be optionally loaded. 
+For other uses, such as line search methods to compute the support function of lazy intersections of certain sets, [`Optim`](https://github.com/JuliaNLSolvers/Optim.jl) can be optionally loaded.
 
 |Dependency|Features|
 |----------|-------|

--- a/test/LazyOperations/AffineMap.jl
+++ b/test/LazyOperations/AffineMap.jl
@@ -3,7 +3,7 @@ for N in [Float64, Rational{Int}, Float32]
     # ==================================
     # Constructor and interface methods
     # ==================================
- 
+
     B = BallInf(zeros(N, 3), N(1))
     v = N[1, 0, 0] # translation along dimension 1
     M = Diagonal(N[1, 2, 3])
@@ -59,7 +59,7 @@ for N in [Float64, Rational{Int}, Float32]
 
     # an affine map of the form I*X + b where I is the identity matrix is a pure translation
     #v = N[1, 0, 2]
-    #am_tr = AffineMap(I, B, v) # crashes, see #1544 
+    #am_tr = AffineMap(I, B, v) # crashes, see #1544
     #@test am_tr isa Translation && am_tr.v == v
 
     # two-dimensional case

--- a/test/LazyOperations/Translation.jl
+++ b/test/LazyOperations/Translation.jl
@@ -81,7 +81,7 @@ for N in [Float64, Rational{Int}, Float32]
     # the translation of a lazy linear map returns an affine map
     M = N[1 0; 0 2]; B = BallInf(zeros(N, 2), N(1)); v = N[1, 0]
     tr = M * B ⊕ v
-    @test tr isa AffineMap && tr.M == M && tr.X == B && tr.v == v 
+    @test tr isa AffineMap && tr.M == M && tr.X == B && tr.v == v
 end
 
 for N in [Float64, Float32]


### PR DESCRIPTION
docs/src/about.md
docs/src/man/getting_started.md
docs/src/man/interval_hulls.md
docs/src/man/optional_dependencies.md
test/LazyOperations/AffineMap.jl
test/LazyOperations/Translation.jl

@schillic 

I noticed in your last PR you removed some trailing whitespace in a markdown file.

This should attend to the remaining trailing whitespace currently found in the repository.