### PR TITLE
`Interval`: remove type parameter from signatures

### DIFF
--- a/docs/src/lib/interfaces/AbstractCentrallySymmetricPolytope.md
+++ b/docs/src/lib/interfaces/AbstractCentrallySymmetricPolytope.md
@@ -26,7 +26,7 @@ center(::AbstractCentrallySymmetricPolytope, ::Int)
 extrema(::AbstractCentrallySymmetricPolytope)
 extrema(::AbstractCentrallySymmetricPolytope, ::Int)
 isempty(::AbstractCentrallySymmetricPolytope)
-isuniversal(::AbstractCentrallySymmetricPolytope{N}, ::Bool=false) where {N}
+isuniversal(::AbstractCentrallySymmetricPolytope, ::Bool=false)
 ```
 
 ## Implementations

--- a/docs/src/lib/sets/Ball1.md
+++ b/docs/src/lib/sets/Ball1.md
@@ -95,4 +95,4 @@ Inherited from [`AbstractCentrallySymmetricPolytope`](@ref):
 * [`extrema`](@ref extrema(::AbstractCentrallySymmetricPolytope))
 * [`extrema`](@ref extrema(::AbstractCentrallySymmetricPolytope, ::Int))
 * [`isempty`](@ref isempty(::AbstractCentrallySymmetricPolytope))
-* [`isuniversal`](@ref isuniversal(::AbstractCentrallySymmetricPolytope{N}, ::Bool=false) where {N})
+* [`isuniversal`](@ref isuniversal(::AbstractCentrallySymmetricPolytope, ::Bool=false))

--- a/docs/src/lib/sets/HParallelotope.md
+++ b/docs/src/lib/sets/HParallelotope.md
@@ -50,7 +50,7 @@ Inherited from [`AbstractCentrallySymmetricPolytope`](@ref):
 * [`an_element`](@ref an_element(::AbstractCentrallySymmetricPolytope))
 * [`extrema`](@ref extrema(::AbstractCentrallySymmetricPolytope))
 * [`extrema`](@ref extrema(::AbstractCentrallySymmetricPolytope, ::Int))
-* [`isuniversal`](@ref isuniversal(::AbstractCentrallySymmetricPolytope{N}, ::Bool=false) where {N})
+* [`isuniversal`](@ref isuniversal(::AbstractCentrallySymmetricPolytope, ::Bool=false))
 
 Inherited from [`AbstractZonotope`](@ref):
 * [`isempty`](@ref isempty(::AbstractZonotope))

--- a/docs/src/lib/sets/Interval.md
+++ b/docs/src/lib/sets/Interval.md
@@ -33,7 +33,7 @@ chebyshev_center_radius(::Interval)
 isflat(::Interval)
 ngens(::Interval)
 radius_hyperrectangle(::Interval)
-radius_hyperrectangle(::Interval{N}, ::Int) where {N}
+radius_hyperrectangle(::Interval, ::Int)
 ```
 ```@meta
 CurrentModule = LazySets.API
@@ -57,7 +57,7 @@ rectify(::LazySet)
 CurrentModule = LazySets.IntervalModule
 ```
 ```@docs
-rectify(::Interval{N}) where {N}
+rectify(::Interval)
 ```
 ```@meta
 CurrentModule = LazySets.API
@@ -106,7 +106,7 @@ difference(::LazySet, ::LazySet)
 CurrentModule = LazySets.IntervalModule
 ```
 ```@docs
-difference(::Interval{N}, ::Interval) where {N}
+difference(::Interval, ::Interval)
 ```
 ```@meta
 CurrentModule = LazySets.API
@@ -209,7 +209,7 @@ Inherited from [`AbstractPolytope`](@ref):
 
 Inherited from [`AbstractCentrallySymmetricPolytope`](@ref):
 * [`isempty`](@ref isempty(::AbstractCentrallySymmetricPolytope))
-* [`isuniversal`](@ref isuniversal(::AbstractCentrallySymmetricPolytope{N}, ::Bool=false) where {N})
+* [`isuniversal`](@ref isuniversal(::AbstractCentrallySymmetricPolytope, ::Bool=false))
 
 Inherited from [`AbstractZonotope`](@ref):
 * [`order`](@ref order(::AbstractZonotope))

--- a/docs/src/lib/sets/LineSegment.md
+++ b/docs/src/lib/sets/LineSegment.md
@@ -83,7 +83,7 @@ Inherited from [`AbstractCentrallySymmetricPolytope`](@ref):
 * [`extrema`](@ref extrema(::AbstractCentrallySymmetricPolytope))
 * [`extrema`](@ref extrema(::AbstractCentrallySymmetricPolytope, ::Int))
 * [`isempty`](@ref isempty(::AbstractCentrallySymmetricPolytope))
-* [`isuniversal`](@ref isuniversal(::AbstractCentrallySymmetricPolytope))
+* [`isuniversal`](@ref isuniversal(::AbstractCentrallySymmetricPolytope, ::Bool=false))
 
 Inherited from [`AbstractZonotope`](@ref):
 * [`order`](@ref order(::AbstractZonotope))

--- a/docs/src/lib/sets/Singleton.md
+++ b/docs/src/lib/sets/Singleton.md
@@ -66,7 +66,7 @@ Inherited from [`AbstractCentrallySymmetricPolytope`](@ref):
 * [`an_element`](@ref an_element(::AbstractCentrallySymmetricPolytope))
 * [`dim`](@ref dim(::AbstractCentrallySymmetricPolytope))
 * [`isempty`](@ref isempty(::AbstractCentrallySymmetricPolytope))
-* [`isuniversal`](@ref isuniversal(::AbstractCentrallySymmetricPolytope))
+* [`isuniversal`](@ref isuniversal(::AbstractCentrallySymmetricPolytope, ::Bool=false))
 
 Inherited from [`AbstractZonotope`](@ref):
 * [`order`](@ref order(::AbstractZonotope))

--- a/docs/src/lib/sets/ZeroSet.md
+++ b/docs/src/lib/sets/ZeroSet.md
@@ -69,7 +69,7 @@ Inherited from [`AbstractPolytope`](@ref):
 Inherited from [`AbstractCentrallySymmetricPolytope`](@ref):
 * [`an_element`](@ref an_element(::AbstractCentrallySymmetricPolytope))
 * [`isempty`](@ref isempty(::AbstractCentrallySymmetricPolytope))
-* [`isuniversal`](@ref isuniversal(::AbstractCentrallySymmetricPolytope))
+* [`isuniversal`](@ref isuniversal(::AbstractCentrallySymmetricPolytope, ::Bool=false))
 
 Inherited from [`AbstractZonotope`](@ref):
 * [`order`](@ref order(::AbstractZonotope))

--- a/src/Interfaces/AbstractCentrallySymmetricPolytope.jl
+++ b/src/Interfaces/AbstractCentrallySymmetricPolytope.jl
@@ -88,8 +88,7 @@ function isempty(::AbstractCentrallySymmetricPolytope)
 end
 
 """
-    isuniversal(S::AbstractCentrallySymmetricPolytope{N},
-                [witness]::Bool=false) where {N}
+    isuniversal(S::AbstractCentrallySymmetricPolytope, [witness]::Bool=false)
 
 Check whether a centrally symmetric, polytopic set is universal.
 
@@ -109,9 +108,9 @@ Centrally symmetric, polytopic sets are bounded.
 A witness is obtained by computing the support vector in direction
 `d = [1, 0, …, 0]` and adding `d` on top.
 """
-function isuniversal(S::AbstractCentrallySymmetricPolytope{N},
-                     witness::Bool=false) where {N}
+function isuniversal(S::AbstractCentrallySymmetricPolytope, witness::Bool=false)
     if witness
+        N = eltype(S)
         d = SingleEntryVector{N}(1, dim(S))
         w = σ(d, S) + d
         return (false, w)

--- a/src/Sets/Interval/difference.jl
+++ b/src/Sets/Interval/difference.jl
@@ -1,7 +1,7 @@
 """
 # Extended help
 
-    difference(X::Interval{N}, Y::Interval) where {N}
+    difference(X::Interval, Y::Interval)
 
 ### Output
 
@@ -49,7 +49,7 @@ julia> difference(Y, Z)
 UnionSet{Float64, Interval{Float64}, Interval{Float64}}(Interval{Float64}([1, 2]), Interval{Float64}([3, 4]))
 ```
 """
-function difference(X::Interval{N}, Y::Interval) where {N}
+function difference(X::Interval, Y::Interval)
     Z = intersection(X, Y)
     if isempty(Z)
         return X
@@ -63,6 +63,7 @@ function difference(X::Interval{N}, Y::Interval) where {N}
         if flat_left && flat_right
             require(@__MODULE__, :LazySets; fun_name="difference")
 
+            N = promote_type(eltype(X), eltype(Y))
             return EmptySet{N}(1)
         elseif flat_left && !flat_right
             return R

--- a/src/Sets/Interval/radius_hyperrectangle.jl
+++ b/src/Sets/Interval/radius_hyperrectangle.jl
@@ -1,5 +1,5 @@
 """
-    radius_hyperrectangle(x::Interval{N}, i::Int) where {N}
+    radius_hyperrectangle(x::Interval, i::Int)
 
 Return the box radius of an interval in a given dimension.
 
@@ -12,7 +12,7 @@ Return the box radius of an interval in a given dimension.
 
 The box radius in the given dimension.
 """
-function radius_hyperrectangle(x::Interval{N}, i::Int) where {N}
+function radius_hyperrectangle(x::Interval, i::Int)
     @assert i == 1 "an interval has dimension 1, but the index is $i"
     return radius(x)
 end

--- a/src/Sets/Interval/rectify.jl
+++ b/src/Sets/Interval/rectify.jl
@@ -1,14 +1,15 @@
 """
 # Extended help
 
-    rectify(x::Interval{N}) where {N}
+    rectify(x::Interval)
 
 ### Output
 
 An `Interval`, even if it represents a singleton only containing the origin
 (which is the case if the original interval was nonpositive).
 """
-function rectify(x::Interval{N}) where {N}
+function rectify(x::Interval)
+    N = eltype(x)
     if x.dat.lo >= zero(N)
         # interval is already nonnegative
         return x


### PR DESCRIPTION
Argument: Methods with docstrings and type parameters are unreliable to link to.