### PR TITLE
Let `remove_redundant_generators` remove almost-zero columns

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -24,7 +24,7 @@ IntervalArithmetic = "0.15 - 0.21, =0.21.2"  # v0.22 removed IntervalBox
 JuMP = "0.21 - 0.23, 1"
 LinearAlgebra = "<0.0.1, 1.6"
 Random = "<0.0.1, 1.6"
-ReachabilityBase = "0.2.1"
+ReachabilityBase = "0.2.5"
 RecipesBase = "0.6 - 0.8, 1"
 Reexport = "0.2, 1"
 Requires = "0.5, 1"

--- a/src/Sets/SimpleSparsePolynomialZonotope.jl
+++ b/src/Sets/SimpleSparsePolynomialZonotope.jl
@@ -377,7 +377,7 @@ function _remove_redundant_generators_polyzono(c, G, E)
 
     visited_exps = Dict{Vector{Int},Int}()
     @inbounds for (gi, ei) in zip(eachcol(G), eachcol(E))
-        iszero(gi) && continue
+        all(isapproxzero, gi) && continue
         if iszero(ei)
             cnew += gi
         elseif haskey(visited_exps, ei) # repeated exponent

--- a/test/Sets/SparsePolynomialZonotope.jl
+++ b/test/Sets/SparsePolynomialZonotope.jl
@@ -89,13 +89,22 @@ for N in [Float64, Float32, Rational{Int}]
     Z = overapproximate(S, Zonotope)
     @test isequivalent(Z, Zonotope(N[0, 0], N[1.5 1 1; 1.5 0 -1]))
 
+    # remove_redundant_generators
     PZ = SparsePolynomialZonotope(N[-1, 2], N[1 2 0 2; 0 1 2 -1], N[1 0; 2 0], [1 0 1 2; 0 0 0 1])
     PZreduced = remove_redundant_generators(PZ)
-
     @test center(PZreduced) == N[1, 3]
     @test genmat_dep(PZreduced) == N[1 2; 2 -1]
     @test genmat_indep(PZreduced) == hcat(N[1, 2])
     @test expmat(PZreduced) == [1 2; 0 1]
+    # also removes almost-zero columns
+    if N <: AbstractFloat
+        PZ = SparsePolynomialZonotope(N[-1, 2], N[1e-16; -1e-16;;], N[1e-16; -1e-16;;], [1; 1;;])
+        PZreduced = remove_redundant_generators(PZ)
+        @test center(PZreduced) == N[-1, 2]
+        @test size(genmat_dep(PZreduced)) == (2, 0)
+        @test size(genmat_indep(PZreduced)) == (2, 0)
+        @test size(expmat(PZreduced)) == (2, 0)
+    end
 
     # support function (enclosure)
     for (d, v) in [(N[1, 0], N(3)), (N[1, 1], N(7)), (N[1, -1], N(3))]


### PR DESCRIPTION
The build error in the documentation is because it takes a while to update to new releases.