### PR TITLE
Fix `distance` of point and `Line`

### DIFF
--- a/src/Sets/Line/distance.jl
+++ b/src/Sets/Line/distance.jl
@@ -1,6 +1,10 @@
 @commutative function distance(x::AbstractVector, L::Line; p::Real=2)
     @assert length(x) == dim(L) "incompatible dimensions $(length(x)) and $(dim(L))"
 
+    if p != 2
+        throw(ArgumentError("`distance` is only implemented for Euclidean norm"))
+    end
+
     d = L.d  # direction of the line
     t = dot(x - L.p, d) / dot(d, d)
     return distance(x, L.p + t * d; p=p)

--- a/test/Sets/Line.jl
+++ b/test/Sets/Line.jl
@@ -63,10 +63,11 @@ for N in [Float64, Rational{Int}, Float32]
     @test translate(l2, N[0, 1]) == Line(N[0, 2], N[1, 0])
 
     # distance
-    distance(N[1, 0], l1) == N(1)
-    distance(l1, N[1, 0]) == N(1)
-    distance(Singleton(N[1, 0]), l1) == N(1)
-    distance(l1, Singleton(N[1, 0])) == N(1)
+    @test distance(N[1, 0], l1) == N(1)
+    @test distance(l1, N[1, 0]) == N(1)
+    @test distance(Singleton(N[1, 0]), l1) == N(1)
+    @test distance(l1, Singleton(N[1, 0])) == N(1)
+    @test_throws ArgumentError distance(N[1, 0], l1; p=N(1))
 
     # concrete linear map special case: singleton result
     l = Line(N[0, 2], N[1, 0])


### PR DESCRIPTION
Here is a counterexample:

```julia
julia> L = Line([1., 0], [-1., 2]);
julia> x = [0., 0];
julia> distance(x, L; p=1)
1.2000000000000002

julia> plot(L, xlims=[-2, 2], ylims=[-2,2], ratio=1); plot!(Singleton(x))
julia> p = 1.; plot!(Ballp(p, x, distance(x, L; p=p)))
```

![plot_6](https://github.com/user-attachments/assets/d7662e05-1874-4140-8be2-e7f63f44d650)

The shortest distance is obviously 1 (horizontal connection). The orthogonal connection is only valid in the Euclidean norm.