### PR TITLE
Let `LazySet` subtype `API.LazySet`

### DIFF
--- a/src/Interfaces/LazySet.jl
+++ b/src/Interfaces/LazySet.jl
@@ -8,7 +8,7 @@ export LazySet,
        flatten
 
 """
-    LazySet{N}
+    LazySet{N} <: API.LazySet
 
 Abstract type for the set types in LazySets.
 
@@ -124,7 +124,7 @@ Zonotope
 
 ```
 """
-abstract type LazySet{N} end
+abstract type LazySet{N} <: API.LazySet end
 
 """
     ○(c, a)


### PR DESCRIPTION
~This is needed to connect the docstrings in the REPL (not sure why I did not notice that before).~

EDIT: My bad, this is the standard Julia behavior. The full docstring is only printed for the _function_. When a method is requested, only that method is printed.