### PR TITLE
Do not use GLPK's presolve in default Polyhedra backend

### DIFF
--- a/src/ConcreteOperations/convex_hull.jl
+++ b/src/ConcreteOperations/convex_hull.jl
@@ -536,8 +536,9 @@ representation.
 
 - `P1`      -- polyhedron
 - `P2`      -- polyhedron
-- `backend` -- (optional, default: `default_polyhedra_backend(P1)`) the
-               backend for polyhedral computations
+- `backend` -- (optional, default:
+    `default_polyhedra_backend(P1, default_lp_solver_polyhedra(N; presolve=true))`)
+               the backend for polyhedral computations
 
 ### Output
 
@@ -552,8 +553,9 @@ for the `convex_hull`.
 For further information on the supported backends see
 [Polyhedra's documentation](https://juliapolyhedra.github.io/).
 """
-function convex_hull(P1::HPoly, P2::HPoly;
-                     backend=default_polyhedra_backend(P1))
+function convex_hull(P1::HPoly{N}, P2::HPoly{N};
+                     backend=default_polyhedra_backend(P1,
+                                 default_lp_solver_polyhedra(N; presolve=true))) where {N}
     require(@__MODULE__, :Polyhedra; fun_name="convex_hull")
     Pch = Polyhedra.convexhull(polyhedron(P1; backend=backend),
                                polyhedron(P2; backend=backend))

--- a/src/Initialization/init_Polyhedra.jl
+++ b/src/Initialization/init_Polyhedra.jl
@@ -12,8 +12,8 @@ function default_polyhedra_backend_nd(N::Type{<:Number},
     return Polyhedra.DefaultLibrary{N}(solver)
 end
 
-function default_lp_solver_polyhedra(N::Type{<:AbstractFloat};
-                                     presolve::Bool=true)
+function default_lp_solver_polyhedra(::Type{<:AbstractFloat};
+                                     presolve::Bool=false)
     if presolve
         return JuMP.optimizer_with_attributes(GLPK.Optimizer,
                                               "presolve" => GLPK_ON)
@@ -22,7 +22,7 @@ function default_lp_solver_polyhedra(N::Type{<:AbstractFloat};
     end
 end
 
-function default_lp_solver_polyhedra(N::Type{<:Rational};
+function default_lp_solver_polyhedra(::Type{<:Rational};
                                      presolve::Bool=false)
     if presolve
         return JuMP.optimizer_with_attributes(() -> GLPK.Optimizer(; method=GLPK.EXACT),
@@ -33,7 +33,7 @@ function default_lp_solver_polyhedra(N::Type{<:Rational};
 end
 
 # solver interface
-function _is_polyhedra_backend(backend::Polyhedra.Library)
+function _is_polyhedra_backend(::Polyhedra.Library)
     return true
 end
 

--- a/src/Interfaces/AbstractPolyhedron_functions.jl
+++ b/src/Interfaces/AbstractPolyhedron_functions.jl
@@ -807,7 +807,7 @@ function _linear_map_hrep(M::AbstractMatrix{NM}, P::AbstractPolyhedron{NP},
     Phrep = polyhedron(Phrep, backend) # define concrete subtype
     Peli_block = Polyhedra.eliminate(Phrep, (m + 1):(m + n), method)
     Peli_block = Polyhedra.removeduplicates(Polyhedra.hrep(Peli_block),
-                                            default_lp_solver_polyhedra(N))
+                                            default_lp_solver_polyhedra(N; presolve=true))
 
     # TODO: take constraints directly -- see #1988
     return constraints_list(HPolyhedron(Peli_block))

--- a/src/Interfaces/LazySet.jl
+++ b/src/Interfaces/LazySet.jl
@@ -236,12 +236,12 @@ true
 isconvextype(X::Type{<:LazySet}) = false
 
 # Polyhedra backend (fallback method)
-function default_polyhedra_backend(P::LazySet{N}) where {N}
+function default_polyhedra_backend(P::LazySet{N}, solver=default_lp_solver_polyhedra(N)) where {N}
     require(@__MODULE__, :Polyhedra; fun_name="default_polyhedra_backend")
     if LazySets.dim(P) == 1
-        return default_polyhedra_backend_1d(N)
+        return default_polyhedra_backend_1d(N, solver)
     else
-        return default_polyhedra_backend_nd(N)
+        return default_polyhedra_backend_nd(N, solver)
     end
 end
 

--- a/test/Sets/Polytope.jl
+++ b/test/Sets/Polytope.jl
@@ -386,7 +386,9 @@ for N in [Float64]
         b = N[2, 2, -2]
         p2 = HPolytope(A, b)
         @test intersection(p1, p2) isa EmptySet{N}
-        @test intersection(p1, p2; backend=LazySets.default_polyhedra_backend(p1)) isa EmptySet{N}
+        solver = LazySets.default_lp_solver_polyhedra(N; presolve=true)
+        backend = LazySets.default_polyhedra_backend(p1, solver)
+        @test intersection(p1, p2; backend=backend) isa EmptySet{N}
         @test intersection(p1, p2; backend=CDDLib.Library()) isa EmptySet{N}
 
         # intersection with half-space


### PR DESCRIPTION
EDIT: I am not convinced about this PR aynmore. It actually does not resolve the OP in #3039 and also not #3456, which was my motivation (I should have checked before opening). Hence I close this PR again. I keep the branch in case this is interesting in the future.

---

#### Original text

This addresses the long-standing #3039 by changing the default solver to `GLPK` without presolve.

And we actually already removed it in #3333 from one method due to annoying outputs.

We added the presolve option in #2195 because sometimes the solver crashes if the presolve option is not used. I went through the tests and added the option manually in these cases.