### PR TITLE
Remove symbol aliases of concrete operations

### DIFF
--- a/docs/src/lib/API.md
+++ b/docs/src/lib/API.md
@@ -86,7 +86,6 @@ cartesian_product(::LazySet, ::LazySet)
 difference(::LazySet, ::LazySet)
 distance(::LazySet, ::LazySet)
 exact_sum(::LazySet, ::LazySet)
-⊞
 intersection(::LazySet, ::LazySet)
 ≈(::LazySet, ::LazySet)
 isdisjoint(::LazySet, ::LazySet)

--- a/docs/src/lib/concrete_binary_operations/difference.md
+++ b/docs/src/lib/concrete_binary_operations/difference.md
@@ -10,6 +10,5 @@ CurrentModule = LazySets
 # Set difference
 
 ```@docs
-\(::LazySet, ::LazySet)
 difference(::AbstractHyperrectangle, ::AbstractHyperrectangle)
 ```

--- a/src/API/API.jl
+++ b/src/API/API.jl
@@ -26,7 +26,7 @@ export
       project, scale!, scale, support_function, ρ, support_vector, σ,
       translate!, translate,
 # binary set operations
-      cartesian_product, difference, distance, exact_sum, ⊞, intersection,
+      cartesian_product, difference, distance, exact_sum, intersection,
       is_intersection_empty, isequivalent, ⊂, linear_combination,
       minkowski_difference, pontryagin_difference, minkowski_sum
 

--- a/src/API/Binary/exact_sum.jl
+++ b/src/API/Binary/exact_sum.jl
@@ -10,22 +10,6 @@ Compute the exact sum of two parametric sets.
 
 ### Output
 
-A set representing the exact sum ``X ⊞ Y``.
-
-### Notes
-
-The convenience alias `⊞` is also available, which can be typed by
-`\\boxplus<tab>`.
+A set representing the exact sum, sometimes written ``X ⊞ Y``.
 """
 function exact_sum(::LazySet, ::LazySet) end
-
-"""
-    ⊞(X::LazySet, Y::LazySet)
-
-Convenience alias for the (concrete) `exact_sum` function.
-
-### Notes
-
-"`⊞`" can be typed by `\\boxplus<tab>`.
-"""
-const ⊞ = exact_sum

--- a/src/ConcreteOperations/difference.jl
+++ b/src/ConcreteOperations/difference.jl
@@ -1,27 +1,4 @@
 """
-    \\(X::LazySet, Y::LazySet)
-
-Convenience alias for the `difference` function.
-
-### Notes
-
-In this library, `X \\ Y` denotes the set difference. If `X` and `Y` are
-intervals, in some libraries it denotes the left division, as the example below
-shows.
-
-```jldoctest
-julia> X = Interval(0, 2); Y = Interval(1, 4);
-
-julia> X \\ Y  # compute the set difference
-Interval{Float64}([0, 1])
-
-julia> X.dat \\ Y.dat  # underlying intervals compute the left division instead
-[0.5, ∞]
-```
-"""
-\(X::LazySet, Y::LazySet) = difference(X, Y)
-
-"""
     difference(X::AbstractHyperrectangle, Y::AbstractHyperrectangle)
 
 Compute the set difference between two hyperrectangular sets.

--- a/src/LazySets.jl
+++ b/src/LazySets.jl
@@ -13,7 +13,7 @@ import .API: eltype, extrema, isdisjoint, isempty, \, ∈, ≈, ==, ⊆,
              linear_map, low, norm, project, radius, reflect, sample, scale,
              scale!, support_function, ρ, support_vector, σ, surface, translate,
              translate!, vertices_list, vertices, volume,
-             cartesian_product, difference, distance, exact_sum, ⊞, intersection,
+             cartesian_product, difference, distance, exact_sum, intersection,
              is_intersection_empty, isequivalent, ⊂, linear_combination,
              minkowski_difference, pontryagin_difference, minkowski_sum
 

--- a/src/Sets/Interval/difference.jl
+++ b/src/Sets/Interval/difference.jl
@@ -38,6 +38,15 @@ flat. Three cases may arise:
   covered by ``Y``. Similarly, if only `R` is flat, then the result is `L`.
 - Finally, if none of the intervals is flat, then ``Y`` is strictly contained
   in ``X`` and the set union of `L` and `R` is returned.
+
+### Examples
+
+```jldoctest
+julia> X = Interval(0, 2); Y = Interval(1, 4);
+
+julia> difference(X, Y)
+Interval{Float64}([0, 1])
+```
 """
 function difference(X::Interval{N}, Y::Interval) where {N}
     Z = intersection(X, Y)

--- a/test/Sets/SparsePolynomialZonotope.jl
+++ b/test/Sets/SparsePolynomialZonotope.jl
@@ -37,7 +37,7 @@ for N in [Float64, Float32, Rational{Int}]
     @test expmat(LMPZ) == [1 0 1; 0 1 3]
     @test indexvector(LMPZ) == indexvector(PZ)
 
-    ESPZ = PZ ⊞ PZ2
+    ESPZ = exact_sum(PZ, PZ2)
     @test center(ESPZ) == [4, 4]
     @test genmat_dep(ESPZ) == [2 1 2 2 0 1; 0 2 2 1 2 1]
     @test genmat_indep(ESPZ) == hcat([1, 0])


### PR DESCRIPTION
I find it inconsistent that `⊞` and `\` are concrete while all other symbols use the lazy operations.
Furthermore, `\` is not a real alias for `difference` because you cannot pass additional (e.g., keyword) arguments to the function.