### PR TITLE
Let binary `convex_hull` with `EmptySet` fall back to the unary method

### DIFF
--- a/src/ConcreteOperations/convex_hull.jl
+++ b/src/ConcreteOperations/convex_hull.jl
@@ -562,9 +562,7 @@ function convex_hull(P1::HPoly, P2::HPoly;
 end
 
 @commutative function convex_hull(X::LazySet, ::EmptySet)
-    @assert isconvextype(typeof(X)) "this implementation requires a convex " *
-                                    "set as input"
-    return X
+    return convex_hull(X)
 end
 
 convex_hull(∅::EmptySet, ::EmptySet) = ∅

--- a/src/Sets/Polygon.jl
+++ b/src/Sets/Polygon.jl
@@ -72,3 +72,11 @@ end
 function ρ(d::AbstractVector, P::Polygon)
     return _ρ_vertices(d, P.vertices)
 end
+
+function isempty(P::Polygon)
+    return isempty(P.vertices)
+end
+
+function convex_hull(P::Polygon)
+    return VPolygon(P.vertices)
+end

--- a/test/ConcreteOperations/convex_hull.jl
+++ b/test/ConcreteOperations/convex_hull.jl
@@ -17,8 +17,8 @@ for N in [Float64, Rational{Int}]
     @test convex_hull([[N(1), N(0)], [N(1), N(0)]]) == [[N(1), N(0)]]
 
     # test corner cases with one and two vectors (see #876)
-    p1 = [1.0, 2.0]
-    p2 = [1.0, 3.0]
+    p1 = N[1, 2]
+    p2 = N[1, 3]
     @test convex_hull([p1]) == [p1]
     @test ispermutation(convex_hull([p1, p2]), [p1, p2])
 
@@ -168,4 +168,21 @@ for N in [Float64, Rational{Int}]
     @test isequivalent(convex_hull(U), P)
     U = UnionSetArray([convert(HPolytope, V1), convert(HPolytope, V2)])
     @test isequivalent(convex_hull(U), P)
+
+    # ==========================
+    # Unary concrete convex hull
+    # ==========================
+
+    # convex set
+    S = Singleton(N[1])
+    @test convex_hull(S) == S
+
+    # non-convex set
+    P = Polygon([N[0, 0], N[0, 2], N[2, 2], N[2, 0], N[1, 1]])
+    Pc = VPolygon([N[0, 0], N[2, 0], N[2, 2], N[0, 2]])
+    @test convex_hull(P) == Pc
+
+    # binary convex hull with an empty set is identical to unary
+    @test convex_hull(S, EmptySet{N}(1)) == convex_hull(EmptySet{N}(1), S) == S
+    @test convex_hull(P, EmptySet{N}(1)) == convex_hull(EmptySet{N}(1), P) == Pc
 end

--- a/test/Sets/PolygonNC.jl
+++ b/test/Sets/PolygonNC.jl
@@ -11,6 +11,13 @@ for N in [Float64, Rational{Int}, Float32]
     d = N[1, 1]
     @test σ(d, P) == N[2, 2]
     @test ρ(d, P) == N(4)
+
+    # isempty
+    @test !isempty(P)
+    @test isempty(Polygon())
+
+    # convex hull
+    @test convex_hull(P) == VPolygon([N[0, 0], N[2, 0], N[2, 2], N[0, 2]])
 end
 
 # default Float64 constructor


### PR DESCRIPTION
The first commit is from #3499 because the `convex_hull` method is needed for the test.