### PR TITLE
Fix `distance` between `EmptySet`s

### DIFF
--- a/src/Sets/EmptySet/distance.jl
+++ b/src/Sets/EmptySet/distance.jl
@@ -5,5 +5,7 @@ end
 function _distance_emptyset(∅::EmptySet, X::LazySet; p::Real=2.0)
     @assert dim(∅) == dim(X) "the dimensions of the given sets should match, " *
                              "but they are $(dim(∅)) and $(dim(X)), respectively"
-    throw(ArgumentError("the distance to an empty set is undefined"))
+
+    N = promote_type(eltype(∅), eltype(X))
+    return N(Inf)
 end

--- a/test/Sets/EmptySet.jl
+++ b/test/Sets/EmptySet.jl
@@ -230,7 +230,8 @@ for N in [Float64, Rational{Int}, Float32]
     @test E2 isa BallInf{N} && E2 == B
 
     # distance
-    @test_throws ArgumentError distance(E, E)
+    res = distance(E, E)
+    @test res isa N && res == N(Inf)
     E2 = EmptySet{N}(3)
     @test_throws AssertionError distance(E, E2)
     @test_throws AssertionError distance(E2, E)


### PR DESCRIPTION
The implementation added in #3672 was not correct.
The distance to an empty set is the infimum over the empty set, which is `Inf`.

https://github.com/JuliaReach/LazySets.jl/blob/efdaaf3812d22b6910e898f1f611dd84450a8948/src/API/Binary/distance.jl#L18-L23