### PR TITLE
Remove documentation for aliases

### DIFF
--- a/docs/src/lib/API.md
+++ b/docs/src/lib/API.md
@@ -72,9 +72,7 @@ sample(::LazySet, ::Int=1)
 scale(::Real, ::LazySet)
 scale!(::Real, ::LazySet)
 ρ(::AbstractVector, ::LazySet)
-support_function
 σ(::AbstractVector, ::LazySet)
-support_vector
 translate(::LazySet, ::AbstractVector)
 translate!(::LazySet, ::AbstractVector)
 ```
@@ -90,13 +88,11 @@ exact_sum(::LazySet, ::LazySet)
 intersection(::LazySet, ::LazySet)
 ≈(::LazySet, ::LazySet)
 isdisjoint(::LazySet, ::LazySet)
-is_intersection_empty
 ==(::LazySet, ::LazySet)
 isequivalent(::LazySet, ::LazySet)
 ⊂(::LazySet, ::LazySet)
 ⊆(::LazySet, ::LazySet)
 linear_combination(::LazySet, ::LazySet)
 minkowski_difference(::LazySet, ::LazySet)
-pontryagin_difference
 minkowski_sum(::LazySet, ::LazySet)
 ```

--- a/docs/src/lib/approximations/box_approximation.md
+++ b/docs/src/lib/approximations/box_approximation.md
@@ -11,9 +11,6 @@ CurrentModule = LazySets.Approximations
 
 ```@docs
 box_approximation
-interval_hull
-□(::LazySet)
 symmetric_interval_hull
-box_approximation_symmetric
 ballinf_approximation
 ```

--- a/docs/src/lib/lazy_operations/ConvexHull.md
+++ b/docs/src/lib/lazy_operations/ConvexHull.md
@@ -8,7 +8,6 @@ CurrentModule = LazySets
 
 ```@docs
 ConvexHull
-CH
 swap(::ConvexHull)
 dim(::ConvexHull)
 ρ(::AbstractVector, ::ConvexHull)
@@ -29,7 +28,6 @@ Inherited from [`LazySet`](@ref):
 
 ```@docs
 ConvexHullArray
-CHArray
 ConvexHull!
 dim(::ConvexHullArray)
 ρ(::AbstractVector, ::ConvexHullArray)

--- a/docs/src/lib/lazy_operations/Intersection.md
+++ b/docs/src/lib/lazy_operations/Intersection.md
@@ -8,7 +8,6 @@ CurrentModule = LazySets
 
 ```@docs
 Intersection
-∩(::LazySet, ::LazySet)
 dim(::Intersection)
 ρ(::AbstractVector, ::Intersection)
 ρ(::AbstractVector, ::Intersection{N, S1, S2}) where {N, S1<:LazySet, S2<:Union{HalfSpace, Hyperplane, Line2D}}
@@ -50,7 +49,6 @@ IntersectionCache
 ```@docs
 IntersectionArray
 Intersection!
-∩(::LazySet, ::LazySet...)
 dim(::IntersectionArray)
 σ(::AbstractVector, ::IntersectionArray)
 isbounded(::IntersectionArray)

--- a/docs/src/lib/lazy_operations/MinkowskiSum.md
+++ b/docs/src/lib/lazy_operations/MinkowskiSum.md
@@ -8,8 +8,6 @@ CurrentModule = LazySets
 
 ```@docs
 MinkowskiSum
-⊕(::LazySet, ::LazySet)
-+(::LazySet, ::LazySet)
 swap(::MinkowskiSum)
 dim(::MinkowskiSum)
 ρ(::AbstractVector, ::MinkowskiSum)
@@ -34,8 +32,6 @@ Inherited from [`LazySet`](@ref):
 ```@docs
 MinkowskiSumArray
 MinkowskiSum!
-⊕(::LazySet, ::LazySet...)
-+(::LazySet, ::LazySet...)
 dim(::MinkowskiSumArray)
 ρ(::AbstractVector, ::MinkowskiSumArray)
 σ(::AbstractVector, ::MinkowskiSumArray)

--- a/docs/src/lib/lazy_operations/SymmetricIntervalHull.md
+++ b/docs/src/lib/lazy_operations/SymmetricIntervalHull.md
@@ -6,7 +6,6 @@ CurrentModule = LazySets
 
 ```@docs
 SymmetricIntervalHull
-⊡
 dim(::SymmetricIntervalHull)
 σ(::AbstractVector, ::SymmetricIntervalHull)
 center(::SymmetricIntervalHull, ::Int)

--- a/docs/src/lib/lazy_operations/Translation.md
+++ b/docs/src/lib/lazy_operations/Translation.md
@@ -6,8 +6,6 @@ CurrentModule = LazySets
 
 ```@docs
 Translation
-+(X::LazySet, v::AbstractVector)
-⊕(X::LazySet, v::AbstractVector)
 ρ(::AbstractVector, ::Translation)
 σ(::AbstractVector, ::Translation)
 an_element(::Translation)

--- a/docs/src/lib/lazy_operations/UnionSet.md
+++ b/docs/src/lib/lazy_operations/UnionSet.md
@@ -8,7 +8,6 @@ CurrentModule = LazySets
 
 ```@docs
 UnionSet
-∪(::LazySet, ::LazySet)
 swap(::UnionSet)
 dim(::UnionSet)
 σ(::AbstractVector, ::UnionSet; algorithm="support_vector")

--- a/docs/src/lib/sets/HalfSpace.md
+++ b/docs/src/lib/sets/HalfSpace.md
@@ -6,7 +6,6 @@ CurrentModule = LazySets.HalfSpaceModule
 
 ```@docs
 HalfSpace
-LinearConstraint
 ```
 
 ## Conversion

--- a/docs/src/man/tour.md
+++ b/docs/src/man/tour.md
@@ -438,12 +438,12 @@ non-negative numbers ``λ_j`` that sum up to ``1`` we have that
 ``∑_{j=1}^m λ_j v_j ∈ S`` as well. Alternatively, a closed convex set is an
 intersection of (possibly infinitely many) closed half-spaces.
 
-One of the central functions are `support_function(d, X)` (with the alias
-`ρ(d, X)` (type `\rho<tab>`)) and `support_vector` (with the alias `σ` (type
-`\sigma<tab>`)). The support function of a set ``X`` along direction
-``d ∈ ℝ^n`` corresponds to the (signed) distance of the maximum element
-in ``X`` along direction ``d``. The support vector is a (among possibly
-infinitely many) maximizer of the support function.
+One of the central functions are `ρ(d, X)` (type `\rho<tab>`; with the alias
+`support_function`) and `σ` (type `\sigma<tab>`; with the alias `support_vector`).
+The support function of a set ``X`` along direction ``d ∈ ℝ^n`` corresponds to
+the (signed) distance of the maximum element in ``X`` along direction ``d``.
+The support vector is a (among possibly infinitely many) maximizer of the support
+function.
 
 The support function also characterizes the half-space that tightly covers a set
 in a given direction. Hence it can be used to obtain a polyhedral

--- a/src/API/Binary/isdisjoint.jl
+++ b/src/API/Binary/isdisjoint.jl
@@ -23,9 +23,4 @@ The convenience alias `is_intersection_empty` is also available.
 """
 function isdisjoint(::LazySet, ::LazySet, ::Bool=false) end
 
-"""
-    is_intersection_empty(X::LazySet, Y::LazySet, [witness]::Bool=false)
-
-Convenience alias for the `isdisjoint` function.
-"""
 const is_intersection_empty = isdisjoint

--- a/src/API/Binary/minkowski_difference.jl
+++ b/src/API/Binary/minkowski_difference.jl
@@ -28,9 +28,4 @@ to the geometric difference of two sets.
 """
 function minkowski_difference(::LazySet, ::LazySet) end
 
-"""
-    pontryagin_difference(X::LazySet, Y::LazySet)
-
-Convenience alias for the `minkowski_difference` function.
-"""
 const pontryagin_difference = minkowski_difference

--- a/src/API/Mixed/support_function.jl
+++ b/src/API/Mixed/support_function.jl
@@ -14,7 +14,7 @@ The evaluation of the support function of `X` in direction `d`.
 
 ### Notes
 
-A convenience alias `support_function` is also available.
+The convenience alias `support_function` is also available.
 
 We have the following identity based on the support vector ``σ``:
 

--- a/src/API/Mixed/support_vector.jl
+++ b/src/API/Mixed/support_vector.jl
@@ -14,7 +14,7 @@ A support vector of `X` in direction `d`.
 
 ### Notes
 
-A convenience alias `support_vector` is also available.
+The convenience alias `support_vector` is also available.
 """
 function σ(::AbstractVector, ::LazySet) end
 

--- a/src/Approximations/box_approximation.jl
+++ b/src/Approximations/box_approximation.jl
@@ -41,7 +41,8 @@ A tight hyperrectangle.
 
 ### Notes
 
-An alias for this function is `interval_hull`.
+The convenience aliases `interval_hull` and `□` are also available. `□` can be
+typed by `\\square<tab>`.
 
 ### Algorithm
 
@@ -90,18 +91,8 @@ function box_approximation(cap::Intersection{N,T1,T2}) where {N,T1,T2}
     return _box_approximation_extrema(S)
 end
 
-"""
-    interval_hull
-
-Alias for `box_approximation`.
-"""
 interval_hull = box_approximation
 
-"""
-    □(X::LazySet)
-
-Alias for `box_approximation(X)`.
-"""
 □(X::LazySet) = box_approximation(X)
 
 # AbstractHyperrectangle specialization

--- a/src/Approximations/symmetric_interval_hull.jl
+++ b/src/Approximations/symmetric_interval_hull.jl
@@ -13,7 +13,7 @@ A tight hyperrectangle that is centrally symmetric wrt. the origin.
 
 ### Notes
 
-An alias for this function is `box_approximation_symmetric`.
+The convenience alias `box_approximation_symmetric` is also available.
 
 ### Algorithm
 
@@ -34,11 +34,6 @@ function symmetric_interval_hull(S::LazySet{N}) where {N}
     return Hyperrectangle(zeros(N, length(r)), r)
 end
 
-"""
-    box_approximation_symmetric
-
-Alias for `symmetric_interval_hull`.
-"""
 box_approximation_symmetric = symmetric_interval_hull
 
 # concretization of a lazy SymmetricIntervalHull

--- a/src/LazyOperations/ConvexHull.jl
+++ b/src/LazyOperations/ConvexHull.jl
@@ -23,6 +23,8 @@ The `EmptySet` is the neutral element for `ConvexHull`.
 
 This type is always convex.
 
+The convenience alias `CH` is also available.
+
 ### Examples
 
 The convex hull of two 100-dimensional Euclidean balls:
@@ -67,11 +69,6 @@ Base.first(ch::ConvexHull) = ch.X
 second(ch::ConvexHull) = ch.Y
 @declare_binary_operation(ConvexHull)
 
-"""
-    CH
-
-Alias for `ConvexHull`.
-"""
 const CH = ConvexHull
 
 """

--- a/src/LazyOperations/ConvexHullArray.jl
+++ b/src/LazyOperations/ConvexHullArray.jl
@@ -16,6 +16,8 @@ The `EmptySet` is the neutral element for `ConvexHullArray`.
 
 A `ConvexHullArray` is always convex.
 
+The convenience alias `CHArray` is also available.
+
 ### Examples
 
 Convex hull of 100 two-dimensional balls whose centers follow a sinusoidal:
@@ -56,11 +58,6 @@ end
 # add functions connecting ConvexHull and ConvexHullArray
 @declare_array_version(ConvexHull, ConvexHullArray)
 
-"""
-    CHArray
-
-Alias for `ConvexHullArray`.
-"""
 const CHArray = ConvexHullArray
 
 """

--- a/src/LazyOperations/Intersection.jl
+++ b/src/LazyOperations/Intersection.jl
@@ -61,6 +61,8 @@ to a polyhedron in constraint representation (`HPolyhedron`).
 The intersection preserves convexity: if the set arguments are convex, then
 their intersection is convex as well.
 
+The convenience alias `∩` can be typed by `\\cap<tab>`.
+
 ### Examples
 
 Create an expression ``Z`` that lazily represents the intersection of two
@@ -112,15 +114,6 @@ Intersection(H1::HalfSpace, H2::HalfSpace) = HPolyhedron([H1, H2])
 Intersection(H::HalfSpace, P::HPolyhedron) = HPolyhedron(vcat(P.constraints, H))
 Intersection(P::HPolyhedron, H::HalfSpace) = HPolyhedron(vcat(P.constraints, H))
 
-"""
-    ∩(X::LazySet, Y::LazySet)
-
-Alias for the lazy intersection.
-
-### Notes
-
-The function symbol can be typed via `\\cap<tab>`.
-"""
 ∩(X::LazySet, Y::LazySet) = Intersection(X, Y)
 
 isoperationtype(::Type{<:Intersection}) = true

--- a/src/LazyOperations/IntersectionArray.jl
+++ b/src/LazyOperations/IntersectionArray.jl
@@ -18,6 +18,8 @@ The `EmptySet` is the absorbing element for `IntersectionArray`.
 
 The intersection preserves convexity: if the set arguments are convex, then
 their intersection is convex as well.
+
+The convenience alias `∩` can be typed by `\\cap<tab>`.
 """
 struct IntersectionArray{N,S<:LazySet{N}} <: LazySet{N}
     array::Vector{S}
@@ -31,12 +33,6 @@ Convenience function to compute the lazy intersection and modify
 """
 function Intersection! end
 
-"""
-    ∩(X::LazySet, Xs::LazySet...)
-    ∩(Xs::Vector{<:LazySet})
-
-Alias for the n-ary lazy intersection.
-"""
 ∩(X::LazySet, Xs::LazySet...) = IntersectionArray(vcat(X, Xs...))
 ∩(X::LazySet) = X
 ∩(Xs::Vector{<:LazySet}) = IntersectionArray(Xs)

--- a/src/LazyOperations/MinkowskiSum.jl
+++ b/src/LazyOperations/MinkowskiSum.jl
@@ -25,6 +25,9 @@ for `MinkowskiSum`.
 
 The Minkowski sum preserves convexity: if the set arguments are convex, then
 their Minkowski sum is convex as well.
+
+The convenience aliases `⊕` and `+` are also available. `⊕` can be typed by
+`\\oplus<tab>`.
 """
 struct MinkowskiSum{N,S1<:LazySet{N},S2<:LazySet{N}} <: LazySet{N}
     X::S1
@@ -37,22 +40,8 @@ struct MinkowskiSum{N,S1<:LazySet{N},S2<:LazySet{N}} <: LazySet{N}
     end
 end
 
-"""
-    +(X::LazySet, Y::LazySet)
-
-Alias for the Minkowski sum.
-"""
 +(X::LazySet, Y::LazySet) = MinkowskiSum(X, Y)
 
-"""
-    ⊕(X::LazySet, Y::LazySet)
-
-Alias for the Minkowski sum.
-
-### Notes
-
-The function symbol can be typed via `\\oplus<tab>`.
-"""
 ⊕(X::LazySet, Y::LazySet) = MinkowskiSum(X, Y)
 
 isoperationtype(::Type{<:MinkowskiSum}) = true

--- a/src/LazyOperations/MinkowskiSumArray.jl
+++ b/src/LazyOperations/MinkowskiSumArray.jl
@@ -19,6 +19,9 @@ for `MinkowskiSumArray`.
 
 The Minkowski sum preserves convexity: if the set arguments are convex, then
 their Minkowski sum is convex as well.
+
+The convenience aliases `⊕` and `+` are also available. `⊕` can be typed by
+`\\oplus<tab>`.
 """
 struct MinkowskiSumArray{N,S<:LazySet{N}} <: LazySet{N}
     array::Vector{S}
@@ -32,26 +35,10 @@ Convenience function to compute the lazy Minkowski sum and modify
 """
 function MinkowskiSum! end
 
-"""
-    +(X::LazySet, Xs::LazySet...)
-    +(Xs::Vector{<:LazySet})
-
-Alias for the n-ary Minkowski sum.
-"""
 +(X::LazySet, Xs::LazySet...) = MinkowskiSumArray(vcat(X, Xs...))
 +(X::LazySet) = X
 +(Xs::Vector{<:LazySet}) = MinkowskiSumArray(Xs)
 
-"""
-    ⊕(X::LazySet, Xs::LazySet...)
-    ⊕(Xs::Vector{<:LazySet})
-
-Alias for the n-ary Minkowski sum.
-
-### Notes
-
-The function symbol can be typed via `\\oplus<tab>`.
-"""
 ⊕(X::LazySet, Xs::LazySet...) = +(X, Xs...)
 ⊕(Xs::Vector{<:LazySet}) = +(Xs)
 

--- a/src/LazyOperations/SymmetricIntervalHull.jl
+++ b/src/LazyOperations/SymmetricIntervalHull.jl
@@ -32,7 +32,7 @@ Misuse of this flag can result in incorrect behavior.
 The symmetric interval hull of a set is a hyperrectangle centered in the origin,
 which in particular is convex.
 
-An alias for this function is `⊡`.
+The convenience alias `⊡` can be typed by `\\boxdot<tab>`.
 """
 struct SymmetricIntervalHull{N,S<:LazySet{N}} <: AbstractHyperrectangle{N}
     X::S
@@ -52,11 +52,6 @@ struct SymmetricIntervalHull{N,S<:LazySet{N}} <: AbstractHyperrectangle{N}
     end
 end
 
-"""
-    ⊡
-
-Alias for `SymmetricIntervalHull`.
-"""
 const ⊡ = SymmetricIntervalHull
 
 isoperationtype(::Type{<:SymmetricIntervalHull}) = true

--- a/src/LazyOperations/Translation.jl
+++ b/src/LazyOperations/Translation.jl
@@ -26,6 +26,9 @@ linear map ``A`` is the identity matrix and the translation vector ``b`` is
 Translation preserves convexity: if `X` is convex, then any translation of `X`
 is convex as well.
 
+The convenience aliases `⊕` and `+` are also available. `⊕` can be typed by
+`\\oplus<tab>`.
+
 ### Example
 
 ```jldoctest translation
@@ -170,34 +173,9 @@ Translation(∅::EmptySet, v::AbstractVector) = ∅
 # Universe is absorbing for Translation
 Translation(U::Universe, v::AbstractVector) = U
 
-"""
-    +(X::LazySet, v::AbstractVector)
+@commutative +(X::LazySet, v::AbstractVector) = Translation(X, v)
 
-Convenience constructor for a translation.
-
-### Input
-
-- `X` -- set
-- `v` -- vector
-
-### Output
-
-The symbolic translation of ``X`` along vector ``v``.
-"""
-+(X::LazySet, v::AbstractVector) = Translation(X, v)
-
-# translation from the left
-+(v::AbstractVector, X::LazySet) = Translation(X, v)
-
-"""
-    ⊕(X::LazySet, v::AbstractVector)
-
-Unicode alias constructor ⊕ (`oplus`) for the lazy translation operator.
-"""
-⊕(X::LazySet, v::AbstractVector) = Translation(X, v)
-
-# translation from the left
-⊕(v::AbstractVector, X::LazySet) = Translation(X, v)
+@commutative ⊕(X::LazySet, v::AbstractVector) = Translation(X, v)
 
 function matrix(tr::Translation{N}) where {N}
     return Diagonal(ones(N, dim(tr)))

--- a/src/LazyOperations/UnionSet.jl
+++ b/src/LazyOperations/UnionSet.jl
@@ -16,6 +16,8 @@ Type that represents the set union of two sets.
 ### Notes
 
 The union of convex sets is typically not convex.
+
+The convenience alias `∪` can be typed by `\\cup<tab>`.
 """
 struct UnionSet{N,S1<:LazySet{N},S2<:LazySet{N}} <: LazySet{N}
     X::S1
@@ -45,11 +47,6 @@ Base.first(U::UnionSet) = U.X
 second(U::UnionSet) = U.Y
 @declare_binary_operation(UnionSet)
 
-"""
-    ∪
-
-Alias for `UnionSet`.
-"""
 ∪(X::LazySet, Y::LazySet) = UnionSet(X, Y)
 
 """

--- a/src/Sets/HalfSpace/HalfSpace.jl
+++ b/src/Sets/HalfSpace/HalfSpace.jl
@@ -8,6 +8,10 @@ Type that represents a (closed) half-space of the form ``a⋅x ≤ b``.
 - `a` -- normal direction (non-zero)
 - `b` -- constraint
 
+### Notes
+
+The convenience alias `LinearConstraint` is also available.
+
 ### Examples
 
 The half-space ``x + 2y - z ≤ 3``:

--- a/src/Sets/HalfSpace/HalfSpaceModule.jl
+++ b/src/Sets/HalfSpace/HalfSpaceModule.jl
@@ -62,11 +62,6 @@ include("iscomplement.jl")
 
 include("convert.jl")
 
-"""
-    LinearConstraint
-
-Alias for `HalfSpace`
-"""
 const LinearConstraint = HalfSpace
 
 """


### PR DESCRIPTION
As per [Julia convention](https://docs.julialang.org/en/v1/manual/documentation/#Global-Variables), aliases should not be documented. The documentation system automatically shows the full docstring of the main function.