### PR TITLE
Specialized disjointness check between zonotope and polyhedron

### DIFF
--- a/test/ConcreteOperations/isdisjoint.jl
+++ b/test/ConcreteOperations/isdisjoint.jl
@@ -12,4 +12,16 @@ for N in [Float64, Float32, Rational{Int}]
     Y = Hyperrectangle(; low=[N(-1), N(-1)], high=[N(2), N(2)])
     @test !isdisjoint(X, Y)
     @test !isdisjoint(Y, X)
+
+    if N == Rational{Int} && test_suite_polyhedra
+        for n in [2, 3]
+            Z = convert(Zonotope, BallInf(zeros(N, n), N(1)))
+            P = convert(HPolyhedron, BallInf(3 * ones(N, n), N(1)))
+            res, w = isdisjoint(Z, P, true)
+            @test isdisjoint(Z, P) && isdisjoint(P, Z) && res && w == N[]
+            P = convert(HPolyhedron, BallInf(ones(N, n), N(1)))
+            res, w = isdisjoint(Z, P, true)
+            @test !isdisjoint(Z, P) && !isdisjoint(P, Z) && !res && w ∈ Z && w ∈ P
+        end
+    end
 end


### PR DESCRIPTION
[Reference implementation](https://github.com/TUMcps/CORA/blob/e07eb39690eb0152058585aa637b07b94e7560b0/contSet/%40mptPolytope/isIntersecting_.m#L170)

In 2D this check seems less efficient (more allocations, see below) than the default algorithm, so I only use it for 3D and higher.

```julia
# 2D

julia> Z = rand(Zonotope);
julia> P1 = rand(HPolygon);  # intersects
julia> P2 = rand(HPolygon);  # disjoint

julia> @time isdisjoint(Z, P1)
  0.000681 seconds (2.23 k allocations: 78.219 KiB)  # this branch
  0.000794 seconds (2.21 k allocations: 77.891 KiB)  # master
false

julia> @time isdisjoint(Z, P2)
  0.001043 seconds (2.19 k allocations: 75.156 KiB)  # this branch
  0.000629 seconds (2.16 k allocations: 73.641 KiB)  # master
true

# 3D

julia> Z = rand(Zonotope, dim=3);
julia> P1 = convert(HPolyhedron, rand(BallInf, dim=3));  # intersects
julia> P2 = convert(HPolyhedron, rand(BallInf, dim=3));  # disjoint

julia> @time isdisjoint(Z, P1)
  0.000609 seconds (2.34 k allocations: 84.328 KiB)  # this branch
  0.001387 seconds (2.65 k allocations: 110.250 KiB)  # master
false

julia> @time isdisjoint(Z, P2)
  0.000661 seconds (2.35 k allocations: 84.781 KiB)  # this branch
  0.000706 seconds (2.65 k allocations: 110.828 KiB)  # master
true
```