### PR TITLE
Inline one-line helper functions

### DIFF
--- a/src/Interfaces/LazySet.jl
+++ b/src/Interfaces/LazySet.jl
@@ -1031,10 +1031,6 @@ end
 The default implementation computes all constraints via `constraints_list`.
 """
 function constraints(X::LazySet)
-    return _constraints_fallback(X)
-end
-
-function _constraints_fallback(X::LazySet)
     return constraints_list(X)
 end
 
@@ -1048,10 +1044,6 @@ end
 The default implementation computes all vertices via `vertices_list`.
 """
 function vertices(X::LazySet)
-    return _vertices_fallback(X)
-end
-
-function _vertices_fallback(X::LazySet)
     return vertices_list(X)
 end
 


### PR DESCRIPTION
Argument: The helper functions are not used anywhere else and consist of only a single function call.