### PR TITLE
Allow passing `nothing` argument to tests

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -36,7 +36,7 @@ global test_suite_basic = true
 global test_suite_polyhedra = true
 global test_suite_plotting = true
 
-if (length(ARGS) == 0) || (ARGS[1] == "--default")
+if (length(ARGS) == 0) || (ARGS[1] == "--default") || isnothing(ARGS[1])
     # default test suite
 elseif ARGS[1] == "--basic"
     # basic test suite


### PR DESCRIPTION
This is needed to run `LocalCoverage`.