### PR TITLE
`EmptySet`: fix and merge binary `convex_hull`

### DIFF
--- a/src/ConcreteOperations/convex_hull.jl
+++ b/src/ConcreteOperations/convex_hull.jl
@@ -482,6 +482,6 @@ function monotone_chain!(points::Vector{VN}; sort::Bool=true) where {N,VN<:Abstr
     return resize!(points, m)
 end
 
-@commutative function convex_hull(X::LazySet, ::EmptySet)
-    return convex_hull(X)
+@commutative function convex_hull(X::LazySet, ∅::EmptySet)
+    return EmptySetModule._convex_hull_emptyset(∅, X)
 end

--- a/src/Sets/EmptySet/convex_hull.jl
+++ b/src/Sets/EmptySet/convex_hull.jl
@@ -6,8 +6,8 @@ function convex_hull(∅₁::EmptySet, ∅₂::EmptySet)
     return _convex_hull_emptyset(∅₁, ∅₂)
 end
 
-function _convex_hull_emptyset(∅::EmptySet, X::EmptySet)
+function _convex_hull_emptyset(∅::EmptySet, X::LazySet)
     @assert dim(∅) == dim(X) "the dimensions of the given sets should match, " *
                              "but they are $(dim(∅)) and $(dim(X)), respectively"
-    return ∅
+    return convex_hull(X)
 end

--- a/test/ConcreteOperations/convex_hull.jl
+++ b/test/ConcreteOperations/convex_hull.jl
@@ -184,5 +184,5 @@ for N in [Float64, Rational{Int}]
 
     # binary convex hull with an empty set is identical to unary
     @test convex_hull(S, EmptySet{N}(1)) == convex_hull(EmptySet{N}(1), S) == S
-    @test convex_hull(P, EmptySet{N}(1)) == convex_hull(EmptySet{N}(1), P) == Pc
+    @test convex_hull(P, EmptySet{N}(2)) == convex_hull(EmptySet{N}(2), P) == Pc
 end


### PR DESCRIPTION
This fixes an error in #3664 and uses the function from the main module.