### PR TITLE
v2.14.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LazySets"
 uuid = "b4f0291d-fe17-52bc-9479-3d1a343d9043"
-version = "2.13.0"
+version = "2.14.0"
 
 [deps]
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"


### PR DESCRIPTION
The current problem with the doctest (see #3538 for the discussion) is external, so I think we do not have to fix it with the next release. I suggest to have a release now to propagate the breaking change in ReachabilityBase further.