### PR TITLE
v4.0.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LazySets"
 uuid = "b4f0291d-fe17-52bc-9479-3d1a343d9043"
-version = "3.1.0"
+version = "4.0.0"
 
 [deps]
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"


### PR DESCRIPTION
#### Breaking changes

- Remove constructors from `HRep`/`VRep` (use `convert` instead) ([#3715](https://github.com/JuliaReach/LazySets.jl/pull/3715))
- Remove scalar `linear_map` (use `scale` instead) ([#3729](https://github.com/JuliaReach/LazySets.jl/pull/3729))
- Remove `surface` function ([#3816](https://github.com/JuliaReach/LazySets.jl/pull/3816))
- `EmptySet`: redefine `norm`/`radius`/`diameter` to 0 (instead of throwing an error) ([#3667](https://github.com/JuliaReach/LazySets.jl/pull/3667))
- Revise plot recipe of small or flat 2D sets; this may change the plotting of sets in some cases ([#3822](https://github.com/JuliaReach/LazySets.jl/pull/3822))
- Rename `delaunay` → `triangulate` and `triangulate` → `triangulate_faces` and export symbols ([#3804](https://github.com/JuliaReach/LazySets.jl/pull/3804))