### PR TITLE
`merge_id` and `scale` functions for SPZ

### DIFF
--- a/docs/src/lib/sets/SparsePolynomialZonotope.md
+++ b/docs/src/lib/sets/SparsePolynomialZonotope.md
@@ -30,6 +30,7 @@ CurrentModule = LazySets.SparsePolynomialZonotopeModule
 ```@docs
 remove_redundant_generators(::SparsePolynomialZonotope)
 uniqueID(::Int)
+merge_id(::AbstractVector{Int64}, ::AbstractVector{Int},::AbstractMatrix, ::AbstractMatrix)
 ```
 ```@meta
 CurrentModule = LazySets

--- a/docs/src/lib/sets/SparsePolynomialZonotope.md
+++ b/docs/src/lib/sets/SparsePolynomialZonotope.md
@@ -93,6 +93,7 @@ Undocumented implementations:
 * [`isoperationtype`](@ref isoperationtype(::Type{LazySet}))
 * [`linear_map`](@ref linear_map(::AbstractMatrix, ::LazySet))
 * [`translate`](@ref translate(::LazySet, ::AbstractVector))
+* [`scale`](@ref scale(::Real, ::LazySet))
 
 ```@meta
 CurrentModule = LazySets

--- a/docs/src/lib/sets/SparsePolynomialZonotope.md
+++ b/docs/src/lib/sets/SparsePolynomialZonotope.md
@@ -30,7 +30,8 @@ CurrentModule = LazySets.SparsePolynomialZonotopeModule
 ```@docs
 remove_redundant_generators(::SparsePolynomialZonotope)
 uniqueID(::Int)
-merge_id(::AbstractVector{Int64}, ::AbstractVector{Int},::AbstractMatrix, ::AbstractMatrix)
+merge_id(::AbstractVector{Int64}, ::AbstractVector{Int}, 
+         ::AbstractMatrix{N}, ::AbstractMatrix{N}) where {N}
 ```
 ```@meta
 CurrentModule = LazySets

--- a/src/ConcreteOperations/minkowski_sum.jl
+++ b/src/ConcreteOperations/minkowski_sum.jl
@@ -335,7 +335,7 @@ end
 @commutative minkowski_sum(::ZeroSet, X::LazySet) = X
 
 # See [Kochdumper21a; Proposition 3.1.19](@citet).
-@commutative function minkowski_sum(PZ::SparsePolynomialZonotope, Z::AbstractZonotope)
+@commutative function minkowski_sum(PZ::AbstractSparsePolynomialZonotope, Z::AbstractZonotope)
     c = center(PZ) + center(Z)
     G = genmat_dep(PZ)
     GI = hcat(genmat_indep(PZ), genmat(Z))

--- a/src/LazySets.jl
+++ b/src/LazySets.jl
@@ -192,7 +192,7 @@ include("Sets/Singleton/SingletonModule.jl")
 
 include("Sets/SparsePolynomialZonotope/SparsePolynomialZonotopeModule.jl")
 @reexport using ..SparsePolynomialZonotopeModule: SparsePolynomialZonotope, SPZ,
-                                                  indexvector
+                                                  indexvector, merge_id
 using ..SparsePolynomialZonotopeModule: uniqueID
 
 include("Sets/Star/StarModule.jl")

--- a/src/Sets/SparsePolynomialZonotope/SparsePolynomialZonotopeModule.jl
+++ b/src/Sets/SparsePolynomialZonotope/SparsePolynomialZonotopeModule.jl
@@ -12,7 +12,8 @@ using ReachabilityBase.Distribution: reseed!
 using ReachabilityBase.Require: require
 
 @reexport import ..API: center, extrema, isoperationtype, rand, linear_map, ρ,
-                        translate, cartesian_product, exact_sum, minkowski_sum
+                        translate, cartesian_product, exact_sum, minkowski_sum,
+                        scale
 @reexport import ..LazySets: expmat, genmat_dep, genmat_indep, ngens_dep,
                              ngens_indep, nparams, polynomial_order,
                              reduce_order, remove_redundant_generators
@@ -38,6 +39,7 @@ include("merge_id.jl")
 include("cartesian_product.jl")
 include("exact_sum.jl")
 include("minkowski_sum.jl")
+include("scale.jl")
 
 include("expmat.jl")
 include("genmat_dep.jl")

--- a/src/Sets/SparsePolynomialZonotope/SparsePolynomialZonotopeModule.jl
+++ b/src/Sets/SparsePolynomialZonotope/SparsePolynomialZonotopeModule.jl
@@ -19,7 +19,8 @@ using ReachabilityBase.Require: require
 @reexport using ..API
 
 export SparsePolynomialZonotope,
-       indexvector
+       indexvector,
+       merge_id
 
 include("SparsePolynomialZonotope.jl")
 
@@ -33,6 +34,7 @@ include("rand.jl")
 include("linear_map.jl")
 include("support_function.jl")
 include("translate.jl")
+include("merge_id.jl")
 include("cartesian_product.jl")
 include("exact_sum.jl")
 include("minkowski_sum.jl")

--- a/src/Sets/SparsePolynomialZonotope/exact_sum.jl
+++ b/src/Sets/SparsePolynomialZonotope/exact_sum.jl
@@ -7,17 +7,12 @@
 
 This method implements [Kochdumper21a; Proposition 3.1.20](@citet).
 """
-function exact_sum(P1::SparsePolynomialZonotope, P2::SparsePolynomialZonotope)
-    if indexvector(P1) != indexvector(P2)
-        throw(ArgumentError("the exact sum is currently only implemented for " *
-                            "sparse polynomial zonotopes with the same index vector"))
-    end
-
+function exact_sum(P1::SparsePolynomialZonotope, P2::SparsePolynomialZonotope)  
+    Ē₁, Ē₂, idx = merge_id(indexvector(P1), indexvector(P2),expmat(P1), expmat(P2))
     c = center(P1) + center(P2)
     G = hcat(genmat_dep(P1), genmat_dep(P2))
     GI = hcat(genmat_indep(P1), genmat_indep(P2))
-    E = hcat(expmat(P1), expmat(P2))
-    idx = indexvector(P1)
+    E = hcat(Ē₁, Ē₂)
 
     return SparsePolynomialZonotope(c, G, GI, E, idx)
 end

--- a/src/Sets/SparsePolynomialZonotope/merge_id.jl
+++ b/src/Sets/SparsePolynomialZonotope/merge_id.jl
@@ -1,0 +1,66 @@
+"""
+    merge_id(id1::AbstractVector{Int64}, id2::AbstractVector{Int}, 
+             E₁::AbstractMatrix{N}, E₂::AbstractMatrix{N}) where {N}
+
+Given two `indexvector`s and their corresponding exponent matrices `E₁` and `E₂`, 
+`merge_id` brings the exponent matrices and id lists into a common format.
+
+### Inputs
+
+- `id1::AbstractVector{Int64}`: Identifiers corresponding to the rows of `E₁`
+- `id2::AbstractVector{Int}`: Identifiers corresponding to the rows of `E₂`
+- `E₁::AbstractMatrix{N}`: First exponent matrix of size `(p₁ × h₁)`.
+- `E₂::AbstractMatrix{N}`: Second exponent matrix of size `(p₂ × h₂)`.
+
+### Outputs
+
+- `Ē₁::Matrix{N}`: Aligned version of `E₁` 
+- `Ē₂::Matrix{N}`: Aligned version of `E₂` 
+- `idx::Vector{Int}`: Merged identifier vector, containing all elements of `id1` and any new ones from `id2`.
+### Algorithm
+
+This method implements [KochdumperA21; Proposition 1](@citet).
+
+### Example
+
+```
+julia> id1 = [1, 2];
+
+julia> E₁ = [1 2; 1 0];
+
+julia> id2 = [2, 3];
+
+julia> E₂ = [1 0 1; 3 2 0]
+
+julia> Ē₁, Ē₂, idx = merge_id(id1, id2, E₁, E₂)
+([1 2; 1 0; 0 0], [0 0 0; 1 0 1; 3 2 0], [1, 2, 3])
+"""
+
+function merge_id(id1::AbstractVector{Int64}, id2::AbstractVector{Int}, E₁::AbstractMatrix{N},
+                  E₂::AbstractMatrix{N}) where {N}
+    p₁, h₁ = size(E₁)
+    p₂, h₂ = size(E₂)
+    if !(length(id1) == p₁ && length(id2) == p₂)
+        throw(ArgumentError("Incompatible dimensions."))
+    end
+
+    if id1 == id2
+        return E₁, E₂, id1
+    end
+
+    # Indices of elements of id2 which do not belong to id1.
+    K = findall(∈(setdiff(id2, id1)), id2)
+    k = length(K)
+
+    idx = vcat(id1, id2[K])
+    Ē₁ = vcat(E₁, zeros(N, k, h₁))
+
+    Ē₂ = zeros(N, p₁ + k, h₂)
+    for i in 1:(p₁ + k)
+        j = findfirst(==(idx[i]), id2)
+        if !isnothing(j)
+            Ē₂[i, :] = E₂[j, :]
+        end
+    end
+    return Ē₁, Ē₂, idx
+end

--- a/src/Sets/SparsePolynomialZonotope/scale.jl
+++ b/src/Sets/SparsePolynomialZonotope/scale.jl
@@ -1,0 +1,7 @@
+function scale(α::Real, P::SparsePolynomialZonotope{N}) where {N<:Real}
+    return SparsePolynomialZonotope(α * center(P),
+                                    α * genmat_dep(P),
+                                    α * genmat_indep(P),
+                                    expmat(P),
+                                    indexvector(P))
+end

--- a/test/Sets/SparsePolynomialZonotope.jl
+++ b/test/Sets/SparsePolynomialZonotope.jl
@@ -102,6 +102,14 @@ for N in [Float64, Float32, Rational{Int}]
                            0 0 0 1 0 1;
                            0 0 0 0 1 3]
 
+    α = 2.0
+    PZscaled = scale(α, PZ)
+    @test center(PZscaled) == N[8, 8]
+    @test genmat_dep(PZscaled) ==  N[4 2 4; 0 4 4]
+    @test genmat_indep(PZscaled) == hcat(N[2, 0])
+    @test expmat(PZscaled) == expmat(PZ)
+    @test PZscaled == linear_map(2*Matrix{N}(I, 2, 2), PZ)
+
     S = SparsePolynomialZonotope(N[-0.5, -0.5], N[1.0 1 1 1; 1 0 -1 1], zeros(N, 2, 0),
                                  [1 0 1 2; 0 1 1 0])
     Z = overapproximate(S, Zonotope)

--- a/test/Sets/SparsePolynomialZonotope.jl
+++ b/test/Sets/SparsePolynomialZonotope.jl
@@ -41,14 +41,22 @@ for N in [Float64, Float32, Rational{Int}]
     @test expmat(LMPZ) == [1 0 1; 0 1 3]
     @test indexvector(LMPZ) == indexvector(PZ)
 
+    # exact sum: same IDs
     ESPZ = exact_sum(PZ, PZ2)
     @test center(ESPZ) == [4, 4]
     @test genmat_dep(ESPZ) == [2 1 2 2 0 1; 0 2 2 1 2 1]
     @test genmat_indep(ESPZ) == hcat([1, 0])
     @test expmat(ESPZ) == [1 0 3 1 0 1; 0 1 1 0 1 3]
     @test indexvector(ESPZ) == indexvector(PZ)
-    PZidx = SparsePolynomialZonotope(c, G, GI, E, 3:4)
-    @test_throws ArgumentError exact_sum(PZ, PZidx)
+    #exact sum: different IDs
+    PZ3 = SparsePolynomialZonotope(N[1, -1], N[1 -1; 0 2],
+                                   hcat(N[0; 1]), [1 0; 2 1], [2, 3])
+    ESPZ2 = exact_sum(PZ, PZ3)
+    @test center(ESPZ2) == [5, 3]
+    @test genmat_dep(ESPZ2) == [2 1 2 1 -1; 0 2 2 0 2]
+    @test genmat_indep(ESPZ2) == [1 0; 0 1]
+    @test expmat(ESPZ2) == [1 0 3 0 0; 0 1 1 1 0; 0 0 0 2 1]
+    @test indexvector(ESPZ2) == [1, 2, 3]
 
     TPZ = translate(PZ, N[1, 2])
     @test center(TPZ) == N[5, 6]
@@ -241,4 +249,51 @@ let
     for r in 4:8
         @test reduce_order(P, r) == P
     end
+end
+
+#test for merge_id
+for N in [Int64]
+    #case 0: dimensions mismatch
+    id1 = [1, 2, 3]
+    id2 = [1, 2]
+    E1 = rand(2,2)
+    E2 = rand(2,2)
+    @test_throws ArgumentError merge_id(id1, id2, E1, E2)
+    
+    #case 1: identical IDs
+    id = Int64[10, 20, 30]
+    E1 = rand(3, 4)
+    E2 = rand(3, 2)
+
+    Ē₁, Ē₂, idx = merge_id(id, id, E1, E2)
+
+    @test idx == id
+    @test Ē₁ === E1
+    @test Ē₂ === E2
+    
+    # case 2: IDs with overlap
+    E1 = N[1 2; 1 0]
+    id1 = [1, 2]
+
+    E2 = N[1 0 1; 3 2 0]
+    id2 = [2, 3]
+
+    Ē₁, Ē₂, idx = merge_id(id1, id2, E1, E2)
+
+    @test idx == [1, 2, 3]
+    @test Ē₁ == [1 2; 1 0; 0 0]
+    @test Ē₂ == [0 0 0; 1 0 1; 3 2 0]
+
+    #case 3: different IDs
+    E1 = N[1 2; 1 0]
+    id1 = [1, 2]
+
+    E2 = N[1 0 1; 3 2 0]
+    id2 = [3, 4]
+
+    Ē₁, Ē₂, idx = merge_id(id1, id2, E1, E2)
+
+    @test idx == [1, 2, 3, 4]
+    @test Ē₁ == [1 2; 1 0; 0 0; 0 0]
+    @test Ē₂ == [0 0 0; 0 0 0; 1 0 1; 3 2 0]
 end


### PR DESCRIPTION
I added the following features including tests and documentations:
- `merge_id` functions to align exponential matrices and `indexvector`s of SPZ
- `scale` function for SPZ
-  generalized `exact_sum` to handle addition of SPZs with different `indexvector`s

I also changed the argument `minkowski_sum` in `src/ConcreteOperations/minkowski_sum.jl` to work on `AbstractSparsePolynomialZonotope`