### PR TITLE
Add `isparametrictype` trait

### DIFF
--- a/src/ConcreteOperations/exact_sum.jl
+++ b/src/ConcreteOperations/exact_sum.jl
@@ -1,12 +1,12 @@
-# the only parametric sets in this library are polynomial zonotopes;
-# hence, we compute the normal Minkowski sum for all other set combinations
+# for non-parametric set types, the exact sum coincides with the Minkowski sum
 function exact_sum(X::LazySet, Y::LazySet)
     @assert dim(X) == dim(Y) "the dimensions of the given sets should match, " *
                              "but they are $(dim(X)) and $(dim(Y)), respectively"
 
-    if X isa AbstractPolynomialZonotope || Y isa AbstractPolynomialZonotope
+    if isparametrictype(typeof(X)) || isparametrictype(typeof(Y))
         throw(ArgumentError("`exact_sum` for set types $(typeof(X)) and " *
                             "$(typeof(Y)) is not implemented"))
     end
+
     return minkowski_sum(X, Y)
 end

--- a/src/Interfaces/AbstractPolynomialZonotope.jl
+++ b/src/Interfaces/AbstractPolynomialZonotope.jl
@@ -119,4 +119,6 @@ end
 
 isboundedtype(::Type{<:AbstractPolynomialZonotope}) = true
 
+isparametrictype(::Type{<:AbstractPolynomialZonotope}) = true
+
 dim(PZ::AbstractPolynomialZonotope) = length(center(PZ))

--- a/src/Interfaces/LazySet.jl
+++ b/src/Interfaces/LazySet.jl
@@ -1669,3 +1669,6 @@ function vertices_list_1d(X::LazySet)
     l, h = extrema(X, 1)
     return _isapprox(l, h) ? [[l]] : [[l], [h]]
 end
+
+# internal function to detect parametric set types
+isparametrictype(::Type{<:LazySet}) = false


### PR DESCRIPTION
This function is used in one place to prevent bugs later when adding other parametric set types.
The function is not exported.