### PR TITLE
Revise tests for `EmptySet`

### DIFF
--- a/test/Sets/EmptySet.jl
+++ b/test/Sets/EmptySet.jl
@@ -1,3 +1,11 @@
+function isidentical(::EmptySet{N1}, ::EmptySet{N2}) where {N1,N2}
+    return false
+end
+
+function isidentical(E1::EmptySet{N}, E2::EmptySet{N}) where {N}
+    return E1.dim == E2.dim
+end
+
 for _dummy_ in 1:1  # avoid global variable warnings
     # default Float64 constructor
     for E in (EmptySet(2), ∅(2))
@@ -6,7 +14,7 @@ for _dummy_ in 1:1  # avoid global variable warnings
     end
 end
 
-for N in [Float64, Rational{Int}, Float32]
+for N in [Float64, Float32, Rational{Int}]
     # auxiliary sets
     B = BallInf(ones(N, 2), N(1))
     Pe = HPolygon([HalfSpace(N[1, 0], N(0)), HalfSpace(N[-1, 0], N(-1)),  # empty
@@ -18,10 +26,13 @@ for N in [Float64, Rational{Int}, Float32]
     E = EmptySet{N}(2)
     @test E isa EmptySet{N}
     @test E.dim == 2
+    E3 = EmptySet{N}(3)
+    @test E3 isa EmptySet{N}
+    @test E3.dim == 3
 
     # convert
     E2 = convert(EmptySet, Pe)
-    @test E2 isa EmptySet{N} && dim(E2) == 2
+    @test isidentical(E, E2)
     @test_throws AssertionError convert(EmptySet, B)
 
     # an_element
@@ -30,7 +41,7 @@ for N in [Float64, Rational{Int}, Float32]
     # area
     res = area(E)
     @test res isa N && res == N(0)
-    @test_throws AssertionError area(EmptySet{N}(3))
+    @test_throws AssertionError area(E3)
 
     # complement
     U = complement(E)
@@ -38,7 +49,10 @@ for N in [Float64, Rational{Int}, Float32]
 
     # concretize
     E2 = concretize(E)
-    @test E2 isa EmptySet{N} && dim(E2) == 2
+    @test isidentical(E, E2)
+
+    # constrained_dimensions
+    @test_broken constrained_dimensions(E)  # TODO implement
 
     # constraints_list
     @test_throws MethodError constraints_list(E)  # TODO this should maybe change
@@ -48,14 +62,16 @@ for N in [Float64, Rational{Int}, Float32]
 
     # convex_hull (unary)
     E2 = convex_hull(E)
-    @test E2 isa EmptySet{N} && dim(E2) == 2
+    @test isidentical(E, E2)
 
     # copy
     E2 = copy(E)
-    @test E2 isa EmptySet{N} && dim(E2) == 2
+    @test isidentical(E, E2)
 
     # delaunay
-    @test_throws ErrorException delaunay(E)
+    if isdefined(@__MODULE__, :MiniQhull)  # TODO this should throw a normal error without MiniQhull
+        @test_broken delaunay(E)
+    end
 
     # diameter
     @test_throws ArgumentError diameter(E)  # TODO this should maybe change
@@ -100,7 +116,7 @@ for N in [Float64, Rational{Int}, Float32]
 
     # isuniversal
     res, w = isuniversal(E, true)
-    @test !isuniversal(E) && !res && w isa Vector{N} && length(w) == 2 && w ∉ E
+    @test !isuniversal(E) && !res && w isa Vector{N} && w ∉ E
 
     # low
     @test_throws ArgumentError low(E)
@@ -112,7 +128,9 @@ for N in [Float64, Rational{Int}, Float32]
     # @test res isa N && res == N(0)
 
     # polyhedron
-    @test_throws MethodError polyhedron(E)  # TODO this should maybe change
+    if test_suite_polyhedra
+        @test_throws MethodError polyhedron(E)  # TODO this should maybe change
+    end
 
     # radius
     @test_throws ArgumentError radius(E)  # TODO this should maybe change
@@ -120,19 +138,16 @@ for N in [Float64, Rational{Int}, Float32]
     # @test res isa N && res == N(0)
 
     # rand
-    @test rand(EmptySet; N=N) isa EmptySet{N}
+    E2 = rand(EmptySet; N=N)
+    @test isidentical(E, E2)
     E2 = rand(EmptySet; N=N, dim=3)
-    @test E2 isa EmptySet{N} && dim(E2) == 3
+    @test isidentical(E3, E2)
 
     # rectify
     @test rectify(E) == E
 
     # reflect
     @test reflect(E) == E
-
-    # sample
-    @test_throws ArgumentError sample(E)
-    @test_throws ArgumentError sample(E, 2)
 
     # singleton_list
     res = singleton_list(E)
@@ -145,6 +160,11 @@ for N in [Float64, Rational{Int}, Float32]
 
     # tosimplehrep
     @test_throws MethodError tosimplehrep(E)  # TODO this should maybe change
+
+    # triangulate
+    if test_suite_polyhedra
+        @test_throws AssertionError triangulate(E3)  # TODO this should maybe change
+    end
 
     # vertices_list
     vs = vertices_list(E)
@@ -161,9 +181,9 @@ for N in [Float64, Rational{Int}, Float32]
     @test_throws AssertionError affine_map(ones(N, 2, 3), E, N[1, 1])
     @test_throws AssertionError affine_map(ones(N, 2, 2), E, N[1])
     E2 = affine_map(ones(N, 2, 2), E, N[1, 1])
-    @test E2 isa EmptySet{N} && dim(E2) == 2
+    @test isidentical(E, E2)
     E2 = affine_map(ones(N, 3, 2), E, N[1, 1, 3])
-    @test E2 isa EmptySet{N} && dim(E2) == 3
+    @test isidentical(E3, E2)
 
     # distance (between point and set)
     @test_throws AssertionError distance(E, N[0])
@@ -176,20 +196,26 @@ for N in [Float64, Rational{Int}, Float32]
     for f in (exponential_map, linear_map)
         @test_throws AssertionError f(ones(N, 2, 3), E)
         E2 = f(ones(N, 2, 2), E)
-        @test E2 isa EmptySet{N} && dim(E2) == 2
-        E2 = f(ones(N, 3, 2), E)
-        @test E2 isa EmptySet{N} && dim(E2) == 3
+        @test isidentical(E, E2)
     end
+    @test_broken exponential_map(ones(N, 3, 2), E) isa ArgumentError  # TODO rectangular matrix should not be accepted
+    E2 = linear_map(ones(N, 3, 2), E)
+    @test isidentical(E3, E2)
 
     # in
     @test_throws AssertionError N[0] ∈ E
     @test N[0, 0] ∉ E
 
+    # linear_map_inverse
+    @test_broken LazySets.linear_map_inverse(ones(N, 2, 3), E)  # TODO this should maybe change
+    # E2 = LazySets.linear_map_inverse(ones(N, 2, 3), E)
+    # @test isidentical(E3, E2)
+
     # permute
     @test_throws AssertionError permute(E, [1, -1])
     @test_throws AssertionError permute(E, [1, 2, 2])
     E2 = permute(E, [2, 1])
-    @test E2 isa EmptySet{N} && dim(E2) == 2
+    @test isidentical(E, E2)
 
     # project
     @test_throws AssertionError project(E, [1, -1])
@@ -197,87 +223,94 @@ for N in [Float64, Rational{Int}, Float32]
     E2 = project(E, [2])
     @test E2 isa EmptySet{N} && dim(E2) == 1
 
+    # sample
+    @test_throws ArgumentError sample(E)
+    @test_throws ArgumentError sample(E, 2)
+
     # scale
     E2 = scale(N(2), E)
-    @test E2 isa EmptySet{N} && dim(E2) == 2
+    @test isidentical(E, E2)
+    E2 = scale(N(0), E)
+    @test isidentical(E, E2)
     # scale!
-    E3 = EmptySet{N}(2)
-    scale!(N(2), E3)
-    @test E3 isa EmptySet{N} && dim(E3) == 2
+    E2 = copy(E)
+    scale!(N(2), E2)
+    @test isidentical(E, E2)
+    scale!(N(0), E2)
+    @test isidentical(E, E2)
 
     # support_function
     @test_throws AssertionError ρ(N[1], E)
-    @test_throws ArgumentError ρ(N[1, 1], E)
+    for v in (N[-1, 2], N[2, 0], N[0, 0])
+        @test_throws ArgumentError ρ(v, E)
+    end
 
     # support_vector
     @test_throws AssertionError σ(N[1], E)
-    @test_throws ArgumentError σ(N[1, 1], E)
+    for v in (N[-1, 2], N[2, 0], N[0, 0])
+        @test_throws ArgumentError σ(v, E)
+    end
 
     # translate
     @test_throws AssertionError translate(E, N[1])
     E2 = translate(E, N[1, 2])
-    @test E2 isa EmptySet{N} && dim(E2) == 2
+    @test isidentical(E, E2)
     # translate!
     @test_throws AssertionError translate!(E, N[1])
-    E2 = EmptySet{N}(2)
+    E2 = copy(E)
     translate!(E2, N[1, 2])
-    @test E2 isa EmptySet{N} && dim(E2) == 2
+    @test isidentical(E, E2)
 
     # cartesian_product
-    E2 = EmptySet{N}(3)
-    for X in (cartesian_product(E, E2), cartesian_product(E2, E))
-        @test X isa EmptySet{N} && dim(X) == 5
+    for E2 in (cartesian_product(E, E3), cartesian_product(E3, E))
+        @test E2 isa EmptySet{N} && dim(E2) == 5
     end
 
     # convex_hull (binary)
-    @test_throws AssertionError convex_hull(E, EmptySet{N}(3))
+    @test_throws AssertionError convex_hull(E, E3)
     E2 = convex_hull(E, E)
-    @test E2 isa EmptySet{N} && dim(E2) == 2
+    @test isidentical(E, E2)
     for X in (convex_hull(E, Pnc), convex_hull(Pnc, E))
         @test X isa LazySet{N} && isequivalent(X, Pc)
     end
 
     # difference
-    E2 = EmptySet{N}(3)
-    @test_throws AssertionError difference(B, E2)
-    @test_throws AssertionError difference(E2, B)
-    for X in (difference(E, E), difference(E, B))
-        @test X isa EmptySet{N} && dim(X) == 2
+    @test_throws AssertionError difference(B, E3)
+    @test_throws AssertionError difference(E3, B)
+    for E2 in (difference(E, E), difference(E, B))
+        @test isidentical(E, E2)
     end
-    E2 = difference(B, E)
-    @test E2 isa BallInf{N} && E2 == B
+    X = difference(B, E)
+    @test X isa BallInf{N} && X == B
 
     # distance (between sets)
+    @test_throws AssertionError distance(E, E3)
+    @test_throws AssertionError distance(E3, E)
     res = distance(E, E)
     @test res isa N && res == N(Inf)
-    E2 = EmptySet{N}(3)
-    @test_throws AssertionError distance(E, E2)
-    @test_throws AssertionError distance(E2, E)
 
     # exact_sum / minkowski_sum
     for f in (exact_sum, minkowski_sum)
-        E2 = EmptySet{N}(3)
-        @test_throws AssertionError f(E, E2)
-        @test_throws AssertionError f(E2, E)
-        for X in (f(E, E), f(E, B), f(B, E))
-            @test X isa EmptySet{N} && dim(X) == 2
+        @test_throws AssertionError f(E, E3)
+        @test_throws AssertionError f(E3, E)
+        for E2 in (f(E, E), f(E, B), f(B, E))
+            @test isidentical(E, E2)
         end
     end
 
     # intersection
-    @test_throws AssertionError convex_hull(E, EmptySet{N}(3))
-    for X in (intersection(E, E), intersection(E, B), intersection(B, E))
-        @test X isa EmptySet{N} && dim(X) == 2
+    @test_throws AssertionError intersection(E, E3)
+    for E2 in (intersection(E, E), intersection(E, B), intersection(B, E))
+        @test isidentical(E, E2)
     end
 
     # isapprox
     @test E ≈ E
-    E2 = EmptySet{N}(3)
-    @test_throws AssertionError E ≈ E2
-    @test_throws AssertionError E2 ≈ E
+    @test_broken !(E ≈ E3)  # TODO this should change
+    @test_broken !(E3 ≈ E)  # TODO this should change
 
     # isdisjoint
-    @test_throws AssertionError isdisjoint(E, EmptySet{N}(3))
+    @test_throws AssertionError isdisjoint(E, E3)
     @test isdisjoint(E, B) && isdisjoint(B, E) && isdisjoint(E, E)
     for (res, w) in (isdisjoint(E, B, true), isdisjoint(B, E, true), isdisjoint(E, E, true))
         @test res && w isa Vector{N} && w == N[]
@@ -285,19 +318,16 @@ for N in [Float64, Rational{Int}, Float32]
 
     # isequal
     @test E == E
-    E2 = EmptySet{N}(3)
-    @test !(E == E2) && !(E2 == E)
+    @test !(E == E3) && !(E3 == E)
 
     # isequivalent
     @test isequivalent(E, E)
-    E2 = EmptySet{N}(3)
-    @test_throws AssertionError isequivalent(E, E2)
-    @test_throws AssertionError isequivalent(E2, E)
+    @test_throws AssertionError isequivalent(E, E3)
+    @test_throws AssertionError isequivalent(E3, E)
 
     # isstrictsubset
-    E2 = EmptySet{N}(3)
-    @test_throws AssertionError B ⊂ E2
-    @test_throws AssertionError E2 ⊂ B
+    @test_throws AssertionError B ⊂ E3
+    @test_throws AssertionError E3 ⊂ B
     for X in (E, B)
         @test !(X ⊂ E)
         res, w = ⊂(X, E, true)
@@ -305,12 +335,11 @@ for N in [Float64, Rational{Int}, Float32]
     end
     @test E ⊂ B
     res, w = ⊂(E, B, true)
-    @test res && w isa Vector{N} && length(w) == 2 && w ∉ E && w ∈ B
+    @test res && w isa Vector{N} && w ∉ E && w ∈ B
 
     # issubset
-    E2 = EmptySet{N}(3)
-    @test_throws AssertionError B ⊆ E2
-    @test_throws AssertionError E2 ⊆ B
+    @test_throws AssertionError B ⊆ E3
+    @test_throws AssertionError E3 ⊆ B
     for X in (E, B)
         @test E ⊆ X
         res, w = ⊆(E, X, true)
@@ -318,23 +347,22 @@ for N in [Float64, Rational{Int}, Float32]
     end
     @test B ⊈ E
     res, w = ⊆(B, E, true)
-    @test !res && w isa Vector{N} && length(w) == 2 && w ∉ E && w ∈ B
+    @test !res && w isa Vector{N} && w ∉ E && w ∈ B
     @test Pe ⊆ E
     res, w = ⊆(Pe, E, true)
     @test res && w isa Vector{N} && w == N[]
 
     # linear_combination
-    @test_throws AssertionError linear_combination(E, EmptySet{N}(3))
-    for X in (E, linear_combination(E, Pnc), linear_combination(Pnc, E))
-        @test X isa EmptySet{N} && dim(X) == 2
+    @test_throws AssertionError linear_combination(E, E3)
+    for E2 in (linear_combination(E, Pnc), linear_combination(Pnc, E))
+        @test isidentical(E, E2)
     end
 
     # minkowski_difference
-    E2 = EmptySet{N}(3)
-    @test_throws AssertionError minkowski_difference(B, E2)
-    @test_throws AssertionError minkowski_difference(E2, B)
-    for X in (minkowski_difference(E, E), minkowski_difference(E, B))
-        @test X isa EmptySet{N} && dim(X) == 2
+    @test_throws AssertionError minkowski_difference(B, E3)
+    @test_throws AssertionError minkowski_difference(E3, B)
+    for E2 in (minkowski_difference(E, E), minkowski_difference(E, B))
+        @test isidentical(E, E2)
     end
     X = minkowski_difference(B, E)
     @test X isa BallInf{N} && X == B


### PR DESCRIPTION
This is a revision of the test structure introduced in #3672.

Main changes:
- guard tests that require external packages
- define `isidentical` shorthand
- test additional functions (`constrained_dimensions`, `triangulate`, `linear_map_inverse`)
- identify validation bug in `exponential_map`
- identify validation bug in `≈`
- do not test length of witness vectors (assumed to be done in membership test)
- define common set `E3` only once