### PR TITLE
Line2D: merge docs, remove method from HalfSpace

### DIFF
--- a/src/ConcreteOperations/intersection.jl
+++ b/src/ConcreteOperations/intersection.jl
@@ -88,10 +88,15 @@ Line2D{Float64, Vector{Float64}}([1.0, 1.0], 1.0)
 ```
 """
 function intersection(L1::Line2D, L2::Line2D)
+    _intersection_line2d(L1, L2)
+end
+
+# this method can also be called with `HalfSpace` arguments
+function _intersection_line2d(L1, L2)
     det = right_turn(L1.a, L2.a)
     if isapproxzero(det)
         if isapprox(L1.b, L2.b) # lines are identical
-            return L1
+            return _to_Line2D(L1)
         else
             N = promote_type(eltype(L1), eltype(L2))
             return EmptySet{N}(dim(L1)) # lines are disjoint
@@ -104,6 +109,9 @@ function intersection(L1::Line2D, L2::Line2D)
         return Singleton([x, y])
     end
 end
+
+_to_Line2D(L::Line2D) = L
+_to_Line2D(H::HalfSpace) = Line2D(H.a, H.b)
 
 """
     intersection(LS::LineSegment, L2::Line2D)

--- a/src/Interfaces/AbstractHPolygon.jl
+++ b/src/Interfaces/AbstractHPolygon.jl
@@ -158,14 +158,14 @@ function vertices_list(P::AbstractHPolygon{N};
         return points
     end
     @inbounds for i in 1:(n - 1)
-        cap = intersection(Line2D(P.constraints[i]), Line2D(P.constraints[i + 1]))
+        cap = _intersection_line2d(P.constraints[i], P.constraints[i + 1])
         if cap isa EmptySet
             return Vector{Vector{N}}()
         else
             points[i] = element(cap)
         end
     end
-    cap = intersection(Line2D(P.constraints[n]), Line2D(P.constraints[1]))
+    cap = _intersection_line2d(P.constraints[n], P.constraints[1])
     if cap isa EmptySet
         return Vector{Vector{N}}()
     else
@@ -217,8 +217,7 @@ of the constraints).
 """
 function an_element(P::AbstractHPolygon)
     @assert length(P.constraints) >= 2 "polygon has less than two constraints"
-    return element(intersection(Line2D(P.constraints[1]),
-                                Line2D(P.constraints[2])))
+    return element(_intersection_line2d(P.constraints[1], P.constraints[2]))
 end
 
 """
@@ -358,7 +357,7 @@ function isredundant(cmid::HalfSpace, cright::HalfSpace, cleft::HalfSpace)
         # not the same direction => constraint is not redundant
         return false
     end
-    cap = intersection(Line2D(cright), Line2D(cleft))
+    cap = _intersection_line2d(cright, cleft)
     @assert cap isa Singleton
     return cap ⊆ cmid
 end

--- a/src/Sets/HPolygon.jl
+++ b/src/Sets/HPolygon.jl
@@ -141,11 +141,9 @@ function σ(d::AbstractVector, P::HPolygon;
 
     if k == 1 || k == n + 1
         # corner cases: wrap-around in constraints list
-        return element(intersection(Line2D(P.constraints[1]),
-                                    Line2D(P.constraints[n])))
+        return element(_intersection_line2d(P.constraints[1], P.constraints[n]))
     else
-        return element(intersection(Line2D(P.constraints[k]),
-                                    Line2D(P.constraints[k - 1])))
+        return element(_intersection_line2d(P.constraints[k], P.constraints[k - 1]))
     end
 end
 

--- a/src/Sets/HPolygonOpt.jl
+++ b/src/Sets/HPolygonOpt.jl
@@ -148,8 +148,7 @@ function σ(d::AbstractVector, P::HPolygonOpt;
             if (k == 0)
                 P.ind = n
                 # corner case: wrap-around in constraints list
-                return element(intersection(Line2D(P.constraints[n]),
-                                            Line2D(P.constraints[1])))
+                return element(_intersection_line2d(P.constraints[n], P.constraints[1]))
             else
                 P.ind = k
             end
@@ -162,26 +161,22 @@ function σ(d::AbstractVector, P::HPolygonOpt;
             if (k == n + 1)
                 P.ind = n
                 # corner case: wrap-around in constraints list
-                return element(intersection(Line2D(P.constraints[n]),
-                                            Line2D(P.constraints[1])))
+                return element(_intersection_line2d(P.constraints[n], P.constraints[1]))
             else
                 P.ind = k - 1
             end
         end
-        return element(intersection(Line2D(P.constraints[P.ind]),
-                                    Line2D(P.constraints[P.ind + 1])))
+        return element(_intersection_line2d(P.constraints[P.ind], P.constraints[P.ind + 1]))
     else
         # binary search
         k = binary_search_constraints(d, P.constraints; start_index=P.ind)
         if k == 1 || k == n + 1
             P.ind = 1
             # corner cases: wrap-around in constraints list
-            return element(intersection(Line2D(P.constraints[n]),
-                                        Line2D(P.constraints[1])))
+            return element(_intersection_line2d(P.constraints[n], P.constraints[1]))
         else
             P.ind = k
-            return element(intersection(Line2D(P.constraints[k - 1]),
-                                        Line2D(P.constraints[k])))
+            return element(_intersection_line2d(P.constraints[k - 1], P.constraints[k]))
         end
     end
 end

--- a/src/Sets/Line2D.jl
+++ b/src/Sets/Line2D.jl
@@ -79,9 +79,6 @@ end
 
 isoperationtype(::Type{<:Line2D}) = false
 
-# constructor from a HalfSpace
-Line2D(c::HalfSpace) = Line2D(c.a, c.b)
-
 """
     constraints_list(L::Line2D)
 

--- a/src/Sets/Line2D.jl
+++ b/src/Sets/Line2D.jl
@@ -24,6 +24,26 @@ The line ``y = -x + 1``:
 julia> Line2D([1., 1.], 1.)
 Line2D{Float64, Vector{Float64}}([1.0, 1.0], 1.0)
 ```
+
+The alternative constructor takes two 2D points (`AbstractVector`s) `p` and `q`
+and creates a canonical line from `p` to `q`. See the algorithm section below
+for details.
+
+```jldoctest
+julia> Line2D([1., 1.], [2., 2])
+Line2D{Float64, Vector{Float64}}([-1.0, 1.0], 0.0)
+```
+
+### Algorithm
+
+Given two points ``p = (x₁, y₁)`` and ``q = (x₂, y₂)``, the line that passes
+through these points is
+
+```math
+ℓ:~~y - y₁ = \\dfrac{(y₂ - y₁)}{(x₂ - x₁)} ⋅ (x-x₁).
+```
+The particular case ``x₂ = x₁`` defines a line parallel to the ``y``-axis
+(vertical line).
 """
 struct Line2D{N,VN<:AbstractVector{N}} <: AbstractPolyhedron{N}
     a::VN
@@ -37,36 +57,6 @@ struct Line2D{N,VN<:AbstractVector{N}} <: AbstractPolyhedron{N}
     end
 end
 
-isoperationtype(::Type{<:Line2D}) = false
-
-# constructor from a HalfSpace
-Line2D(c::HalfSpace) = Line2D(c.a, c.b)
-
-"""
-    Line2D(p::AbstractVector, q::AbstractVector)
-
-Constructor of a 2D line from two points.
-
-### Input
-
-- `p` -- point in 2D
-- `q` -- another point in 2D
-
-### Output
-
-The line which passes through `p` and `q`.
-
-### Algorithm
-
-Given two points ``p = (x₁, y₁)`` and ``q = (x₂, y₂)``, the line that passes
-through these points is
-
-```math
-ℓ:~~y - y₁ = \\dfrac{(y₂ - y₁)}{(x₂ - x₁)} ⋅ (x-x₁).
-```
-The particular case ``x₂ = x₁`` defines a line parallel to the ``y``-axis
-(vertical line).
-"""
 function Line2D(p::AbstractVector, q::AbstractVector)
     @assert length(p) == length(q) == 2 "a Line2D must be two-dimensional"
 
@@ -78,7 +68,7 @@ function Line2D(p::AbstractVector, q::AbstractVector)
         @assert y₁ != y₂ "a line needs two distinct points"
         a = [one(N), zero(N)]
         b = x₁
-        return LazySets.Line2D(a, b)
+        return Line2D(a, b)
     end
 
     k = (y₁ - y₂) / (x₂ - x₁)
@@ -86,6 +76,11 @@ function Line2D(p::AbstractVector, q::AbstractVector)
     b = y₁ + k * x₁
     return Line2D(a, b)
 end
+
+isoperationtype(::Type{<:Line2D}) = false
+
+# constructor from a HalfSpace
+Line2D(c::HalfSpace) = Line2D(c.a, c.b)
 
 """
     constraints_list(L::Line2D)


### PR DESCRIPTION
1. commit: Move constructor docs to struct docs.
2. commit: Remove method `Line2D(::HalfSpace)` because this is part of the public API and it is unclear what that means. It was exclusively used to intersect 2D polygon edges represented as `HalfSpace`s. Instead I added an internal method, which even avoids the conversion to `Line2D`.