### PR TITLE
Revise binary and n-ary lazy operations

### DIFF
--- a/docs/src/lib/utils.md
+++ b/docs/src/lib/utils.md
@@ -10,6 +10,7 @@ CurrentModule = LazySets
 @neutral
 @absorbing
 @neutral_absorbing
+@declare_binary_operation
 @declare_array_version
 @array_neutral
 @array_absorbing

--- a/src/Approximations/Approximations.jl
+++ b/src/Approximations/Approximations.jl
@@ -11,7 +11,7 @@ import IntervalArithmetic as IA
 using ReachabilityBase.Comparison: _isapprox, _leq, _geq, _rtol, isapproxzero
 using LazySets: default_lp_solver, _isbounded_stiemke, require, dim, linprog,
                 is_lp_optimal, _normal_Vector, default_sdp_solver,
-                get_exponential_backend, _expmv
+                get_exponential_backend, _expmv, second
 using LazySets.JuMP: Model, set_silent, @variable, @constraint, optimize!,
                      value, @NLobjective, @objective
 

--- a/src/Approximations/box_approximation.jl
+++ b/src/Approximations/box_approximation.jl
@@ -333,9 +333,9 @@ it does not need to allocate the intermediate hyperrectangles.
 """
 function box_approximation(ch::ConvexHull; algorithm::String="box")
     if algorithm == "extrema"
-        return _box_approximation_chull_extrema(ch.X, ch.Y)
+        return _box_approximation_chull_extrema(first(ch), second(ch))
     elseif algorithm == "box"
-        return _box_approximation_chull_box(ch.X, ch.Y)
+        return _box_approximation_chull_box(first(ch), second(ch))
     else
         throw(ArgumentError("unknown algorithm $algorithm"))
     end
@@ -398,7 +398,7 @@ It suffices to compute the box approximation of each summand and then take the
 concrete Minkowski sum for hyperrectangles.
 """
 function box_approximation(ms::MinkowskiSum)
-    H1 = box_approximation(ms.X)
-    H2 = box_approximation(ms.Y)
+    H1 = box_approximation(first(ms))
+    H2 = box_approximation(second(ms))
     return minkowski_sum(H1, H2)
 end

--- a/src/Approximations/decompositions.jl
+++ b/src/Approximations/decompositions.jl
@@ -62,7 +62,7 @@ We can decompose using polygons in constraint representation:
 ```jldoctest decompose_examples
 julia> Y = decompose(S, P2d, HPolygon);
 
-julia> all(ai isa HPolygon for ai in array(Y))
+julia> all(ai isa HPolygon for ai in Y)
 true
 ```
 
@@ -71,7 +71,7 @@ For decomposition into 1D subspaces, we can use `Interval`:
 ```jldoctest decompose_examples
 julia> Y = decompose(S, P1d, Interval);
 
-julia> all(ai isa Interval for ai in array(Y))
+julia> all(ai isa Interval for ai in Y)
 true
 ```
 

--- a/src/Approximations/overapproximate.jl
+++ b/src/Approximations/overapproximate.jl
@@ -332,7 +332,7 @@ function overapproximate(cap::Intersection{N,  # TODO use better mechanism to de
                                            <:AbstractPolyhedron},
                          dirs::AbstractDirections;
                          kwargs...) where {N}
-    return overapproximate_cap_helper(cap.X, cap.Y, dirs; kwargs...)
+    return overapproximate_cap_helper(first(cap), second(cap), dirs; kwargs...)
 end
 
 # symmetric method
@@ -341,7 +341,7 @@ function overapproximate(cap::Intersection{N,
                                            <:LazySet},
                          dirs::AbstractDirections;
                          kwargs...) where {N}
-    return overapproximate_cap_helper(cap.Y, cap.X, dirs; kwargs...)
+    return overapproximate_cap_helper(second(cap), first(cap), dirs; kwargs...)
 end
 
 # disambiguation
@@ -351,7 +351,7 @@ function overapproximate(cap::Intersection{N,
                          dirs::AbstractDirections;
                          kwargs...) where {N}
     # important: the result may not be a polytope!
-    return overapproximate_cap_helper(cap.X, cap.Y, dirs; kwargs...)
+    return overapproximate_cap_helper(first(cap), second(cap), dirs; kwargs...)
 end
 
 # disambiguation
@@ -360,7 +360,7 @@ function overapproximate(cap::Intersection{N,
                                            <:AbstractPolyhedron},
                          dirs::AbstractDirections;
                          kwargs...) where {N}
-    return overapproximate_cap_helper(cap.X, cap.Y, dirs; kwargs...)
+    return overapproximate_cap_helper(first(cap), second(cap), dirs; kwargs...)
 end
 
 # symmetric method
@@ -369,7 +369,7 @@ function overapproximate(cap::Intersection{N,
                                            <:AbstractPolytope},
                          dirs::AbstractDirections;
                          kwargs...) where {N}
-    return overapproximate_cap_helper(cap.Y, cap.X, dirs; kwargs...)
+    return overapproximate_cap_helper(second(cap), first(cap), dirs; kwargs...)
 end
 
 # disambiguation
@@ -378,7 +378,7 @@ function overapproximate(cap::Intersection{N,
                                            <:AbstractPolytope},
                          dirs::AbstractDirections;
                          kwargs...) where {N}
-    return overapproximate_cap_helper(cap.X, cap.Y, dirs; kwargs...)
+    return overapproximate_cap_helper(first(cap), second(cap), dirs; kwargs...)
 end
 
 """
@@ -409,8 +409,8 @@ function overapproximate(cap::Intersection{N,
                          kwargs...) where {N}
     H = HPolytope{N,Vector{N}}()
     c = H.constraints
-    push!(c, _normal_Vector(cap.X))
-    append!(c, _normal_Vector(cap.Y))
+    push!(c, _normal_Vector(first(cap)))
+    append!(c, _normal_Vector(second(cap)))
     return overapproximate(H, dirs; kwargs...)
 end
 
@@ -511,7 +511,7 @@ function overapproximate(X::Intersection{N,<:AbstractZonotope,<:Hyperplane},
                          dirs::AbstractDirections) where {N}
     dim(X) == dim(dirs) || throw(ArgumentError("the dimension of the set " *
                                                "$(dim(X)) does not match the dimension of the directions $(dim(dirs))"))
-    Z, G = X.X, X.Y
+    Z, G = first(X), second(X)
 
     if isdisjoint(Z, G)
         return EmptySet{N}(dim(Z))
@@ -537,7 +537,7 @@ end
 # symmetric method
 function overapproximate(X::Intersection{N,<:Hyperplane,<:AbstractZonotope},
                          dirs::AbstractDirections) where {N}
-    return overapproximate(X.Y ∩ X.X, dirs)
+    return overapproximate(second(X) ∩ first(X), dirs)
 end
 
 # overload on direction type
@@ -549,7 +549,7 @@ end
 # symmetric method
 function overapproximate(X::Intersection{N,<:Hyperplane,<:AbstractZonotope},
                          dirs::Type{<:AbstractDirections}) where {N}
-    return overapproximate(X.Y ∩ X.X, dirs(dim(X)))
+    return overapproximate(second(X) ∩ first(X), dirs(dim(X)))
 end
 
 """

--- a/src/Approximations/overapproximate_cartesianproductarray.jl
+++ b/src/Approximations/overapproximate_cartesianproductarray.jl
@@ -173,7 +173,7 @@ function overapproximate(cap::Intersection{N,
                                            <:CartesianProductArray,
                                            <:AbstractPolyhedron},
                          ::Type{<:CartesianProductArray}, oa) where {N}
-    cpa, P = cap.X, cap.Y
+    cpa, P = first(cap), second(cap)
 
     cpa_low_dim, vars, block_structure, blocks = get_constrained_lowdimset(cpa, P)
 
@@ -194,5 +194,5 @@ function overapproximate(cap::Intersection{N,
                                            <:AbstractPolyhedron,
                                            <:CartesianProductArray},
                          ::Type{<:CartesianProductArray}, oa) where {N}
-    return overapproximate(Intersection(cap.Y, cap.X), oa)
+    return overapproximate(swap(cap), oa)
 end

--- a/src/Approximations/overapproximate_interval.jl
+++ b/src/Approximations/overapproximate_interval.jl
@@ -50,8 +50,8 @@ function overapproximate(cap::Intersection, ::Type{<:Interval})
                           "intersection with an `Interval`"
     # TODO this does not work for unbounded sets; better define extrema and
     # then copy the default implementation except if result is empty
-    X = overapproximate(cap.X, Interval)
-    Y = overapproximate(cap.Y, Interval)
+    X = overapproximate(first(cap), Interval)
+    Y = overapproximate(second(cap), Interval)
     return intersection(X, Y)
 end
 

--- a/src/Approximations/overapproximate_zonotope.jl
+++ b/src/Approximations/overapproximate_zonotope.jl
@@ -124,18 +124,19 @@ function overapproximate(X::ConvexHull{N,<:AbstractZonotope,<:AbstractZonotope},
     end
 end
 
-function _overapproximate_convex_hull_zonotope_G05(X::ConvexHull{N}) where {N}
+function _overapproximate_convex_hull_zonotope_G05(ch::ConvexHull{N}) where {N}
     # reduce to the same order if possible
-    m1, m2 = ngens(X.X), ngens(X.Y)
+    X, Y = first(ch), second(ch)
+    m1, m2 = ngens(X), ngens(Y)
     if m1 < m2
-        Z1 = X.X
-        Z2 = reduce_order(X.Y, max(1, m1))
+        Z1 = X
+        Z2 = reduce_order(Y, max(1, m1))
     elseif m1 > m2
-        Z1 = reduce_order(X.X, max(1, m2))
-        Z2 = X.Y
+        Z1 = reduce_order(X, max(1, m2))
+        Z2 = Y
     else
-        Z1 = X.X
-        Z2 = X.Y
+        Z1 = X
+        Z2 = Y
     end
 
     if order(Z2) > order(Z1)
@@ -164,12 +165,12 @@ function _overapproximate_convex_hull_zonotope_G05(X::ConvexHull{N}) where {N}
     return remove_zero_generators(Z)
 end
 
-function _overapproximate_convex_hull_zonotope_GGP09(X::ConvexHull{N}) where {N}
-    Z1, Z2 = X.X, X.Y
+function _overapproximate_convex_hull_zonotope_GGP09(ch::ConvexHull{N}) where {N}
+    Z1, Z2 = first(ch), second(ch)
     m = min(ngens(Z1), ngens(Z2))
     G1, G2 = genmat(Z1), genmat(Z2)
     n = dim(Z1)
-    box = box_approximation(X)
+    box = box_approximation(ch)
 
     # new center: mid point of box approximation
     c = center(box)
@@ -1174,13 +1175,13 @@ nonlinear hybrid reachability*. Mathematics in Computer Science (8) 2014.
 """
 function overapproximate(X::Intersection{N,<:AbstractZonotope,<:Hyperplane},
                          ::Type{<:Zonotope}) where {N}
-    return _overapproximate_zonotope_hyperplane(X.X, X.Y)
+    return _overapproximate_zonotope_hyperplane(first(X), second(X))
 end
 
 # symmetric method
 function overapproximate(X::Intersection{N,<:Hyperplane,<:AbstractZonotope},
                          ::Type{<:Zonotope}) where {N}
-    return _overapproximate_zonotope_hyperplane(X.Y, X.X)
+    return _overapproximate_zonotope_hyperplane(second(X), first(X))
 end
 
 function _overapproximate_zonotope_hyperplane(Z::AbstractZonotope, H::Hyperplane)

--- a/src/Approximations/symmetric_interval_hull.jl
+++ b/src/Approximations/symmetric_interval_hull.jl
@@ -90,7 +90,7 @@ end
 
 function symmetric_interval_hull(X::MinkowskiSum{N,<:AbstractSingleton,<:AbstractSingleton}) where {N}
     n = dim(X)
-    r = abs.(element(X.X) + element(X.Y))
+    r = abs.(element(first(X)) + element(second(X)))
     return Hyperrectangle(zeros(N, n), r)
 end
 

--- a/src/ConcreteOperations/intersection.jl
+++ b/src/ConcreteOperations/intersection.jl
@@ -814,7 +814,7 @@ If one of those sets is empty, only the other set is returned.
 end
 
 function _intersection_us(cup::UnionSet, X::LazySet)
-    return intersection(cup.X, X) ∪ intersection(cup.Y, X)
+    return intersection(first(cup), X) ∪ intersection(second(cup), X)
 end
 
 # disambiguation

--- a/src/ConcreteOperations/intersection.jl
+++ b/src/ConcreteOperations/intersection.jl
@@ -842,7 +842,7 @@ The union of the pairwise intersections, expressed as a `UnionSetArray`.
 end
 
 function _intersection_usa(cup::UnionSetArray, X::LazySet)
-    return UnionSetArray([intersection(Y, X) for Y in array(cup)])
+    return UnionSetArray([intersection(Y, X) for Y in cup])
 end
 
 # disambiguation

--- a/src/ConcreteOperations/isdisjoint.jl
+++ b/src/ConcreteOperations/isdisjoint.jl
@@ -864,7 +864,7 @@ otherwise optionally compute a witness.
 `true` iff ``\\text{U} ∩ X = ∅``.
 """
 @commutative function isdisjoint(U::UnionSet, X::LazySet, witness::Bool=false)
-    return _isdisjoint_union((U.X, U.Y), X, witness)
+    return _isdisjoint_union(U, X, witness)
 end
 
 """
@@ -885,11 +885,12 @@ intersect, and otherwise optionally compute a witness.
 """
 @commutative function isdisjoint(U::UnionSetArray, X::LazySet,
                                  witness::Bool=false)
-    return _isdisjoint_union(array(U), X, witness)
+    return _isdisjoint_union(U, X, witness)
 end
 
-function _isdisjoint_union(sets, X::LazySet{N}, witness::Bool=false) where {N}
-    for Y in sets
+function _isdisjoint_union(cup::Union{UnionSet,UnionSetArray}, X::LazySet{N},
+                           witness::Bool=false) where {N}
+    for Y in cup
         if witness
             result, w = isdisjoint(Y, X, witness)
         else
@@ -905,25 +906,25 @@ end
 # disambiguations
 for ST in [:AbstractPolyhedron, :Hyperplane, :Line2D, :HalfSpace]
     @eval @commutative function isdisjoint(U::UnionSet, X::($ST), witness::Bool=false)
-        return _isdisjoint_union((U.X, U.Y), X, witness)
+        return _isdisjoint_union(U, X, witness)
     end
     @eval @commutative function isdisjoint(U::UnionSetArray, X::($ST),
                                            witness::Bool=false)
-        return _isdisjoint_union(array(U), X, witness)
+        return _isdisjoint_union(U, X, witness)
     end
 end
 
 @commutative function isdisjoint(U1::UnionSet, U2::UnionSetArray,
                                  witness::Bool=false)
-    return _isdisjoint_union((U1.X, U1.Y), U2, witness)
+    return _isdisjoint_union(U1, U2, witness)
 end
 
 function isdisjoint(U1::UnionSet, U2::UnionSet, witness::Bool=false)
-    return _isdisjoint_union((U1.X, U1.Y), U2, witness)
+    return _isdisjoint_union(U1, U2, witness)
 end
 
 function isdisjoint(U1::UnionSetArray, U2::UnionSetArray, witness::Bool=false)
-    return _isdisjoint_union(array(U1), U2, witness)
+    return _isdisjoint_union(U1, U2, witness)
 end
 
 """
@@ -1223,15 +1224,15 @@ end
 for ST in [:AbstractZonotope, :AbstractSingleton]
     @eval @commutative function isdisjoint(C::CartesianProduct{N,<:LazySet,<:Universe},
                                            Z::$(ST)) where {N}
-        X = C.X
+        X = first(C)
         Zp = project(Z, 1:dim(X))
         return isdisjoint(X, Zp)
     end
 
     @eval @commutative function isdisjoint(C::CartesianProduct{N,<:Universe,<:LazySet},
                                            Z::$(ST)) where {N}
-        Y = C.Y
-        Zp = project(Z, (dim(C.X) + 1):dim(C))
+        Y = second(C)
+        Zp = project(Z, (dim(first(C)) + 1):dim(C))
         return isdisjoint(Y, Zp)
     end
 

--- a/src/ConcreteOperations/isdisjoint.jl
+++ b/src/ConcreteOperations/isdisjoint.jl
@@ -1147,7 +1147,7 @@ We perform these checks sequentially.
     end
     n = dim(H)
     block_start = 1
-    for bi in array(cpa)
+    for bi in cpa
         ni = dim(bi)
         block = block_start:(block_start + ni - 1)
         Hi = project(H, block, Hyperrectangle, n)

--- a/src/ConcreteOperations/issubset.jl
+++ b/src/ConcreteOperations/issubset.jl
@@ -586,17 +586,17 @@ Otherwise we compute the set difference ``y = x \\ a`` and check whether
 function ⊆(x::Interval, U::UnionSet, witness::Bool=false)
     @assert dim(U) == 1 "an interval is incompatible with a set of dimension " *
                         "$(dim(U))"
-    if !isconvextype(typeof(U.X)) || !isconvextype(typeof(U.Y))
+    if !isconvextype(typeof(first(U))) || !isconvextype(typeof(second(U)))
         error("an inclusion check for the given combination of set types is " *
               "not available")
     end
-    return _issubset_interval(x, convert(Interval, U.X), convert(Interval, U.Y),
-                              witness)
+    return _issubset_interval(x, convert(Interval, first(U)),
+                              convert(Interval, second(U)), witness)
 end
 
 function ⊆(x::Interval, U::UnionSet{N,<:Interval,<:Interval},
            witness::Bool=false) where {N}
-    return _issubset_interval(x, U.X, U.Y, witness)
+    return _issubset_interval(x, first(U), second(U), witness)
 end
 
 function _issubset_interval(x::Interval{N}, a::Interval, b::Interval,
@@ -883,7 +883,7 @@ Check whether a union of two convex sets is contained in another set.
     ``v ∈ \\text{U} \\setminus X``
 """
 function ⊆(U::UnionSet, X::LazySet, witness::Bool=false)
-    return _issubset_union_in_set((U.X, U.Y), X, witness)
+    return _issubset_union_in_set(U, X, witness)
 end
 
 """
@@ -907,14 +907,15 @@ set.
     ``v ∈ \\text{U} \\setminus X``
 """
 function ⊆(U::UnionSetArray, X::LazySet, witness::Bool=false)
-    return _issubset_union_in_set(array(U), X, witness)
+    return _issubset_union_in_set(U, X, witness)
 end
 
 # check for each set in `sets` that they are included in X
-function _issubset_union_in_set(sets, X::LazySet{N}, witness::Bool=false) where {N}
+function _issubset_union_in_set(cup::Union{UnionSet,UnionSetArray}, X::LazySet{N},
+                                witness::Bool=false) where {N}
     result = true
     v = N[]
-    for Y in sets
+    for Y in cup
         if witness
             result, v = ⊆(Y, X, witness)
         else
@@ -931,11 +932,11 @@ end
 for ST in [:AbstractHyperrectangle, :AbstractPolyhedron, :UnionSet,
            :UnionSetArray]
     @eval function ⊆(U::UnionSet, X::($ST), witness::Bool=false)
-        return _issubset_union_in_set((U.X, U.Y), X, witness)
+        return _issubset_union_in_set(U, X, witness)
     end
 
     @eval function ⊆(U::UnionSetArray, X::($ST), witness::Bool=false)
-        return _issubset_union_in_set(array(U), X, witness)
+        return _issubset_union_in_set(U, X, witness)
     end
 end
 
@@ -1086,29 +1087,29 @@ blocks (using `an_element`) and concatenating these (lower-dimensional) points.
 """
 function ⊆(X::CartesianProduct, Y::CartesianProduct, witness::Bool=false;
            check_block_equality::Bool=true)
-    n1 = dim(X.X)
-    n2 = dim(X.Y)
-    if check_block_equality && (n1 != dim(Y.X) || n2 != dim(Y.Y))
+    n1 = dim(first(X))
+    n2 = dim(second(X))
+    if check_block_equality && (n1 != dim(first(Y)) || n2 != dim(second(Y)))
         return _issubset_constraints_list(X, Y, witness)
     end
 
     # check first block
-    result = ⊆(X.X, Y.X, witness)
+    result = ⊆(first(X), first(Y), witness)
     if !witness && !result
         return false
     elseif witness && !result[1]
         # construct a witness
-        w = vcat(result[2], an_element(X.Y))
+        w = vcat(result[2], an_element(second(X)))
         return (false, w)
     end
 
     # check second block
-    result = ⊆(X.Y, Y.Y, witness)
+    result = ⊆(second(X), second(Y), witness)
     if !witness && !result
         return false
     elseif witness && !result[1]
         # construct a witness
-        w = vcat(an_element(X.X), result[2])
+        w = vcat(an_element(first(X)), result[2])
         return (false, w)
     end
     return _witness_result_empty(witness, true, X, Y)
@@ -1230,14 +1231,14 @@ end
 
 for ST in (AbstractZonotope, AbstractSingleton, LineSegment)
     @eval function ⊆(Z::$(ST), C::CartesianProduct{N,<:LazySet,<:Universe}) where {N}
-        X = C.X
+        X = first(C)
         Zp = project(Z, 1:dim(X))
         return ⊆(Zp, X)
     end
 
     @eval function ⊆(Z::$(ST), C::CartesianProduct{N,<:Universe,<:LazySet}) where {N}
-        Y = C.Y
-        Zp = project(Z, (dim(C.X) + 1):dim(C))
+        Y = second(C)
+        Zp = project(Z, (dim(first(C)) + 1):dim(C))
         return ⊆(Zp, Y)
     end
 

--- a/src/ConcreteOperations/issubset.jl
+++ b/src/ConcreteOperations/issubset.jl
@@ -639,7 +639,7 @@ function ⊆(x::Interval, U::UnionSetArray{N,<:AbstractHyperrectangle},
 end
 
 function _get_interval_array_copy(U::UnionSetArray)
-    return [convert(Interval, X) for X in array(U)]
+    return [convert(Interval, X) for X in U]
 end
 
 function _get_interval_array_copy(U::UnionSetArray{N,<:AbstractVector{<:Interval}}) where {N}
@@ -705,7 +705,7 @@ end
 function _issubset_unionsetarray(X, U, witness::Bool=false;
                                  filter_redundant_sets::Bool=true)
     # heuristics (necessary check): is X contained in any set in U?
-    for rhs in array(U)
+    for rhs in U
         if X ⊆ rhs
             return _witness_result_empty(witness, true, X, U)
         end
@@ -714,7 +714,7 @@ function _issubset_unionsetarray(X, U, witness::Bool=false;
     if filter_redundant_sets
         # filter out those sets in U that do not intersect with X
         sets = Vector{eltype(array(U))}()
-        for rhs in array(U)
+        for rhs in U
             if !isdisjoint(X, rhs)
                 push!(sets, rhs)
             end

--- a/src/Interfaces/AbstractArraySet.jl
+++ b/src/Interfaces/AbstractArraySet.jl
@@ -4,8 +4,12 @@ const AbstractArraySet = Union{CartesianProductArray,
                                MinkowskiSumArray,
                                UnionSetArray}
 
-function Base.getindex(X::AbstractArraySet, i)
+function Base.getindex(X::AbstractArraySet, i::Int)
     return getindex(array(X), i)
+end
+
+function Base.getindex(X::AbstractArraySet, indices::AbstractVector{Int})
+    return [X[i] for i in indices]
 end
 
 function Base.length(X::AbstractArraySet)

--- a/src/Interfaces/AbstractArraySet.jl
+++ b/src/Interfaces/AbstractArraySet.jl
@@ -15,3 +15,17 @@ end
 function Base.iterate(X::AbstractArraySet, state=1)
     return iterate(array(X), state)
 end
+
+function flatten!(arr, X, bin_op)
+    if X isa bin_op
+        flatten!(arr, first(X), bin_op)
+        flatten!(arr, second(X), bin_op)
+    elseif X isa array_constructor(bin_op)
+        for Xi in X
+            flatten!(arr, Xi, bin_op)
+        end
+    else
+        push!(arr, X)
+    end
+    return arr
+end

--- a/src/Interfaces/AbstractArraySet.jl
+++ b/src/Interfaces/AbstractArraySet.jl
@@ -11,3 +11,7 @@ end
 function Base.length(X::AbstractArraySet)
     return length(array(X))
 end
+
+function Base.iterate(X::AbstractArraySet, state=1)
+    return iterate(array(X), state)
+end

--- a/src/Interfaces/AbstractArraySet.jl
+++ b/src/Interfaces/AbstractArraySet.jl
@@ -12,6 +12,10 @@ function Base.getindex(X::AbstractArraySet, indices::AbstractVector{Int})
     return [X[i] for i in indices]
 end
 
+function Base.lastindex(X::AbstractArraySet)
+    return length(array(X))
+end
+
 function Base.length(X::AbstractArraySet)
     return length(array(X))
 end

--- a/src/Interfaces/LazySet.jl
+++ b/src/Interfaces/LazySet.jl
@@ -1,4 +1,4 @@
-import Base: isempty, extrema, ==, ≈, copy, eltype, rationalize
+import Base: isempty, extrema, ==, ≈, copy, eltype, rationalize, ∈
 import Random.rand
 
 export LazySet,
@@ -2027,6 +2027,10 @@ function tovrep(X::LazySet)
                              "non-polyhedral sets"
 
     return VPolytope(vertices_list(X))
+end
+
+function ∈(::AbstractVector, X::LazySet)
+    throw(ArgumentError("membership check for set type $(basetype(X)) not implemented"))
 end
 
 function linear_map_inverse(A::AbstractMatrix, P::LazySet)

--- a/src/Interfaces/LazySet.jl
+++ b/src/Interfaces/LazySet.jl
@@ -41,7 +41,8 @@ export LazySet,
        rectify,
        permute,
        chebyshev_center_radius,
-       ○
+       ○,
+       flatten
 
 """
     LazySet{N}

--- a/src/LazyOperations/CartesianProduct.jl
+++ b/src/LazyOperations/CartesianProduct.jl
@@ -69,6 +69,7 @@ struct CartesianProduct{N,S1<:LazySet{N},S2<:LazySet{N}} <: LazySet{N}
 end
 
 isoperationtype(::Type{<:CartesianProduct}) = true
+concrete_function(::Type{<:CartesianProduct}) = cartesian_product
 
 function isconvextype(::Type{CartesianProduct{N,S1,S2}}) where {N,S1,S2}
     return isconvextype(S1) && isconvextype(S2)
@@ -376,10 +377,6 @@ function _linear_map_cartesian_product(M, cp)
     T = isbounded(cp) ? HPolytope : HPolyhedron
     P = T(constraints_list(cp))
     return linear_map(M, P)
-end
-
-function concretize(cp::CartesianProduct)
-    return cartesian_product(concretize(cp.X), concretize(cp.Y))
 end
 
 function project(cp::CartesianProduct, block::AbstractVector{Int}; kwargs...)

--- a/src/LazyOperations/CartesianProduct.jl
+++ b/src/LazyOperations/CartesianProduct.jl
@@ -87,6 +87,11 @@ function CartesianProduct(∅1::EmptySet, ∅2::EmptySet)
     return EmptySet{N}(dim(∅1) + dim(∅2))
 end
 
+# interface for binary set operations
+Base.first(cp::CartesianProduct) = cp.X
+second(cp::CartesianProduct) = cp.Y
+@declare_binary_operation(CartesianProduct)
+
 """
 ```
     *(X::LazySet, Y::LazySet)

--- a/src/LazyOperations/CartesianProduct.jl
+++ b/src/LazyOperations/CartesianProduct.jl
@@ -302,7 +302,7 @@ Return the list of constraints of a (polyhedral) Cartesian product.
 A list of constraints.
 """
 function constraints_list(cp::CartesianProduct)
-    return constraints_list(CartesianProductArray([cp.X, cp.Y]))
+    return _constraints_list_cartesian_product(cp)
 end
 
 """

--- a/src/LazyOperations/CartesianProductArray.jl
+++ b/src/LazyOperations/CartesianProductArray.jl
@@ -356,13 +356,17 @@ number of sets.
 A list of constraints.
 """
 function constraints_list(cpa::CartesianProductArray)
-    N = eltype(cpa)
+    return _constraints_list_cartesian_product(cpa)
+end
+
+function _constraints_list_cartesian_product(cp::Union{CartesianProduct,CartesianProductArray})
+    N = eltype(cp)
     clist = Vector{HalfSpace{N,SparseVector{N,Int}}}()
-    n = dim(cpa)
+    n = dim(cp)
     sizehint!(clist, n)
     prev_step = 1
     # create high-dimensional constraints list
-    for c_low in cpa
+    for c_low in cp
         c_low_list = constraints_list(c_low)
         if isempty(c_low_list)
             n_low = dim(c_low)

--- a/src/LazyOperations/CartesianProductArray.jl
+++ b/src/LazyOperations/CartesianProductArray.jl
@@ -338,7 +338,7 @@ centrally-symmetric sets.
 The center of the Cartesian product of a finite number of sets.
 """
 function center(cpa::CartesianProductArray)
-    return reduce(vcat, center(X) for X in array(cpa))
+    return reduce(vcat, center(X) for X in cpa)
 end
 
 """
@@ -362,7 +362,7 @@ function constraints_list(cpa::CartesianProductArray)
     sizehint!(clist, n)
     prev_step = 1
     # create high-dimensional constraints list
-    for c_low in array(cpa)
+    for c_low in cpa
         c_low_list = constraints_list(c_low)
         if isempty(c_low_list)
             n_low = dim(c_low)
@@ -402,7 +402,7 @@ low-dimensional sets of vertices.
 """
 function vertices_list(cpa::CartesianProductArray)
     # collect low-dimensional vertices lists
-    vlist_low = [vertices_list(X) for X in array(cpa)]
+    vlist_low = [vertices_list(X) for X in cpa]
 
     # create high-dimensional vertices list
     indices_max = [length(vl) for vl in vlist_low]

--- a/src/LazyOperations/ConvexHull.jl
+++ b/src/LazyOperations/ConvexHull.jl
@@ -61,6 +61,11 @@ is_polyhedral(ch::ConvexHull) = is_polyhedral(ch.X) && is_polyhedral(ch.Y)
 # Universe is the absorbing element for ConvexHull
 @absorbing(ConvexHull, Universe)
 
+# interface for binary set operations
+Base.first(ch::ConvexHull) = ch.X
+second(ch::ConvexHull) = ch.Y
+@declare_binary_operation(ConvexHull)
+
 """
     CH
 

--- a/src/LazyOperations/ConvexHull.jl
+++ b/src/LazyOperations/ConvexHull.jl
@@ -52,7 +52,10 @@ struct ConvexHull{N,S1<:LazySet{N},S2<:LazySet{N}} <: ConvexSet{N}
 end
 
 isoperationtype(::Type{<:ConvexHull}) = true
+concrete_function(::Type{<:ConvexHull}) = convex_hull
+
 isconvextype(::Type{<:ConvexHull}) = true
+
 is_polyhedral(ch::ConvexHull) = is_polyhedral(ch.X) && is_polyhedral(ch.Y)
 
 # EmptySet is the neutral element for ConvexHull
@@ -213,10 +216,4 @@ function vertices_list(ch::ConvexHull;
         convex_hull!(vlist; backend=backend)
     end
     return vlist
-end
-
-# concretization of a convex hull computes the (concrete) convex hull of the
-# concretization of each wrapped set
-function concretize(ch::ConvexHull)
-    return convex_hull(concretize(ch.X), concretize(ch.Y))
 end

--- a/src/LazyOperations/ConvexHullArray.jl
+++ b/src/LazyOperations/ConvexHullArray.jl
@@ -135,7 +135,7 @@ This algorithm calculates the maximum over all ``ρ(d, X_i)``, where the
 ``X_1, …, X_k`` are the sets in the array of `cha`.
 """
 function ρ(d::AbstractVector, cha::ConvexHullArray)
-    return maximum(ρ(d, Xi) for Xi in array(cha))
+    return maximum(ρ(d, Xi) for Xi in cha)
 end
 
 """
@@ -200,7 +200,7 @@ function vertices_list(cha::ConvexHullArray;
                        apply_convex_hull::Bool=true,
                        backend=nothing,
                        prune::Bool=apply_convex_hull)
-    vlist = vcat([vertices_list(Xi) for Xi in array(cha)]...)
+    vlist = vcat([vertices_list(Xi) for Xi in cha]...)
     if apply_convex_hull || prune
         convex_hull!(vlist; backend=backend)
     end

--- a/src/LazyOperations/Intersection.jl
+++ b/src/LazyOperations/Intersection.jl
@@ -137,6 +137,11 @@ is_polyhedral(cap::Intersection) = is_polyhedral(cap.X) && is_polyhedral(cap.Y)
 # EmptySet is the absorbing element for Intersection
 @absorbing(Intersection, EmptySet)
 
+# interface for binary set operations
+Base.first(cap::Intersection) = cap.X
+second(cap::Intersection) = cap.Y
+@declare_binary_operation(Intersection)
+
 """
     isempty_known(cap::Intersection)
 

--- a/src/LazyOperations/Intersection.jl
+++ b/src/LazyOperations/Intersection.jl
@@ -126,6 +126,7 @@ The function symbol can be typed via `\\cap[TAB]`.
 ∩(X::LazySet, Y::LazySet) = Intersection(X, Y)
 
 isoperationtype(::Type{<:Intersection}) = true
+concrete_function(::Type{<:Intersection}) = intersection
 
 isconvextype(::Type{Intersection{N,S1,S2}}) where {N,S1,S2} = isconvextype(S1) && isconvextype(S2)
 
@@ -743,10 +744,6 @@ This method computes the concrete intersection.
 """
 function linear_map(M::AbstractMatrix, cap::Intersection)
     return linear_map(M, intersection(cap.X, cap.Y))
-end
-
-function concretize(cap::Intersection)
-    return intersection(concretize(cap.X), concretize(cap.Y))
 end
 
 """

--- a/src/LazyOperations/IntersectionArray.jl
+++ b/src/LazyOperations/IntersectionArray.jl
@@ -201,7 +201,7 @@ redundant constraints.
 function constraints_list(ia::IntersectionArray)
     N = eltype(ia)
     constraints = Vector{HalfSpace{N,Vector{N}}}() # TODO: use vector type of ia
-    for X in array(ia)
+    for X in ia
         clist_X = _normal_Vector(X)
         append!(constraints, clist_X)
     end

--- a/src/LazyOperations/MinkowskiSum.jl
+++ b/src/LazyOperations/MinkowskiSum.jl
@@ -56,6 +56,7 @@ The function symbol can be typed via `\\oplus[TAB]`.
 ⊕(X::LazySet, Y::LazySet) = MinkowskiSum(X, Y)
 
 isoperationtype(::Type{<:MinkowskiSum}) = true
+concrete_function(::Type{<:MinkowskiSum}) = minkowski_sum
 
 isconvextype(::Type{MinkowskiSum{N,S1,S2}}) where {N,S1,S2} = isconvextype(S1) && isconvextype(S2)
 
@@ -272,10 +273,6 @@ function ∈(x::AbstractVector,
 end
 
 @inline _in_singleton_msum(x, X, Y) = (x - element(X)) ∈ Y
-
-function concretize(ms::MinkowskiSum)
-    return minkowski_sum(concretize(ms.X), concretize(ms.Y))
-end
 
 """
     vertices_list(ms::MinkowskiSum)

--- a/src/LazyOperations/MinkowskiSum.jl
+++ b/src/LazyOperations/MinkowskiSum.jl
@@ -68,6 +68,11 @@ is_polyhedral(ms::MinkowskiSum) = is_polyhedral(ms.X) && is_polyhedral(ms.Y)
 @absorbing(MinkowskiSum, EmptySet)
 # @absorbing(MinkowskiSum, Universe)  # TODO problematic
 
+# interface for binary set operations
+Base.first(ms::MinkowskiSum) = ms.X
+second(ms::MinkowskiSum) = ms.Y
+@declare_binary_operation(MinkowskiSum)
+
 """
     swap(ms::MinkowskiSum)
 

--- a/src/LazyOperations/MinkowskiSumArray.jl
+++ b/src/LazyOperations/MinkowskiSumArray.jl
@@ -204,7 +204,7 @@ sets.
 The center of the set.
 """
 function center(msa::MinkowskiSumArray)
-    return sum(center(X) for X in array(msa))
+    return sum(center(X) for X in msa)
 end
 
 function concretize(msa::MinkowskiSumArray)

--- a/src/LazyOperations/Rectification.jl
+++ b/src/LazyOperations/Rectification.jl
@@ -232,7 +232,7 @@ concatenates vectors ``x`` and ``y``.
 """
 function σ(d::AbstractVector,
            R::Rectification{N,<:CartesianProduct{N}}) where {N}
-    X, Y = R.X.X, R.X.Y
+    X, Y = first(R.X), second(R.X)
     n1 = dim(X)
     return vcat(σ(d[1:n1], Rectification(X)), σ(d[(n1 + 1):end], Rectification(Y)))
 end

--- a/src/LazyOperations/Rectification.jl
+++ b/src/LazyOperations/Rectification.jl
@@ -272,7 +272,7 @@ function σ(d::AbstractVector,
            R::Rectification{N,<:CartesianProductArray{N}}) where {N}
     svec = similar(d)
     i = 1
-    for X in array(R.X)
+    for X in R.X
         nX = dim(X)
         j = i + nX - 1
         svec[i:j] = σ(d[i:j], Rectification(X))

--- a/src/LazyOperations/UnionSet.jl
+++ b/src/LazyOperations/UnionSet.jl
@@ -40,6 +40,11 @@ is_polyhedral(U::UnionSet) = is_polyhedral(U.X) && is_polyhedral(U.Y)
 # Universe is the absorbing element for UnionSet
 @absorbing(UnionSet, Universe)
 
+# interface for binary set operations
+Base.first(U::UnionSet) = U.X
+second(U::UnionSet) = U.Y
+@declare_binary_operation(UnionSet)
+
 """
     ∪
 

--- a/src/LazyOperations/UnionSetArray.jl
+++ b/src/LazyOperations/UnionSetArray.jl
@@ -181,7 +181,7 @@ An element in the union of a finite number of sets.
 We use `an_element` on the first non-empty wrapped set.
 """
 function an_element(cup::UnionSetArray)
-    for Xi in array(cup)
+    for Xi in cup
         if !isempty(Xi)
             return an_element(Xi)
         end
@@ -267,7 +267,7 @@ A list of vertices, possibly reduced to the list of vertices of the convex hull.
 function vertices_list(cup::UnionSetArray;
                        apply_convex_hull::Bool=false,
                        backend=nothing)
-    vlist = vcat([vertices_list(Xi) for Xi in array(cup)]...)
+    vlist = vcat([vertices_list(Xi) for Xi in cup]...)
     if apply_convex_hull
         convex_hull!(vlist; backend=backend)
     end
@@ -275,13 +275,13 @@ function vertices_list(cup::UnionSetArray;
 end
 
 function linear_map(M::AbstractMatrix, cup::UnionSetArray)
-    return UnionSetArray([linear_map(M, X) for X in array(cup)])
+    return UnionSetArray([linear_map(M, X) for X in cup])
 end
 
 function project(cup::UnionSetArray, block::AbstractVector{Int}; kwargs...)
-    return UnionSetArray([project(X, block; kwargs...) for X in array(cup)])
+    return UnionSetArray([project(X, block; kwargs...) for X in cup])
 end
 
 function translate(cup::UnionSetArray, v::AbstractVector)
-    return UnionSetArray([translate(X, v) for X in array(cup)])
+    return UnionSetArray([translate(X, v) for X in cup])
 end

--- a/src/Plotting/plot_recipes.jl
+++ b/src/Plotting/plot_recipes.jl
@@ -521,11 +521,11 @@ julia> plot(X, 0.0, 100)  # equivalent to the above line
     if !isbounded(cap)
         _set_auto_limits_to_extrema!(lims, extr)
         bounding_box = _bounding_hyperrectangle(lims, n, eltype(cap))
-        if !isbounded(cap.X)
-            bounded_X = Intersection(bounding_box, cap.X)
-            cap = Intersection(bounded_X, cap.Y)
+        if !isbounded(first(cap))
+            bounded_X = Intersection(bounding_box, first(cap))
+            cap = Intersection(bounded_X, second(cap))
         else
-            cap = Intersection(bounding_box, cap.Y)
+            cap = Intersection(bounding_box, second(cap))
         end
 
         # if there is already a plotted set and the limits are fixed,
@@ -581,9 +581,9 @@ end
         seriesalpha --> DEFAULT_ALPHA
         seriescolor --> DEFAULT_COLOR
         seriestype --> :shape
-        return _plot_list_same_recipe(_union_sets(cup), ε, Nφ)
+        return _plot_list_same_recipe(array(cup), ε, Nφ)
     else
-        for Xi in _union_sets(cup)
+        for Xi in array(cup)
             if Xi isa Intersection
                 @series Xi, ε, Nφ
             else
@@ -592,9 +592,6 @@ end
         end
     end
 end
-
-_union_sets(cup::UnionSet) = [cup.X, cup.Y]
-_union_sets(cup::UnionSetArray) = array(cup)
 
 @recipe function plot_polyzono(P::AbstractPolynomialZonotope{N},
                                ε::Real=N(PLOT_PRECISION); nsdiv=10,

--- a/src/Utils/macros.jl
+++ b/src/Utils/macros.jl
@@ -153,14 +153,16 @@ Nothing.
 
 ### Notes
 
-This macro generates five methods. See the example below.
+This macro generates seven methods. See the example below.
 
 ### Examples
 
 `@declare_binary_operation(MinkowskiSum)` creates the following methods:
 * `iterate(::MinkowskiSum)`
 * `length(::MinkowskiSum)`
-* `getindex(::Minkowski, ::Int)`
+* `getindex(::MinkowskiSum, ::Int)`
+* `getindex(::MinkowskiSum, ::AbstractVector{Int})`
+* `lastindex(::MinkowskiSum)`
 * `array(::MinkowskiSum)`
 * `is_array_constructor(::Type{MinkowskiSum})`
 """
@@ -177,6 +179,10 @@ macro declare_binary_operation(SET)
         end
 
         function Base.length(::$SET)
+            return 2
+        end
+
+        function Base.lastindex(X::$SET)
             return 2
         end
 

--- a/src/Utils/macros.jl
+++ b/src/Utils/macros.jl
@@ -196,6 +196,13 @@ macro declare_binary_operation(SET)
         function is_array_constructor(::Type{$SET})
             return false
         end
+
+        if hasmethod(concrete_function, (Type{<:$SET},))
+            function concretize(X::$SET)
+                f = concrete_function($SET)
+                return f(concretize(first(X)), concretize(second(X)))
+            end
+        end
     end
     return nothing
 end

--- a/src/Utils/macros.jl
+++ b/src/Utils/macros.jl
@@ -180,13 +180,17 @@ macro declare_binary_operation(SET)
             return 2
         end
 
-        function Base.getindex(X::$SET, i)
+        function Base.getindex(X::$SET, i::Int)
             if i == 1
                 return first(X)
             elseif i == 2
                 return second(X)
             end
             throw(ArgumentError("invalid index $i for binary set operation"))
+        end
+
+        function Base.getindex(X::$SET, indices::AbstractVector{Int})
+            return [X[i] for i in indices]
         end
 
         function array(X::$SET)

--- a/src/Utils/macros.jl
+++ b/src/Utils/macros.jl
@@ -257,6 +257,18 @@ macro declare_array_version(SET, SETARR)
             return true
         end
 
+        # create function to flatten a lazy set operation
+        function flatten(X::Union{<:$SET,<:$SETARR})
+            arr = flatten!([], X, $SET)
+            @inbounds if length(arr) == 1
+                return arr[1]
+            elseif length(arr) == 2
+                return $SET(2)
+            else
+                return $SETARR([Xi for Xi in arr])
+            end
+        end
+
         # create in-place modification functions for array version
         function $_SET!(X::LazySet{N}, Y::LazySet{N}) where {N}
             # no array type: just use the lazy operation

--- a/src/Utils/macros.jl
+++ b/src/Utils/macros.jl
@@ -139,6 +139,68 @@ macro absorbing(SET, ABS)
 end
 
 """
+    @declare_binary_operation(SET)
+
+Create common methods for binary set operations.
+
+### Input
+
+- `SET` -- set type of the lazy operation
+
+### Output
+
+Nothing.
+
+### Notes
+
+This macro generates five methods. See the example below.
+
+### Examples
+
+`@declare_binary_operation(MinkowskiSum)` creates the following methods:
+* `iterate(::MinkowskiSum)`
+* `length(::MinkowskiSum)`
+* `getindex(::Minkowski, ::Int)`
+* `array(::MinkowskiSum)`
+* `is_array_constructor(::Type{MinkowskiSum})`
+"""
+macro declare_binary_operation(SET)
+    @eval begin
+        function Base.iterate(X::$SET, state=1)
+            if state == 1
+                return (first(X), 2)
+            elseif state == 2
+                return (second(X), 3)
+            else
+                return nothing
+            end
+        end
+
+        function Base.length(::$SET)
+            return 2
+        end
+
+        function Base.getindex(X::$SET, i)
+            if i == 1
+                return first(X)
+            elseif i == 2
+                return second(X)
+            end
+            throw(ArgumentError("invalid index $i for binary set operation"))
+        end
+
+        function array(X::$SET)
+            return [first(X), second(X)]
+        end
+
+        function is_array_constructor(::Type{$SET})
+            return false
+        end
+    end
+    return nothing
+end
+
+"""
     @declare_array_version(SET, SETARR)
 
 Create methods to connect a lazy set operation with its array set type.
@@ -154,16 +216,17 @@ Nothing.
 
 ### Notes
 
-This macro generates six functions (and possibly up to eight more if
+This macro generates six methods (and possibly up to eight more if
 `@neutral`/`@absorbing` has been used in advance for the base and/or array set
-type).
+type). See the example below.
 
 ### Examples
 
 `@declare_array_version(MinkowskiSum, MinkowskiSumArray)` creates at least the
 following methods:
-* `array_constructor(::MinkowskiSum) = MinkowskiSumArray`
-* `is_array_constructor(::MinkowskiSumArray) = true`
+* `array_constructor(::Type{MinkowskiSum}) = MinkowskiSumArray`
+* `binary_constructor(::Type{MinkowskiSumArray}) = MinkowskiSum`
+* `is_array_constructor(::Type{MinkowskiSumArray}) = true`
 * `MinkowskiSum!(X, Y)`
 * `MinkowskiSum!(X, arr)`
 * `MinkowskiSum!(arr, X)`
@@ -177,7 +240,12 @@ macro declare_array_version(SET, SETARR)
             return $SETARR
         end
 
-        # create function to check that this is an array version
+        # create function to obtain the binary version
+        function binary_constructor(::Type{$SETARR})
+            return $SET
+        end
+
+        # create function to check whether an operation is the array version
         function is_array_constructor(::Type{$SETARR})
             return true
         end

--- a/src/convert.jl
+++ b/src/convert.jl
@@ -227,7 +227,7 @@ _convert_zonotope_fallback(Z) = Zonotope(center(Z), genmat(Z))
 function convert(::Type{Singleton},
                  cp::CartesianProduct{N,S1,S2}) where {N,S1<:AbstractSingleton,
                                                        S2<:AbstractSingleton}
-    return Singleton(vcat(element(cp.X), element(cp.Y)))
+    return Singleton(vcat(element(first(cp)), element(second(cp))))
 end
 
 """
@@ -473,7 +473,7 @@ hyperrectangle. This implementation uses the `center` and
 function convert(::Type{Hyperrectangle},
                  cp::CartesianProduct{N,HN1,HN2}) where {N,HN1<:AbstractHyperrectangle,
                                                          HN2<:AbstractHyperrectangle}
-    X, Y = cp.X, cp.Y
+    X, Y = first(cp), second(cp)
     c = vcat(center(X), center(Y))
     r = vcat(radius_hyperrectangle(X), radius_hyperrectangle(Y))
     return Hyperrectangle(c, r)
@@ -588,7 +588,7 @@ The Cartesian product is obtained by:
 function convert(::Type{Zonotope},
                  cp::CartesianProduct{N,ZN1,ZN2}) where {N,ZN1<:AbstractZonotope,
                                                          ZN2<:AbstractZonotope}
-    Z1, Z2 = cp.X, cp.Y
+    Z1, Z2 = first(cp), second(cp)
     c = vcat(center(Z1), center(Z2))
     G = blockdiag(sparse(genmat(Z1)), sparse(genmat(Z2)))
     return Zonotope(c, G)
@@ -739,25 +739,25 @@ A Minkowski sum array.
 """
 function convert(::Type{MinkowskiSumArray},
                  X::MinkowskiSum{N,ST,MinkowskiSumArray{N,ST}}) where {N,ST}
-    return MinkowskiSumArray(vcat(X.X, X.Y.array))
+    return MinkowskiSumArray(vcat(first(X), array(second(X))))
 end
 
 """
-    convert(::Type{Interval}, x::MinkowskiSum{N, IT, IT}) where {N, IT<:Interval}
+    convert(::Type{Interval}, ms::MinkowskiSum{N, IT, IT}) where {N, IT<:Interval}
 
 Convert the Minkowski sum of two intervals to an interval.
 
 ### Input
 
 - `Interval` -- target type
-- `x`        -- Minkowski sum of two intervals
+- `ms`       -- Minkowski sum of two intervals
 
 ### Output
 
 An interval.
 """
-function convert(::Type{Interval}, x::MinkowskiSum{N,IT,IT}) where {N,IT<:Interval}
-    return minkowski_sum(x.X, x.Y)
+function convert(::Type{Interval}, ms::MinkowskiSum{N,IT,IT}) where {N,IT<:Interval}
+    return concretize(ms)
 end
 
 # convert to concrete Vector representation
@@ -842,7 +842,7 @@ convert(::Type{HPolyhedron}, P::HPolytope) = HPolyhedron(copy(constraints_list(P
 for T in [HPolygon, HPolygonOpt, HPolytope, HPolyhedron]
     @eval begin
         function convert(::Type{$T}, P::Intersection)
-            clist = vcat(constraints_list(P.X), constraints_list(P.Y))
+            clist = vcat(constraints_list(first(P)), constraints_list(second(P)))
             return ($T)(clist)
         end
 

--- a/src/convert.jl
+++ b/src/convert.jl
@@ -439,7 +439,7 @@ function convert(::Type{Hyperrectangle},
     c = Vector{N}(undef, n)
     r = Vector{N}(undef, n)
     i = 1
-    @inbounds for block_set in array(cpa)
+    @inbounds for block_set in cpa
         j = i + dim(block_set) - 1
         c[i:j] = center(block_set)
         r[i:j] = radius_hyperrectangle(block_set)

--- a/test/LazyOperations/CartesianProduct.jl
+++ b/test/LazyOperations/CartesianProduct.jl
@@ -17,6 +17,13 @@ for N in [Float64, Float32, Rational{Int}]
           cpa
     @test *(b1) == ×(b1) == b1
 
+    # array interface
+    @test array(cp) == [b1, b2] && array(cpa) == [b1, b2, b1]
+    @test cp[1] == cpa[1] == b1
+    @test length(cp) == 2 && length(cpa) == 3
+    v = Vector{LazySet{N}}()
+    @test array(CartesianProductArray(v)) ≡ v
+
     # swap
     cp2 = swap(cp)
     @test cp.X == cp2.Y && cp.Y == cp2.X
@@ -222,6 +229,8 @@ for N in [Float64, Float32, Rational{Int}]
 
     # relation to base type (internal helper functions)
     @test LazySets.array_constructor(CartesianProduct) == CartesianProductArray
+    @test LazySets.binary_constructor(CartesianProductArray) == CartesianProduct
+    @test !LazySets.is_array_constructor(CartesianProduct)
     @test LazySets.is_array_constructor(CartesianProductArray)
 
     # standard constructor
@@ -234,9 +243,6 @@ for N in [Float64, Float32, Rational{Int}]
 
     # constructor with size hint and type
     CartesianProductArray(10, N)
-
-    # array getter
-    @test array(cpa) ≡ v
 
     # getindex & length
     @test cpa[1] == S1 && cpa[2] == S2

--- a/test/LazyOperations/CartesianProduct.jl
+++ b/test/LazyOperations/CartesianProduct.jl
@@ -20,6 +20,7 @@ for N in [Float64, Float32, Rational{Int}]
     # array interface
     @test array(cp) == [b1, b2] && array(cpa) == [b1, b2, b1]
     @test cp[1] == cpa[1] == b1
+    @test cp[1:2] == cpa[1:2] == [b1, b2]
     @test length(cp) == 2 && length(cpa) == 3
     v = Vector{LazySet{N}}()
     @test array(CartesianProductArray(v)) ≡ v

--- a/test/LazyOperations/CartesianProduct.jl
+++ b/test/LazyOperations/CartesianProduct.jl
@@ -21,6 +21,7 @@ for N in [Float64, Float32, Rational{Int}]
     @test array(cp) == [b1, b2] && array(cpa) == [b1, b2, b1]
     @test cp[1] == cpa[1] == b1
     @test cp[1:2] == cpa[1:2] == [b1, b2]
+    @test cp[end] == b2 && cpa[end] == b1
     @test length(cp) == 2 && length(cpa) == 3
     v = Vector{LazySet{N}}()
     @test array(CartesianProductArray(v)) ≡ v

--- a/test/LazyOperations/CartesianProduct.jl
+++ b/test/LazyOperations/CartesianProduct.jl
@@ -28,6 +28,14 @@ for N in [Float64, Float32, Rational{Int}]
     cp2 = swap(cp)
     @test cp.X == cp2.Y && cp.Y == cp2.X
 
+    # flatten
+    b3 = Ball1(N[0, 0], N(1))
+    for M3 in (CartesianProduct(CartesianProduct(b1, CartesianProductArray([b2])), b3),
+               CartesianProductArray([CartesianProduct(b1, CartesianProductArray([b2])), b3]))
+        M3f = flatten(M3)
+        @test M3f isa CartesianProductArray && array(M3f) == [b1, b2, b3]
+    end
+
     # Test Dimension
     @test dim(cp) == 3
     # Test Support Vector

--- a/test/LazyOperations/CartesianProduct.jl
+++ b/test/LazyOperations/CartesianProduct.jl
@@ -152,9 +152,10 @@ for N in [Float64, Float32, Rational{Int}]
     @test lm isa (N == Float64 ? HPolytope{N} : HPolytope)
     @test box_approximation(lm) == Hyperrectangle(N[7 // 2, 0], N[3 // 2, 0])
 
+    # concretize
+    @test LazySets.concrete_function(CartesianProduct) == cartesian_product
     cp = CartesianProduct(VPolytope([N[1]]), VPolytope([N[2]]))
     if test_suite_polyhedra
-        # concretize
         @test concretize(cp) == VPolytope([N[1, 2]])
     else
         @test concretize(cp) === cp
@@ -332,9 +333,9 @@ for N in [Float64, Float32, Rational{Int}]
     @test lm isa (N == Float64 ? HPolytope{N} : HPolytope)
     @test box_approximation(lm) == Hyperrectangle(N[7 // 2, 0], N[3 // 2, 0])
 
+    # concretize
     cpa = CartesianProductArray([VPolytope([N[1]]), VPolytope([N[2]])])
     if test_suite_polyhedra
-        # concretize
         @test concretize(cpa) == VPolytope([N[1, 2]])
     else
         @test concretize(cpa) === cpa

--- a/test/LazyOperations/ConvexHull.jl
+++ b/test/LazyOperations/ConvexHull.jl
@@ -66,6 +66,7 @@ for N in [Float64, Rational{Int}, Float32]
     @test array(ch) == array(cha) == [b1, b2]
     @test ch[1] == cha[1] == b1
     @test ch[1:2] == cha[1:2] == [b1, b2]
+    @test ch[end] == cha[end] == b2
     @test length(ch) == length(cha) == 2
     v = Vector{LazySet{N}}()
     @test array(ConvexHullArray(v)) ≡ v

--- a/test/LazyOperations/ConvexHull.jl
+++ b/test/LazyOperations/ConvexHull.jl
@@ -10,6 +10,14 @@ for N in [Float64, Rational{Int}, Float32]
     ch2 = swap(ch)
     @test ch.X == ch2.Y && ch.Y == ch2.X
 
+    # flatten
+    b3 = BallInf(N[0, 0], N(1))
+    for M3 in (ConvexHull(ConvexHull(b1, ConvexHullArray([b2])), b3),
+               ConvexHullArray([ConvexHull(b1, ConvexHullArray([b2])), b3]))
+        M3f = flatten(M3)
+        @test M3f isa ConvexHullArray && array(M3f) == [b1, b2, b3]
+    end
+
     # Test Dimension
     @test dim(ch) == 2
     # Test Support Vector

--- a/test/LazyOperations/ConvexHull.jl
+++ b/test/LazyOperations/ConvexHull.jl
@@ -65,6 +65,7 @@ for N in [Float64, Rational{Int}, Float32]
     # array interface
     @test array(ch) == array(cha) == [b1, b2]
     @test ch[1] == cha[1] == b1
+    @test ch[1:2] == cha[1:2] == [b1, b2]
     @test length(ch) == length(cha) == 2
     v = Vector{LazySet{N}}()
     @test array(ConvexHullArray(v)) ≡ v

--- a/test/LazyOperations/ConvexHull.jl
+++ b/test/LazyOperations/ConvexHull.jl
@@ -38,6 +38,7 @@ for N in [Float64, Rational{Int}, Float32]
     @test !isempty(ch)
 
     # concretize
+    @test LazySets.concrete_function(ConvexHull) == convex_hull
     @test concretize(ch) == convex_hull(ch.X, ch.Y)
 
     # ===============

--- a/test/LazyOperations/ConvexHull.jl
+++ b/test/LazyOperations/ConvexHull.jl
@@ -46,10 +46,20 @@ for N in [Float64, Rational{Int}, Float32]
 
     # relation to base type (internal helper functions)
     @test LazySets.array_constructor(ConvexHull) == ConvexHullArray
+    @test LazySets.binary_constructor(ConvexHullArray) == ConvexHull
+    @test !LazySets.is_array_constructor(ConvexHull)
     @test LazySets.is_array_constructor(ConvexHullArray)
 
     # convex hull array of 2 sets
     cha = ConvexHullArray([b1, b2])
+
+    # array interface
+    @test array(ch) == array(cha) == [b1, b2]
+    @test ch[1] == cha[1] == b1
+    @test length(ch) == length(cha) == 2
+    v = Vector{LazySet{N}}()
+    @test array(ConvexHullArray(v)) ≡ v
+
     # constructor with size hint and type
     ConvexHullArray(10, N)
     # test alias
@@ -82,10 +92,6 @@ for N in [Float64, Rational{Int}, Float32]
     ConvexHullArray([Singleton(N[10, 1 // 2]), Singleton(N[11 // 10, 1 // 5]),
                      Singleton(N[7 // 5, 3 // 10]), Singleton(N[17 // 10, 1 // 2]),
                      Singleton(N[7 // 5, 4 // 5])])
-
-    # array getter
-    v = Vector{LazySet{N}}()
-    @test array(ConvexHullArray(v)) ≡ v
 
     # in-place modification
     cha = ConvexHullArray(LazySet{N}[])

--- a/test/LazyOperations/Intersection.jl
+++ b/test/LazyOperations/Intersection.jl
@@ -15,6 +15,7 @@ for N in [Float64, Rational{Int}, Float32]
     # array interface
     @test array(I) == [B, H] && array(cap) == [B, H, B]
     @test I[1] == cap[1] == B
+    @test I[1:2] == cap[1:2] == [B, H]
     @test length(I) == 2 && length(cap) == 3
     v = Vector{LazySet{N}}()
     @test array(IntersectionArray(v)) ≡ v

--- a/test/LazyOperations/Intersection.jl
+++ b/test/LazyOperations/Intersection.jl
@@ -12,6 +12,13 @@ for N in [Float64, Rational{Int}, Float32]
     @test ∩(B, H, B) == ∩([B, H, B]) == cap
     @test ∩(B) == B
 
+    # array interface
+    @test array(I) == [B, H] && array(cap) == [B, H, B]
+    @test I[1] == cap[1] == B
+    @test length(I) == 2 && length(cap) == 3
+    v = Vector{LazySet{N}}()
+    @test array(IntersectionArray(v)) ≡ v
+
     # swap
     I2 = swap(I)
     @test I.X == I2.Y && I.Y == I2.X
@@ -80,6 +87,8 @@ for N in [Float64, Rational{Int}, Float32]
 
     # relation to base type (internal helper functions)
     @test LazySets.array_constructor(Intersection) == IntersectionArray
+    @test LazySets.binary_constructor(IntersectionArray) == Intersection
+    @test !LazySets.is_array_constructor(Intersection)
     @test LazySets.is_array_constructor(IntersectionArray)
 
     # intersection of an array of sets
@@ -114,10 +123,6 @@ for N in [Float64, Rational{Int}, Float32]
 
     # membership
     @test ones(N, 2) ∈ IArr && N[5, 5] ∉ IArr
-
-    # array getter
-    v = Vector{LazySet{N}}()
-    @test array(IntersectionArray(v)) ≡ v
 
     # constructor with size hint and type
     IntersectionArray(10, N)

--- a/test/LazyOperations/Intersection.jl
+++ b/test/LazyOperations/Intersection.jl
@@ -23,6 +23,14 @@ for N in [Float64, Rational{Int}, Float32]
     I2 = swap(I)
     @test I.X == I2.Y && I.Y == I2.X
 
+    # flatten
+    B2 = Ball1(N[0, 0], N(1))
+    for M3 in (Intersection(Intersection(B, IntersectionArray([H])), B2),
+               IntersectionArray([Intersection(B, IntersectionArray([H])), B2]))
+        M3f = flatten(M3)
+        @test M3f isa IntersectionArray && array(M3f) == [B, H, B2]
+    end
+
     # dim
     @test dim(I) == 2
 

--- a/test/LazyOperations/Intersection.jl
+++ b/test/LazyOperations/Intersection.jl
@@ -57,6 +57,7 @@ for N in [Float64, Rational{Int}, Float32]
     @test !isempty(I)
 
     # concretize
+    @test LazySets.concrete_function(Intersection) == intersection
     @test concretize(I) == intersection(B, H)
 
     # volume

--- a/test/LazyOperations/Intersection.jl
+++ b/test/LazyOperations/Intersection.jl
@@ -16,6 +16,7 @@ for N in [Float64, Rational{Int}, Float32]
     @test array(I) == [B, H] && array(cap) == [B, H, B]
     @test I[1] == cap[1] == B
     @test I[1:2] == cap[1:2] == [B, H]
+    @test I[end] == H && cap[end] == B
     @test length(I) == 2 && length(cap) == 3
     v = Vector{LazySet{N}}()
     @test array(IntersectionArray(v)) ≡ v

--- a/test/LazyOperations/MinkowskiSum.jl
+++ b/test/LazyOperations/MinkowskiSum.jl
@@ -17,6 +17,7 @@ for N in [Float64, Rational{Int}, Float32]
     # array interface
     @test array(ms) == [b1, b2] && array(msa) == [b1, b2, b1]
     @test ms[1] == msa[1] == b1
+    @test ms[1:2] == msa[1:2] == [b1, b2]
     @test length(ms) == 2 && length(msa) == 3
     v = Vector{LazySet{N}}()
     @test array(MinkowskiSumArray(v)) ≡ v

--- a/test/LazyOperations/MinkowskiSum.jl
+++ b/test/LazyOperations/MinkowskiSum.jl
@@ -3,35 +3,42 @@ for N in [Float64, Rational{Int}, Float32]
     b1 = BallInf(N[0, 0], N(2))
     b2 = Ball1(N[0, 0], N(1))
     # Test Construction
-    X = MinkowskiSum(b1, b2)
-    @test X.X == b1
-    @test X.Y == b2
+    ms = MinkowskiSum(b1, b2)
+    @test ms.X == b1
+    @test ms.Y == b2
 
     # convenience constructors
-    @test b1 + b2 == b1 ⊕ b2 == X
+    @test b1 + b2 == b1 ⊕ b2 == ms
     msa = MinkowskiSumArray([b1, b2, b1])
     @test b1 + b2 + b1 == +(b1, b2, b1) == ⊕(b1, b2, b1) == +([b1, b2, b1]) == ⊕([b1, b2, b1]) ==
           msa
     @test +(b1) == ⊕(b1) == b1
 
+    # array interface
+    @test array(ms) == [b1, b2] && array(msa) == [b1, b2, b1]
+    @test ms[1] == msa[1] == b1
+    @test length(ms) == 2 && length(msa) == 3
+    v = Vector{LazySet{N}}()
+    @test array(MinkowskiSumArray(v)) ≡ v
+
     # swap
-    ms2 = swap(X)
-    @test X.X == ms2.Y && X.Y == ms2.X
+    ms2 = swap(ms)
+    @test ms.X == ms2.Y && ms.Y == ms2.X
 
     # Test Dimension
-    @test dim(X) == 2
+    @test dim(ms) == 2
     # Test Support Vector
     d = N[1, 0]
-    v = σ(d, X)
+    v = σ(d, ms)
     @test v[1] == N(3)
     d = N[-1, 0]
-    v = σ(d, X)
+    v = σ(d, ms)
     @test v[1] == N(-3)
     d = N[0, 1]
-    v = σ(d, X)
+    v = σ(d, ms)
     @test v[2] == N(3)
     d = N[0, -1]
-    v = σ(d, X)
+    v = σ(d, ms)
     @test v[2] == N(-3)
 
     # Sum of not-centered 2D balls in norm 1 and infinity
@@ -127,11 +134,9 @@ for N in [Float64, Rational{Int}, Float32]
 
     # relation to base type (internal helper functions)
     @test LazySets.array_constructor(MinkowskiSum) == MinkowskiSumArray
+    @test LazySets.binary_constructor(MinkowskiSumArray) == MinkowskiSum
+    @test !LazySets.is_array_constructor(MinkowskiSum)
     @test LazySets.is_array_constructor(MinkowskiSumArray)
-
-    # array getter
-    v = Vector{LazySet{N}}()
-    @test array(MinkowskiSumArray(v)) ≡ v
 
     # constructor with size hint and type
     MinkowskiSumArray(10, N)

--- a/test/LazyOperations/MinkowskiSum.jl
+++ b/test/LazyOperations/MinkowskiSum.jl
@@ -25,6 +25,14 @@ for N in [Float64, Rational{Int}, Float32]
     ms2 = swap(ms)
     @test ms.X == ms2.Y && ms.Y == ms2.X
 
+    # flatten
+    b3 = Ball1(N[1, 1], N(1))
+    for M3 in (MinkowskiSum(MinkowskiSum(b1, MinkowskiSumArray([b2])), b3),
+               MinkowskiSumArray([MinkowskiSum(b1, MinkowskiSumArray([b2])), b3]))
+        M3f = flatten(M3)
+        @test M3f isa MinkowskiSumArray && array(M3f) == [b1, b2, b3]
+    end
+
     # Test Dimension
     @test dim(ms) == 2
     # Test Support Vector

--- a/test/LazyOperations/MinkowskiSum.jl
+++ b/test/LazyOperations/MinkowskiSum.jl
@@ -113,6 +113,7 @@ for N in [Float64, Rational{Int}, Float32]
     @test ispermutation(vertices_list(X + Y), [N[2, 1], N[0, 1], N[-2, -1], N[0, -1]])
 
     # concretize
+    @test LazySets.concrete_function(MinkowskiSum) == minkowski_sum
     @test concretize(ms) == minkowski_sum(B, B)
 
     # linear_map

--- a/test/LazyOperations/MinkowskiSum.jl
+++ b/test/LazyOperations/MinkowskiSum.jl
@@ -18,6 +18,7 @@ for N in [Float64, Rational{Int}, Float32]
     @test array(ms) == [b1, b2] && array(msa) == [b1, b2, b1]
     @test ms[1] == msa[1] == b1
     @test ms[1:2] == msa[1:2] == [b1, b2]
+    @test ms[end] == b2 && msa[end] == b1
     @test length(ms) == 2 && length(msa) == 3
     v = Vector{LazySet{N}}()
     @test array(MinkowskiSumArray(v)) ≡ v

--- a/test/LazyOperations/UnionSet.jl
+++ b/test/LazyOperations/UnionSet.jl
@@ -22,6 +22,7 @@ for N in [Float64, Rational{Int}, Float32]
     @test array(UXY) == array(Uarr) == [B1, B2]
     @test UXY[1] == Uarr[1] == B1
     @test UXY[1:2] == Uarr[1:2] == [B1, B2]
+    @test UXY[end] == Uarr[end] == B2
     @test length(UXY) == length(Uarr) == 2
     v = Vector{LazySet{N}}()
     @test array(UnionSetArray(v)) ≡ v

--- a/test/LazyOperations/UnionSet.jl
+++ b/test/LazyOperations/UnionSet.jl
@@ -21,6 +21,7 @@ for N in [Float64, Rational{Int}, Float32]
     # array interface
     @test array(UXY) == array(Uarr) == [B1, B2]
     @test UXY[1] == Uarr[1] == B1
+    @test UXY[1:2] == Uarr[1:2] == [B1, B2]
     @test length(UXY) == length(Uarr) == 2
     v = Vector{LazySet{N}}()
     @test array(UnionSetArray(v)) ≡ v

--- a/test/LazyOperations/UnionSet.jl
+++ b/test/LazyOperations/UnionSet.jl
@@ -18,6 +18,13 @@ for N in [Float64, Rational{Int}, Float32]
     @test Uarr[1] == B1 && Uarr[2] == B2
     @test length(Uarr) == 2
 
+    # array interface
+    @test array(UXY) == array(Uarr) == [B1, B2]
+    @test UXY[1] == Uarr[1] == B1
+    @test length(UXY) == length(Uarr) == 2
+    v = Vector{LazySet{N}}()
+    @test array(UnionSetArray(v)) ≡ v
+
     # swap
     U2 = swap(UXY)
     @test UXY.X == U2.Y && UXY.Y == U2.X
@@ -29,6 +36,12 @@ for N in [Float64, Rational{Int}, Float32]
     U = Universe{N}(2)
     @test absorbing(UnionSet) == absorbing(UnionSetArray) == Universe
     @test UnionSet(B1, U) == UnionSet(U, B1) == U
+
+    # relation to base type (internal helper functions)
+    @test LazySets.array_constructor(UnionSet) == UnionSetArray
+    @test LazySets.binary_constructor(UnionSetArray) == UnionSet
+    @test !LazySets.is_array_constructor(UnionSet)
+    @test LazySets.is_array_constructor(UnionSetArray)
 
     for U in [UXY, Uarr]
         # dimension

--- a/test/LazyOperations/UnionSet.jl
+++ b/test/LazyOperations/UnionSet.jl
@@ -43,6 +43,13 @@ for N in [Float64, Rational{Int}, Float32]
     @test !LazySets.is_array_constructor(UnionSet)
     @test LazySets.is_array_constructor(UnionSetArray)
 
+    # flatten
+    for U3 in (UnionSet(UnionSet(B1, UnionSetArray([B2])), B3),
+               UnionSetArray([UnionSet(B1, UnionSetArray([B2])), B3]))
+        U3f = flatten(U3)
+        @test U3f isa UnionSetArray && array(U3f) == [B1, B2, B3]
+    end
+
     for U in [UXY, Uarr]
         # dimension
         @test dim(U) == dim(B1)


### PR DESCRIPTION
Closes #269.
Closes #1857.
Closes #1858.

New features:

- `flatten`
- `length` and `getindex` for binary operations
- `iterate`
- `∈` default (for getting an error message instead of a wrong default via `iterate`)

New internal features (not exported):

- `@declare_binary_operation` (some internal convenience definitions)
- `first` and `second` for binary operations
- `concrete_function` (allows to define `concretize` only once)