### PR TITLE
Run Aqua in tests and fix problems

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -18,12 +18,17 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StaticArraysCore = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
 
 [compat]
+Distributed = "<0.0.1, 1.6"
 GLPK = "0.11 - 0.15, 1"
 IntervalArithmetic = "0.15 - 0.21, =0.21.2"  # v0.22 removed IntervalBox
 JuMP = "0.21 - 0.23, 1"
+LinearAlgebra = "<0.0.1, 1.6"
+Random = "<0.0.1, 1.6"
 ReachabilityBase = "0.2.1"
 RecipesBase = "0.6 - 0.8, 1"
 Reexport = "0.2, 1"
 Requires = "0.5, 1"
+SharedArrays = "<0.0.1, 1.6"
+SparseArrays = "<0.0.1, 1.6"
 StaticArraysCore = "1"
 julia = "1.6"

--- a/test/Aqua.jl
+++ b/test/Aqua.jl
@@ -1,0 +1,14 @@
+using LazySets, Test
+import Aqua
+
+@testset "Aqua tests" begin
+    Aqua.test_all(LazySets; ambiguities=false,
+                  # the unbound args should be resolved in the future
+                  unbound_args=(broken=true,),
+                  # known piracies
+                  piracies=(treat_as_own=[<=, rand, LazySets.activate_assertions,
+                                          LazySets.deactivate_assertions],))
+
+    # do not warn about ambiguities in dependencies
+    Aqua.test_ambiguities(LazySets)
+end

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 CDDLib = "3391f64e-dcde-5f30-b752-e11513730f60"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
@@ -30,6 +31,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 WriteVTK = "64499a7a-5c06-52f2-abe2-ccb03c286192"
 
 [compat]
+Aqua = "0.8"
 CDDLib = "0.6 - 0.9"
 Distributions = "0.19 - 0.25"
 Documenter = "1"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -339,3 +339,5 @@ if test_suite_doctests
         doctest(LazySets)
     end
 end
+
+include("Aqua.jl")


### PR DESCRIPTION
Aqua reports piracies (`<=`, `rand`) and unbound args (the latter of which I do not understand - maybe that is a bug in Aqua) that we should fix.