### PR TITLE
Remove scalar `linear_map`

### DIFF
--- a/docs/src/lib/interfaces/LazySet.md
+++ b/docs/src/lib/interfaces/LazySet.md
@@ -413,7 +413,6 @@ CurrentModule = LazySets
 ```
 ```@docs
 linear_map(::AbstractMatrix, ::LazySet; kwargs...)
-linear_map(::Number, ::LazySet; kwargs...)
 project(::LazySet, ::AbstractVector{Int}, ::Nothing=nothing, ::Int=dim(X))
 project(::LazySet, ::AbstractVector{Int}, ::Type{<:LazySet}, ::Int=dim(X))
 project(::LazySet, ::AbstractVector{Int}, ::Pair{<:UnionAll,<:Real}, ::Int=dim(X))

--- a/src/Interfaces/LazySet.jl
+++ b/src/Interfaces/LazySet.jl
@@ -1565,15 +1565,6 @@ function linear_map(M::AbstractMatrix, P::LazySet; kwargs...)
 end
 
 """
-    linear_map(a::Number, X::LazySet; kwargs...)
-
-Alias for `scale(a, X; kwargs...)`.
-"""
-function linear_map(a::Number, X::LazySet; kwargs...)
-    return scale(a, X; kwargs...)
-end
-
-"""
 # Extended help
 
     scale(α::Real, X::LazySet)

--- a/test/Sets/Interval.jl
+++ b/test/Sets/Interval.jl
@@ -48,8 +48,6 @@ for N in [Float64, Float32, Rational{Int}]
 
     # concrete linear map
     @test linear_map(hcat(N(2)...), x) == Interval(N(2) * x.dat)
-    # alias for scale
-    @test linear_map(N(2), x) == Interval(N(2) * x.dat)
 
     # concrete linear map with zonotope output
     M2 = hcat(N[1, 2, 3])


### PR DESCRIPTION
This is a proposal to remove a confusing method, in particular given that we have `scale` now.