### PR TITLE
#3814 - Allow `area` for 3D sets and add common cases

### DIFF
--- a/src/API/Unary/area.jl
+++ b/src/API/Unary/area.jl
@@ -1,14 +1,15 @@
 """
     area(X::LazySet)
 
-Compute the area of a two-dimensional set.
+Compute the area of a two-dimensional set, respectively the surface area of a
+three-dimensional set.
 
 ### Input
 
-- `X` -- two-dimensional set
+- `X` -- two- or three-dimensional set
 
 ### Output
 
-A number representing the area of `X`.
+A number representing the (surface) area of `X`.
 """
 function area(::LazySet) end

--- a/src/Interfaces/AbstractHyperrectangle.jl
+++ b/src/Interfaces/AbstractHyperrectangle.jl
@@ -574,14 +574,29 @@ function volume(H::AbstractHyperrectangle)
     return _volume_hyperrectangle(H)
 end
 
-function _volume_hyperrectangle(H::LazySet)
+function _volume_hyperrectangle(H)
     return mapreduce(x -> 2x, *, radius_hyperrectangle(H))
 end
 
+function _surface_area_hyperrectangle(H)
+    l, b, h = radius_hyperrectangle(H)
+    l *= 2
+    b *= 2
+    h *= 2
+    return 2 * (l * b + l * h + b * h)
+end
+
 function area(H::AbstractHyperrectangle)
-    @assert dim(H) == 2 "this function only applies to two-dimensional sets, " *
-                        "but the given set is $(dim(H))-dimensional"
-    return _volume_hyperrectangle(H)
+    n = dim(H)
+    @assert n ∈ (2, 3) "this function only applies to two-dimensional or " *
+                        "three-dimensional sets, but the given set is " *
+                        "$n-dimensional"
+
+    if n == 2
+        return _volume_hyperrectangle(H)
+    else
+        return _surface_area_hyperrectangle(H)
+    end
 end
 
 function project(H::AbstractHyperrectangle, block::AbstractVector{Int};

--- a/src/Interfaces/LazySet.jl
+++ b/src/Interfaces/LazySet.jl
@@ -924,8 +924,8 @@ end
 
 ### Notes
 
-This algorithm is applicable to any polytopic set `X` whose list of vertices can
-be computed via `vertices_list`.
+This algorithm is applicable to any two-dimensional polytopic set `X` whose list
+of vertices can be computed via `vertices_list`.
 
 ### Algorithm
 

--- a/src/Sets/Ball2/area.jl
+++ b/src/Sets/Ball2/area.jl
@@ -1,5 +1,12 @@
 function area(B::Ball2)
-    @assert dim(B) == 2 "this function only applies to two-dimensional sets, " *
-                        "but the given set is $(dim(B))-dimensional"
-    return Base.pi * B.radius^2
+    n = dim(B)
+    @assert n ∈ (2, 3) "this function only applies to two-dimensional or " *
+                        "three-dimensional sets, but the given set is " *
+                        "$n-dimensional"
+
+    if n == 2
+        return Base.pi * B.radius^2
+    else
+        return 4 * Base.pi * B.radius^2
+    end
 end

--- a/src/Sets/BallInf/area.jl
+++ b/src/Sets/BallInf/area.jl
@@ -1,5 +1,12 @@
 function area(B::BallInf)
-    @assert dim(B) == 2 "this function only applies to two-dimensional sets, " *
-                        "but the given set is $(dim(B))-dimensional"
-    return (2 * B.radius)^2
+    n = dim(B)
+    @assert n ∈ (2, 3) "this function only applies to two-dimensional or " *
+                        "three-dimensional sets, but the given set is " *
+                        "$n-dimensional"
+
+    if n == 2
+        return (2 * B.radius)^2
+    else
+        return 6 * (2 * B.radius)^2
+    end
 end

--- a/src/Sets/EmptySet/area.jl
+++ b/src/Sets/EmptySet/area.jl
@@ -1,6 +1,7 @@
 function area(∅::EmptySet)
-    @assert dim(∅) == 2 "this function only applies to two-dimensional sets, " *
-                        "but the given set is $(dim(∅))-dimensional"
+    @assert dim(∅) ∈ (2, 3) "this function only applies to two-dimensional " *
+                              "or three-dimensional sets, but the given set " *
+                              "is $(dim(∅))-dimensional"
 
     N = eltype(∅)
     return zero(N)

--- a/test/ConcreteOperations/area.jl
+++ b/test/ConcreteOperations/area.jl
@@ -1,7 +1,9 @@
 for N in [Float64, Float32, Rational{Int}]
-    # not implemented for dimension != 2
-    p = BallInf(zeros(N, 3), N(1))
-    @test_throws AssertionError area(p)
+    # not implemented for dimension other than 2 or 3
+    for d in (1, 4)
+        p = BallInf(zeros(N, d), N(1))
+        @test_throws AssertionError area(p)
+    end
 
     # sets with zero area
     p = Singleton(N[0, 1])

--- a/test/Sets/Ball2.jl
+++ b/test/Sets/Ball2.jl
@@ -144,10 +144,13 @@ for N in [Float64, Float32]
 
     # area/volume
     B = Ball2(zeros(N, 2), N(2))
-    @test area(B) == volume(B) == N(pi) * radius(B)^2
+    @test area(B) == volume(B) == 4 * N(pi)
     B = Ball2(zeros(N, 3), N(2))
+    @test area(B) ≈ 16 * N(pi)
+    @test volume(B) == 32 / 3 * N(pi)
+    B = Ball2(zeros(N, 4), N(2))
     @test_throws AssertionError area(B)
-    @test volume(B) == 4 / 3 * N(pi) * radius(B)^3
+    @test volume(B) == 8 * N(pi)^2
 
     # projection
     b4 = Ball2(N[4, 3, 2, 1], N(2))

--- a/test/Sets/BallInf.jl
+++ b/test/Sets/BallInf.jl
@@ -157,16 +157,15 @@ for N in [Float64, Rational{Int}, Float32]
 
     # area/volume
     B = BallInf(N[0, 0], N(1))
-    @test area(B) == volume(B) ≈ N(4)
+    @test area(B) == volume(B) == N(4)
+    B = BallInf(zeros(N, 3), N(2))
+    @test area(B) == N(96)
+    @test volume(B) == N(64)
     if N <: AbstractFloat
         B = BallInf(zeros(N, 100), N(1 / 2 + 1e-5))
         @test_throws AssertionError area(B)
         @test volume(B) ≈ N(1.0020019812942185)
     end
-
-    # area
-    B = BallInf(N[0, 0], N(1))
-    @test area(B) ≈ N(4)
 
     # concretize
     B = BallInf(N[0, 0], N(1))

--- a/test/Sets/EmptySet.jl
+++ b/test/Sets/EmptySet.jl
@@ -42,9 +42,11 @@ for N in [Float64, Float32, Rational{Int}]
     @test_throws ArgumentError an_element(E)
 
     # area
-    res = area(E)
-    @test res isa N && res == N(0)
-    @test_throws AssertionError area(E3)
+    for X in (E, E3)
+        res = area(X)
+        @test res isa N && res == N(0)
+    end
+    @test_throws AssertionError area(EmptySet{N}(4))
 
     # chebyshev_center_radius
     @test_throws ArgumentError chebyshev_center_radius(E)

--- a/test/Sets/Hyperrectangle.jl
+++ b/test/Sets/Hyperrectangle.jl
@@ -110,6 +110,9 @@ for N in [Float64, Rational{Int}, Float32]
     h1 = Hyperrectangle(N[0], N[1])
     @test_throws AssertionError area(h1)
     @test volume(h1) == N(2)
+    h1 = Hyperrectangle(N[0, 0, 0], N[1, 3//2, 2])
+    @test area(h1) == N(52)
+    @test volume(h1) == N(24)
 
     # unicode constructor
     @test □(center(h), radius_hyperrectangle(h)) == h


### PR DESCRIPTION
Closes #3814.

Since `surface` was removed in #3816, we agreed to let `area` also work for 3D sets (interpreted as the *surface area*). In higher dimensions, the definition is far less clear and probably not interesting, so for now the usage is restricted to 2D and 3D arguments.

This PR also implements `area` for the following 3D sets:
- `AbstractHyperrectangle`
- `Ball2`
- `BallInf`
- `EmptySet`

The only missing case is the general 3D polytope (`LazySet` method → #3853).