### PR TITLE
Switch from thread-local to task-local LP solvers

### DIFF
--- a/src/init.jl
+++ b/src/init.jl
@@ -15,8 +15,6 @@ function __init__()
     @require Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7" include("Initialization/init_Symbolics.jl")
     @require WriteVTK = "64499a7a-5c06-52f2-abe2-ccb03c286192" include("Initialization/init_WriteVTK.jl")
 
-    init_lp_solvers()
-
     return nothing
 end
 


### PR DESCRIPTION
As part of another project where we also use LP solvers in parallel, I've realized that it is better/more correct to use a task-local solver. The problem is that as tasks are executed, they may [migrate between threads](https://docs.julialang.org/en/v1/manual/multi-threading/#man-task-migration) (in particular when they yield). This means that an LP started in one task on say thread 1, might move to thread 2 following a yield and another task might start on thread 1. In this case, the second task interferes with the model used for the first task, as that was selected from thread 1. Instead, we should use task-local storage (so does the global RNGs, not sure why I read the older version of the RNG code where it was thread-local). With the current thread-local version, it is still correct if parallelized with `Threads.@threads :static for ...` - however, there might be performance gains with not using `:static`. I am also unsure whether the code yields at all, and thus might not perform task migration, but I would rather be on the safe side wrt. correctness. I expect the performance to be fairly similar to the thread-local version as `Threads.@threads` spawn `Threads.nthreads()` tasks and the entry point of the program is also wrapped in a single Task object. 