### PR TITLE
Update doctest to Symbolics@v5.31.0

### DIFF
--- a/src/Sets/Hyperplane.jl
+++ b/src/Sets/Hyperplane.jl
@@ -567,7 +567,7 @@ function load_symbolics_hyperplane()
          y
 
         julia> Hyperplane(x - y == 2)
-        Hyperplane{Float64, Vector{Float64}}([1.0, -1.0], 2.0)
+        Hyperplane{Float64, Vector{Float64}}([-1.0, 1.0], 2.0)
 
         julia> Hyperplane(x == y)
         Hyperplane{Float64, Vector{Float64}}([1.0, -1.0], -0.0)


### PR DESCRIPTION
This fixes the recent failure of the documentation build. It was caused by [a new Symbolics release](https://github.com/JuliaSymbolics/Symbolics.jl/releases/tag/v5.31.0) (v5.31.0), which changes the order of arguments.

Actually, I am not sure we should just change the doctest. I think this is a bad change in Symbolics:
`Hyperplane(x - y == 2)` should not translate to `Hyperplane{Float64, Vector{Float64}}([-1.0, 1.0], 2.0)`.
I see two options:

1. Check whether we can change the translation in LazySets.
2. Restrict the Symbolics version to pre-v5.31.0.

EDIT: I asked in Symbolics#1182. They will add an argument for sorting to the function `get_variables`.