### PR TITLE
Remove redundant generators in zonotope overapproximations

### DIFF
--- a/src/Approximations/overapproximate_zonotope.jl
+++ b/src/Approximations/overapproximate_zonotope.jl
@@ -382,7 +382,7 @@ function load_taylormodels_overapproximation()
 
         """
             overapproximate(vTM::Vector{TaylorModel1{T, S}}, ::Type{<:Zonotope};
-                            [remove_zero_generators]::Bool=true
+                            [remove_redundant_generators]::Bool=true
                             [normalize]::Bool=true) where {T, S}
 
         Overapproximate a Taylor model in one variable with a zonotope.
@@ -391,8 +391,8 @@ function load_taylormodels_overapproximation()
 
         - `vTM`       -- vector of `TaylorModel1`
         - `Zonotope`  --  target set type
-        - `remove_zero_generators` -- (optional; default: `true`) flag to remove zero
-                                      generators of the resulting zonotope
+        - `remove_redundant_generators` -- (optional; default: `true`) flag to remove
+                                           redundant generators of the resulting zonotope
         - `normalize` -- (optional; default: `true`) flag to skip the normalization of
                          the Taylor models
 
@@ -529,16 +529,16 @@ function load_taylormodels_overapproximation()
            normalization onto the symmetric intervals ``[-1, 1]``.
         """
         function overapproximate(vTM::Vector{TaylorModel1{T,S}}, ::Type{<:Zonotope};
-                                 remove_zero_generators::Bool=true,
+                                 remove_redundant_generators::Bool=true,
                                  normalize::Bool=true) where {T,S}
             return _overapproximate_vTM_zonotope(vTM, 1, T;
-                                                 remove_zero_generators=remove_zero_generators,
+                                                 remove_redundant_generators=remove_redundant_generators,
                                                  normalize=normalize)
         end
 
         """
             overapproximate(vTM::Vector{TaylorModelN{N, T, S}}, ::Type{<:Zonotope};
-                            [remove_zero_generators]::Bool=true
+                            [remove_redundant_generators]::Bool=true
                             [normalize]::Bool=true) where {N, T, S}
 
 
@@ -548,8 +548,8 @@ function load_taylormodels_overapproximation()
 
         - `vTM`       -- vector of `TaylorModelN`
         - `Zonotope`  -- target set type
-        - `remove_zero_generators` -- (optional; default: `true`) flag to remove zero
-                                      generators of the resulting zonotope
+        - `remove_redundant_generators` -- (optional; default: `true`) flag to remove
+                                           redundant generators of the resulting zonotope
         - `normalize` -- (optional; default: `true`) flag to skip the normalization of
                          the Taylor models
 
@@ -616,16 +616,16 @@ function load_taylormodels_overapproximation()
         We refer to the algorithm description for the univariate case.
         """
         function overapproximate(vTM::Vector{TaylorModelN{N,T,S}}, ::Type{<:Zonotope};
-                                 remove_zero_generators::Bool=true,
+                                 remove_redundant_generators::Bool=true,
                                  normalize::Bool=true) where {N,T,S}
             n = N  # number of variables is get_numvars() in TaylorSeries
             return _overapproximate_vTM_zonotope(vTM, n, T;
-                                                 remove_zero_generators=remove_zero_generators,
+                                                 remove_redundant_generators=remove_redundant_generators,
                                                  normalize=normalize)
         end
 
         function _overapproximate_vTM_zonotope(vTM, n, N;
-                                               remove_zero_generators::Bool=true,
+                                               remove_redundant_generators::Bool=true,
                                                normalize::Bool=true)
             m = length(vTM)
 
@@ -658,8 +658,8 @@ function load_taylormodels_overapproximation()
             end
 
             Z = Zonotope(c, G)
-            if remove_zero_generators
-                Z = LazySets.remove_zero_generators(Z)
+            if remove_redundant_generators
+                Z = LazySets.remove_redundant_generators(Z)
             end
             return Z
         end

--- a/src/Approximations/overapproximate_zonotope.jl
+++ b/src/Approximations/overapproximate_zonotope.jl
@@ -606,9 +606,9 @@ function load_taylormodels_overapproximation()
          124.0
 
         julia> Matrix(genmat(Z))
-        2×4 Matrix{Float64}:
-         0.0  -1.0  5.0    0.0
-         1.5   0.0  0.0  123.0
+        2×2 Matrix{Float64}:
+           0.0  -6.0
+         124.5   0.0
         ```
 
         ### Algorithm

--- a/src/Approximations/overapproximate_zonotope.jl
+++ b/src/Approximations/overapproximate_zonotope.jl
@@ -303,7 +303,9 @@ A zonotope.
 """
 function overapproximate(P::SparsePolynomialZonotope, ::Type{<:Zonotope})
     cnew, Gnew = _zonotope_overapprox(center(P), genmat_dep(P), expmat(P))
-    return Zonotope(cnew, hcat(Gnew, genmat_indep(P)))
+    Z = Zonotope(cnew, hcat(Gnew, genmat_indep(P)))
+    Zred = remove_redundant_generators(Z)
+    return Zred
 end
 
 """

--- a/test/Sets/SparsePolynomialZonotope.jl
+++ b/test/Sets/SparsePolynomialZonotope.jl
@@ -87,9 +87,7 @@ for N in [Float64, Float32, Rational{Int}]
     S = SparsePolynomialZonotope(N[-0.5, -0.5], N[1.0 1 1 1; 1 0 -1 1], zeros(N, 2, 0),
                                  [1 0 1 2; 0 1 1 0])
     Z = overapproximate(S, Zonotope)
-
-    @test center(Z) == N[0, 0]
-    @test genmat(Z) == N[1 1 1 0.5; 1 0 -1 0.5]
+    @test isequivalent(Z, Zonotope(N[0, 0], N[1.5 1 1; 1.5 0 -1]))
 
     PZ = SparsePolynomialZonotope(N[-1, 2], N[1 2 0 2; 0 1 2 -1], N[1 0; 2 0], [1 0 1 2; 0 0 0 1])
     PZreduced = remove_redundant_generators(PZ)


### PR DESCRIPTION
This is a breaking change because it renames a keyword argument.