### PR TITLE
Move API in docs

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -33,8 +33,8 @@ makedocs(; sitename="LazySets.jl",
                                 "Lazy Intersections" => "man/lazy_intersections.md"
                                 #
                                 ],
-                "API" => "lib/API.md",
-                "Library" => Any["Set Interfaces" => [
+                "Library" => Any["API" => "lib/API.md",
+                                 "Set Interfaces" => [
                                                       #
                                                       "lib/interfaces/overview.md",
                                                       "lib/interfaces/LazySet.md",


### PR DESCRIPTION
Some of the builds are marked in yellow because there was a GitHub outage. But a second run has finished if you click on them.