### PR TITLE
Fix `convert` of `HPolyhedron` from `Polyhedra.HRep` 

### DIFF
--- a/src/Sets/HPolyhedron/convert.jl
+++ b/src/Sets/HPolyhedron/convert.jl
@@ -57,6 +57,8 @@ function load_Polyhedra_convert_HPolyhedron()
             for hi in Polyhedra.allhalfspaces(P)
                 a, b = hi.a, hi.β
                 if isapproxzero(norm(a))
+                    @assert b >= zero(N) "the half-space is inconsistent since it has a zero " *
+                                         "normal direction but the constraint is negative"
                     continue
                 end
                 push!(constraints, HalfSpace(a, b))

--- a/src/Sets/HPolytope/convert.jl
+++ b/src/Sets/HPolytope/convert.jl
@@ -42,11 +42,11 @@ function load_Polyhedra_convert_HPolytope()
             for hi in Polyhedra.allhalfspaces(P)
                 a, b = hi.a, hi.β
                 if isapproxzero(norm(a))
-                    @assert b >= zero(N) "the half-space is inconsistent since it " *
-                                         "has a zero normal direction but the constraint is negative"
+                    @assert b >= zero(N) "the half-space is inconsistent since it has a zero " *
+                                         "normal direction but the constraint is negative"
                     continue
                 end
-                push!(constraints, HalfSpace(hi.a, hi.β))
+                push!(constraints, HalfSpace(a, b))
             end
             return HPolytope(constraints)
         end

--- a/test/Sets/Polyhedron.jl
+++ b/test/Sets/Polyhedron.jl
@@ -96,6 +96,9 @@ for N in [Float64, Rational{Int}, Float32]
         # filtering of trivial constraint
         P = Polyhedra.HalfSpace(N[0], N(1)) ∩ Polyhedra.HalfSpace(N[1], N(1))
         @test HPolyhedron(P).constraints == [HalfSpace(N[1], N(1))]
+        # detection of invalid constraints
+        P = Polyhedra.HalfSpace(N[0], N(1)) ∩ Polyhedra.HalfSpace(N[0], N(-1))
+        @test_throws AssertionError HPolyhedron(P)
 
         # convert hyperrectangle to a HPolyhedron
         H = Hyperrectangle(N[1, 1], N[2, 2])


### PR DESCRIPTION
Now the methods for `HPolyhedron` and `HPolytope` are (correctly) identical (up to the set type) and should be shared.