### PR TITLE
`EmptySet`: redefine `norm`/`radius`/`diameter`

### DIFF
--- a/src/API/Unary/diameter.jl
+++ b/src/API/Unary/diameter.jl
@@ -16,6 +16,6 @@ A real number representing the diameter.
 
 The diameter of a set is the maximum distance between any two elements of the
 set, or, equivalently, the diameter of the enclosing ball (of the given
-``p``-norm) of minimal volume with the same center.
+``p``-norm) of minimal volume.
 """
 function diameter(::LazySet, ::Real=Inf) end

--- a/src/API/Unary/radius.jl
+++ b/src/API/Unary/radius.jl
@@ -15,6 +15,6 @@ A real number representing the radius.
 ### Notes
 
 The radius of a set is the radius of the enclosing ball (of the given
-``p``-norm) of minimal volume with the same center.
+``p``-norm) of minimal volume.
 """
 function radius(::LazySet, ::Real=Inf) end

--- a/src/Sets/EmptySet/diameter.jl
+++ b/src/Sets/EmptySet/diameter.jl
@@ -1,3 +1,4 @@
-function diameter(::EmptySet, ::Real=Inf)
-    throw(ArgumentError("the diameter of an empty set is undefined"))
+function diameter(∅::EmptySet, ::Real=Inf)
+    N = eltype(∅)
+    return zero(N)
 end

--- a/src/Sets/EmptySet/norm.jl
+++ b/src/Sets/EmptySet/norm.jl
@@ -1,3 +1,4 @@
-function norm(::EmptySet, ::Real=Inf)
-    throw(ArgumentError("the norm of an empty set is undefined"))
+function norm(∅::EmptySet, ::Real=Inf)
+    N = eltype(∅)
+    return zero(N)
 end

--- a/src/Sets/EmptySet/radius.jl
+++ b/src/Sets/EmptySet/radius.jl
@@ -1,3 +1,4 @@
-function radius(::EmptySet, ::Real=Inf)
-    throw(ArgumentError("the radius of an empty set is undefined"))
+function radius(∅::EmptySet, ::Real=Inf)
+    N = eltype(∅)
+    return zero(N)
 end

--- a/test/Sets/EmptySet.jl
+++ b/test/Sets/EmptySet.jl
@@ -50,9 +50,8 @@ for N in [Float64, Rational{Int}, Float32]
     @test E2 isa EmptySet{N} && dim(E2) == 2
 
     # diameter
-    @test_throws ArgumentError diameter(E)  # TODO this should maybe change
-    # res = diameter(E)
-    # @test res isa N && res == N(0)
+    res = diameter(E)
+    @test res isa N && res == N(0)
 
     # dim
     @test dim(E) == 2
@@ -99,14 +98,12 @@ for N in [Float64, Rational{Int}, Float32]
     @test_throws ArgumentError low(E, 1)
 
     # norm
-    @test_throws ArgumentError norm(E)  # TODO this should maybe change
-    # res = norm(E)
-    # @test res isa N && res == N(0)
+    res = norm(E)
+    @test res isa N && res == N(0)
 
     # radius
-    @test_throws ArgumentError radius(E)  # TODO this should maybe change
-    # res = radius(E)
-    # @test res isa N && res == N(0)
+    res = radius(E)
+    @test res isa N && res == N(0)
 
     # rand
     @test rand(EmptySet; N=N) isa EmptySet{N}


### PR DESCRIPTION
I would argue that the old implementations of `norm`/`radius`/`diameter` for `EmptySet` were not correct. Instead of throwing an error, they should return 0 because the smallest enclosing ball has radius/diameter 0.