### PR TITLE
Allow passing empty string to tests

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -37,7 +37,7 @@ global test_suite_basic = true
 global test_suite_polyhedra = true
 global test_suite_plotting = true
 
-if (length(ARGS) == 0) || (ARGS[1] == "--default") || isnothing(ARGS[1])
+if (length(ARGS) == 0) || (ARGS[1] ∈ ("--default", ""))
     # default test suite
 elseif ARGS[1] == "--basic"
     # basic test suite


### PR DESCRIPTION
In #3522 I proposed to pass `nothing`, but it turns out the correct way is to pass `""`.