### PR TITLE
Remove old (now duplicate) ambiguity tests

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -298,16 +298,6 @@ if test_suite_basic
         include("Utils/lp_solvers.jl")
     end
 
-    # ========================
-    # Testing method ambiguity
-    # ========================
-    @time @testset "LazySets.method_ambiguities" begin
-        for package in [LazySets, Approximations, LazySets.Parallel]
-            ambiguities = detect_ambiguities(package)
-            @test isempty(ambiguities)
-        end
-    end
-
     # =====================================================
     # Testing common API of all interfaces
     # (must be the last test because it loads Polyhedra.jl)


### PR DESCRIPTION
We now check for ambiguities with Aqua.