### PR TITLE
#2778 - Simplify code in 2D minkowski_sum

### DIFF
--- a/src/ConcreteOperations/minkowski_sum.jl
+++ b/src/ConcreteOperations/minkowski_sum.jl
@@ -318,8 +318,8 @@ function _minkowski_sum_vpolygon(P::LazySet, Q::LazySet)
     return minkowski_sum(convert(VPolygon, P), convert(VPolygon, Q))
 end
 
-function _minkowski_sum_vrep_2d(vlistP::Vector{VT},
-                                vlistQ::Vector{VT}) where {N,VT<:AbstractVector{N}}
+function _minkowski_sum_vrep_2d(vlistP::AbstractVector{<:AbstractVector{N}},
+                                vlistQ::AbstractVector{<:AbstractVector{N}}) where {N}
     mP = length(vlistP)
     mQ = length(vlistQ)
     if mP == 1 || mQ == 1
@@ -328,10 +328,9 @@ function _minkowski_sum_vrep_2d(vlistP::Vector{VT},
 
     EAST = N[1, 0]
     ORIGIN = N[0, 0]
+    R = fill(ORIGIN, mP + mQ)
     k = _σ_helper(EAST, vlistP)
     j = _σ_helper(EAST, vlistQ)
-    R = Vector{VT}(undef, mP + mQ)
-    fill!(R, ORIGIN)
 
     i = 1
     while i <= size(R, 1)

--- a/src/ConcreteOperations/minkowski_sum.jl
+++ b/src/ConcreteOperations/minkowski_sum.jl
@@ -41,17 +41,7 @@ function minkowski_sum(P::LazySet, Q::LazySet;
 
     if n == 2 && isboundedtype(typeof(P)) && isboundedtype(typeof(Q))
         # use vertex representation
-        Pv = vertices_list(P)
-        if prune
-            Pv = _convex_hull_2d_preprocess!(copy(Pv))
-        end
-        Qv = vertices_list(Q)
-        if prune
-            Qv = _convex_hull_2d_preprocess!(copy(Qv))
-        end
-        R = _minkowski_sum_vrep_2d(Pv, Qv)
-        return VPolygon(R)
-        # return _minkowski_sum_vpolygon(P, Q) # crashes, see JuliaLang#41561
+        return _minkowski_sum_vpolygon(P, Q)
     end
 
     # use constraint representation


### PR DESCRIPTION
Closes #2778.

This PR removes the workaround for the "unreachable reached" Julia bug (which is still around). The solution is to just use a different dispatch. For that the method `_minkowski_sum_vrep_2d` had to be changed. It tried to be generic in `VT` but was not. The vector `R` was filled with `Vector{N}`s, so unless `VT` was `Vector{N}` (or a supertype like `AbstractVector{N}`, but that would be strange), the code would crash.