### PR TITLE
`AbstractHyperrectangle`: let `difference` return results of different types

### DIFF
--- a/src/ConcreteOperations/difference.jl
+++ b/src/ConcreteOperations/difference.jl
@@ -26,7 +26,15 @@ This implementation uses `IntervalArithmetic.setdiff`.
 function difference(X::AbstractHyperrectangle, Y::AbstractHyperrectangle)
     Xib = convert(IA.IntervalBox, X)
     Yib = convert(IA.IntervalBox, Y)
-    return UnionSetArray(convert.(Hyperrectangle, IA.setdiff(Xib, Yib)))
+    list = IA.setdiff(Xib, Yib)
+    if isempty(list)
+        N = promote_type(eltype(X), eltype(Y))
+        return EmptySet{N}(dim(X))
+    elseif length(list) == 1
+        return convert(Hyperrectangle, first(list))
+    else
+        return UnionSetArray(convert.(Hyperrectangle, list))
+    end
 end
 
 function difference(X::Interval{N}, H::HalfSpace) where {N}

--- a/test/Sets/Hyperrectangle.jl
+++ b/test/Sets/Hyperrectangle.jl
@@ -331,8 +331,15 @@ for N in [Float64, Rational{Int}, Float32]
 
     # set difference
     h = Hyperrectangle(; low=N[0], high=N[1])
-    q = Hyperrectangle(; low=N[0], high=N[0.5])
-    @test convert(Interval, difference(h, q).array[1]) == Interval(N(0.5), N(1))
+    q = Hyperrectangle(; low=N[0], high=N[2])
+    @test difference(h, q) == EmptySet{N}(1)
+    q = Hyperrectangle(; low=N[0], high=N[1//2])
+    d = difference(h, q)
+    @test d isa Hyperrectangle{N} && convert(Interval, d) == Interval(N(1//2), N(1))
+    q = Hyperrectangle(N[1//2], N[1//4])
+    d = difference(h, q)
+    @test d isa UnionSetArray{N}
+    @test ispermutation(convert.(Interval, d.array), [Interval(N(0), N(1//4)), Interval(N(3//4), N(1))])
 
     # concrete projection
     @test project(Hyperrectangle(N[4, 3, 2, 1], N[8, 7, 6, 5]), [2, 4]) ==


### PR DESCRIPTION
This is an optional PR. It arguably makes the result easier to understand if empty, but since it leads to type instability, I am not sure about it.