### PR TITLE
Fix and generalize `linear_combination`

### DIFF
--- a/docs/src/lib/sets/Polygon.md
+++ b/docs/src/lib/sets/Polygon.md
@@ -74,5 +74,6 @@ Inherited from [`LazySet`](@ref):
 * [`isequivalent`](@ref isequivalent(::LazySet, ::LazySet))
 * [`⊂`](@ref ⊂(::LazySet, ::LazySet))
 * [`⊆`](@ref ⊆(::LazySet, ::LazySet))
+* [`linear_combination`](@ref linear_combination(::LazySet, ::LazySet))
 * [`minkowski_difference`](@ref minkowski_difference(::LazySet, ::LazySet))
 * [`minkowski_sum`](@ref minkowski_sum(::LazySet, ::LazySet))

--- a/docs/src/lib/sets/SimpleSparsePolynomialZonotope.md
+++ b/docs/src/lib/sets/SimpleSparsePolynomialZonotope.md
@@ -185,6 +185,7 @@ Inherited from [`LazySet`](@ref):
 * [`isequivalent`](@ref isequivalent(::LazySet, ::LazySet))
 * [`⊂`](@ref ⊂(::LazySet, ::LazySet))
 * [`⊆`](@ref ⊆(::LazySet, ::LazySet))
+* [`linear_combination`](@ref linear_combination(::LazySet, ::LazySet))
 * [`minkowski_difference`](@ref minkowski_difference(::LazySet, ::LazySet))
 
 Inherited from [`AbstractPolynomialZonotope`](@ref):

--- a/docs/src/lib/sets/SparsePolynomialZonotope.md
+++ b/docs/src/lib/sets/SparsePolynomialZonotope.md
@@ -139,6 +139,7 @@ Inherited from [`LazySet`](@ref):
 * [`isequivalent`](@ref isequivalent(::LazySet, ::LazySet))
 * [`⊂`](@ref ⊂(::LazySet, ::LazySet))
 * [`⊆`](@ref ⊆(::LazySet, ::LazySet))
+* [`linear_combination`](@ref linear_combination(::LazySet, ::LazySet))
 * [`minkowski_difference`](@ref minkowski_difference(::LazySet, ::LazySet))
 
 Inherited from [`AbstractPolynomialZonotope`](@ref):

--- a/src/ConcreteOperations/linear_combination.jl
+++ b/src/ConcreteOperations/linear_combination.jl
@@ -1,3 +1,10 @@
+function linear_combination(X::LazySet, Y::LazySet)
+    if isconvextype(typeof(X)) && isconvextype(typeof(Y))
+        return _linear_combination_convex(X, Y)
+    end
+    throw(ArgumentError("the linear combination of non-convex sets is not implemented"))
+end
+
 function linear_combination(X::ConvexSet, Y::ConvexSet)
     return _linear_combination_convex(X, Y)
 end

--- a/src/ConcreteOperations/linear_combination.jl
+++ b/src/ConcreteOperations/linear_combination.jl
@@ -1,4 +1,16 @@
 function linear_combination(X::ConvexSet, Y::ConvexSet)
+    return _linear_combination_convex(X, Y)
+end
+
+function _linear_combination_convex(X, Y)
+    @assert dim(X) == dim(Y) "the dimensions of the given sets should match, " *
+                             "but they are $(dim(X)) and $(dim(Y)), respectively"
+
+    if isempty(X)
+        return X
+    elseif isempty(Y)
+        return Y
+    end
     return convex_hull(X, Y)
 end
 

--- a/test/LazyOperations/ConvexHull.jl
+++ b/test/LazyOperations/ConvexHull.jl
@@ -159,4 +159,11 @@ for N in [Float64, Rational{Int}, Float32]
                             [N[1, 1], N[1, -1], N[-1, 1], N[-1, -1],
                              N[1, 2], N[1, 0], N[2, 1], N[0, 1]])
     end
+
+    # linear_combination with empty argument
+    for X in (Chull, CHarr)
+        for Y in (linear_combination(X, e), linear_combination(e, X))
+            @test isempty(Y) && Y isa LazySet{N} && dim(Y) == 2
+        end
+    end
 end

--- a/test/Sets/Polygon.jl
+++ b/test/Sets/Polygon.jl
@@ -541,6 +541,12 @@ for N in [Float64, Float32, Rational{Int}]
     Q = VPolygon(M)
     @test Q == VPolygon(Vs) == P
     @test eltype(Q.vertices) == eltype(Vs)
+
+    # linear_combination with empty argument
+    Q = VPolygon{N}()
+    for R in (linear_combination(P, Q), linear_combination(Q, P))
+        @test isempty(R) && R isa LazySet{N} && dim(R) == 2
+    end
 end
 
 for N in [Float64, Float32]


### PR DESCRIPTION
If one argument is empty, the result of `linear_combination` is empty as well.