### PR TITLE
#3414 - fix _two_points_1d! & better vertices_list of 1D HPolytope

### DIFF
--- a/src/ConcreteOperations/convex_hull.jl
+++ b/src/ConcreteOperations/convex_hull.jl
@@ -184,9 +184,8 @@ function _two_points_1d!(points)
     if _isapprox(p1[1], p2[1]) # check for redundancy
         pop!(points)
     elseif p1[1] > p2[1]
-        tmp = p1[1]
-        p1[1] = p2[1]
-        p2[1] = tmp
+        points[1] = p2
+        points[2] = p1
     end
     return points
 end

--- a/src/Interfaces/LazySet.jl
+++ b/src/Interfaces/LazySet.jl
@@ -2063,3 +2063,8 @@ function affine_map_inverse(A::AbstractMatrix, P::LazySet, b::AbstractVector)
     end
     return HPolyhedron(constraints)
 end
+
+function vertices_list_1d(X::LazySet)
+    l, h = extrema(X, 1)
+    return _isapprox(l, h) ? [[l]] : [[l], [h]]
+end

--- a/test/ConcreteOperations/convex_hull.jl
+++ b/test/ConcreteOperations/convex_hull.jl
@@ -8,6 +8,8 @@ for N in [Float64, Rational{Int}]
     @test convex_hull([[N(0)]]) == [[N(0)]]
     @test ispermutation(convex_hull([N[2], N[1]]), [N[2], N[1]])
     @test convex_hull([[N(2)], [N(2)]]) == [[N(2)]]
+    @test convex_hull([SVector{1}([N(2)]), SVector{1}([N(1)])]) ==
+          [SVector{1}([N(1)]), SVector{1}([N(2)])]
 
     # corner cases in dimension 2
     @test convex_hull([[N(0), N(0)]]) == [[N(0), N(0)]]

--- a/test/ConcreteOperations/convex_hull.jl
+++ b/test/ConcreteOperations/convex_hull.jl
@@ -163,7 +163,9 @@ for N in [Float64, Rational{Int}]
     # UnionSetArray
     V1 = VPolytope([N[0, 0], N[1, 0], N[0, 1]])
     V2 = VPolytope([N[1, 1], N[1, 0], N[0, 1]])
+    P = VPolygon([N[0, 0], N[1, 0], N[0, 1], N[1, 1]])
     U = UnionSetArray([V1, V2])
-    chull = convex_hull(U)
-    @test isequivalent(chull, VPolygon([N[0, 0], N[1, 0], N[0, 1], N[1, 1]]))
+    @test isequivalent(convex_hull(U), P)
+    U = UnionSetArray([convert(HPolytope, V1), convert(HPolytope, V2)])
+    @test isequivalent(convex_hull(U), P)
 end

--- a/test/Sets/Polytope.jl
+++ b/test/Sets/Polytope.jl
@@ -72,16 +72,25 @@ for N in [Float64, Rational{Int}, Float32]
     # vertices_list of "universal polytope" (strictly speaking: illegal input)
     @test vertices_list(HPolytope{N}()) == Vector{Vector{N}}()
 
-    if test_suite_polyhedra
-        # convert hyperrectangle to a HPolytope
-        H = Hyperrectangle(N[1, 1], N[2, 2])
-        P = convert(HPolytope, H)
-        vlist = vertices_list(P)
-        @test ispermutation(vlist, [N[3, 3], N[3, -1], N[-1, -1], N[-1, 3]])
+    # 1D vertices_list
+    P = convert(HPolytope, Interval(1, 2))
+    @test vertices_list(P) == [N[1], N[2]]
 
-        # isempty
-        @test !isempty(HPolytope{N}())  # note: this object is illegal
+    # 2D vertices_list
+    P = convert(HPolytope, Hyperrectangle(N[1, 1], N[2, 2]))
+    @test vertices_list(P) == [N[3, 3], N[-1, 3], N[-1, -1], N[3, -1]]
+
+    if test_suite_polyhedra
+        # nD (n > 2) vertices_list
+        P = convert(HPolytope, Hyperrectangle(N[1, 1, 1], N[2, 2, 2]))
+        vlist = vertices_list(P)
+        @test ispermutation(vlist,
+                            [N[3, 3, -1], N[3, -1, -1], N[-1, -1, -1], N[-1, 3, -1],
+                             N[3, 3, 3], N[3, -1, 3], N[-1, -1, 3], N[-1, 3, 3]])
     end
+
+    # isempty
+    @test !isempty(HPolytope{N}())  # note: this object is illegal
 
     # translation
     P = HPolytope([HalfSpace(N[1, 0], N(1)),


### PR DESCRIPTION
Closes #3414.

Interestingly, `Polyhedra`'s 1D backend is much better. This suggests to use a smarter algorithm for `low`/`high`/`extrema` of `HPolytope`/`HPolyhedron` in 1D. I still suggest that we merge this branch and add these algorithms in a separate issue.

```julia
julia> P = convert(HPolytope, Interval(1, 2))

julia> @time vertices_list(P)  # new behavior in this branch
  0.000328 seconds (691 allocations: 41.000 KiB)
2-element Vector{Vector{Float64}}:
 [1.0]
 [2.0]

julia> @time vertices_list(P; backend=LazySets.default_polyhedra_backend_1d(Float64))  # old behavior
  0.000092 seconds (51 allocations: 2.094 KiB)
2-element Vector{SVector{1, Float64}}:
 [2.0]
 [1.0]

julia> @time vertices_list(P; backend=LazySets.default_polyhedra_backend_nd(Float64))
glp_simplex: unable to recover undefined or non-optimal solution
  0.001231 seconds (2.28 k allocations: 55.672 KiB)
2-element Vector{Vector{Float64}}:
 [1.0]
 [2.0]
```