### PR TITLE
Better linear_map of AbstractZonotope for 1D output

### DIFF
--- a/src/Interfaces/AbstractZonotope.jl
+++ b/src/Interfaces/AbstractZonotope.jl
@@ -306,6 +306,27 @@ function linear_map(M::AbstractMatrix, Z::AbstractZonotope)
     @assert dim(Z) == size(M, 2) "a linear map of size $(size(M)) cannot be " *
                                  "applied to a set of dimension $(dim(Z))"
 
+    if size(M, 1) == 1
+        # yields only one generator
+        return _linear_map_zonotope_1D(M, Z)
+    else
+        return _linear_map_zonotope_nD(M, Z)
+    end
+end
+
+function _linear_map_zonotope_1D(M::AbstractMatrix, Z::LazySet)
+    N = promote_type(eltype(M), eltype(Z))
+    c = M * center(Z)
+    gi = zero(N)
+    @inbounds for g in generators(Z)
+        for i in eachindex(g)
+            gi += M[1, i] * g[i]
+        end
+    end
+    return Zonotope(c, hcat(gi))
+end
+
+function _linear_map_zonotope_nD(M::AbstractMatrix, Z::LazySet)
     c = M * center(Z)
     gi = M * genmat(Z)
     return Zonotope(c, gi)

--- a/test/Sets/Zonotope.jl
+++ b/test/Sets/Zonotope.jl
@@ -95,6 +95,10 @@ for N in [Float64, Rational{Int}, Float32]
     Z5 = scale(1 // 2, Z3)
     @test Z5.center == N[0, 1]
     @test Z5.generators == N[1//2 1//2 1//2 0; -1//2 1//2 0 1//2]
+    # 1D simplifies to 1 generator
+    M = N[1 1;]
+    Z6 = linear_map(M, Z3)
+    @test ngens(Z6) == 1 && genmat(Z6) == hcat(N[4])
 
     # in-place linear map
     Zin = convert(Zonotope, BallInf(zeros(N, 2), N(1)))


### PR DESCRIPTION
If the output dimension is 1, we may still want to return a `Zonotope` for type stability. But the result can have just one generator.

```julia
julia> @time linear_map(M, Z)  # master
  0.000015 seconds (3 allocations: 176 bytes)
Zonotope{Float64, Vector{Float64}, Matrix{Float64}}([0.6565135067379049], [0.06137160508809101 -1.0290195455026827 -0.29127884051790404])

julia> @time linear_map(M, Z)  # this branch
  0.000011 seconds (3 allocations: 160 bytes)
Zonotope{Float64, Vector{Float64}, Matrix{Float64}}([0.6565135067379049], [-1.2589267809324955;;])
```