### PR TITLE
Convenience constructors and == for Intersection

### DIFF
--- a/docs/src/lib/lazy_operations/CartesianProduct.md
+++ b/docs/src/lib/lazy_operations/CartesianProduct.md
@@ -38,6 +38,8 @@ Inherited from [`LazySet`](@ref):
 
 ```@docs
 CartesianProductArray
+×(::LazySet, ::LazySet...)
+*(::LazySet, ::LazySet...)
 dim(::CartesianProductArray)
 ρ(::AbstractVector, ::CartesianProductArray)
 σ(::AbstractVector, ::CartesianProductArray)

--- a/docs/src/lib/lazy_operations/Intersection.md
+++ b/docs/src/lib/lazy_operations/Intersection.md
@@ -49,6 +49,7 @@ IntersectionCache
 
 ```@docs
 IntersectionArray
+∩(::LazySet, ::LazySet...)
 dim(::IntersectionArray)
 σ(::AbstractVector, ::IntersectionArray)
 isbounded(::IntersectionArray)

--- a/docs/src/lib/lazy_operations/MinkowskiSum.md
+++ b/docs/src/lib/lazy_operations/MinkowskiSum.md
@@ -33,6 +33,8 @@ Inherited from [`LazySet`](@ref):
 
 ```@docs
 MinkowskiSumArray
+⊕(::LazySet, ::LazySet...)
++(::LazySet, ::LazySet...)
 dim(::MinkowskiSumArray)
 ρ(::AbstractVector, ::MinkowskiSumArray)
 σ(::AbstractVector, ::MinkowskiSumArray)

--- a/src/LazyOperations/CartesianProduct.jl
+++ b/src/LazyOperations/CartesianProduct.jl
@@ -86,7 +86,6 @@ function CartesianProduct(∅1::EmptySet, ∅2::EmptySet)
     return EmptySet{N}(dim(∅1) + dim(∅2))
 end
 
-
 """
 ```
     *(X::LazySet, Y::LazySet)
@@ -97,13 +96,13 @@ Alias for the binary Cartesian product.
 *(X::LazySet, Y::LazySet) = CartesianProduct(X, Y)
 
 """
-    ×
+    ×(X::LazySet, Y::LazySet)
 
-Unicode alias (`times`) for the binary Cartesian product operator.
+Alias for the binary Cartesian product.
 
 ### Notes
 
-Write `\\times[TAB]` to enter this symbol.
+The function symbol can be typed via `\\times[TAB]`.
 """
 ×(X::LazySet, Y::LazySet) = CartesianProduct(X, Y)
 

--- a/src/LazyOperations/CartesianProductArray.jl
+++ b/src/LazyOperations/CartesianProductArray.jl
@@ -29,6 +29,31 @@ function CartesianProductArray(n::Int=0, N::Type=Float64)
     return CartesianProductArray(arr)
 end
 
+"""
+```
+    *(X::LazySet, Xs::LazySet...)
+    *(Xs::Vector{<:LazySet})
+```
+
+Alias for the n-ary Cartesian product.
+"""
+*(X::LazySet, Xs::LazySet...) = CartesianProductArray(vcat(X, Xs...))
+*(X::LazySet) = X
+*(Xs::Vector{<:LazySet}) = CartesianProductArray(Xs)
+
+"""
+    ×(X::LazySet, Xs::LazySet...)
+    ×(Xs::Vector{<:LazySet})
+
+Alias for the n-ary Cartesian product.
+
+### Notes
+
+The function symbol can be typed via `\\times[TAB]`.
+"""
+×(X::LazySet, Xs::LazySet...) = *(X, Xs...)
+×(Xs::Vector{<:LazySet}) = *(Xs)
+
 isoperationtype(::Type{<:CartesianProductArray}) = true
 isconvextype(::Type{CartesianProductArray{N, S}}) where {N, S} = isconvextype(S)
 

--- a/src/LazyOperations/Intersection.jl
+++ b/src/LazyOperations/Intersection.jl
@@ -114,6 +114,17 @@ Intersection(H1::HalfSpace, H2::HalfSpace) = HPolyhedron([H1, H2])
 Intersection(H::HalfSpace, P::HPolyhedron) = HPolyhedron(vcat(P.constraints, H))
 Intersection(P::HPolyhedron, H::HalfSpace) = HPolyhedron(vcat(P.constraints, H))
 
+"""
+    ∩(X::LazySet, Y::LazySet)
+
+Alias for the lazy intersection.
+
+### Notes
+
+The function symbol can be typed via `\\cap[TAB]`.
+"""
+∩(X::LazySet, Y::LazySet) = Intersection(X, Y)
+
 isoperationtype(::Type{<:Intersection}) = true
 
 isconvextype(::Type{Intersection{N, S1, S2}}) where {N, S1, S2} =
@@ -126,13 +137,6 @@ is_polyhedral(cap::Intersection) = is_polyhedral(cap.X) && is_polyhedral(cap.Y)
 
 # EmptySet is the absorbing element for Intersection
 @absorbing(Intersection, EmptySet)
-
-"""
-    ∩
-
-Alias for `Intersection`.
-"""
-∩(X::LazySet, Y::LazySet) = Intersection(X, Y)
 
 """
     isempty_known(cap::Intersection)
@@ -164,6 +168,17 @@ Set the status of emptiness in the cache.
 """
 function set_isempty!(cap::Intersection, isempty::Bool)
     return set_isempty!(cap.cache, isempty)
+end
+
+# equality test ignores the IntersectionCache
+function ==(X::Intersection, Y::Intersection)
+    if X.X != Y.X
+        return false
+    end
+    if X.Y != Y.Y
+        return false
+    end
+    return true
 end
 
 """

--- a/src/LazyOperations/IntersectionArray.jl
+++ b/src/LazyOperations/IntersectionArray.jl
@@ -23,6 +23,16 @@ struct IntersectionArray{N, S<:LazySet{N}} <: LazySet{N}
    array::Vector{S}
 end
 
+"""
+    ∩(X::LazySet, Xs::LazySet...)
+    ∩(Xs::Vector{<:LazySet})
+
+Alias for the n-ary lazy intersection.
+"""
+∩(X::LazySet, Xs::LazySet...) = IntersectionArray(vcat(X, Xs...))
+∩(X::LazySet) = X
+∩(Xs::Vector{<:LazySet}) = IntersectionArray(Xs)
+
 isoperationtype(::Type{<:IntersectionArray}) = true
 isconvextype(::Type{IntersectionArray{N, S}}) where {N, S} = isconvextype(S)
 

--- a/src/LazyOperations/MinkowskiSum.jl
+++ b/src/LazyOperations/MinkowskiSum.jl
@@ -37,6 +37,24 @@ struct MinkowskiSum{N, S1<:LazySet{N}, S2<:LazySet{N}} <: LazySet{N}
     end
 end
 
+"""
+    +(X::LazySet, Y::LazySet)
+
+Alias for the Minkowski sum.
+"""
++(X::LazySet, Y::LazySet) = MinkowskiSum(X, Y)
+
+"""
+    ⊕(X::LazySet, Y::LazySet)
+
+Alias for the Minkowski sum.
+
+### Notes
+
+The function symbol can be typed via `\\oplus[TAB]`.
+"""
+⊕(X::LazySet, Y::LazySet) = MinkowskiSum(X, Y)
+
 isoperationtype(::Type{<:MinkowskiSum}) = true
 
 isconvextype(::Type{MinkowskiSum{N, S1, S2}}) where {N, S1, S2} =
@@ -50,42 +68,6 @@ is_polyhedral(ms::MinkowskiSum) = is_polyhedral(ms.X) && is_polyhedral(ms.Y)
 # EmptySet and Universe are the absorbing elements for MinkowskiSum
 @absorbing(MinkowskiSum, EmptySet)
 # @absorbing(MinkowskiSum, Universe)  # TODO problematic
-
-"""
-    +(X::LazySet, Y::LazySet)
-
-Convenience constructor for the Minkowski sum of two sets.
-
-### Input
-
-- `X` -- set
-- `Y` -- set
-
-### Output
-
-The symbolic Minkowski sum of ``X`` and ``Y``.
-"""
-+(X::LazySet, Y::LazySet) = MinkowskiSum(X, Y)
-
-"""
-    ⊕(X::LazySet, Y::LazySet)
-
-Unicode alias constructor ⊕ (`oplus`) for the lazy Minkowski sum operator.
-
-### Input
-
-- `X` -- set
-- `Y` -- set
-
-### Output
-
-The symbolic Minkowski sum of ``X`` and ``Y``.
-
-### Notes
-
-Write `\\oplus[TAB]` to enter this symbol.
-"""
-⊕(X::LazySet, Y::LazySet) = MinkowskiSum(X, Y)
 
 """
     swap(ms::MinkowskiSum)

--- a/src/LazyOperations/MinkowskiSumArray.jl
+++ b/src/LazyOperations/MinkowskiSumArray.jl
@@ -24,6 +24,29 @@ struct MinkowskiSumArray{N, S<:LazySet{N}} <: LazySet{N}
    array::Vector{S}
 end
 
+"""
+    +(X::LazySet, Xs::LazySet...)
+    +(Xs::Vector{<:LazySet})
+
+Alias for the n-ary Minkowski sum.
+"""
++(X::LazySet, Xs::LazySet...) = MinkowskiSumArray(vcat(X, Xs...))
++(X::LazySet) = X
++(Xs::Vector{<:LazySet}) = MinkowskiSumArray(Xs)
+
+"""
+    ⊕(X::LazySet, Xs::LazySet...)
+    ⊕(Xs::Vector{<:LazySet})
+
+Alias for the n-ary Minkowski sum.
+
+### Notes
+
+The function symbol can be typed via `\\oplus[TAB]`.
+"""
+⊕(X::LazySet, Xs::LazySet...) = +(X, Xs...)
+⊕(Xs::Vector{<:LazySet}) = +(Xs)
+
 isoperationtype(::Type{<:MinkowskiSumArray}) = true
 isconvextype(::Type{MinkowskiSumArray{N, S}}) where {N, S} = isconvextype(S)
 

--- a/test/LazyOperations/CartesianProduct.jl
+++ b/test/LazyOperations/CartesianProduct.jl
@@ -10,6 +10,12 @@ for N in [Float64, Float32, Rational{Int}]
     @test cp.X == b1
     @test cp.Y == b2
 
+    # convenience constructors
+    @test b1 * b2 == b1 × b2 == cp
+    cpa = CartesianProductArray([b1, b2, b1])
+    @test b1 * b2 * b1 == *(b1, b2, b1) == ×(b1, b2, b1) == *([b1, b2, b1]) == ×([b1, b2, b1]) == cpa
+    @test *(b1) == ×(b1) == b1
+
     # swap
     cp2 = swap(cp)
     @test cp.X == cp2.Y && cp.Y == cp2.X

--- a/test/LazyOperations/Intersection.jl
+++ b/test/LazyOperations/Intersection.jl
@@ -6,6 +6,12 @@ for N in [Float64, Rational{Int}, Float32]
     # intersection of two sets
     I = Intersection(B, H)
 
+    # convenience constructors
+    @test B ∩ H == I
+    cap = IntersectionArray([B, H, B])
+    @test ∩(B, H, B) == ∩([B, H, B]) == cap
+    @test ∩(B) == B
+
     # swap
     I2 = swap(I)
     @test I.X == I2.Y && I.Y == I2.X

--- a/test/LazyOperations/MinkowskiSum.jl
+++ b/test/LazyOperations/MinkowskiSum.jl
@@ -7,6 +7,12 @@ for N in [Float64, Rational{Int}, Float32]
     @test X.X == b1
     @test X.Y == b2
 
+    # convenience constructors
+    @test b1 + b2 == b1 ⊕ b2 == X
+    msa = MinkowskiSumArray([b1, b2, b1])
+    @test b1 + b2 + b1 == +(b1, b2, b1) == ⊕(b1, b2, b1) == +([b1, b2, b1]) == ⊕([b1, b2, b1]) == msa
+    @test +(b1) == ⊕(b1) == b1
+
     # swap
     ms2 = swap(X)
     @test X.X == ms2.Y && X.Y == ms2.X


### PR DESCRIPTION
The commits extend the convenience constructors for binary lazy operations to the n-ary case (and also move the old methods closer to the constructors).
The second commit also defines `==` for `Intersection` so that it ignores the `IntersectionCache`.

~~This currently does not work because of some peculiarity in `detect_ambiguities` together with `...`. I asked in JuliaLang#49571.~~