### PR TITLE
#3169 Outsource common code in concretize

### DIFF
--- a/src/ConcreteOperations/utils_concrete.jl
+++ b/src/ConcreteOperations/utils_concrete.jl
@@ -1,0 +1,13 @@
+"""
+_concretize_lazy_array(arr, operation) -> LazySet
+Helper to concretize lazy array operations (MinkowskiSumArray, CartesianProductArray).
+"""
+function _concretize_lazy_array(arr::AbstractVector, operation::Function)
+    @assert !isempty(arr) "operation not supported on an empty array"
+    x = first(arr)
+    x = concretize(x)
+    @inbounds for Y in @view arr[2:end]
+        x = operation(x, concretize(Y))
+    end
+    return x
+end

--- a/src/LazyOperations/CartesianProductArray.jl
+++ b/src/LazyOperations/CartesianProductArray.jl
@@ -717,16 +717,7 @@ end
 
 function concretize(cpa::CartesianProductArray)
     a = array(cpa)
-    @assert !isempty(a) "an empty Cartesian product is not allowed"
-    X = cpa
-    @inbounds for (i, Y) in enumerate(a)
-        if i == 1
-            X = concretize(Y)
-        else
-            X = cartesian_product(X, concretize(Y))
-        end
-    end
-    return X
+    return _concretize_lazy_array(a, cartesian_product)
 end
 
 """

--- a/src/LazyOperations/MinkowskiSumArray.jl
+++ b/src/LazyOperations/MinkowskiSumArray.jl
@@ -208,16 +208,7 @@ end
 
 function concretize(msa::MinkowskiSumArray)
     a = array(msa)
-    @assert !isempty(a) "an empty Minkowski sum is not allowed"
-    X = msa
-    @inbounds for (i, Y) in enumerate(a)
-        if i == 1
-            X = concretize(Y)
-        else
-            X = minkowski_sum(X, concretize(Y))
-        end
-    end
-    return X
+    return _concretize_lazy_array(a, minkowski_sum)
 end
 
 function translate(msa::MinkowskiSumArray, x::AbstractVector)

--- a/src/LazySets.jl
+++ b/src/LazySets.jl
@@ -290,7 +290,7 @@ include("ConcreteOperations/linear_combination.jl")
 include("ConcreteOperations/minkowski_difference.jl")
 include("ConcreteOperations/minkowski_sum.jl")
 include("Utils/samples.jl")
-
+include("ConcreteOperations/utils_concrete.jl")
 # =====================
 # Approximations module
 # =====================


### PR DESCRIPTION
I created a helper function saved in the file ConcreteOperations/utils_concrete.jl to outsource the implementation of the concretize function in LazyOperations/MinkowskiSumArray and CartesianProductArray. The error message is now more generic