### PR TITLE
Faster infinity norm

### DIFF
--- a/src/Interfaces/LazySet.jl
+++ b/src/Interfaces/LazySet.jl
@@ -670,7 +670,8 @@ A real number representing the norm.
 """
 function norm(S::LazySet, p::Real=Inf)
     if p == Inf
-        return norm(box_approximation(S), p)
+        l, h = extrema(S)
+        return max(maximum(abs, l), maximum(abs, h))
     elseif is_polyhedral(S) && isboundedtype(typeof(S))
         return maximum(norm(v, p) for v in vertices_list(S))
     else


### PR DESCRIPTION
The allocations for the box approximation can be avoided.

```julia
julia> Z = rand(Zonotope)
Zonotope{Float64, Vector{Float64}, Matrix{Float64}}([0.10104230899250279, -1.1832339310014397],
 [-0.262802732729493 1.238614056354156 0.055185218674978366; -0.2756791598938217 0.4863133839073846 -0.09633869247786447])

julia> @time norm(Z, Inf)  # master
  0.000027 seconds (8 allocations: 336 bytes)
2.0415651672805106

julia> @time norm(Z, Inf)  # this branch
  0.000017 seconds (3 allocations: 176 bytes)
2.0415651672805106
```