### PR TITLE
Add `norm` and `overapproximate_norm` for matrix zonotope

### DIFF
--- a/docs/src/lib/matrixsets/MatrixZonotope.md
+++ b/docs/src/lib/matrixsets/MatrixZonotope.md
@@ -11,8 +11,12 @@ MatrixZonotope
 ```@docs
 center(::MatrixZonotope)
 generators(::MatrixZonotope)
+transpose(::MatrixZonotope)
+size(::MatrixZonotope)
 ngens(::MatrixZonotope)
 rand(::Type{MatrixZonotope})
+norm(::MatrixZonotope, ::Real)
+_rowwise_zonotope_norm
 ```
 
 ```@meta
@@ -21,3 +25,4 @@ CurrentModule = LazySets.API
 Undocumented implementations:
 * [`scale`](@ref scale(::Real, ::LazySet))
 * [`scale!`](@ref scale!(::Real, ::LazySet))
+* [`eltype`](@ref eltype(::Type{<:LazySet}))

--- a/src/Approximations/Approximations.jl
+++ b/src/Approximations/Approximations.jl
@@ -33,6 +33,7 @@ using ..LazySets: ACS, default_lp_solver, _isbounded_stiemke, require, linprog,
                   get_exponential_backend, _expmv, second, @assert
 using ..LazySets.JuMP: Model, set_silent, @variable, @constraint, optimize!,
                        value, @NLobjective, @objective
+using ..LazySets.MatrixZonotopeModule: _matrixzonotope_norm
 
 include("box_approximation.jl")
 include("iterative_refinement.jl")

--- a/src/Approximations/Approximations.jl
+++ b/src/Approximations/Approximations.jl
@@ -33,7 +33,7 @@ using ..LazySets: ACS, default_lp_solver, _isbounded_stiemke, require, linprog,
                   get_exponential_backend, _expmv, second, @assert
 using ..LazySets.JuMP: Model, set_silent, @variable, @constraint, optimize!,
                        value, @NLobjective, @objective
-using ..LazySets.MatrixZonotopeModule: _matrixzonotope_norm
+using ..LazySets.MatrixZonotopeModule: _rowwise_zonotope_norm
 
 include("box_approximation.jl")
 include("iterative_refinement.jl")

--- a/src/Approximations/overapproximate_norm.jl
+++ b/src/Approximations/overapproximate_norm.jl
@@ -95,5 +95,11 @@ Compute an upper bound on the ``p``-norm of a matrix zonotope.
 An upper bound on ``\\sup_{A ∈ \\mathcal{A} } \\|A\\|_p ``.
 """
 function overapproximate_norm(MZ::MatrixZonotope, p::Real=Inf)
-    return _matrixzonotope_norm(MZ, p, _overapproximate_l1_norm)
+    if p == 1
+        return _rowwise_zonotope_norm(transpose(MZ), overapproximate_norm)
+    elseif p == Inf
+        return _rowwise_zonotope_norm(MZ, overapproximate_norm)
+    else
+        throw(ArgumentError("the norm for p=$p has not been implemented"))
+    end
 end

--- a/src/Approximations/overapproximate_norm.jl
+++ b/src/Approximations/overapproximate_norm.jl
@@ -81,7 +81,7 @@ function _overapproximate_l1_norm(Z::AbstractZonotope{N}) where {N}
 end
 
 """
-    overapproximate_norm(MZ::MatrixZonotope, [p]::Real=1)
+    overapproximate_norm(MZ::MatrixZonotope, [p]::Real=Inf)
 
 Compute an upper bound on the ``p``-norm of a matrix zonotope.
 

--- a/src/Approximations/overapproximate_norm.jl
+++ b/src/Approximations/overapproximate_norm.jl
@@ -79,3 +79,21 @@ function _overapproximate_l1_norm(Z::AbstractZonotope{N}) where {N}
     linear_max = dot(w, c) + sum(abs.(At_mul_B(G, w)))
     return linear_max + const_term
 end
+
+"""
+    overapproximate_norm(MZ::MatrixZonotope, [p]::Real=1)
+
+Compute an upper bound on the ``p``-norm of a matrix zonotope.
+
+### Input
+
+- `MZ` -- Matrix zonotope
+- `p` -- (optional, default: `1`) norm
+
+### Output
+
+An upper bound on ``\\sup_{A ∈ \\mathcal{A} } \\|A\\|_p ``.
+"""
+function overapproximate_norm(MZ::MatrixZonotope, p::Real=Inf)
+    return _matrixzonotope_norm(MZ, p, _overapproximate_l1_norm)
+end

--- a/src/LazySets.jl
+++ b/src/LazySets.jl
@@ -237,6 +237,12 @@ include("Sets/ZonotopeMD/ZonotopeMDModule.jl")
 include("Sets/Interval/IntervalModule.jl")
 @reexport using ..IntervalModule: Interval
 
+# ==========================
+# Matrix sets module
+# ==========================
+include("MatrixSets/MatrixZonotopeModule.jl")
+@reexport using ..MatrixZonotopeModule: MatrixZonotope
+
 # =================================
 # Types representing set operations
 # =================================
@@ -322,12 +328,6 @@ include("Plotting/mesh.jl")
 # Parallel-algorithms module
 # ==========================
 include("Parallel/Parallel.jl")
-
-# ==========================
-# Matrix sets module
-# ==========================
-include("MatrixSets/MatrixZonotopeModule.jl")
-@reexport using ..MatrixZonotopeModule: MatrixZonotope
 
 # ==============================
 # Activate assertions by default

--- a/src/MatrixSets/MatrixZonotope.jl
+++ b/src/MatrixSets/MatrixZonotope.jl
@@ -56,7 +56,7 @@ Base.eltype(::Type{<:MatrixZonotope{N}}) where {N} = N
 """
     size(MZ::MatrixZonotope)
 
-Return the dimensions of the center matrix of the matrix zonotope `MZ`.  
+Return the dimensions of a matrix zonotope.  
 
 """
 Base.size(MZ::MatrixZonotope) = size(center(MZ))
@@ -65,14 +65,14 @@ Base.size(MZ::MatrixZonotope, d::Int) = size(center(MZ), d)
 """
     transpose(MZ::MatrixZonotope)
 
-Returns the transpose of the matrix zonotope `MZ`.
+Return the transpose of a matrix zonotope.
 
 ### Notes
 
 The transpose of a matrix zonotope is defined as:
 
 ```math
-    \\mathcal{A}^⊺ = \\braket{(A^{(0)})^⊺,(A^{(1)})^⊺, \\dots, (A^{(p)})^⊺ }
+    \\mathcal{A}ᵀ = \\braket{(A^{(0)})ᵀ,(A^{(1)})ᵀ, \\dots, (A^{(p)})ᵀ }
 ```
 """
 Base.transpose(MZ::MatrixZonotope{N}) where {N} = begin

--- a/src/MatrixSets/MatrixZonotope.jl
+++ b/src/MatrixSets/MatrixZonotope.jl
@@ -18,7 +18,7 @@ Mathematically a matrix zonotope is defined as the set of matrices
 \\mathcal{A} = \\left\\{A ∈ ℝ^{n×m} : A^{(0)} + ∑_{i=1}^p ξ_i A^{(i)},~~ ξ_i ∈ [-1, 1]~~ ∀ i = 1,…, p \\right\\},
 ```
 
-It is alternatively written in shortand notation as ``\\mathcal{A} = \\braket{A^{(0)},A^{(1)}, ..., A^{(p)} }.
+It can be written in shorthand notation as ``\\mathcal{A} = \\braket{A^{(0)},A^{(1)}, ..., A^{(p)} }_{MZ}.
 Matrix zonotopes were introduced in [HuangLBS2025](@citet).
 
 ### Examples
@@ -56,25 +56,26 @@ Base.eltype(::Type{<:MatrixZonotope{N}}) where {N} = N
 """
     size(MZ::MatrixZonotope)
 
-Return the size dimensions of the center matrix of the matrix zonotope `MZ`.  
+Return the dimensions of the center matrix of the matrix zonotope `MZ`.  
 
 """
 Base.size(MZ::MatrixZonotope) = size(center(MZ))
+Base.size(MZ::MatrixZonotope, d::Int) = size(center(MZ), d)
 
 """
     transpose(MZ::MatrixZonotope)
 
-Returns the transpose of the `MZ`.
+Returns the transpose of the matrix zonotope `MZ`.
 
 ### Notes
 
-The transpose of a matrix zonotope can is defined as:
+The transpose of a matrix zonotope is defined as:
 
 ```math
     \\mathcal{A}^⊺ = \\braket{(A^{(0)})^⊺,(A^{(1)})^⊺, \\dots, (A^{(p)})^⊺ }
 ```
 """
-Base.transpose(MZ::MatrixZonotope{T}) where {T} = begin
+Base.transpose(MZ::MatrixZonotope{N}) where {N} = begin
     Ct = transpose(center(MZ))
     Gts = map(transpose, generators(MZ))
     MatrixZonotope(Ct, Gts)

--- a/src/MatrixSets/MatrixZonotope.jl
+++ b/src/MatrixSets/MatrixZonotope.jl
@@ -18,6 +18,7 @@ Mathematically a matrix zonotope is defined as the set of matrices
 \\mathcal{A} = \\left\\{A ∈ ℝ^{n×m} : A^{(0)} + ∑_{i=1}^p ξ_i A^{(i)},~~ ξ_i ∈ [-1, 1]~~ ∀ i = 1,…, p \\right\\},
 ```
 
+It is alternatively written in shortand notation as ``\\mathcal{A} = \\braket{A^{(0)},A^{(1)}, ..., A^{(p)} }.
 Matrix zonotopes were introduced in [HuangLBS2025](@citet).
 
 ### Examples
@@ -50,5 +51,31 @@ struct MatrixZonotope{N, MN <: AbstractMatrix{N}}
     end
 end
 
-Base.size(Z::MatrixZonotope) = size(center(Z))
 Base.eltype(::Type{<:MatrixZonotope{N}}) where {N} = N
+
+"""
+    size(MZ::MatrixZonotope)
+
+Return the size dimensions of the center matrix of the matrix zonotope `MZ`.  
+
+"""
+Base.size(MZ::MatrixZonotope) = size(center(MZ))
+
+"""
+    transpose(MZ::MatrixZonotope)
+
+Returns the transpose of the `MZ`.
+
+### Notes
+
+The transpose of a matrix zonotope can is defined as:
+
+```math
+    \\mathcal{A}^⊺ = \\braket{(A^{(0)})^⊺,(A^{(1)})^⊺, \\dots, (A^{(p)})^⊺ }
+```
+"""
+Base.transpose(MZ::MatrixZonotope{T}) where {T} = begin
+    Ct = transpose(center(MZ))
+    Gts = map(transpose, generators(MZ))
+    MatrixZonotope(Ct, Gts)
+end

--- a/src/MatrixSets/MatrixZonotopeModule.jl
+++ b/src/MatrixSets/MatrixZonotopeModule.jl
@@ -6,13 +6,14 @@ using Random: AbstractRNG, GLOBAL_RNG
 using ReachabilityBase.Distribution: reseed!
 using ..LazySets.SparsePolynomialZonotopeModule
 
-@reexport import ..API: center, scale, scale!, rand
+@reexport import ..API: center, scale, scale!, rand, norm
 @reexport import ..LazySets: generators, ngens, indexvector
 
-export MatrixZonotope
+export MatrixZonotope, _matrixzonotope_norm
 
 include("MatrixZonotope.jl")
 include("indexvector.jl")
+include("norm.jl")
 include("scale.jl")
 include("center.jl")
 include("rand.jl")

--- a/src/MatrixSets/MatrixZonotopeModule.jl
+++ b/src/MatrixSets/MatrixZonotopeModule.jl
@@ -5,11 +5,12 @@ using Reexport
 using Random: AbstractRNG, GLOBAL_RNG
 using ReachabilityBase.Distribution: reseed!
 using ..LazySets.SparsePolynomialZonotopeModule
+using ..LazySets: Zonotope
 
 @reexport import ..API: center, scale, scale!, rand, norm
 @reexport import ..LazySets: generators, ngens, indexvector
 
-export MatrixZonotope, _matrixzonotope_norm
+export MatrixZonotope
 
 include("MatrixZonotope.jl")
 include("indexvector.jl")

--- a/src/MatrixSets/center.jl
+++ b/src/MatrixSets/center.jl
@@ -1,7 +1,7 @@
 """
     center(MZ::MatrixZonotope)
 
-Return the center matrix of the matrix zonotope `Z`.
+Return the center matrix of the matrix zonotope `MZ`.
 
 ### Input
 

--- a/src/MatrixSets/norm.jl
+++ b/src/MatrixSets/norm.jl
@@ -1,0 +1,73 @@
+"""
+    norm(MZ::MatrixZonotope, p::Real=Inf)
+
+Compute the operator ``p-norm`` of a matrix zonotope.
+
+### Definition
+
+For a matrix zonotope `\\mathcal{A}``, its ``p``-norm is defined as
+
+```
+\\|\\mathcal{A}\\|_p = \\sup_{A \\in \\mathcal{A}} \\|A\\|_p
+```
+
+where \``\\|A\\|_p\`` denotes the induced matrix norm.
+
+### Input
+
+- `MZ` -- A `MatrixZonotope` representing the set ``\\mathcal{A}\``
+- `p`  -- (optional, default: `Inf`) norm
+
+### Output
+
+A real number representing the norm.
+"""
+function norm(MZ::MatrixZonotope, p::Real=Inf)
+    return _matrixzonotope_norm(MZ, p, norm)
+end
+
+"""
+    _rowwise_zonotope_norm(MZ::MatrixZonotope{N}, norm_fn::Function) where {N}
+
+Compute the induced matrix norm of a matrix zonotope by reducing to row-wise zonotope norms.
+
+### Input
+
+- `MZ` -- A matrix zonotope (possibly transposed depending on the norm direction).
+- `norm_fn` -- A function that computes a norm on zonotopes (e.g., `norm`, `_overapproximate_l1_norm`).
+
+### Output
+
+The induced matrix ``p``-norm of the matrix zonotope.
+
+### Algorithm
+
+For each row index `i = 1, ..., n`, we construct a zonotope from the `i`-th row
+of the center matrix and the corresponding rows from each generator matrix.
+We then compute the norm of this zonotope using the provided `norm_fn`.
+
+The final result is the maximum of these `n` row-wise zonotope norms.
+"""
+function _rowwise_zonotope_norm(MZ::MatrixZonotope{N}, norm_fn::Function) where {N}
+    C = center(MZ)
+    Gs = generators(MZ)
+    n, d = size(C)
+    k = ngens(MZ)
+    Zmat = Matrix{N}(undef, d, k)
+    best = -Inf
+    @inbounds for i in 1:n
+        c = @view(C[i, :])
+        for j in 1:k
+            Zmat[:, j] = @view(Gs[j][i, :])
+        end
+        Z = Zonotope(vec(c), Zmat)
+        best = max(best, norm_fn(Z))
+    end
+    return best
+end
+
+function _matrixzonotope_norm(MZ::MatrixZonotope, p::Real, norm_fn::Function)
+    dir = p == 1 ? transpose(MZ) : p == Inf ? MZ :
+          throw(ArgumentError("the norm for p=$p has not been implemented"))
+    return _rowwise_zonotope_norm(dir, norm_fn)
+end

--- a/src/MatrixSets/norm.jl
+++ b/src/MatrixSets/norm.jl
@@ -1,7 +1,7 @@
 """
     norm(MZ::MatrixZonotope, p::Real=Inf)
 
-Compute the operator ``p-norm`` of a matrix zonotope.
+Compute the operator ``p``-norm of a matrix zonotope.
 
 ### Definition
 
@@ -11,7 +11,7 @@ For a matrix zonotope `\\mathcal{A}``, its ``p``-norm is defined as
 \\|\\mathcal{A}\\|_p = \\sup_{A \\in \\mathcal{A}} \\|A\\|_p
 ```
 
-where \``\\|A\\|_p\`` denotes the induced matrix norm.
+where ``\\|A\\|_p`` denotes the induced matrix norm.
 
 ### Input
 

--- a/src/MatrixSets/norm.jl
+++ b/src/MatrixSets/norm.jl
@@ -15,7 +15,7 @@ where \``\\|A\\|_p\`` denotes the induced matrix norm.
 
 ### Input
 
-- `MZ` -- A `MatrixZonotope` representing the set ``\\mathcal{A}\``
+- `MZ` -- matrix zonotope set
 - `p`  -- (optional, default: `Inf`) norm
 
 ### Output
@@ -29,12 +29,12 @@ end
 """
     _rowwise_zonotope_norm(MZ::MatrixZonotope{N}, norm_fn::Function) where {N}
 
-Compute the induced matrix norm of a matrix zonotope by reducing to row-wise zonotope norms.
+Compute the induced matrix norm of a matrix zonotope by reducing to row-wise zonotope ``ℓ₁`` norms.
 
 ### Input
 
-- `MZ` -- A matrix zonotope (possibly transposed depending on the norm direction).
-- `norm_fn` -- A function that computes a norm on zonotopes (e.g., `norm`, `_overapproximate_l1_norm`).
+- `MZ` -- matrix zonotope set
+- `norm_fn` -- a function to approximate the zonotope ``ℓ₁`` norm
 
 ### Output
 
@@ -42,10 +42,9 @@ The induced matrix ``p``-norm of the matrix zonotope.
 
 ### Algorithm
 
-For each row index `i = 1, ..., n`, we construct a zonotope from the `i`-th row
-of the center matrix and the corresponding rows from each generator matrix.
-We then compute the norm of this zonotope using the provided `norm_fn`.
-
+For each row index `i = 1, ..., n`, we construct a zonotope with center given 
+by the `i`-th row of the center matrix and as generators the `i`-th row of each generator matrix.
+The norm of this zonotope is then computed using the provided `norm_fn`.
 The final result is the maximum of these `n` row-wise zonotope norms.
 """
 function _rowwise_zonotope_norm(MZ::MatrixZonotope{N}, norm_fn::Function) where {N}

--- a/test/Approximations/overapproximate_norm.jl
+++ b/test/Approximations/overapproximate_norm.jl
@@ -12,6 +12,6 @@ for N in [Float64, Float32]
 
     for _ in 1:5
         MZ = rand(MatrixZonotope; N=N, dim=(3, 3), num_generators=3)
-        @test _geq(overapproximate_norm(Z, 1), norm(Z, 1), atol=1e-3)
+        @test _geq(overapproximate_norm(MZ, 1), norm(MZ, 1), atol=1e-3)
     end
 end

--- a/test/Approximations/overapproximate_norm.jl
+++ b/test/Approximations/overapproximate_norm.jl
@@ -1,12 +1,17 @@
 using LazySets, Test
-using LazySets.Approximations: overapproximate_norm
 
 for N in [Float64, Float32]
+    TOL = 1e-3 #tolerance due to floating-point rounding errors
     for _ in 1:5
         Z = rand(Zonotope; N=N, dim=8, num_generators=5)
-        @test overapproximate_norm(Z, 1) ≥ norm(Z, 1)
+        @test overapproximate_norm(Z, 1) ≥ (norm(Z, 1) -TOL)
     end
 
     Z = Zonotope(N[1, -1], zeros(N, 2, 0))
     @test overapproximate_norm(Z, 1) == 2
+
+    for _ in 1:5
+        MZ = rand(MatrixZonotope; N=N, dim=(3,3), num_generators=3)
+        @test overapproximate_norm(MZ, 1) ≥ (norm(MZ, 1) -TOL)
+    end
 end

--- a/test/Approximations/overapproximate_norm.jl
+++ b/test/Approximations/overapproximate_norm.jl
@@ -1,17 +1,17 @@
 using LazySets, Test
+using LazySets.ReachabilityBase.Comparison: _geq
 
 for N in [Float64, Float32]
-    TOL = 1e-3 #tolerance due to floating-point rounding errors
     for _ in 1:5
         Z = rand(Zonotope; N=N, dim=8, num_generators=5)
-        @test overapproximate_norm(Z, 1) ≥ (norm(Z, 1) -TOL)
+        @test _geq(overapproximate_norm(Z, 1), norm(Z, 1), atol=1e-3)
     end
 
     Z = Zonotope(N[1, -1], zeros(N, 2, 0))
     @test overapproximate_norm(Z, 1) == 2
 
     for _ in 1:5
-        MZ = rand(MatrixZonotope; N=N, dim=(3,3), num_generators=3)
-        @test overapproximate_norm(MZ, 1) ≥ (norm(MZ, 1) -TOL)
+        MZ = rand(MatrixZonotope; N=N, dim=(3, 3), num_generators=3)
+        @test _geq(overapproximate_norm(Z, 1), norm(Z, 1), atol=1e-3)
     end
 end

--- a/test/MatrixSets/MatrixZonotope.jl
+++ b/test/MatrixSets/MatrixZonotope.jl
@@ -2,7 +2,7 @@ using LazySets, Test
 
 for N in [Float64, Float32, Rational{Int}]
     # test constructor
-    c = N[1 0; 0 1]
+    c = N[1 0; 0 3]
     gens = [N[1 -1; 0 2], N[2 -1; -1 1]]
     MZ = MatrixZonotope(c, gens)
     @test MZ isa MatrixZonotope{N}
@@ -43,8 +43,8 @@ for N in [Float64, Float32, Rational{Int}]
     @test generators(MZt)== [transpose(Ai) for Ai in generators(MZ)]
 
     #norm
-    @test norm(MZ, Inf) == 6
-    @test norm(MZ, 1) == 6
+    @test norm(MZ, Inf) == 7
+    @test norm(MZ, 1) == 8
 end
 
 for N in [Float64, Float32]

--- a/test/MatrixSets/MatrixZonotope.jl
+++ b/test/MatrixSets/MatrixZonotope.jl
@@ -36,6 +36,15 @@ for N in [Float64, Float32, Rational{Int}]
     @test center(MZ3) == c
     @test isempty(generators(MZ3))
     @test isempty(indexvector(MZ3))
+
+    #transpose
+    MZt = transpose(MZ)
+    @test center(MZt) == c
+    @test generators(MZt)== [transpose(Ai) for Ai in generators(MZ)]
+
+    #norm
+    @test norm(MZ, Inf) == 6
+    @test norm(MZ, 1) == 6
 end
 
 for N in [Float64, Float32]


### PR DESCRIPTION
The function `_rowwise_zonotope_norm`  encapsulates the shared code between `norm` and `overapproximate_norm`. Passing as an argument the transpose of the matrix zonotope returns the $$\ell_1$$ norm since this is just the maximum column sum.
I moved the `MatrixZonotopeModule`  in the  `LazySets.jl` file  to be located before the `Approximation` module