### PR TITLE
Fix linear_map of AbstractZonotope for 1D output

### DIFF
--- a/src/Interfaces/AbstractZonotope.jl
+++ b/src/Interfaces/AbstractZonotope.jl
@@ -319,9 +319,7 @@ function _linear_map_zonotope_1D(M::AbstractMatrix, Z::LazySet)
     c = M * center(Z)
     gi = zero(N)
     @inbounds for g in generators(Z)
-        for i in eachindex(g)
-            gi += M[1, i] * g[i]
-        end
+        gi += abs(sum(M[1, i] * g[i] for i in eachindex(g)))
     end
     return Zonotope(c, hcat(gi))
 end

--- a/test/Sets/Zonotope.jl
+++ b/test/Sets/Zonotope.jl
@@ -96,7 +96,7 @@ for N in [Float64, Rational{Int}, Float32]
     @test Z5.center == N[0, 1]
     @test Z5.generators == N[1//2 1//2 1//2 0; -1//2 1//2 0 1//2]
     # 1D simplifies to 1 generator
-    M = N[1 1;]
+    M = N[-1 1;]
     Z6 = linear_map(M, Z3)
     @test ngens(Z6) == 1 && genmat(Z6) == hcat(N[4])
 


### PR DESCRIPTION
The change in #3364 was not correct. Negative generators should be added absolute-wise.