### PR TITLE
Fix  `_minkowski_sum_vrep_2d`

### DIFF
--- a/src/ConcreteOperations/minkowski_sum.jl
+++ b/src/ConcreteOperations/minkowski_sum.jl
@@ -222,14 +222,13 @@ function _minkowski_sum_vrep_2d(vlistP::AbstractVector{<:AbstractVector{N}},
         return _minkowski_sum_vrep_2d_singleton(vlistP, vlistQ)
     end
 
-    EAST = N[1, 0]
-    NORTH = N[0, 1]
     ORIGIN = N[0, 0]
     R = fill(ORIGIN, mP + mQ)
-    k = _σ_helper(EAST, vlistP)
-    j = _σ_helper(EAST, vlistQ)
+    k = argmin(vlistP)
+    j = argmin(vlistQ)
 
-    for i in eachindex(R)
+    i = 1
+    while i <= size(R, 1)
         P₁, P₂ = vlistP[mod1(k, mP)], vlistP[mod1(k + 1, mP)]
         P₁P₂ = P₂ - P₁
         Q₁, Q₂ = vlistQ[mod1(j, mQ)], vlistQ[mod1(j + 1, mQ)]
@@ -241,13 +240,20 @@ function _minkowski_sum_vrep_2d(vlistP::AbstractVector{<:AbstractVector{N}},
         elseif turn < 0
             j += 1
         elseif dot(P₁P₂, Q₁Q₂) < 0 # collinear and opposite direction
-            last_dir = (i == 1) ? NORTH : R[i] - R[i - 1]
+            if i == 1  # for the first iteration, we pick an orthogonal vector counterclockwise around R[1]
+                last_dir = copy(R[1])
+                last_dir[1] *= -1
+            else
+                last_dir = R[i] - R[i - 1]
+            end
+
             if dot(last_dir, P₁P₂) > 0
                 k += 1
             else
                 j += 1
             end
         else
+            pop!(R)
             k += 1
             j += 1
         end

--- a/src/ConcreteOperations/minkowski_sum.jl
+++ b/src/ConcreteOperations/minkowski_sum.jl
@@ -224,6 +224,14 @@ function _minkowski_sum_vrep_2d(vlistP::AbstractVector{<:AbstractVector{N}},
 
     ORIGIN = N[0, 0]
     R = fill(ORIGIN, mP + mQ)
+
+    # `_σ_helper(WEST, vlistP)` would be faster but if the direction is
+    # orthogonal to a facet, it may return a pair of vertices (k, j) that is
+    # not part of the Minkowski sum.
+
+    # Instead, argmin searches WEST and if two such vertices exist, it
+    # arbitrates between them by picking the one with the smallest x[2].
+    # This is guaranteed to be a vertex of the Minkowski sum.
     k = argmin(vlistP)
     j = argmin(vlistQ)
 

--- a/src/ConcreteOperations/minkowski_sum.jl
+++ b/src/ConcreteOperations/minkowski_sum.jl
@@ -227,8 +227,8 @@ function _minkowski_sum_vrep_2d(vlistP::AbstractVector{<:AbstractVector{N}},
     Q₁Q₂ = N[0, 0]
 
     # `_σ_helper(WEST, vlistP)` would be faster but if the direction is
-    # orthogonal to a facet, it may return a pair of vertices (k, j) that is
-    # not part of the Minkowski sum.
+    # orthogonal to a facet, it may return a pair of vertices (k, j) that
+    # added together is not a vertex of the Minkowski sum.
 
     # Instead, argmin searches WEST and if two such vertices exist, it
     # arbitrates between them by picking the one with the smallest x[2].

--- a/src/ConcreteOperations/minkowski_sum.jl
+++ b/src/ConcreteOperations/minkowski_sum.jl
@@ -242,7 +242,7 @@ function _minkowski_sum_vrep_2d(vlistP::AbstractVector{<:AbstractVector{N}},
         @. P₁P₂ = P₂ - P₁
         Q₁, Q₂ = vlistQ[mod1(j, mQ)], vlistQ[mod1(j + 1, mQ)]
         @. Q₁Q₂ = Q₂ - Q₁
-        @. R[i] = P₁ + Q₁
+        R[i] = P₁ + Q₁
         turn = right_turn(P₁P₂, Q₁Q₂)
         if turn > 0
             k += 1

--- a/src/ConcreteOperations/minkowski_sum.jl
+++ b/src/ConcreteOperations/minkowski_sum.jl
@@ -222,8 +222,9 @@ function _minkowski_sum_vrep_2d(vlistP::AbstractVector{<:AbstractVector{N}},
         return _minkowski_sum_vrep_2d_singleton(vlistP, vlistQ)
     end
 
-    ORIGIN = N[0, 0]
-    R = fill(ORIGIN, mP + mQ)
+    R = fill(N[0, 0], mP + mQ)
+    P₁P₂ = N[0, 0]
+    Q₁Q₂ = N[0, 0]
 
     # `_σ_helper(WEST, vlistP)` would be faster but if the direction is
     # orthogonal to a facet, it may return a pair of vertices (k, j) that is
@@ -238,10 +239,10 @@ function _minkowski_sum_vrep_2d(vlistP::AbstractVector{<:AbstractVector{N}},
     i = 1
     while i <= size(R, 1)
         P₁, P₂ = vlistP[mod1(k, mP)], vlistP[mod1(k + 1, mP)]
-        P₁P₂ = P₂ - P₁
+        @. P₁P₂ = P₂ - P₁
         Q₁, Q₂ = vlistQ[mod1(j, mQ)], vlistQ[mod1(j + 1, mQ)]
-        Q₁Q₂ = Q₂ - Q₁
-        R[i] = P₁ + Q₁
+        @. Q₁Q₂ = Q₂ - Q₁
+        @. R[i] = P₁ + Q₁
         turn = right_turn(P₁P₂, Q₁Q₂)
         if turn > 0
             k += 1

--- a/src/ConcreteOperations/minkowski_sum.jl
+++ b/src/ConcreteOperations/minkowski_sum.jl
@@ -239,23 +239,15 @@ function _minkowski_sum_vrep_2d(vlistP::AbstractVector{<:AbstractVector{N}},
             k += 1
         elseif turn < 0
             j += 1
-        elseif dot(P₁P₂, Q₁Q₂) < 0 # collinear and opposite direction
-            if i == 1  # for the first iteration, we pick an orthogonal vector counterclockwise around R[1]
-                last_dir = copy(R[1])
-                last_dir[1] *= -1
-            else
-                last_dir = R[i] - R[i - 1]
-            end
-
-            if dot(last_dir, P₁P₂) > 0
-                k += 1
-            else
-                j += 1
-            end
-        else
+        else  # collinear and same direction
+            # Increment both k and j, and Minkowski sum will have one less vertex.
             pop!(R)
             k += 1
             j += 1
+
+            # Note: collinear and opposite direction is not possible, as the
+            # the one of the two vertices would lie outside the respective polygons.
+            # This only holds for proper initialization and sorted vertices.
         end
         i += 1
     end

--- a/src/ConcreteOperations/minkowski_sum.jl
+++ b/src/ConcreteOperations/minkowski_sum.jl
@@ -228,24 +228,20 @@ function _minkowski_sum_vrep_2d(vlistP::AbstractVector{<:AbstractVector{N}},
     k = _σ_helper(EAST, vlistP)
     j = _σ_helper(EAST, vlistQ)
 
-    i = 1
-    while i <= size(R, 1)
-        P₁, P₂ = vlistP[(k - 1) % mP + 1], vlistP[(k % mP + 1)]
+    for i in 1:(mP + mQ)
+        P₁, P₂ = vlistP[mod1(k, mP)], vlistP[mod1(k + 1, mP)]
         P₁P₂ = P₂ - P₁
-        Q₁, Q₂ = vlistQ[(j - 1) % mQ + 1], vlistQ[(j % mQ + 1)]
+        Q₁, Q₂ = vlistQ[mod1(j, mQ)], vlistQ[mod1(j + 1, mQ)]
         Q₁Q₂ = Q₂ - Q₁
         R[i] = P₁ + Q₁
-        turn = right_turn(P₁P₂, Q₁Q₂, ORIGIN)
-        if turn > 0
+        turn = right_turn(P₁P₂, Q₁Q₂)
+        if turn >= 0
             k += 1
-        elseif turn < 0
-            j += 1
-        else
-            pop!(R)
-            k += 1
+        end
+
+        if turn <= 0
             j += 1
         end
-        i += 1
     end
     return R
 end

--- a/src/ConcreteOperations/minkowski_sum.jl
+++ b/src/ConcreteOperations/minkowski_sum.jl
@@ -223,25 +223,35 @@ function _minkowski_sum_vrep_2d(vlistP::AbstractVector{<:AbstractVector{N}},
     end
 
     EAST = N[1, 0]
+    NORTH = N[0, 1]
     ORIGIN = N[0, 0]
     R = fill(ORIGIN, mP + mQ)
     k = _σ_helper(EAST, vlistP)
     j = _σ_helper(EAST, vlistQ)
 
-    for i in 1:(mP + mQ)
+    for i in eachindex(R)
         P₁, P₂ = vlistP[mod1(k, mP)], vlistP[mod1(k + 1, mP)]
         P₁P₂ = P₂ - P₁
         Q₁, Q₂ = vlistQ[mod1(j, mQ)], vlistQ[mod1(j + 1, mQ)]
         Q₁Q₂ = Q₂ - Q₁
         R[i] = P₁ + Q₁
         turn = right_turn(P₁P₂, Q₁Q₂)
-        if turn >= 0
+        if turn > 0
             k += 1
-        end
-
-        if turn <= 0
+        elseif turn < 0
+            j += 1
+        elseif dot(P₁P₂, Q₁Q₂) < 0 # collinear and opposite direction
+            last_dir = (i == 1) ? NORTH : R[i] - R[i - 1]
+            if dot(last_dir, P₁P₂) > 0
+                k += 1
+            else
+                j += 1
+            end
+        else
+            k += 1
             j += 1
         end
+        i += 1
     end
     return R
 end

--- a/src/Sets/VPolygon/minkowski_sum.jl
+++ b/src/Sets/VPolygon/minkowski_sum.jl
@@ -14,5 +14,5 @@ sorted in counter-clockwise fashion and has linear complexity ``O(m+n)``, where
 """
 function minkowski_sum(P::VPolygon, Q::VPolygon)
     R = _minkowski_sum_vrep_2d(P.vertices, Q.vertices)
-    return VPolygon(R)
+    return VPolygon(R, apply_convex_hull=false)
 end

--- a/test/Sets/Polygon.jl
+++ b/test/Sets/Polygon.jl
@@ -191,12 +191,32 @@ for N in [Float64, Float32, Rational{Int}]
                                      N[8, 4], N[6, 6], N[2, 8]])
 
         P = VPolygon([N[0, -1], N[2, 0], N[1, 1], N[0, 1]], apply_convex_hull=false)
-        Q = VPolygon([N[0, 1], N[0, -1]], apply_convex_hull=false)
-        PQ = minkowski_sum(P, Q)
-        @test length(PQ.vertices) == 5
-        @test is_cyclic_permutation(PQ.vertices,
+        Q1 = VPolygon([N[0, 1], N[0, -1]], apply_convex_hull=false)
+        Q2 = VPolygon([N[0, 1], N[0, -1]], apply_convex_hull=false)
+        PQ1 = minkowski_sum(P, Q1)
+        PQ2 = minkowski_sum(P, Q2)
+        @test length(PQ1.vertices) == 5
+        @test is_cyclic_permutation(PQ1.vertices,
                                     [N[0, -2], N[2, -1], N[2, 1],
                                      N[1, 2], N[0, 2]])
+        @test length(PQ2.vertices) == 5
+        @test is_cyclic_permutation(PQ2.vertices,
+                                    [N[0, -2], N[2, -1], N[2, 1],
+                                    N[1, 2], N[0, 2]])
+
+        P = VPolygon([N[-1, -1], N[2, 0], N[2, 1], N[0, 1]], apply_convex_hull=false)
+        Q1 = VPolygon([N[0, 1], N[0, -1]], apply_convex_hull=false)
+        Q2 = VPolygon([N[0, -1], N[0, 1]], apply_convex_hull=false)
+        PQ1 = minkowski_sum(P, Q1)
+        PQ2 = minkowski_sum(P, Q2)
+        @test length(PQ1.vertices) == 5
+        @test is_cyclic_permutation(PQ1.vertices,
+                                    [N[-1, -2], N[2, -1], N[2, 2],
+                                    N[0, 2], N[-1, 0]])
+        @test length(PQ2.vertices) == 5
+        @test is_cyclic_permutation(PQ2.vertices,
+                                    [N[-1, -2], N[2, -1], N[2, 2],
+                                    N[0, 2], N[-1, 0]])
 
         # test for different starting points in vertices_list of minkowski sum
         P = VPolygon([N[4, 0], N[6, 2], N[4, 4]])

--- a/test/Sets/Polygon.jl
+++ b/test/Sets/Polygon.jl
@@ -190,13 +190,13 @@ for N in [Float64, Float32, Rational{Int}]
                                     [N[2, -2], N[6, 0], N[8, 2],
                                      N[8, 4], N[6, 6], N[2, 8]])
 
-        P = VPolygon([N[0.0, 0.025], N[1.0, -0.125], N[1.1, 0.9],
-            N[1.1, 1.9], [0.1, 2.05], [0.0, 1.025]])
-        Q = VPolygon([N[0.0, 0.05], N[0.0, -0.025]])
+        P = VPolygon([N[0, -1], N[2, 0], N[1, 1], N[0, 1]], apply_convex_hull=false)
+        Q = VPolygon([N[0, 1], N[0, -1]], apply_convex_hull=false)
         PQ = minkowski_sum(P, Q)
+        @test length(PQ.vertices) == 5
         @test is_cyclic_permutation(PQ.vertices,
-                                    [N[0.0, 0.0], N[1.0, -0.15], N[1.1, 0.875],
-                                     N[1.1, 1.95], [0.1, 2.1], N[0.0, 1.075]])
+                                    [N[0, -2], N[2, -1], N[2, 1],
+                                     N[1, 2], N[0, 2]])
 
         # test for different starting points in vertices_list of minkowski sum
         P = VPolygon([N[4, 0], N[6, 2], N[4, 4]])

--- a/test/Sets/Polygon.jl
+++ b/test/Sets/Polygon.jl
@@ -196,8 +196,7 @@ for N in [Float64, Float32, Rational{Int}]
         PQ = minkowski_sum(P, Q)
         @test is_cyclic_permutation(PQ.vertices,
                                     [N[0.0, 0.0], N[1.0, -0.15], N[1.1, 0.875],
-                                     N[1.1, 1.95], [0.1, 2.1], [0.1, 2.1],
-                                     N[0.0, 1.075]])
+                                     N[1.1, 1.95], [0.1, 2.1], N[0.0, 1.075]])
 
         # test for different starting points in vertices_list of minkowski sum
         P = VPolygon([N[4, 0], N[6, 2], N[4, 4]])

--- a/test/Sets/Polygon.jl
+++ b/test/Sets/Polygon.jl
@@ -190,6 +190,15 @@ for N in [Float64, Float32, Rational{Int}]
                                     [N[2, -2], N[6, 0], N[8, 2],
                                      N[8, 4], N[6, 6], N[2, 8]])
 
+        P = VPolygon([N[0.0, 0.025], N[1.0, -0.125], N[1.1, 0.9],
+            N[1.1, 1.9], [0.1, 2.05], [0.0, 1.025]])
+        Q = VPolygon([N[0.0, 0.05], N[0.0, -0.025]])
+        PQ = minkowski_sum(P, Q)
+        @test is_cyclic_permutation(PQ.vertices,
+                                    [N[0.0, 0.0], N[1.0, -0.15], N[1.1, 0.875],
+                                     N[1.1, 1.95], [0.1, 2.1], [0.1, 2.1],
+                                     N[0.0, 1.075]])
+
         # test for different starting points in vertices_list of minkowski sum
         P = VPolygon([N[4, 0], N[6, 2], N[4, 4]])
         P2 = VPolygon([N[4, 4], N[4, 0], N[6, 2]])


### PR DESCRIPTION
Fix #3836 

There ought to be a solution where it is not necessary to take the convex hull after, but for now, this is an easy fix. The convex hull is right now (without these changes) computed implicitly by constructing a `VPolygon` in Sets/VPolygon/minkowski_sum.jl.