### PR TITLE
Use switching logic from expm for SDP solver

### DIFF
--- a/src/Approximations/underapproximate.jl
+++ b/src/Approximations/underapproximate.jl
@@ -117,7 +117,7 @@ end
 
 """
     underapproximate(P::AbstractPolyhedron{N}, ::Type{Ellipsoid};
-                     backend=default_sdp_solver(N),
+                     backend=default_sdp_solver(),
                      interior_point::AbstractVector{N}=chebyshev_center_radius(P)[1]
                     ) where {N<:Real}
 
@@ -127,7 +127,7 @@ Underapproximate a polyhedral set by the maximum-volume ellipsoid.
 
 - `P`         -- polyhedral set
 - `Ellipsoid` -- type for dispatch
-- `backend`   -- (optional, default: `default_sdp_solver(N)`) backend to solve
+- `backend`   -- (optional, default: `default_sdp_solver()`) backend to solve
                  the semi-definite program
 - `interior_point` -- (optional, default: `chebyshev_center_radius(P)[1]`) an
                       interior point of the ellipsoid (needed for the algorithm:
@@ -161,7 +161,7 @@ An algorithm is described
 [here](https://systemanalysisdpt-cmc-msu.github.io/ellipsoids/doc/chap_ellcalc.html#maximum-volume-ellipsoids).
 """
 function underapproximate(P::AbstractPolyhedron{N}, ::Type{Ellipsoid};
-                          backend=default_sdp_solver(N),
+                          backend=default_sdp_solver(),
                           interior_point::AbstractVector{N}=chebyshev_center_radius(P)[1]) where {N}
     require(@__MODULE__, :SetProg; fun_name="underapproximate")
     return _underapproximate_ellipsoid(P, Ellipsoid; backend=backend,
@@ -171,7 +171,7 @@ end
 function load_setprog_underapproximate()
     return quote
         function _underapproximate_ellipsoid(P::AbstractPolyhedron{N}, ::Type{Ellipsoid};
-                                             backend=default_sdp_solver(N),
+                                             backend=default_sdp_solver(),
                                              interior_point::AbstractVector{N}=chebyshev_center_radius(P)[1]) where {N}
             # create SDP model
             model = Model(backend)

--- a/src/Initialization/init_SCS.jl
+++ b/src/Initialization/init_SCS.jl
@@ -1,6 +1,1 @@
-# default semidefinite-programming solver
-function default_sdp_solver(::Type{<:Number})
-    solver = JuMP.optimizer_with_attributes(() -> SCS.Optimizer())
-    JuMP.set_attribute(solver, JuMP.MOI.Silent(), true)
-    return solver
-end
+eval(load_scs())

--- a/src/Utils/sdp_solvers.jl
+++ b/src/Utils/sdp_solvers.jl
@@ -1,4 +1,42 @@
+# currently supported packages
+const SUPPORTED_SDP_PACKAGES = [:SCS]
+
+# =============
+# Global option
+# =============
+
+global sdp_solver = missing  # global state of the SDP solver
+
+function set_sdp_solver!(solver::Module)
+    return global sdp_solver = Val(Symbol(solver))
+end
+
+function get_sdp_solver()
+    ismissing(sdp_solver) && error("no semi-definite-SDP solver is loaded; load one of these " *
+                                   "packages: $SUPPORTED_SDP_PACKAGES")
+    return sdp_solver
+end
+
 # default semidefinite-programming solver
-function default_sdp_solver(N::Type{<:Number})
-    return error("no default SDP solver for numeric type $N")
+function default_sdp_solver()
+    solver = get_sdp_solver()
+    return _default_sdp_solver(solver)
+end
+
+# ===
+# SCS
+# ===
+
+function load_scs()
+    return quote
+        if ismissing(sdp_solver)
+            set_sdp_solver!(SCS)
+        end
+    end
+end  # quote / load_scs
+
+function _default_sdp_solver(::Val{:SCS})
+    solver = JuMP.optimizer_with_attributes(() -> SCS.Optimizer())
+    JuMP.set_attribute(solver, JuMP.MOI.Silent(), true)
+    return solver
 end


### PR DESCRIPTION
The old implementation overwrote a function, which caused printing of a warning (see below).
This PR uses the same approach as for exponential backends (only that currently there is only one solver available).
To simplify things, I removed the numeric argument for `default_sdp_solver`, which was anyway not used.

```julia
WARNING: Method definition default_sdp_solver(Type{var"#s13"} where var"#s13"<:Number) in module LazySets at LazySets/src/Utils/sdp_solvers.jl:2 overwritten at LazySets/src/Initialization/init_SCS.jl:2.
```