### PR TITLE
Add missing `convert` methods for `HPolytope`/`HPolyhedron`

### DIFF
--- a/src/convert.jl
+++ b/src/convert.jl
@@ -74,6 +74,8 @@ function convert(::Type{HPolytope}, X::LazySet)
     return HPolytope(constraints_list(X))
 end
 
+convert(::Type{HPolytope{N,VT}}, P::HPolytope{N,VT}) where {N,VT} = P
+
 function convert(::Type{HPolytope{N,VT}}, X::LazySet) where {N,VT}
     if !isboundedtype(typeof(X)) || !is_polyhedral(X)
         error("conversion to `HPolytope` requires a polytopic set")
@@ -105,6 +107,8 @@ function convert(::Type{HPolyhedron}, X::LazySet)
     end
     return HPolyhedron(constraints_list(X))
 end
+
+convert(::Type{HPolyhedron{N,VT}}, P::HPolyhedron{N,VT}) where {N,VT} = P
 
 function convert(::Type{HPolyhedron{N,VT}}, X::LazySet) where {N,VT}
     if !is_polyhedral(X)

--- a/test/Sets/Polyhedron.jl
+++ b/test/Sets/Polyhedron.jl
@@ -141,6 +141,11 @@ for N in [Float64, Rational{Int}, Float32]
             @test isempty(P; use_polyhedra_interface=true, backend=CDDLib.Library(:exact)) == true
         end
     end
+
+    # convert
+    P = HPolyhedron([HalfSpace(SingleEntryVector(1, 2, N(1)), N(0))])
+    Q = convert(typeof(P), P)
+    @test P == Q
 end
 
 # default Float64 constructors

--- a/test/Sets/Polytope.jl
+++ b/test/Sets/Polytope.jl
@@ -175,6 +175,12 @@ for N in [Float64, Rational{Int}, Float32]
     Y = affine_map_inverse(M, P, zeros(N, 2))
     @test X == Y
 
+    # convert
+    P = HPolytope([HalfSpace(SingleEntryVector(1, 1, N(1)), N(1)),
+                   HalfSpace(SingleEntryVector(1, 1, N(-1)), N(0))])
+    Q = convert(typeof(P), P)
+    @test P == Q
+
     # -----
     # V-rep
     # -----


### PR DESCRIPTION
The change in #3466 introduced a problem when there is no identity constructor for the constraints' vectors. This is for instance the case for `SingleEntryVector`. I am not sure we want this constructor, but this case should be caught earlier anyway with the new methods added here.