### PR TITLE
Add binary `convex_hull` method to `API` module

### DIFF
--- a/docs/src/lib/API.md
+++ b/docs/src/lib/API.md
@@ -84,6 +84,7 @@ translate!(::LazySet, ::AbstractVector)
 
 ```@docs
 cartesian_product(::LazySet, ::LazySet)
+convex_hull(::LazySet, ::LazySet)
 difference(::LazySet, ::LazySet)
 distance(::LazySet, ::LazySet)
 exact_sum(::LazySet, ::LazySet)

--- a/src/API/API.jl
+++ b/src/API/API.jl
@@ -80,6 +80,7 @@ include("Mixed/translate!.jl")
 include("Mixed/translate.jl")
 
 include("Binary/cartesian_product.jl")
+include("Binary/convex_hull.jl")
 include("Binary/difference.jl")
 include("Binary/distance.jl")
 include("Binary/exact_sum.jl")

--- a/src/API/Binary/convex_hull.jl
+++ b/src/API/Binary/convex_hull.jl
@@ -1,0 +1,19 @@
+"""
+    convex_hull(X::LazySet, Y::LazySet)
+
+Compute the convex hull of (the union of) two sets.
+
+### Input
+
+- `X` -- set
+- `Y` -- set
+
+### Output
+
+A set representing the convex hull of ``X ∪ Y``.
+
+### Notes
+
+See [`convex_hull(::LazySet)`](@ref) for the convex hull of a single set.
+"""
+function convex_hull(::LazySet, ::LazySet) end


### PR DESCRIPTION
As an alternative to this PR, I was wondering whether we should remove the binary `convex_hull` method from the library.

The convex hull is traditionally defined for a single set. Originally, there was no way to express unions of two sets, but now we can express that via a `UnionSet`. So it feels a bit arbitrary that we offer this binary method.

A similar argument goes for the lazy binary operation `ConvexHull`, which could be turned into a unary operation.