### PR TITLE
Add overapproximation of the l1 norm of a zonotope

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -137,7 +137,8 @@ makedocs(; sitename="LazySets.jl",
                                                    "lib/approximations/underapproximate.md",
                                                    "lib/approximations/approximate.md",
                                                    "lib/approximations/decompose.md",
-                                                   "lib/approximations/hausdorff_distance.md"
+                                                   "lib/approximations/hausdorff_distance.md",
+                                                   "lib/approximations/overapproximate_norm.md"
                                                    #
                                                    ],
                               "Utilities" => "lib/utils.md",

--- a/docs/src/lib/approximations/overapproximate_norm.md
+++ b/docs/src/lib/approximations/overapproximate_norm.md
@@ -1,0 +1,15 @@
+```@contents
+Pages = ["overapproximate_norm.md"]
+Depth = 3
+```
+
+```@meta
+CurrentModule = LazySets.Approximations
+```
+
+# Norm Overapproximation
+
+```@docs
+overapproximate_norm
+_overapproximate_l1_norm
+```

--- a/docs/src/refs.bib
+++ b/docs/src/refs.bib
@@ -521,3 +521,13 @@
   url          = {https://doi.org/10.1109/TAC.2023.3292008},
   doi          = {10.1109/TAC.2023.3292008}
 }
+
+@misc{Jordan2021,
+author={Matt Jordan and Alexandros G. Dimakis},
+title={Provable Lipschitz Certification for Generative Models}, 
+year={2021},
+eprint={2107.02732},
+archivePrefix={arXiv},
+primaryClass={cs.LG},
+url={https://arxiv.org/abs/2107.02732}, 
+}

--- a/src/Approximations/Approximations.jl
+++ b/src/Approximations/Approximations.jl
@@ -20,7 +20,8 @@ export approximate,
        PolarDirections,
        SphericalDirections,
        CustomDirections,
-       isbounding
+       isbounding,
+       overapproximate_norm
 
 using ..LazySets, ReachabilityBase.Arrays, Requires, LinearAlgebra, SparseArrays
 import IntervalArithmetic as IA
@@ -46,6 +47,7 @@ include("underapproximate.jl")
 include("approximate.jl")
 include("decompositions.jl")
 include("hausdorff_distance.jl")
+include("overapproximate_norm.jl")
 include("init.jl")
 
 end # module

--- a/src/Approximations/overapproximate_norm.jl
+++ b/src/Approximations/overapproximate_norm.jl
@@ -1,0 +1,54 @@
+"""
+	overapproximate_norm(Z::AbstractZonotope, p::Real=1)
+
+Compute an upper bound on the ``\\ell_p`` norm over a zonotope `Z`.
+
+### Input
+- `Z::AbstractZonotope`-- A zonotope or subtype thereof.
+- `p::Real`-- The `ℓ_p` norm to overapproximate.
+
+### Output
+- `Float64`: An upper bound on ``\\max_{z ∈ Z} \\|z\\|_p``.
+
+"""
+function overapproximate_norm(Z::AbstractZonotope, p::Real = 1)
+	if p == 1
+		return _overapproximate_l1_norm(Z)
+	else
+		error("an overapproximation of the norm for this value of p=$p is not implemented")
+	end
+end
+
+"""
+	_overapproximate_l1_norm(Z::AbstractZonotope)
+
+Compute an upper bound on the ``\\ell_1`` norm over a zonotope `Z`.
+
+### Notes
+
+The problem ``\\max_{z ∈ Z} \\|z\\|_1`` is NP-hard in general. This function computes a convex relaxation
+using a formulation described in [Jordan2021](@citet), which fits a tight upper envelope to the 
+absolute value operator. For a zonotope `Z ∈ \\mathbb{R}^d` with `n` generators, this function
+has time complexity ``\\mathcal{O}(n ⋅ d)`` compared to ``\\mathcal{O}(2ⁿ ⋅ d)`` for the exact function.
+"""
+function _overapproximate_l1_norm(Z::AbstractZonotope)
+	H = box_approximation(Z)
+	ℓ = low(H)
+	u = high(H)
+
+	c = center(Z)
+	G = generators(Z)
+
+	S⁺ = ℓ .> 0
+	S⁻ = u .< 0
+	S = .!(S⁺ .| S⁻)
+
+	w = zeros(length(c))
+	w[S⁺] .= 1.0
+	w[S⁻] .= -1.0
+	@. w[S] = (u[S] + ℓ[S]) / (u[S] - ℓ[S])
+
+	const_term = sum(-2 .* u[S] .* ℓ[S] ./ (u[S] .- ℓ[S]))
+	linear_max = dot(w, c) + sum(abs.(G' * w))
+	return linear_max + const_term
+end

--- a/src/Approximations/overapproximate_norm.jl
+++ b/src/Approximations/overapproximate_norm.jl
@@ -27,10 +27,20 @@ Compute an upper bound on the ``\\ell_1`` norm over a zonotope `Z`.
 
 ### Notes
 
-The problem ``\\max_{z ∈ Z} \\|z\\|_1`` is NP-hard in general. This function computes a convex relaxation
-using a formulation described in [Jordan2021; Theorem 5](@citet), which fits a tight upper envelope to the 
-absolute value operator. For a zonotope ``Z ∈ ℝ^d`` with `n` generators, this function
-has time complexity ``\\mathcal{O}(n ⋅ d)`` compared to ``\\mathcal{O}(2ⁿ ⋅ d)`` for the exact function.
+The problem ``\\max_{z ∈ Z} \\|z\\|_1`` is NP-hard in general. This function computes a convex relaxation 
+by combining the MILP formulation described in [Jordan2021; Theorem 5](@citet) with the convex-hull construction
+in their supplement section §C.3.
+
+### Algorithm 
+
+We replace each coordinate's absolute value
+``
+|z_i|\\quad z_i ∈ [ℓ_i, u_i]
+``
+by its convex-hull secant upper envelope: the line through
+the two points ``((ℓ_i,|ℓ_i|)`` and ``((u_i,|u_i|)``.  This yields a
+linear-programming relaxation of complexity \\(O(n·d)\\), where `n` is the
+number of generators and `d` the ambient dimension.
 """
 function _overapproximate_l1_norm(Z::AbstractZonotope{N}) where {N}
     lb = low(Z)

--- a/src/Approximations/overapproximate_norm.jl
+++ b/src/Approximations/overapproximate_norm.jl
@@ -49,6 +49,7 @@ function _overapproximate_l1_norm(Z::AbstractZonotope{N}) where {N}
     @. w[S] = (ub[S] + lb[S]) / (ub[S] - lb[S])
 
     const_term = -2 * sum(ub[S] .* lb[S] ./ (ub[S] .- lb[S]))
+    # max_{x ∈ Z} wᵀx
     linear_max = dot(w, c) + sum(abs.(At_mul_B(G, w)))
     return linear_max + const_term
 end

--- a/src/Approximations/overapproximate_norm.jl
+++ b/src/Approximations/overapproximate_norm.jl
@@ -1,54 +1,54 @@
 """
-	overapproximate_norm(Z::AbstractZonotope, p::Real=1)
+    overapproximate_norm(Z::AbstractZonotope, p::Real=1)
 
 Compute an upper bound on the ``\\ell_p`` norm over a zonotope `Z`.
 
 ### Input
-- `Z::AbstractZonotope`-- A zonotope or subtype thereof.
-- `p::Real`-- The `ℓ_p` norm to overapproximate.
+
+- `Z` -- A zonotopic set
+- `p` -- The ``ℓ_p`` norm to overapproximate
 
 ### Output
-- `Float64`: An upper bound on ``\\max_{z ∈ Z} \\|z\\|_p``.
 
+- An upper bound on ``\\max_{z ∈ Z} \\|z\\|_p``.
 """
-function overapproximate_norm(Z::AbstractZonotope, p::Real = 1)
-	if p == 1
-		return _overapproximate_l1_norm(Z)
-	else
-		error("an overapproximation of the norm for this value of p=$p is not implemented")
-	end
+function overapproximate_norm(Z::AbstractZonotope, p::Real=1)
+    if p == 1
+        return _overapproximate_l1_norm(Z)
+    else
+        return norm(Z, p)
+    end
 end
 
 """
-	_overapproximate_l1_norm(Z::AbstractZonotope)
+    _overapproximate_l1_norm(Z::AbstractZonotope)
 
 Compute an upper bound on the ``\\ell_1`` norm over a zonotope `Z`.
 
 ### Notes
 
 The problem ``\\max_{z ∈ Z} \\|z\\|_1`` is NP-hard in general. This function computes a convex relaxation
-using a formulation described in [Jordan2021](@citet), which fits a tight upper envelope to the 
-absolute value operator. For a zonotope `Z ∈ \\mathbb{R}^d` with `n` generators, this function
+using a formulation described in [Jordan2021; Theorem 5](@citet), which fits a tight upper envelope to the 
+absolute value operator. For a zonotope ``Z ∈ ℝ^d`` with `n` generators, this function
 has time complexity ``\\mathcal{O}(n ⋅ d)`` compared to ``\\mathcal{O}(2ⁿ ⋅ d)`` for the exact function.
 """
-function _overapproximate_l1_norm(Z::AbstractZonotope)
-	H = box_approximation(Z)
-	ℓ = low(H)
-	u = high(H)
+function _overapproximate_l1_norm(Z::AbstractZonotope{N}) where {N}
+    lb = low(Z)
+    ub = high(Z)
 
-	c = center(Z)
-	G = generators(Z)
+    c = center(Z)
+    G = genmat(Z)
 
-	S⁺ = ℓ .> 0
-	S⁻ = u .< 0
-	S = .!(S⁺ .| S⁻)
+    S⁺ = lb .> 0
+    S⁻ = ub .< 0
+    S = .!(S⁺ .| S⁻)
 
-	w = zeros(length(c))
-	w[S⁺] .= 1.0
-	w[S⁻] .= -1.0
-	@. w[S] = (u[S] + ℓ[S]) / (u[S] - ℓ[S])
+    w = zeros(N, length(c))
+    w[S⁺] .= 1.0
+    w[S⁻] .= -1.0
+    @. w[S] = (ub[S] + lb[S]) / (ub[S] - lb[S])
 
-	const_term = sum(-2 .* u[S] .* ℓ[S] ./ (u[S] .- ℓ[S]))
-	linear_max = dot(w, c) + sum(abs.(G' * w))
-	return linear_max + const_term
+    const_term = -2 * sum(ub[S] .* lb[S] ./ (ub[S] .- lb[S]))
+    linear_max = dot(w, c) + sum(abs.(At_mul_B(G, w)))
+    return linear_max + const_term
 end

--- a/src/Approximations/overapproximate_norm.jl
+++ b/src/Approximations/overapproximate_norm.jl
@@ -44,8 +44,8 @@ function _overapproximate_l1_norm(Z::AbstractZonotope{N}) where {N}
     S = .!(S⁺ .| S⁻)
 
     w = zeros(N, length(c))
-    w[S⁺] .= 1.0
-    w[S⁻] .= -1.0
+    w[S⁺] .= N(1)
+    w[S⁻] .= N(-1)
     @. w[S] = (ub[S] + lb[S]) / (ub[S] - lb[S])
 
     const_term = -2 * sum(ub[S] .* lb[S] ./ (ub[S] .- lb[S]))

--- a/test/Approximations/box_approximation.jl
+++ b/test/Approximations/box_approximation.jl
@@ -86,7 +86,7 @@ for N in [Float64, Rational{Int}, Float32]
     @test h.radius ≈ hexp.radius
 
     # Testing alias symmetric_interval_hull
-    h == symmetric_interval_hull(b)
+    h = symmetric_interval_hull(b)
 
     # empty set
     E = EmptySet{N}(2)

--- a/test/Approximations/box_approximation.jl
+++ b/test/Approximations/box_approximation.jl
@@ -86,7 +86,7 @@ for N in [Float64, Rational{Int}, Float32]
     @test h.radius ≈ hexp.radius
 
     # Testing alias symmetric_interval_hull
-    h = symmetric_interval_hull(b)
+    h == symmetric_interval_hull(b)
 
     # empty set
     E = EmptySet{N}(2)

--- a/test/Approximations/overapproximate_norm.jl
+++ b/test/Approximations/overapproximate_norm.jl
@@ -1,0 +1,12 @@
+using LazySets, Test
+using LazySets.Approximations: overapproximate_norm
+
+let
+	for _ in 1:10
+		Z = rand(Zonotope; dim = 10, num_generators = 10)
+		@test overapproximate_norm(Z, 1) ≥ norm(Z, 1)
+	end
+
+	Z = Zonotope([1., -1.], zeros(Float64, 2, 2))
+	@test norm(Z, 1) == 2
+end

--- a/test/Approximations/overapproximate_norm.jl
+++ b/test/Approximations/overapproximate_norm.jl
@@ -1,12 +1,12 @@
 using LazySets, Test
 using LazySets.Approximations: overapproximate_norm
 
-let
+for N in [Float64, Float32, Rational{Int}]
     for _ in 1:5
-        Z = rand(Zonotope; dim=8, num_generators=5)
+        Z = rand(Zonotope; N=N, dim=8, num_generators=5)
         @test overapproximate_norm(Z, 1) ≥ norm(Z, 1)
     end
 
-    Z = Zonotope([1.0, -1.0], zeros(Float64, 2, 0))
+    Z = Zonotope(N[1, -1], zeros(N, 2, 0))
     @test overapproximate_norm(Z, 1) == 2
 end

--- a/test/Approximations/overapproximate_norm.jl
+++ b/test/Approximations/overapproximate_norm.jl
@@ -2,11 +2,11 @@ using LazySets, Test
 using LazySets.Approximations: overapproximate_norm
 
 let
-	for _ in 1:10
-		Z = rand(Zonotope; dim = 10, num_generators = 10)
-		@test overapproximate_norm(Z, 1) ≥ norm(Z, 1)
-	end
+    for _ in 1:5
+        Z = rand(Zonotope; dim=8, num_generators=5)
+        @test overapproximate_norm(Z, 1) ≥ norm(Z, 1)
+    end
 
-	Z = Zonotope([1., -1.], zeros(Float64, 2, 2))
-	@test norm(Z, 1) == 2
+    Z = Zonotope([1.0, -1.0], zeros(Float64, 2, 0))
+    @test overapproximate_norm(Z, 1) == 2
 end

--- a/test/Approximations/overapproximate_norm.jl
+++ b/test/Approximations/overapproximate_norm.jl
@@ -1,7 +1,7 @@
 using LazySets, Test
 using LazySets.Approximations: overapproximate_norm
 
-for N in [Float64, Float32, Rational{Int}]
+for N in [Float64, Float32]
     for _ in 1:5
         Z = rand(Zonotope; N=N, dim=8, num_generators=5)
         @test overapproximate_norm(Z, 1) ≥ norm(Z, 1)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -335,6 +335,9 @@ if test_suite_basic
     @testset "LazySets.Approximations.hausdorff_distance" begin
         include("Approximations/hausdorff_distance.jl")
     end
+    @testset "LazySets.Approximations.overapproximate_norm" begin
+        include("Approximations/overapproximate_norm.jl")
+    end
 
     # ================================
     # Testing shared utility functions


### PR DESCRIPTION
I added a function to efficiently compute an upper bound over the l1 norm of a zonotope