### PR TITLE
Merge metaprogramming loops

### DIFF
--- a/src/ConcreteOperations/issubset.jl
+++ b/src/ConcreteOperations/issubset.jl
@@ -790,13 +790,8 @@ function _issubset_in_emptyset(X::LazySet, ∅::EmptySet, witness::Bool=false)
 end
 
 # disambiguations
-for ST in [:AbstractPolytope, :UnionSet, :UnionSetArray]
+for ST in [:AbstractPolytope, :UnionSet, :UnionSetArray, :AbstractSingleton, :LineSegment]
     @eval ⊆(X::($ST), ∅::EmptySet, witness::Bool=false) = _issubset_in_emptyset(X, ∅, witness)
-end
-
-# disambiguations for sets that are never empty
-for ST in [:AbstractSingleton, :LineSegment]
-    @eval ⊆(X::($ST), ::EmptySet, witness::Bool=false) = witness ? (false, an_element(X)) : false
 end
 
 """


### PR DESCRIPTION
The function `_issubset_in_emptyset` calls `isempty`. The removed loop used a shortcut for set types that are never empty, but the compiler figures that out and also skips `isempty`. So this was not really faster. Hence, I suggest to remove the loop to keep the codebase smaller.