### PR TITLE
#3347 - Remove citation from manual

### DIFF
--- a/docs/src/man/tour.md
+++ b/docs/src/man/tour.md
@@ -543,19 +543,3 @@ Development happens on [github](https://github.com/JuliaReach/LazySets.jl/).
 New contributors should follow the links provided in the
 [About](https://juliareach.github.io/LazySets.jl/dev/about/) section of this
 documentation.
-
-
-## How to cite
-
-When citing `LazySets.jl`, please cite [JuliaReach: a toolbox for set-based
-reachability](https://dl.acm.org/doi/10.1145/3302504.3311804).
-
-```
-@inproceedings{bogomolov2019juliareach,
-  title={JuliaReach: a toolbox for set-based reachability},
-  author={Bogomolov, Sergiy and Forets, Marcelo and Frehse, Goran and Potomkin, Kostiantyn and Schilling, Christian},
-  booktitle={Proceedings of the 22nd ACM International Conference on Hybrid Systems: Computation and Control},
-  pages={39--44},
-  year={2019}
-}
-```


### PR DESCRIPTION
Closes #3347.
This is option 1. See #3354 for an alternative.