### PR TITLE
More robust `isdisjoint` witness for `Interval`

### DIFF
--- a/src/Sets/Interval/isdisjoint.jl
+++ b/src/Sets/Interval/isdisjoint.jl
@@ -24,11 +24,14 @@ function _isdisjoint(I1::Interval, I2::Interval, ::Val{false})
 end
 
 function _isdisjoint(I1::Interval, I2::Interval, ::Val{true})
-    check = _isdisjoint(I1, I2, Val(false))
-    if check
+    if _isdisjoint(I1, I2, Val(false))
         N = promote_type(eltype(I1), eltype(I2))
         return (true, N[])
     else
-        return (false, [max(min(I1), min(I2))])
+        # mid-point, most robust witness
+        l = max(min(I1), min(I2))
+        h = min(max(I1), max(I2))
+        w = [l + (h - l) / 2]
+        return (false, w)
     end
 end

--- a/test/Sets/Interval.jl
+++ b/test/Sets/Interval.jl
@@ -492,25 +492,29 @@ for N in [Float64, Float32, Rational{Int}]
     @test_throws AssertionError isdisjoint(X, X2)
     # disjoint
     Y = Interval(N(3), N(4))
-    @test isdisjoint(X, Y) && isdisjoint(Y, X)
-    for (pair, Z) in ((isdisjoint(X, Y, true), Y), (isdisjoint(Y, X, true), Y))
-        res, w = pair
+    for (Z, W) in ((X, Y), (Y, X))
+        @test isdisjoint(Z, W)
+        res, w = isdisjoint(Z, W, true)
         @test res && w isa Vector{N} && isempty(w)
     end
     # overlapping
     Y = Interval(N(1), N(3))
-    @test !isdisjoint(X, X) && !isdisjoint(X, Y) && !isdisjoint(Y, X)
-    for (pair, Z) in ((isdisjoint(X, X, true), X), (isdisjoint(X, Y, true), Y),
-                      (isdisjoint(Y, X, true), Y))
-        res, w = pair
-        @test !res && w isa Vector{N} && w ∈ X && w ∈ Z
+    for (Z, W) in ((X, X), (X, Y), (Y, X))
+        @test !isdisjoint(Z, W)
+        res, w = isdisjoint(Z, W, true)
+        @test !res && w isa Vector{N} && w ∈ Z && w ∈ W
     end
     # tolerance
     if N == Float64
         Y = Interval(2.0 + 1e-9, 3.0)
         @test !isdisjoint(X, Y)
+        res, w = isdisjoint(X, Y, true)
+        # TODO ∈ and isdisjoint should be consistent
+        @test_broken !res && w isa Vector{N} && w ∈ X && w ∈ Y
         LazySets.set_rtol(Float64, 1e-10)
         @test isdisjoint(X, Y)
+        res, w = isdisjoint(X, Y, true)
+        @test res && w isa Vector{N} && isempty(w)
         # restore tolerance
         LazySets.set_rtol(Float64, LazySets.default_tolerance(Float64).rtol)
     end


### PR DESCRIPTION
This PR computes a more robust witness if two `Interval`s overlap.

I also discovered that `isdisjoint` is numerically conservative, but `∈` is not. This should maybe be fixed. For now, there is a broken test revealing it.