### PR TITLE
`ConvexSet`: make `σ` a required method

### DIFF
--- a/docs/src/lib/interfaces/ConvexSet.md
+++ b/docs/src/lib/interfaces/ConvexSet.md
@@ -15,6 +15,18 @@ Every convex set in this library implements this interface.
 ConvexSet
 ```
 
+This interface requires to implement the following function:
+
+```@meta
+CurrentModule = LazySets.API
+```
+```@docs; canonical=false
+σ(::AbstractVector, ::LazySet)
+```
+```@meta
+CurrentModule = LazySets
+```
+
 This interface defines the following functions (undocumented):
 
 ```@meta

--- a/src/Interfaces/ConvexSet.jl
+++ b/src/Interfaces/ConvexSet.jl
@@ -6,6 +6,12 @@ export ConvexSet
 Abstract type for convex sets, i.e., sets characterized by a (possibly infinite)
 intersection of halfspaces, or equivalently, sets ``S`` such that for any two
 elements ``x, y ∈ S`` and ``0 ≤ λ ≤ 1`` it holds that ``λ·x + (1-λ)·y ∈ S``.
+
+### Notes
+
+Every concrete `ConvexSet` must define the following function:
+
+- `σ(::AbstractVector, ::LazySet)` -- return a support vector in the given direction
 """
 abstract type ConvexSet{N} <: LazySet{N} end
 


### PR DESCRIPTION
The build error on Windows is simply a timeout.