### PR TITLE
Outsource `basetype` to ReachabilityBase

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -24,7 +24,7 @@ IntervalArithmetic = "0.15 - 0.21, =0.21.2"  # v0.22 removed IntervalBox
 JuMP = "0.21 - 0.23, 1"
 LinearAlgebra = "<0.0.1, 1.6"
 Random = "<0.0.1, 1.6"
-ReachabilityBase = "0.2.1"
+ReachabilityBase = "0.2.5"
 RecipesBase = "0.6 - 0.8, 1"
 Reexport = "0.2, 1"
 Requires = "0.5, 1"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -88,13 +88,19 @@ instantaneous.
 julia> Y = CH(SparseMatrixExp(A * δ) * X0 + δ * B * U, X0);
 ```
 
-By asking for the concrete type of `Y`, we see that it has a convex hull type,
-parameterized by the types of its arguments, corresponding to the mathematical
-formulation:
+By asking for the (parameter-free) type of `Y`, we see that it is a lazy convex
+hull:
 
 ```jldoctest index_label
-julia> basetype(Y)
+julia> LazySets.basetype(Y)
 ConvexHull
+```
+
+The full type includes type parameters for the types of the arguments:
+
+```jldoctest index_label
+julia> typeof(Y)
+ConvexHull{Float64, MinkowskiSum{Float64, ExponentialMap{Float64, Ball2{Float64, Vector{Float64}}}, LinearMap{Float64, BallInf{Float64, Vector{Float64}}, Float64, Matrix{Float64}}}, Ball2{Float64, Vector{Float64}}}
 ```
 
 Now suppose that we are interested in observing the projection of ``\mathcal{Y}``

--- a/docs/src/lib/interfaces/LazySet.md
+++ b/docs/src/lib/interfaces/LazySet.md
@@ -49,7 +49,6 @@ extrema(::LazySet, ::Int)
 extrema(::LazySet)
 convex_hull(::LazySet; kwargs...)
 triangulate(::LazySet)
-basetype
 isboundedtype(::Type{<:LazySet})
 isbounded(::LazySet)
 _isbounded_unit_dimensions(::LazySet)

--- a/src/Interfaces/LazySet.jl
+++ b/src/Interfaces/LazySet.jl
@@ -1,5 +1,4 @@
 export LazySet,
-       basetype,
        neutral,
        absorbing,
        tosimplehrep,
@@ -325,51 +324,6 @@ eltype(::Type{<:LazySet{N}}) where {N} = N
 The default implementation assumes that the first type parameter is `N`.
 """
 eltype(::LazySet{N}) where {N} = N
-
-"""
-    basetype(T::Type{<:LazySet})
-
-Return the base type of the given set type (i.e., without type parameters).
-
-### Input
-
-- `T` -- set type
-
-### Output
-
-The base type of `T`.
-"""
-basetype(T::Type{<:LazySet}) = Base.typename(T).wrapper
-
-"""
-    basetype(X::LazySet)
-
-Return the base type of the given set (i.e., without type parameters).
-
-### Input
-
-- `X` -- set
-
-### Output
-
-The base type of `X`.
-
-### Examples
-
-```jldoctest
-julia> Z = rand(Zonotope);
-
-julia> basetype(Z)
-Zonotope
-
-julia> basetype(Z + Z)
-MinkowskiSum
-
-julia> basetype(LinearMap(rand(2, 2), Z + Z))
-LinearMap
-```
-"""
-basetype(X::LazySet) = basetype(typeof(X))
 
 """
 ### Algorithm

--- a/src/LazySets.jl
+++ b/src/LazySets.jl
@@ -50,6 +50,7 @@ using ReachabilityBase.Commutative
 using ReachabilityBase.Distribution
 using ReachabilityBase.Subtypes
 using ReachabilityBase.Arrays
+using ReachabilityBase.Basetype
 
 # =================
 # External packages

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -29,9 +29,8 @@ using Symbolics
 # ==============================
 # Non-exported helper functions
 # ==============================
-using LazySets: _leq, _geq, isapproxzero, _isapprox, _ztol, ispermutation
-using LazySets.Arrays: isinvertible, inner, allequal,
-                       is_cyclic_permutation, SingleEntryVector
+using LazySets: _leq, _geq, isapproxzero, _isapprox, _ztol, ispermutation, basetype
+using LazySets.Arrays: isinvertible, inner, allequal, is_cyclic_permutation, SingleEntryVector
 
 global test_suite_basic = true
 global test_suite_polyhedra = true


### PR DESCRIPTION
I decided to not re-export the function because it has nothing to do with this library. A user can always get it via `LazySets.basetype`.

The build error in the documentation is because it takes a while to update to new releases.