### PR TITLE
Added `Base.length` for `EmptySet` and `SingleTon`

### DIFF
--- a/src/Sets/EmptySet.jl
+++ b/src/Sets/EmptySet.jl
@@ -45,6 +45,8 @@ function dim(∅::EmptySet)
     return ∅.dim
 end
 
+Base.length(::EmptySet) = 0
+
 """
     σ(d::AbstractVector, ∅::EmptySet)
 

--- a/src/Sets/Singleton.jl
+++ b/src/Sets/Singleton.jl
@@ -30,6 +30,7 @@ function Singleton(args::Real...)
 end
 
 isoperationtype(::Type{<:Singleton}) = false
+Base.length(::Singleton) = 1
 
 """
     element(S::Singleton)

--- a/test/Sets/EmptySet.jl
+++ b/test/Sets/EmptySet.jl
@@ -8,6 +8,9 @@ for N in [Float64, Rational{Int}, Float32]
     # dim
     @test dim(E) == 2
 
+    # length
+    @test length(E) == 0
+
     # support vector
     @test_throws ErrorException σ(N[0], E)
 

--- a/test/Sets/Singleton.jl
+++ b/test/Sets/Singleton.jl
@@ -6,6 +6,7 @@ for N in [Float64, Rational{Int}, Float32]
     c = N[0, 0]
     r = N[0, 0]
     s = Singleton(c)
+    @test length(s) == 1
     @test center(s) == c
     @test radius_hyperrectangle(s) == r
     @test high(s) == r


### PR DESCRIPTION
We're using LazySets in our new textbook with Mykel Kochenderfer and would like to use `length` on `EmptySet` and `Singleton`. It is already defined for `AbstractArraySet` and the code for the other two types is straightforward. 