### PR TITLE
Remove redundant `VectorIterator`

### DIFF
--- a/src/Interfaces/LazySet.jl
+++ b/src/Interfaces/LazySet.jl
@@ -857,7 +857,7 @@ function constraints(X::LazySet)
 end
 
 function _constraints_fallback(X::LazySet)
-    return VectorIterator(constraints_list(X))
+    return constraints_list(X)
 end
 
 """
@@ -870,7 +870,7 @@ function vertices(X::LazySet)
 end
 
 function _vertices_fallback(X::LazySet)
-    return VectorIterator(vertices_list(X))
+    return vertices_list(X)
 end
 
 function load_delaunay_MiniQhull()


### PR DESCRIPTION
The wrapper type `VectorIterator` is redundant because an `AbstractVector` already exposes all relevant functions. I will also remove it from `ReachabilityBase`.