### PR TITLE
Fixes for `Universe`

### DIFF
--- a/src/Interfaces/AbstractPolyhedron_functions.jl
+++ b/src/Interfaces/AbstractPolyhedron_functions.jl
@@ -365,9 +365,6 @@ function _linear_map_polyhedron(M::AbstractMatrix,
         M = N.(M)
     end
 
-    size(M, 2) != dim(P) && throw(ArgumentError("a linear map of size " *
-                                                "$(size(M)) cannot be applied to a set of dimension $(dim(P))"))
-
     got_algorithm = !isnothing(algorithm)
     got_inv = got_algorithm && (algorithm == "inv" || algorithm == "inverse")
     got_inv_right = got_algorithm && (algorithm ==

--- a/src/Interfaces/LazySet.jl
+++ b/src/Interfaces/LazySet.jl
@@ -1566,6 +1566,9 @@ The default implementation assumes that `P` is polyhedral and applies an
 algorithm based on the set type (see [`_linear_map_polyhedron`](@ref)).
 """
 function linear_map(M::AbstractMatrix, P::LazySet; kwargs...)
+    @assert size(M, 2) == dim(P) "a linear map of size $(size(M)) cannot be " *
+                                 "applied to a set of dimension $(dim(P))"
+
     if ispolyhedral(P)
         return _linear_map_polyhedron(M, P; kwargs...)
     else

--- a/src/Interfaces/LazySet.jl
+++ b/src/Interfaces/LazySet.jl
@@ -622,6 +622,11 @@ end
 The default implementation applies the functions `linear_map` and `translate`.
 """
 function affine_map(M, X::LazySet, v::AbstractVector; kwargs...)
+    @assert size(M, 2) == dim(X) "an affine map of size $(size(M)) cannot be " *
+                                 "applied to a set of dimension $(dim(X))"
+    @assert size(M, 1) == length(v) "an affine map of sizes $(size(M)) and " *
+                                    "$(length(v)) is incompatible"
+
     return translate(linear_map(M, X; kwargs...), v)
 end
 

--- a/src/Sets/Universe/UniverseModule.jl
+++ b/src/Sets/Universe/UniverseModule.jl
@@ -11,8 +11,9 @@ using ReachabilityBase.Require: require
 @reexport import ..API: an_element, complement, constraints, constraints_list,
                         diameter, dim, isbounded, isboundedtype, isempty,
                         isoperationtype, isuniversal, norm, radius, rand,
-                        reflect, ∈, permute, project, scale, scale!, ρ, σ,
-                        translate, translate!, cartesian_product, intersection
+                        reflect, volume, ∈, permute, project, scale, scale!, ρ,
+                        σ, translate, translate!, cartesian_product,
+                        intersection
 @reexport import ..LazySets: constrained_dimensions, linear_map_inverse,
                              rationalize, tosimplehrep
 import Base: copy
@@ -39,6 +40,7 @@ include("radius.jl")
 include("rand.jl")
 include("rationalize.jl")
 include("reflect.jl")
+include("volume.jl")
 include("in.jl")
 include("permute.jl")
 include("project.jl")

--- a/src/Sets/Universe/diameter.jl
+++ b/src/Sets/Universe/diameter.jl
@@ -1,3 +1,3 @@
 function diameter(::Universe, ::Real=Inf)
-    return error("a universe does not have a diameter")
+    throw(ArgumentError("a universe does not have a diameter"))
 end

--- a/src/Sets/Universe/norm.jl
+++ b/src/Sets/Universe/norm.jl
@@ -1,3 +1,3 @@
 function norm(::Universe, ::Real=Inf)
-    return error("a universe does not have a norm")
+    throw(ArgumentError("a universe does not have a norm"))
 end

--- a/src/Sets/Universe/permute.jl
+++ b/src/Sets/Universe/permute.jl
@@ -1,3 +1,7 @@
-function permute(U::Universe, ::AbstractVector{Int})
+function permute(U::Universe, p::AbstractVector{Int})
+    @assert length(p) == dim(U) "the dimensions should match, but they are $(length(p)) and " *
+                                "$(dim(U)), respectively"
+    @assert all(1 <= v <= dim(U) for v in p) "invalid dimension in index vector"
+
     return U
 end

--- a/src/Sets/Universe/project.jl
+++ b/src/Sets/Universe/project.jl
@@ -1,3 +1,6 @@
 function project(U::Universe{N}, block::AbstractVector{Int}; kwargs...) where {N}
+    @assert length(block) <= dim(U) "incompatible dimensions $(length(block)) and $(dim(U))"
+    @assert all(1 <= v <= dim(U) for v in block) "invalid dimension in index vector"
+
     return Universe{N}(length(block))
 end

--- a/src/Sets/Universe/radius.jl
+++ b/src/Sets/Universe/radius.jl
@@ -1,3 +1,3 @@
 function radius(::Universe, ::Real=Inf)
-    return error("a universe does not have a radius")
+    throw(ArgumentError("a universe does not have a radius"))
 end

--- a/src/Sets/Universe/volume.jl
+++ b/src/Sets/Universe/volume.jl
@@ -1,0 +1,4 @@
+function volume(U::Universe)
+    N = eltype(U)
+    return N(Inf)
+end

--- a/test/Sets/Universe.jl
+++ b/test/Sets/Universe.jl
@@ -173,7 +173,8 @@ for N in [Float64, Float32, Rational{Int}]
     @test_throws ArgumentError vertices(U)
 
     # volume
-    @test_throws MethodError volume(U)  # TODO this should maybe change
+    x = volume(U)
+    @test x isa N && x == N(Inf)
 
     # affine_map
     @test_broken affine_map(ones(N, 2, 3), U, N[1, 1])  # TODO this should be caught earlier

--- a/test/Sets/Universe.jl
+++ b/test/Sets/Universe.jl
@@ -192,8 +192,7 @@ for N in [Float64, Float32, Rational{Int}]
     @test N[0, 0] ∈ U
 
     # linear_map
-    @test_broken linear_map(ones(N, 2, 3), U)  # TODO this should become an AssertionError
-    # @test_throws AssertionError linear_map(ones(N, 2, 3), U)
+    @test_throws AssertionError linear_map(ones(N, 2, 3), U)
     @test_broken linear_map(ones(N, 2, 2), U)  # TODO this should work, even without Polyhedra
     # U2 = linear_map(ones(N, 2, 2), U)
     # @test_broken isidentical(U, U2)

--- a/test/Sets/Universe.jl
+++ b/test/Sets/Universe.jl
@@ -177,8 +177,8 @@ for N in [Float64, Float32, Rational{Int}]
     @test x isa N && x == N(Inf)
 
     # affine_map
-    @test_broken affine_map(ones(N, 2, 3), U, N[1, 1])  # TODO this should be caught earlier
-    @test_broken affine_map(ones(N, 2, 2), U, N[1])  # TODO this should be caught earlier and not require Polyhedra
+    @test_throws AssertionError affine_map(ones(N, 2, 3), U, N[1, 1])
+    @test_throws AssertionError affine_map(ones(N, 2, 2), U, N[1])
     if test_suite_polyhedra  # TODO this should work, even without Polyhedra
         @test_broken affine_map(ones(N, 2, 2), U, N[1, 1])
         # U2 = affine_map(ones(N, 2, 2), U, N[1, 1])

--- a/test/Sets/Universe.jl
+++ b/test/Sets/Universe.jl
@@ -135,7 +135,7 @@ for N in [Float64, Float32, Rational{Int}]
     end
 
     # radius
-    @test_throws ErrorException radius(U)  # TODO this should become an ArgumentError
+    @test_throws ArgumentError radius(U)
 
     # rand
     @test rand(Universe; N=N) isa Universe{N}

--- a/test/Sets/Universe.jl
+++ b/test/Sets/Universe.jl
@@ -75,7 +75,7 @@ for N in [Float64, Float32, Rational{Int}]
     end
 
     # diameter
-    @test_throws ErrorException diameter(U)  # TODO this should become an ArgumentError
+    @test_throws ArgumentError diameter(U)
 
     # dim
     @test dim(U) == 2

--- a/test/Sets/Universe.jl
+++ b/test/Sets/Universe.jl
@@ -214,8 +214,8 @@ for N in [Float64, Float32, Rational{Int}]
     @test isidentical(U, U2)
 
     # project
-    @test_broken project(U, [1, -1]) isa AssertionError  # TODO this should change
-    @test_broken project(U, [1, 2, 3]) isa AssertionError  # TODO this should change
+    @test_throws AssertionError project(U, [1, -1])
+    @test_throws AssertionError project(U, [1, 2, 3])
     U2 = project(U, [2])
     @test U2 isa Universe{N} && dim(U2) == 1
 

--- a/test/Sets/Universe.jl
+++ b/test/Sets/Universe.jl
@@ -122,7 +122,7 @@ for N in [Float64, Float32, Rational{Int}]
     @test low(U, 1) == N(-Inf)
 
     # norm
-    @test_throws ErrorException norm(U)  # TODO this should become an ArgumentError
+    @test_throws ArgumentError norm(U)
 
     # polyhedron
     if test_suite_polyhedra

--- a/test/Sets/Universe.jl
+++ b/test/Sets/Universe.jl
@@ -208,8 +208,8 @@ for N in [Float64, Float32, Rational{Int}]
     @test isidentical(U3, U2)
 
     # permute
-    @test_broken permute(U, [1, -1]) isa AssertionError  # TODO this should change
-    @test_broken permute(U, [1, 2, 2]) isa AssertionError  # TODO this should change
+    @test_throws AssertionError permute(U, [1, -1])
+    @test_throws AssertionError permute(U, [1, 2, 2])
     U2 = permute(U, [2, 1])
     @test isidentical(U, U2)
 


### PR DESCRIPTION
- let `diameter` for `Universe` throw `ArgumentError`
- let `norm` for `Universe` throw `ArgumentError`
- let `radius` for `Universe` throw `ArgumentError`
- add `volume` for `Universe`
- add input validation to `affine_map`
- change input validation for `linear_map` to assertion and move
- let `permute` for `Universe` validate inputs
- let `project` for `Universe` validate inputs