### PR TITLE
Let `remove_redundant_constraints` return `nothing`

### DIFF
--- a/src/Interfaces/AbstractPolyhedron_functions.jl
+++ b/src/Interfaces/AbstractPolyhedron_functions.jl
@@ -235,7 +235,7 @@ Remove the redundant constraints of a given list of linear constraints.
                    linear program
 ### Output
 
-The list of constraints with the redundant ones removed, or an empty set if the
+The list of constraints with the redundant ones removed, or `nothing` if the
 constraints are infeasible.
 
 ### Notes
@@ -253,8 +253,7 @@ function remove_redundant_constraints(constraints::AbstractVector{S};
     if remove_redundant_constraints!(constraints_copy; backend=backend)
         return constraints_copy
     else  # the constraints are infeasible
-        N = eltype(first(constraints))
-        return EmptySet{N}(dim(constraints[1]))
+        return nothing
     end
 end
 

--- a/src/Sets/HPolyhedron/is_hyperplanar.jl
+++ b/src/Sets/HPolyhedron/is_hyperplanar.jl
@@ -6,6 +6,10 @@ function is_hyperplanar(P::HPolyhedron)
     if m > 2
         # try to remove redundant constraints
         clist = remove_redundant_constraints(clist)
+        if isnothing(clist)
+            # constraints are contradictory
+            return false
+        end
         m = length(clist)
     end
     if m != 2


### PR DESCRIPTION
Currently, `remove_redundant_constraints` returns an `EmptySet` if the constraints are contradicting. I think this is unexpected. Instead, I suggest to return `nothing`.