### PR TITLE
Remove redundant `_vertices_list` methods

### DIFF
--- a/src/Interfaces/AbstractPolytope.jl
+++ b/src/Interfaces/AbstractPolytope.jl
@@ -144,11 +144,6 @@ function _linear_map_hrep_helper(M::AbstractMatrix, P::AbstractPolytope,
     end
 end
 
-# the "backend" argument is ignored, used for dispatch
-function _vertices_list(P::AbstractPolytope, backend)
-    return vertices_list(P)
-end
-
 """
     volume(P::AbstractPolytope; backend=default_polyhedra_backend(P))
 

--- a/src/Sets/HPolytope/HPolytopeModule.jl
+++ b/src/Sets/HPolytope/HPolytopeModule.jl
@@ -13,7 +13,7 @@ using ReachabilityBase.Require: require
 
 @reexport import ..API: isbounded, isoperationtype, rand, vertices_list,
                         minkowski_sum
-import ..LazySets: _linear_map_hrep_helper, _vertices_list
+import ..LazySets: _linear_map_hrep_helper
 import Base: convert
 @reexport using ..API
 

--- a/src/Sets/HPolytope/vertices_list.jl
+++ b/src/Sets/HPolytope/vertices_list.jl
@@ -56,7 +56,3 @@ function vertices_list(P::HPolytope; backend=nothing, prune::Bool=true)
     end
     return collect(Polyhedra.points(Q))
 end
-
-function _vertices_list(P::HPolytope, backend)
-    return vertices_list(P; backend=backend)
-end

--- a/src/Sets/VPolytope/VPolytopeModule.jl
+++ b/src/Sets/VPolytope/VPolytopeModule.jl
@@ -5,7 +5,7 @@ using Reexport, Requires
 using ..LazySets: AbstractPolytope, LazySet, LinearMapVRep, default_lp_solver,
                   default_lp_solver_polyhedra, default_polyhedra_backend,
                   is_lp_infeasible, is_lp_optimal, linprog,
-                  _minkowski_sum_vrep_nd, _vertices_list
+                  _minkowski_sum_vrep_nd
 using LinearAlgebra: dot
 using Random: AbstractRNG, GLOBAL_RNG
 using ReachabilityBase.Arrays: projection_matrix

--- a/src/Sets/VPolytope/minkowski_sum.jl
+++ b/src/Sets/VPolytope/minkowski_sum.jl
@@ -30,8 +30,8 @@ function minkowski_sum(P1::VPolytope, P2::VPolytope;
     @assert dim(P1) == dim(P2) "cannot compute the Minkowski sum of two " *
                                "polytopes of dimension $(dim(P1)) and $(dim(P2)), respectively"
 
-    vlist1 = _vertices_list(P1, backend)
-    vlist2 = _vertices_list(P2, backend)
+    vlist1 = vertices_list(P1)
+    vlist2 = vertices_list(P2)
     Vout = _minkowski_sum_vrep_nd(vlist1, vlist2;
                                   apply_convex_hull=apply_convex_hull,
                                   backend=backend, solver=solver)


### PR DESCRIPTION
These `_vertices_list` methods were added in #1495. The purpose was to selectively pass the `backend` argument, to be ignored by some subtypes of `AbstractPolytope`. Now this method is only available for `VPolytope`; hence, one can directly call `vertices_list` and these helper methods are redundant.