### PR TITLE
Generalize reduce_order with StaticArrays matrix

### DIFF
--- a/src/Sets/Zonotope.jl
+++ b/src/Sets/Zonotope.jl
@@ -600,7 +600,7 @@ end
 function load_reduce_order_static_zonotope()
     return quote
         # conversion for static matrix
-        function reduce_order(Z::Zonotope{N,SVector,MMatrix}, r::Real,
+        function reduce_order(Z::Zonotope{N,<:AbstractVector,<:MMatrix}, r::Real,
                               method::AbstractReductionMethod=GIR05()) where {N}
             return reduce_order(Zonotope(center(Z), SMatrix(genmat(Z))), r, method)
         end


### PR DESCRIPTION
This is a follow-up to #3467, which just copy-pasted from ReachabilityAnalysis.
1. The vector type should not be restricted because it is just copied.
2. The method was actually never used because `MMatrix` is not a concrete type and the `<:` was missing.