### PR TITLE
Allow `≈` for `EmptySet`s of different dimension

### DIFF
--- a/src/Sets/EmptySet/isapprox.jl
+++ b/src/Sets/EmptySet/isapprox.jl
@@ -1,5 +1,3 @@
 function ≈(∅₁::EmptySet, ∅₂::EmptySet)
-    @assert dim(∅₁) == dim(∅₂) "the dimensions of the given sets should match, " *
-                               "but they are $(dim(∅₁)) and $(dim(∅₂)), respectively"
-    return true
+    return dim(∅₁) == dim(∅₂)
 end

--- a/test/Sets/EmptySet.jl
+++ b/test/Sets/EmptySet.jl
@@ -306,8 +306,8 @@ for N in [Float64, Float32, Rational{Int}]
 
     # isapprox
     @test E ≈ E
-    @test_broken !(E ≈ E3)  # TODO this should change
-    @test_broken !(E3 ≈ E)  # TODO this should change
+    @test !(E ≈ E3)
+    @test !(E3 ≈ E)
 
     # isdisjoint
     @test_throws AssertionError isdisjoint(E, E3)


### PR DESCRIPTION
The implementation added in [10ed89b](https://github.com/JuliaReach/LazySets.jl/pull/3664/commits/10ed89b192f964381cd1ad2b364bf05509169fc6) is not good. While most binary operations should validate the input sets and throw an error, this should not be the case for `==` and `≈`, which should just return `false`.