### PR TITLE
fix `cartesian_product` with `EmptySet`

### DIFF
--- a/src/Sets/EmptySet/cartesian_product.jl
+++ b/src/Sets/EmptySet/cartesian_product.jl
@@ -5,5 +5,6 @@ end
 function _cartesian_product_emptyset(∅::EmptySet, X::LazySet)
     @assert dim(∅) == dim(X) "the dimensions of the given sets should match, " *
                              "but they are $(dim(∅)) and $(dim(X)), respectively"
-    throw(ArgumentError("cannot take the Cartesian product with an empty set"))
+    N = promote_type(eltype(∅), eltype(X))
+    return EmptySet{N}(dim(∅) + dim(X))
 end


### PR DESCRIPTION
The implementation in #3664 was not consistent with the behavior of the lazy `CartesianProduct`. Instead, an empty set of the corresponding dimension should be returned (see for instance the example [here](https://en.wikipedia.org/wiki/Cartesian_product#Non-commutativity_and_non-associativity)).