### PR TITLE
Rename variables to avoid typos warnings

### DIFF
--- a/docs/src/man/iterative_refinement.md
+++ b/docs/src/man/iterative_refinement.md
@@ -104,13 +104,13 @@ plot(b, 1e-3, aspectratio=1, alpha=0.3)
 
 # initialize box directions
 DIR_EAST, DIR_NORTH, DIR_WEST, DIR_SOUTH = [1., 0.], [0., 1.], [-1., 0.], [0., -1.]
-pe, pn, pw, ps = σ(DIR_EAST, b), σ(DIR_NORTH, b), σ(DIR_WEST, b), σ(DIR_SOUTH, b)
+pE, pN, pW, pS = σ(DIR_EAST, b), σ(DIR_NORTH, b), σ(DIR_WEST, b), σ(DIR_SOUTH, b)
 
 Ω = PolygonalOverapproximation(b)
-addapproximation!(Ω, ps, DIR_SOUTH, pe, DIR_EAST)
-addapproximation!(Ω, pw, DIR_WEST, ps, DIR_SOUTH)
-addapproximation!(Ω, pn, DIR_NORTH, pw, DIR_WEST)
-addapproximation!(Ω, pe, DIR_EAST, pn, DIR_NORTH)
+addapproximation!(Ω, pS, DIR_SOUTH, pE, DIR_EAST)
+addapproximation!(Ω, pW, DIR_WEST, pS, DIR_SOUTH)
+addapproximation!(Ω, pN, DIR_NORTH, pW, DIR_WEST)
+addapproximation!(Ω, pE, DIR_EAST, pN, DIR_NORTH)
 
 plot!(tohrep(Ω), alpha=0.2, color="orange")
 ```

--- a/src/Approximations/iterative_refinement.jl
+++ b/src/Approximations/iterative_refinement.jl
@@ -207,22 +207,22 @@ function overapproximate_hausdorff(X::S, ε::Real) where {N<:AbstractFloat,S<:La
     end
 
     # initialize box directions
-    pe = σ(DIR_EAST(N), X)
-    pn = σ(DIR_NORTH(N), X)
-    pw = σ(DIR_WEST(N), X)
-    ps = σ(DIR_SOUTH(N), X)
-    east = dir_east(N, pe)
-    north = dir_north(N, pe)
-    west = dir_west(N, pe)
-    south = dir_south(N, pe)
+    pE = σ(DIR_EAST(N), X)
+    pN = σ(DIR_NORTH(N), X)
+    pW = σ(DIR_WEST(N), X)
+    pS = σ(DIR_SOUTH(N), X)
+    east = dir_east(N, pE)
+    north = dir_north(N, pE)
+    west = dir_west(N, pE)
+    south = dir_south(N, pE)
 
     Ω = PolygonalOverapproximation(X)
 
     # add constraints in reverse (i.e., clockwise) order to the stack
-    addapproximation!(Ω, ps, south, pe, east)
-    addapproximation!(Ω, pw, west, ps, south)
-    addapproximation!(Ω, pn, north, pw, west)
-    addapproximation!(Ω, pe, east, pn, north)
+    addapproximation!(Ω, pS, south, pE, east)
+    addapproximation!(Ω, pW, west, pS, south)
+    addapproximation!(Ω, pN, north, pW, west)
+    addapproximation!(Ω, pE, east, pN, north)
 
     approx_stack = Ω.approx_stack
     while !isempty(approx_stack)

--- a/src/Approximations/template_directions.jl
+++ b/src/Approximations/template_directions.jl
@@ -197,10 +197,10 @@ julia> collect(dirs)
 The numeric type can be specified as well:
 
 ```jldoctest
-julia> BoxDirections{Rational{Int}}(10)
+julia> dirs = BoxDirections{Rational{Int}}(10)
 BoxDirections{Rational{Int64}, ReachabilityBase.Arrays.SingleEntryVector{Rational{Int64}}}(10)
 
-julia> length(ans)
+julia> length(dirs)
 20
 ```
 """
@@ -312,10 +312,10 @@ julia> Vector.(collect(dirs))
 The numeric type can be specified as well:
 
 ```jldoctest
-julia> OctDirections{Rational{Int}}(10)
+julia> dirs = OctDirections{Rational{Int}}(10)
 OctDirections{Rational{Int64}, SparseArrays.SparseVector{Rational{Int64}, Int64}}(10)
 
-julia> length(ans)
+julia> length(dirs)
 200
 ```
 """
@@ -452,10 +452,10 @@ julia> collect(dirs)
 The numeric type can be specified as well:
 
 ```jldoctest
-julia> DiagDirections{Rational{Int}}(10)
+julia> dirs = DiagDirections{Rational{Int}}(10)
 DiagDirections{Rational{Int64}, Vector{Rational{Int64}}}(10)
 
-julia> length(ans)
+julia> length(dirs)
 1024
 ```
 """
@@ -551,10 +551,10 @@ julia> collect(dirs)
 The numeric type can be specified as well:
 
 ```jldoctest
-julia> BoxDiagDirections{Rational{Int}}(10)
+julia> dirs = BoxDiagDirections{Rational{Int}}(10)
 BoxDiagDirections{Rational{Int64}, Vector{Rational{Int64}}}(10)
 
-julia> length(ans)
+julia> length(dirs)
 1044
 ```
 """

--- a/src/convert.jl
+++ b/src/convert.jl
@@ -541,9 +541,9 @@ function convert(::Type{CartesianProduct{N,Interval{N},Interval{N}}},
                         "convert it to the Cartesian product of two intervals, but it is " *
                         "$(dim(H))-dimensional; consider converting it to a " *
                         "`CartesianProductArray{$N, Interval{$N}}` instead"
-    Ix = Interval(low(H, 1), high(H, 1))
-    Iy = Interval(low(H, 2), high(H, 2))
-    return CartesianProduct(Ix, Iy)
+    I1 = Interval(low(H, 1), high(H, 1))
+    I2 = Interval(low(H, 2), high(H, 2))
+    return CartesianProduct(I1, I2)
 end
 
 """

--- a/test/Approximations/hausdorff_distance.jl
+++ b/test/Approximations/hausdorff_distance.jl
@@ -6,11 +6,11 @@ for N in [Float64, Float32, Rational{Int}]
     b1 = BallInf(zeros(N, 2), N(1))
     b2 = BallInf(ones(N, 2), N(1))
 
-    hd = hausdorff_distance(b1, b2; p=N(Inf), ε=ε)
-    @test _in_interval(hd, N(1), ε)
+    dist = hausdorff_distance(b1, b2; p=N(Inf), ε=ε)
+    @test _in_interval(dist, N(1), ε)
 
-    hd = hausdorff_distance(b1, b1; p=N(Inf), ε=ε)
-    @test _in_interval(hd, N(0), ε)
+    dist = hausdorff_distance(b1, b1; p=N(Inf), ε=ε)
+    @test _in_interval(dist, N(0), ε)
 end
 
 if test_suite_polyhedra
@@ -20,7 +20,7 @@ if test_suite_polyhedra
         b1 = N[1 0; 0 1] * BallInf(zeros(N, 2), N(1))
         b2 = BallInf(ones(N, 2), N(1))
 
-        hd = hausdorff_distance(b1, b2; p=N(Inf), ε=ε)
-        @test _in_interval(hd, N(1), ε)
+        dist = hausdorff_distance(b1, b2; p=N(Inf), ε=ε)
+        @test _in_interval(dist, N(1), ε)
     end
 end

--- a/test/Utils/plot.jl
+++ b/test/Utils/plot.jl
@@ -44,9 +44,9 @@ for N in [Float64, Float32, Rational{Int}]
 
     # unary set operations
     spI = SparseMatrixCSC{N}(2I, 2, 2)
-    sme = SparseMatrixExp(spI)
-    em = ExponentialMap(sme, b2)
-    psme = ProjectionSparseMatrixExp(spI, sme, spI)
+    smIe = SparseMatrixExp(spI)
+    em = ExponentialMap(smIe, b2)
+    psme = ProjectionSparseMatrixExp(spI, smIe, spI)
     epm = ExponentialProjectionMap(psme, b2)
 
     # binary set operations


### PR DESCRIPTION
These warnings are reported in the latest `typos` version.