### PR TITLE
Disallow `box_approximation` for unbounded sets

### DIFF
--- a/src/Approximations/box_approximation.jl
+++ b/src/Approximations/box_approximation.jl
@@ -54,6 +54,9 @@ function box_approximation(S::LazySet{N}) where {N}
     r = Vector{N}(undef, n)
     @inbounds for i in 1:n
         lo, hi = extrema(S, i)
+        if isinf(lo) || isinf(hi)
+            throw(ArgumentError("the box approximation of an unbounded set is undefined"))
+        end
         ri = (hi - lo) / 2
         if ri < zero(N)
             if !_geq(ri, zero(N))

--- a/test/Sets/Line.jl
+++ b/test/Sets/Line.jl
@@ -46,6 +46,9 @@ for N in [Float64, Rational{Int}, Float32]
     # boundedness
     @test !isbounded(l1)
 
+    # box_approximation
+    @test_throws ArgumentError box_approximation(l1)
+
     # ispolyhedral
     @test ispolyhedral(l1)
 


### PR DESCRIPTION
```julia
julia> X = Line([0.0, 1.0], [-1.0, 1.0]);

julia> box_approximation(X)  # master
Hyperrectangle{Float64, Vector{Float64}, Vector{Float64}}([NaN, NaN], [Inf, Inf])

julia> box_approximation(X)  # this branch
ERROR: ArgumentError: the box approximation of an unbounded set is undefined
```