### PR TITLE
Add macro to only run `Float64` tests

### DIFF
--- a/test/Approximations/approximate.jl
+++ b/test/Approximations/approximate.jl
@@ -1,4 +1,4 @@
-for N in [Float64, Float32, Rational{Int}]
+for N in @tN([Float64, Float32, Rational{Int}])
     # approximate rectification by rectifying the vertices
     # - exact approximation
     X = Ball1(N[1, 1], N(1))

--- a/test/Approximations/ballinf_approximation.jl
+++ b/test/Approximations/ballinf_approximation.jl
@@ -1,4 +1,4 @@
-for N in [Float64, Float32, Rational{Int}]
+for N in @tN([Float64, Float32, Rational{Int}])
     # BallInf approximation of a 3D unit ball in the 1-norm centered at [1,2,0]
     b = Ball1(N[1, 2, 0], N(1))
     bi = ballinf_approximation(b)

--- a/test/Approximations/box_approximation.jl
+++ b/test/Approximations/box_approximation.jl
@@ -1,4 +1,4 @@
-for N in [Float64, Float32, Rational{Int}]
+for N in @tN([Float64, Float32, Rational{Int}])
     # ==============================
     # Testing box approximation
     # ==============================

--- a/test/Approximations/decompose.jl
+++ b/test/Approximations/decompose.jl
@@ -1,4 +1,4 @@
-for N in [Float64, Float32, Rational{Int}]
+for N in @tN([Float64, Float32, Rational{Int}])
     # =====================================
     # Run decompose for different set types
     # =====================================
@@ -79,7 +79,7 @@ for N in [Float64, Float32, Rational{Int}]
 end
 
 # tests that do not work with Rational{Int}
-for N in [Float64, Float32]
+for N in @tN([Float64, Float32])
     # =============================
     # Check that Issue #43 is fixed
     # =============================

--- a/test/Approximations/hausdorff_distance.jl
+++ b/test/Approximations/hausdorff_distance.jl
@@ -1,6 +1,6 @@
 _in_interval(v, x, ε) = x - ε <= v <= x + ε
 
-for N in [Float64, Float32, Rational{Int}]
+for N in @tN([Float64, Float32, Rational{Int}])
     ε = N(1e-3)
 
     b1 = BallInf(zeros(N, 2), N(1))

--- a/test/Approximations/overapproximate.jl
+++ b/test/Approximations/overapproximate.jl
@@ -2,7 +2,7 @@ using LazySets.Approximations: project
 
 using LazySets.Approximations: get_linear_coeffs, _nonlinear_polynomial
 
-for N in [Float64, Float32, Rational{Int}]
+for N in @tN([Float64, Float32, Rational{Int}])
     c = N[0, 0]
     b = Ball1(c, N(1))
 
@@ -157,7 +157,7 @@ for N in [Float64, Float32, Rational{Int}]
 end
 
 # tests that do not work with Rational{Int}
-for N in [Float64, Float32]
+for N in @tN([Float64, Float32])
     # useful for benchmarking overapproximate and LinearMap's support vector
     # (see #290)
     function overapproximate_lmap(n)

--- a/test/Approximations/overapproximate_norm.jl
+++ b/test/Approximations/overapproximate_norm.jl
@@ -1,7 +1,7 @@
 using LazySets, Test
 using LazySets.ReachabilityBase.Comparison: _geq
 
-for N in [Float64, Float32]
+for N in @tN([Float64, Float32])
     for _ in 1:5
         Z = rand(Zonotope; N=N, dim=8, num_generators=5)
         @test _geq(overapproximate_norm(Z, 1), norm(Z, 1), atol=1e-3)

--- a/test/Approximations/radiusdiameter.jl
+++ b/test/Approximations/radiusdiameter.jl
@@ -1,4 +1,4 @@
-for N in [Float64, Float32, Rational{Int}]
+for N in @tN([Float64, Float32, Rational{Int}])
     # =======
     #  Ball1
     # =======

--- a/test/Approximations/symmetric_interval_hull.jl
+++ b/test/Approximations/symmetric_interval_hull.jl
@@ -1,4 +1,4 @@
-for N in [Float64, Float32, Rational{Int}]
+for N in @tN([Float64, Float32, Rational{Int}])
     # singleton
     S = Singleton(N[1, -2, 3, -4])
     H = Hyperrectangle(zeros(N, 4), N[1, 2, 3, 4])
@@ -26,7 +26,7 @@ for N in [Float64, Float32, Rational{Int}]
     end
 end
 
-for N in [Float64, Float32]
+for N in @tN([Float64, Float32])
     # exponential map of singleton
     M = sparse(diagm(N[1, 1, 1]))
     E = SparseMatrixExp(M) * Singleton(N[1, 2, 3])

--- a/test/Approximations/template_directions.jl
+++ b/test/Approximations/template_directions.jl
@@ -1,4 +1,4 @@
-for N in [Float64, Float32, Rational{Int}]
+for N in @tN([Float64, Float32, Rational{Int}])
     # unit vector
     for n in 1:3
         for i in 1:n

--- a/test/Approximations/underapproximate.jl
+++ b/test/Approximations/underapproximate.jl
@@ -1,4 +1,4 @@
-for N in [Float64, Float32, Rational{Int}]
+for N in @tN([Float64, Float32, Rational{Int}])
     X = Hyperrectangle(zeros(N, 2), ones(N, 2))
     U = underapproximate(X, BoxDirections{N}(2))
     @test U ⊆ X
@@ -8,7 +8,7 @@ for N in [Float64, Float32, Rational{Int}]
     @test U ≈ Hyperrectangle(N[2, 2], ones(N, 2))
 end
 
-for N in [Float64, Float32]
+for N in @tN([Float64, Float32])
     X = VPolygon([N[1, 0], N[1, 2], N[-1, 2], N[-1, 1 // 3], N[-2 // 3, 0]])
     U = underapproximate(X, Ball2)
     @test U ≈ Ball2(N[0, 1], N(1))

--- a/test/ConcreteOperations/area.jl
+++ b/test/ConcreteOperations/area.jl
@@ -1,4 +1,4 @@
-for N in [Float64, Float32, Rational{Int}]
+for N in @tN([Float64, Float32, Rational{Int}])
     # not implemented for dimension other than 2 or 3
     for d in (1, 4)
         p = BallInf(zeros(N, d), N(1))

--- a/test/ConcreteOperations/cartesian_product.jl
+++ b/test/ConcreteOperations/cartesian_product.jl
@@ -1,4 +1,4 @@
-for N in [Float64, Float32, Rational{Int}]
+for N in @tN([Float64, Float32, Rational{Int}])
     c1 = N[1, 2]
     c2 = N[3, 4, 5]
     Z1 = Zonotope(c1, N[1 0; 0 1])

--- a/test/ConcreteOperations/difference.jl
+++ b/test/ConcreteOperations/difference.jl
@@ -1,4 +1,4 @@
-for N in [Float64, Float32, Rational{Int}]
+for N in @tN([Float64, Float32, Rational{Int}])
     # interval \ half-space
     x = Interval(N(1), N(3))
     U = HalfSpace(N[1], N(2))

--- a/test/ConcreteOperations/distance.jl
+++ b/test/ConcreteOperations/distance.jl
@@ -1,4 +1,4 @@
-for N in [Float64, Float32, Rational{Int}]
+for N in @tN([Float64, Float32, Rational{Int}])
     H1 = BallInf(N[0, 0], N(1))
     H2 = BallInf(N[-1 // 10, 0], N(1))
     H3 = Hyperrectangle(N[-16 // 10, -2], N[1 // 2, 1 // 2])

--- a/test/ConcreteOperations/exact_sum.jl
+++ b/test/ConcreteOperations/exact_sum.jl
@@ -1,4 +1,4 @@
-for N in [Float64, Float32, Rational{Int}]
+for N in @tN([Float64, Float32, Rational{Int}])
     B = Ball1(N[0, 0], N(1))
     c = N[4, 4]
     G = N[2 1 2; 0 2 2]

--- a/test/ConcreteOperations/interior.jl
+++ b/test/ConcreteOperations/interior.jl
@@ -1,4 +1,4 @@
-for N in [Float64, Float32, Rational{Int}]
+for N in @tN([Float64, Float32, Rational{Int}])
     P = BallInf(zeros(N, 2), N(1 // 10))
     d = N[1 // 10, 1 // 10]
     if N <: AbstractFloat
@@ -19,7 +19,7 @@ for N in [Float64, Float32, Rational{Int}]
 end
 
 # tests that do not work with Rational{Int}
-for N in [Float64, Float32]
+for N in @tN([Float64, Float32])
     P = BallInf(zeros(N, 2), N(1 // 10))
     d = N[1 // 10, 1 // 10]
     @test !is_interior_point(d, P; p=N(2))

--- a/test/ConcreteOperations/intersection.jl
+++ b/test/ConcreteOperations/intersection.jl
@@ -1,4 +1,4 @@
-for N in [Float64, Float32, Rational{Int}]
+for N in @tN([Float64, Float32, Rational{Int}])
     # Interval with HalfSpace
     X = Interval(N(1), N(2))
     H = HalfSpace(N[1], N(1.5))

--- a/test/ConcreteOperations/isdisjoint.jl
+++ b/test/ConcreteOperations/isdisjoint.jl
@@ -1,4 +1,4 @@
-for N in [Float64, Float32, Rational{Int}]
+for N in @tN([Float64, Float32, Rational{Int}])
     # using IA types
     X = IA.interval(N(0), N(1)) # IA
     Y = Interval(N(-1), N(2))

--- a/test/ConcreteOperations/isequivalent.jl
+++ b/test/ConcreteOperations/isequivalent.jl
@@ -1,4 +1,4 @@
-for N in [Float64, Float32, Rational{Int}]
+for N in @tN([Float64, Float32, Rational{Int}])
     # -- singletons --
     S = Singleton(N[1, 2])
     @test isequivalent(S, S)

--- a/test/ConcreteOperations/isstrictsubset.jl
+++ b/test/ConcreteOperations/isstrictsubset.jl
@@ -1,4 +1,4 @@
-for N in [Float64, Float32, Rational{Int}]
+for N in @tN([Float64, Float32, Rational{Int}])
     H1 = BallInf(N[0, 0], N(1))
     H2 = BallInf(N[0, 0], N(2))
 

--- a/test/ConcreteOperations/issubset.jl
+++ b/test/ConcreteOperations/issubset.jl
@@ -1,4 +1,4 @@
-for N in [Float64, Float32, Rational{Int}]
+for N in @tN([Float64, Float32, Rational{Int}])
     # interval in union of intervals
     X = Interval(N(0), N(1))
 

--- a/test/ConcreteOperations/minkowski_difference.jl
+++ b/test/ConcreteOperations/minkowski_difference.jl
@@ -1,4 +1,4 @@
-for N in [Float64, Float32, Rational{Int}]
+for N in @tN([Float64, Float32, Rational{Int}])
     # intervals, nonempty difference
     X = Interval(N(1), N(3))
     Y = Interval(N(2), N(3))

--- a/test/ConcreteOperations/minkowski_sum.jl
+++ b/test/ConcreteOperations/minkowski_sum.jl
@@ -1,4 +1,4 @@
-for N in [Float64, Float32, Rational{Int}]
+for N in @tN([Float64, Float32, Rational{Int}])
     X = Interval(N(1), N(2))
     Y = X + X
     if test_suite_polyhedra
@@ -25,7 +25,7 @@ for N in [Float64, Float32, Rational{Int}]
     end
 end
 
-for N in [Float64, Float32]
+for N in @tN([Float64, Float32])
     B1 = Ball2(N[1, 2], N(3))
     B2 = Ball2(N[4, 5], N(6))
     @test minkowski_sum(B1, B2) == Ball2(N[5, 7], N(9))

--- a/test/Interfaces/CompactSet.jl
+++ b/test/Interfaces/CompactSet.jl
@@ -1,4 +1,4 @@
-for N in [Float64, Float32, Rational{Int}]
+for N in @tN([Float64, Float32, Rational{Int}])
     # compact set
     @test Ball1 <: CompactSet && !(Ball1 <: NonCompactSet)
     b = Ball1(N[0, 1], N(1))

--- a/test/Interfaces/IntervalArithmetic.jl
+++ b/test/Interfaces/IntervalArithmetic.jl
@@ -3,7 +3,7 @@ using IntervalArithmetic: IntervalBox
 import IntervalArithmetic as IA
 using LazySets.ReachabilityBase.Arrays: ispermutation
 
-for N in [Float64, Float32, Rational{Int}]
+for N in @tN([Float64, Float32, Rational{Int}])
     # vertices_list for IA types
     Y = IntervalBox(IA.interval(N(0), N(1)), IA.interval(N(2), N(3)))
     res = vertices_list(Y)

--- a/test/Interfaces/LazySet.jl
+++ b/test/Interfaces/LazySet.jl
@@ -2,7 +2,7 @@
 using LazySets, Test
 using LazySets.ReachabilityBase.Basetype
 
-for N in [Float64, Float32, Rational{Int}]
+for N in @tN([Float64, Float32, Rational{Int}])
     Z = ZeroSet{N}(2)
 
     # basetype

--- a/test/LazyOperations/AffineMap.jl
+++ b/test/LazyOperations/AffineMap.jl
@@ -1,4 +1,4 @@
-for N in [Float64, Float32, Rational{Int}]
+for N in @tN([Float64, Float32, Rational{Int}])
 
     # ==================================
     # Constructor and interface methods
@@ -113,7 +113,7 @@ for N in [Float64, Float32, Rational{Int}]
     @test concretize(am) == affine_map(M, B, v)
 end
 
-for N in [Float64, Float32]
+for N in @tN([Float64, Float32])
     B = BallInf(zeros(N, 3), N(1))
 
     # the translation is the origin and the linear map is the identity => constraints remain unchanged

--- a/test/LazyOperations/Bloating.jl
+++ b/test/LazyOperations/Bloating.jl
@@ -1,4 +1,4 @@
-for N in [Float64, Float32]
+for N in @tN([Float64, Float32])
     B = BallInf(zeros(N, 2), N(1))
     E = HPolyhedron([HalfSpace(N[1], N(0)), HalfSpace(N[-1], N(-1))])  # empty
     U = Universe{N}(3)

--- a/test/LazyOperations/CartesianProduct.jl
+++ b/test/LazyOperations/CartesianProduct.jl
@@ -1,6 +1,6 @@
 using LazySets.Approximations: overapproximate
 
-for N in [Float64, Float32, Rational{Int}]
+for N in @tN([Float64, Float32, Rational{Int}])
     # Cartesian Product of a centered 1D BallInf and a centered 2D BallInf
     # Here a 3D BallInf
     b1 = BallInf(N[0], N(1))
@@ -445,7 +445,7 @@ for N in [Float64, Float32, Rational{Int}]
     @test volume(cp) == volume(cpa) == N(3456)
 end
 
-for N in [Float64, Float32]
+for N in @tN([Float64, Float32])
     # is_intersection_empty
     i1 = Interval(N[0, 1])
     i2 = Interval(N[2, 3])

--- a/test/LazyOperations/Complement.jl
+++ b/test/LazyOperations/Complement.jl
@@ -1,4 +1,4 @@
-for N in [Float64, Float32, Rational{Int}]
+for N in @tN([Float64, Float32, Rational{Int}])
     B1 = BallInf(N[0, 0], N(1))
     B2 = BallInf(N[4, -4], N(1))
     B3 = BallInf(N[1, -1], N(1))

--- a/test/LazyOperations/ConvexHull.jl
+++ b/test/LazyOperations/ConvexHull.jl
@@ -1,4 +1,4 @@
-for N in [Float64, Float32, Rational{Int}]
+for N in @tN([Float64, Float32, Rational{Int}])
     # ConvexHull of two 2D Ball1
     b1 = Ball1(N[0, 0], N(1))
     b2 = Ball1(N[1, 2], N(1))

--- a/test/LazyOperations/ExponentialMap.jl
+++ b/test/LazyOperations/ExponentialMap.jl
@@ -2,7 +2,7 @@ for exp_backend in [ExponentialUtilities, Expokit]
     # test changing the exponentiation backend
     LazySets.set_exponential_backend!(exp_backend)
 
-    for N in [Float64, Float32]
+    for N in @tN([Float64, Float32])
         # dimension (choose a multiple of 3)
         n = 3 * 2
 

--- a/test/LazyOperations/Intersection.jl
+++ b/test/LazyOperations/Intersection.jl
@@ -5,7 +5,7 @@ else
     vGLPK = PkgVersion.Version(GLPK)
 end
 
-for N in [Float64, Float32, Rational{Int}]
+for N in @tN([Float64, Float32, Rational{Int}])
     B = BallInf(ones(N, 2), N(3))
     H = Hyperrectangle(ones(N, 2), ones(N, 2))
     E = EmptySet{N}(2)

--- a/test/LazyOperations/InverseLinearMap.jl
+++ b/test/LazyOperations/InverseLinearMap.jl
@@ -1,4 +1,4 @@
-for N in [Float64, Float32, Rational{Int}]
+for N in @tN([Float64, Float32, Rational{Int}])
 
     # π/2 trigonometric rotation
     b = BallInf(N[1, 2], N(1))

--- a/test/LazyOperations/LinearMap.jl
+++ b/test/LazyOperations/LinearMap.jl
@@ -1,4 +1,4 @@
-for N in [Float64, Float32, Rational{Int}]
+for N in @tN([Float64, Float32, Rational{Int}])
     # π/2 trigonometric rotation
     b = BallInf(N[1, 2], N(1))
     M = N[0 -1; 1 0]

--- a/test/LazyOperations/MinkowskiSum.jl
+++ b/test/LazyOperations/MinkowskiSum.jl
@@ -1,4 +1,4 @@
-for N in [Float64, Float32, Rational{Int}]
+for N in @tN([Float64, Float32, Rational{Int}])
     # Sum of 2D centered balls in norm 1 and infinity
     b1 = BallInf(N[0, 0], N(2))
     b2 = Ball1(N[0, 0], N(1))

--- a/test/LazyOperations/Rectification.jl
+++ b/test/LazyOperations/Rectification.jl
@@ -1,4 +1,4 @@
-for N in [Float64, Float32, Rational{Int}]
+for N in @tN([Float64, Float32, Rational{Int}])
     I1 = Interval(N(-1), N(1))
     I2 = Interval(N(2), N(3))
     I3 = Interval(N(-2), N(-1))

--- a/test/LazyOperations/ResetMap.jl
+++ b/test/LazyOperations/ResetMap.jl
@@ -1,4 +1,4 @@
-for N in [Float64, Float32, Rational{Int}]
+for N in @tN([Float64, Float32, Rational{Int}])
     # constructor
     b = BallInf(N[2, 2, 2], N(1))
     s = Singleton(N[0, 0])

--- a/test/LazyOperations/SymmetricIntervalHull.jl
+++ b/test/LazyOperations/SymmetricIntervalHull.jl
@@ -1,4 +1,4 @@
-for N in [Float64, Float32, Rational{Int}]
+for N in @tN([Float64, Float32, Rational{Int}])
     # constructor from empty set
     E = EmptySet{N}(2)
     @test SymmetricIntervalHull(E) == E

--- a/test/LazyOperations/Translation.jl
+++ b/test/LazyOperations/Translation.jl
@@ -1,4 +1,4 @@
-for N in [Float64, Float32, Rational{Int}]
+for N in @tN([Float64, Float32, Rational{Int}])
     # ==================================
     # Constructor and interface methods
     # ==================================
@@ -90,7 +90,7 @@ for N in [Float64, Float32, Rational{Int}]
     @test tr isa AffineMap && tr.M == M && tr.X == B && tr.v == v
 end
 
-for N in [Float64, Float32]
+for N in @tN([Float64, Float32])
     # translation of a set not represented by a finite number of constraints
     tr = Ball2(zeros(N, 2), N(1)) ⊕ N[1, 0]
     @test ρ(N[1, 0], tr) == N(2)

--- a/test/LazyOperations/UnionSet.jl
+++ b/test/LazyOperations/UnionSet.jl
@@ -1,4 +1,4 @@
-for N in [Float64, Float32, Rational{Int}]
+for N in @tN([Float64, Float32, Rational{Int}])
     B1 = BallInf(zeros(N, 2), N(1))
     B2 = Ball1(ones(N, 2), N(1))
     B3 = Hyperrectangle(; low=N[-1, -1], high=N[2, 2])

--- a/test/MatrixSets/MatrixZonotope.jl
+++ b/test/MatrixSets/MatrixZonotope.jl
@@ -1,6 +1,6 @@
 using LazySets, Test
 
-for N in [Float64, Float32, Rational{Int}]
+for N in @tN([Float64, Float32, Rational{Int}])
     # test constructor
     c = N[1 0; 0 3]
     gens = [N[1 -1; 0 2], N[2 -1; -1 1]]
@@ -47,7 +47,7 @@ for N in [Float64, Float32, Rational{Int}]
     @test norm(MZ, 1) == 8
 end
 
-for N in [Float64, Float32]
+for N in @tN([Float64, Float32])
     MZ = rand(MatrixZonotope; N=N)
     @test MZ isa MatrixZonotope{N}
 end

--- a/test/Sets/Ball1.jl
+++ b/test/Sets/Ball1.jl
@@ -1,7 +1,12 @@
 using LazySets, Test
 using LazySets.ReachabilityBase.Arrays: ispermutation
+if !isdefined(@__MODULE__, Symbol("@tN"))
+    macro tN(v)
+        return v
+    end
+end
 
-for N in [Float64, Float32, Rational{Int}]
+for N in @tN([Float64, Float32, Rational{Int}])
     # invalid inputs
     @test_throws AssertionError Ball1(N[0], N(-1))
     if N <: AbstractFloat
@@ -135,7 +140,7 @@ for N in [Float64, Float32, Rational{Int}]
     @test scale(N(-2), B) == Ball1(N[4, -6], N(2))
 end
 
-for N in [Float64, Float32]
+for N in @tN([Float64, Float32])
     # rand
     @test rand(Ball1; N=N) isa Ball1{N}
 end

--- a/test/Sets/Ball2.jl
+++ b/test/Sets/Ball2.jl
@@ -1,6 +1,11 @@
 using LazySets, Test
+if !isdefined(@__MODULE__, Symbol("@tN"))
+    macro tN(v)
+        return v
+    end
+end
 
-for N in [Float64, Float32]
+for N in @tN([Float64, Float32])
     # rand
     @test rand(Ball2; N=N) isa Ball2{N}
 

--- a/test/Sets/BallInf.jl
+++ b/test/Sets/BallInf.jl
@@ -1,7 +1,12 @@
 using LazySets, Test
 using LazySets.ReachabilityBase.Arrays: SingleEntryVector, ispermutation
+if !isdefined(@__MODULE__, Symbol("@tN"))
+    macro tN(v)
+        return v
+    end
+end
 
-for N in [Float64, Float32, Rational{Int}]
+for N in @tN([Float64, Float32, Rational{Int}])
     # invalid inputs
     @test_throws AssertionError BallInf(N[0], N(-1))
     if N <: AbstractFloat
@@ -260,7 +265,7 @@ for N in [Float64, Float32, Rational{Int}]
     @test scale(N(-2), B) == BallInf(N[4, -6], N(2))
 end
 
-for N in [Float64, Float32]
+for N in @tN([Float64, Float32])
     # rand
     @test rand(BallInf; N=N) isa BallInf{N}
 end

--- a/test/Sets/Ballp.jl
+++ b/test/Sets/Ballp.jl
@@ -1,6 +1,11 @@
 using LazySets, Test
+if !isdefined(@__MODULE__, Symbol("@tN"))
+    macro tN(v)
+        return v
+    end
+end
 
-for N in [Float64, Float32]
+for N in @tN([Float64, Float32])
     # rand
     @test rand(Ballp; N=N) isa Ballp{N}
 

--- a/test/Sets/DensePolynomialZonotope.jl
+++ b/test/Sets/DensePolynomialZonotope.jl
@@ -1,6 +1,11 @@
 using LazySets, Test, LinearAlgebra
+if !isdefined(@__MODULE__, Symbol("@tN"))
+    macro tN(v)
+        return v
+    end
+end
 
-for N in [Float64, Float32, Rational{Int}]
+for N in @tN([Float64, Float32, Rational{Int}])
     # example set from Figure 2 in original paper
     c = zeros(N, 2)
     E1 = Matrix(Diagonal(N[-1, 0.5]))

--- a/test/Sets/Ellipsoid.jl
+++ b/test/Sets/Ellipsoid.jl
@@ -1,6 +1,11 @@
 using LazySets, Test, LinearAlgebra
+if !isdefined(@__MODULE__, Symbol("@tN"))
+    macro tN(v)
+        return v
+    end
+end
 
-for N in [Float64, Float32]
+for N in @tN([Float64, Float32])
     # rand
     @test rand(Ellipsoid; N=N) isa Ellipsoid{N}
 

--- a/test/Sets/EmptySet.jl
+++ b/test/Sets/EmptySet.jl
@@ -1,4 +1,9 @@
 using LazySets, Test
+if !isdefined(@__MODULE__, Symbol("@tN"))
+    macro tN(v)
+        return v
+    end
+end
 
 function isidentical(::EmptySet, ::EmptySet)
     return false
@@ -16,7 +21,7 @@ let
     end
 end
 
-for N in [Float64, Float32, Rational{Int}]
+for N in @tN([Float64, Float32, Rational{Int}])
     # auxiliary sets
     B = BallInf(ones(N, 2), N(1))
     U = Universe{N}(2)
@@ -411,7 +416,7 @@ for N in [Float64, Float32, Rational{Int}]
     end
 end
 
-for N in [Float64, Float32]
+for N in @tN([Float64, Float32])
     E = EmptySet{N}(2)
 
     # rationalize

--- a/test/Sets/HParallelotope.jl
+++ b/test/Sets/HParallelotope.jl
@@ -1,7 +1,12 @@
 using LazySets, Test
 using LazySets.ReachabilityBase.Arrays: ispermutation
+if !isdefined(@__MODULE__, Symbol("@tN"))
+    macro tN(v)
+        return v
+    end
+end
 
-for N in [Float64, Float32, Rational{Int}]
+for N in @tN([Float64, Float32, Rational{Int}])
     # See [DreossiDP17; Example 6](@citet).
     D = N[-1 0 0; -1 -1 0; 0 0 -1]
     c = N[-0.80, -0.95, 0, 0.85, 1, 0]
@@ -65,7 +70,7 @@ for N in [Float64, Float32, Rational{Int}]
                         [N[1, 1], N[1, -1], N[-1, 1], N[-1, -1]])
 end
 
-for N in [Float64, Float32]
+for N in @tN([Float64, Float32])
     # rand
     @test rand(HParallelotope; N=N) isa HParallelotope{N}
 

--- a/test/Sets/HalfSpace.jl
+++ b/test/Sets/HalfSpace.jl
@@ -1,7 +1,12 @@
 using LazySets, Test, SparseArrays
 using LazySets.ReachabilityBase.Arrays: SingleEntryVector
+if !isdefined(@__MODULE__, Symbol("@tN"))
+    macro tN(v)
+        return v
+    end
+end
 
-for N in [Float64, Float32, Rational{Int}]
+for N in @tN([Float64, Float32, Rational{Int}])
     # normal constructor
     hs = HalfSpace(ones(N, 3), N(5))
 
@@ -200,7 +205,7 @@ for N in [Float64, Float32, Rational{Int}]
     @test !res
 end
 
-for N in [Float64, Float32]
+for N in @tN([Float64, Float32])
     # rand
     @test rand(HalfSpace; N=N) isa HalfSpace{N}
 

--- a/test/Sets/Hyperplane.jl
+++ b/test/Sets/Hyperplane.jl
@@ -1,7 +1,12 @@
 using LazySets, Test
 using LazySets.ReachabilityBase.Arrays: ispermutation
+if !isdefined(@__MODULE__, Symbol("@tN"))
+    macro tN(v)
+        return v
+    end
+end
 
-for N in [Float64, Float32, Rational{Int}]
+for N in @tN([Float64, Float32, Rational{Int}])
     # normal constructor
     a = ones(N, 3)
     b = N(5)
@@ -160,7 +165,7 @@ for N in [Float64, Float32, Rational{Int}]
     @test project(N[1, 0], H) ≈ N[1 // 2, 1 // 2]
 end
 
-for N in [Float64, Float32]
+for N in @tN([Float64, Float32])
     # rand
     @test rand(Hyperplane; N=N) isa Hyperplane{N}
 

--- a/test/Sets/Hyperrectangle.jl
+++ b/test/Sets/Hyperrectangle.jl
@@ -3,8 +3,13 @@ using LazySets.ReachabilityBase.Arrays: ispermutation
 using LazySets.ReachabilityBase.Arrays: SingleEntryVector
 using IntervalArithmetic: IntervalBox
 import IntervalArithmetic as IA
+if !isdefined(@__MODULE__, Symbol("@tN"))
+    macro tN(v)
+        return v
+    end
+end
 
-for N in [Float64, Float32, Rational{Int}]
+for N in @tN([Float64, Float32, Rational{Int}])
     # constructor with mixed vectors
     Hyperrectangle(sparsevec([1], N[1], 1), N[1])
     Hyperrectangle(N[1], sparsevec([1], N[1], 1))
@@ -378,7 +383,7 @@ for N in [Float64, Float32, Rational{Int}]
     @test H2 == H3 == Hyperrectangle(N[3, 5, 7], N[4, 5, 6])
 end
 
-for N in [Float64, Float32]
+for N in @tN([Float64, Float32])
     # rand
     @test rand(Hyperrectangle; N=N) isa Hyperrectangle{N}
 

--- a/test/Sets/Interval.jl
+++ b/test/Sets/Interval.jl
@@ -8,6 +8,11 @@ else
 end
 using LazySets.ReachabilityBase.Arrays: ispermutation
 using LazySets.ReachabilityBase.Arrays: SingleEntryVector
+if !isdefined(@__MODULE__, Symbol("@tN"))
+    macro tN(v)
+        return v
+    end
+end
 
 function isidentical(::Interval, ::Interval)
     return false
@@ -17,7 +22,7 @@ function isidentical(X1::Interval{N}, X2::Interval{N}) where {N}
     return X1.dat == X2.dat
 end
 
-for N in [Float64, Float32, Rational{Int}]
+for N in @tN([Float64, Float32, Rational{Int}])
     # auxiliary sets
     X2 = Singleton(N[0, 0])  # 2D set
     B = BallInf(N[1], N(1))  # equivalent set
@@ -605,7 +610,7 @@ for N in [Float64, Float32, Rational{Int}]
     end
 end
 
-for N in [Float64, Float32]
+for N in @tN([Float64, Float32])
     X = Interval(N(0), N(2))
 
     # rand

--- a/test/Sets/Line.jl
+++ b/test/Sets/Line.jl
@@ -1,7 +1,12 @@
 using LazySets, Test
 using LazySets.ReachabilityBase.Arrays: ispermutation
+if !isdefined(@__MODULE__, Symbol("@tN"))
+    macro tN(v)
+        return v
+    end
+end
 
-for N in [Float64, Float32, Rational{Int}]
+for N in @tN([Float64, Float32, Rational{Int}])
     # construction
     l1 = Line(; from=N[0, 1], to=N[1, 1]) # two points on the line
     l2 = Line(N[0, 1], N[1, 0]) # point and direction
@@ -81,7 +86,7 @@ for N in [Float64, Float32, Rational{Int}]
     @test project(L, [2, 3]) == Singleton(N[2, 3])
 end
 
-for N in [Float64, Float32]
+for N in @tN([Float64, Float32])
     # rand
     @test rand(Line; N=N) isa Line{N}
 

--- a/test/Sets/Line2D.jl
+++ b/test/Sets/Line2D.jl
@@ -1,7 +1,12 @@
 using LazySets, Test
 using LazySets.ReachabilityBase.Arrays: ispermutation
+if !isdefined(@__MODULE__, Symbol("@tN"))
+    macro tN(v)
+        return v
+    end
+end
 
-for N in [Float64, Float32, Rational{Int}]
+for N in @tN([Float64, Float32, Rational{Int}])
     # construction
     a1 = N[0, 1]
     b1 = N(1)
@@ -130,7 +135,7 @@ for N in [Float64, Float32, Rational{Int}]
     @test res && w isa Vector{N} && isempty(w)
 end
 
-for N in [Float64, Float32]
+for N in @tN([Float64, Float32])
     # rand
     @test rand(Line2D; N=N) isa Line2D{N}
 

--- a/test/Sets/LineSegment.jl
+++ b/test/Sets/LineSegment.jl
@@ -1,7 +1,12 @@
 using LazySets, Test
 using LazySets.ReachabilityBase.Arrays: ispermutation
+if !isdefined(@__MODULE__, Symbol("@tN"))
+    macro tN(v)
+        return v
+    end
+end
 
-for N in [Float64, Float32, Rational{Int}]
+for N in @tN([Float64, Float32, Rational{Int}])
     # construction
     p, q = N[1, 1], N[2, 2]
     l = LineSegment(p, q)
@@ -200,7 +205,7 @@ for N in [Float64, Float32, Rational{Int}]
     @test scale(N(2), L) == L2 == LineSegment(N[0, 0], N[2, 2])
 end
 
-for N in [Float64, Float32]
+for N in @tN([Float64, Float32])
     # rand
     @test rand(LineSegment; N=N) isa LineSegment{N}
 end

--- a/test/Sets/Polygon.jl
+++ b/test/Sets/Polygon.jl
@@ -3,8 +3,13 @@ using LazySets: ⪯
 using LazySets.ReachabilityBase.Arrays: is_cyclic_permutation
 using LazySets.ReachabilityBase.Comparison: _isapprox
 using LazySets.ReachabilityBase.Arrays: ispermutation
+if !isdefined(@__MODULE__, Symbol("@tN"))
+    macro tN(v)
+        return v
+    end
+end
 
-for N in [Float64, Float32, Rational{Int}]
+for N in @tN([Float64, Float32, Rational{Int}])
     # Empty polygon
     p = HPolygon{N}()
 
@@ -585,7 +590,7 @@ for N in [Float64, Float32, Rational{Int}]
     end
 end
 
-for N in [Float64, Float32]
+for N in @tN([Float64, Float32])
     v1 = N[1 // 10, 3 // 10]
     v2 = N[1 // 5, 1 // 10]
     v3 = N[2 // 5, 3 // 10]

--- a/test/Sets/PolygonNC.jl
+++ b/test/Sets/PolygonNC.jl
@@ -1,6 +1,11 @@
 using LazySets, Test
+if !isdefined(@__MODULE__, Symbol("@tN"))
+    macro tN(v)
+        return v
+    end
+end
 
-for N in [Float64, Float32, Rational{Int}]
+for N in @tN([Float64, Float32, Rational{Int}])
     # constructor from empty vertex list
     P_empty = Polygon{N}()
     @test P_empty isa Polygon{N,Vector{N}} && isempty(P_empty.vertices)

--- a/test/Sets/Polyhedron.jl
+++ b/test/Sets/Polyhedron.jl
@@ -1,8 +1,13 @@
 using LazySets, Test
 using LazySets: _isbounded_stiemke, _isbounded_unit_dimensions
 using LazySets.ReachabilityBase.Arrays: SingleEntryVector, ispermutation, isinvertible
+if !isdefined(@__MODULE__, Symbol("@tN"))
+    macro tN(v)
+        return v
+    end
+end
 
-for N in [Float64, Float32, Rational{Int}]
+for N in @tN([Float64, Float32, Rational{Int}])
     @test HPolyhedron{N}() isa HPolyhedron{N}
     @test HPolyhedron{N,Vector{N}}() isa HPolyhedron{N,Vector{N}}
     p_univ = HPolyhedron{N}()
@@ -187,7 +192,7 @@ end
 # default Float64 constructors
 @test HPolyhedron() isa HPolyhedron{Float64}
 
-for N in [Float64, Float32]
+for N in @tN([Float64, Float32])
     # rand
     @test rand(HPolyhedron; N=N) isa HPolyhedron{N}
 

--- a/test/Sets/Polytope.jl
+++ b/test/Sets/Polytope.jl
@@ -1,8 +1,13 @@
 using LazySets, Test, LinearAlgebra
 using LazySets: linear_map_inverse, affine_map_inverse
 using LazySets.ReachabilityBase.Arrays: SingleEntryVector, ispermutation
+if !isdefined(@__MODULE__, Symbol("@tN"))
+    macro tN(v)
+        return v
+    end
+end
 
-for N in [Float64, Float32, Rational{Int}]
+for N in @tN([Float64, Float32, Rational{Int}])
     # random polytopes
     @test_throws ArgumentError rand(HPolytope; N=N, dim=1, num_vertices=3)
     p = rand(HPolytope; N=N, dim=1, num_vertices=0)
@@ -351,7 +356,7 @@ end
 @test HPolytope() isa HPolytope{Float64}
 @test VPolytope() isa VPolytope{Float64,Vector{Float64}}
 
-for N in [Float64, Float32]
+for N in @tN([Float64, Float32])
     # rand
     p = rand(HPolytope; N=N, dim=2, num_vertices=0)
     @test p isa HPolytope{N} && dim(p) == 2 && isempty(p)

--- a/test/Sets/SimpleSparsePolynomialZonotope.jl
+++ b/test/Sets/SimpleSparsePolynomialZonotope.jl
@@ -6,8 +6,13 @@ else
     import PkgVersion
     vIA = PkgVersion.Version(IA)
 end
+if !isdefined(@__MODULE__, Symbol("@tN"))
+    macro tN(v)
+        return v
+    end
+end
 
-for N in [Float64, Float32, Rational{Int}]
+for N in @tN([Float64, Float32, Rational{Int}])
     # example from slide 13 of Niklas talk at JuliaReach & JuliaIntervals Days 3
     c = N[2, 0]
     G = N[1 2; 2 2.0]
@@ -155,7 +160,7 @@ for N in [Float64, Float32, Rational{Int}]
     @test P2 == TPZ
 end
 
-for N in [Float64, Float32]
+for N in @tN([Float64, Float32])
     # rand
     @test rand(SimpleSparsePolynomialZonotope; N=N) isa SimpleSparsePolynomialZonotope{N}
 end

--- a/test/Sets/Singleton.jl
+++ b/test/Sets/Singleton.jl
@@ -1,8 +1,13 @@
 using LazySets, Test
 using LazySets.ReachabilityBase.Arrays: ispermutation
 using LazySets.ReachabilityBase.Arrays: SingleEntryVector
+if !isdefined(@__MODULE__, Symbol("@tN"))
+    macro tN(v)
+        return v
+    end
+end
 
-for N in [Float64, Float32, Rational{Int}]
+for N in @tN([Float64, Float32, Rational{Int}])
     # constructors
     S1 = Singleton(N[1, 2])
     S2 = Singleton(N(1), N(2))
@@ -189,7 +194,7 @@ for N in [Float64, Float32, Rational{Int}]
     @test singleton_list(S) == [S]
 end
 
-for N in [Float64, Float32]
+for N in @tN([Float64, Float32])
     # rand
     @test rand(Singleton; N=N) isa Singleton{N}
 end

--- a/test/Sets/SparsePolynomialZonotope.jl
+++ b/test/Sets/SparsePolynomialZonotope.jl
@@ -2,8 +2,13 @@ using LazySets, Test, LinearAlgebra
 import IntervalArithmetic as IA
 using IntervalArithmetic: IntervalBox
 using LazySets.SparsePolynomialZonotopeModule: merge_id
+if !isdefined(@__MODULE__, Symbol("@tN"))
+    macro tN(v)
+        return v
+    end
+end
 
-for N in [Float64, Float32, Rational{Int}]
+for N in @tN([Float64, Float32, Rational{Int}])
     # Example 3.1.2 from thesis
     c = N[4, 4]
     G = N[2 1 2; 0 2 2]
@@ -338,7 +343,7 @@ let
     @test Ē₂ == [0 0 0; 0 0 0; 1 0 1; 3 2 0]
 end
 
-for N in [Float64, Float32]
+for N in @tN([Float64, Float32])
     # rand
     @test rand(SparsePolynomialZonotope; N=N) isa SparsePolynomialZonotope{N}
 end

--- a/test/Sets/Star.jl
+++ b/test/Sets/Star.jl
@@ -1,7 +1,12 @@
 using LazySets, Test
 using LazySets.ReachabilityBase.Arrays: ispermutation
+if !isdefined(@__MODULE__, Symbol("@tN"))
+    macro tN(v)
+        return v
+    end
+end
 
-for N in [Float64, Float32, Rational{Int}]
+for N in @tN([Float64, Float32, Rational{Int}])
     # constructor with basis matrix
     S = Star(N[3, 3], N[1 0; 0 1], BallInf(N[0, 0], N(1)))
 
@@ -82,7 +87,7 @@ for N in [Float64, Float32, Rational{Int}]
     @test ispermutation(vertices_list(S), vertices_list(B))
 end
 
-for N in [Float64, Float32]
+for N in @tN([Float64, Float32])
     # random star
     @test rand(Star; N=N) isa Star{N}
 end

--- a/test/Sets/Tetrahedron.jl
+++ b/test/Sets/Tetrahedron.jl
@@ -1,6 +1,11 @@
 using LazySets, Test
+if !isdefined(@__MODULE__, Symbol("@tN"))
+    macro tN(v)
+        return v
+    end
+end
 
-for N in [Float64, Float32, Rational{Int}]
+for N in @tN([Float64, Float32, Rational{Int}])
     # constructor
     vertices = [N[1, 0, -1 / sqrt(2)], N[-1, 0, -1 / sqrt(2)], N[0, 1, 1 / sqrt(2)],
                 N[0, -1, 1 / sqrt(2)]]
@@ -34,7 +39,7 @@ for N in [Float64, Float32, Rational{Int}]
     @test zeros(N, 3) ∈ T
 end
 
-for N in [Float64, Float32]
+for N in @tN([Float64, Float32])
     # rand
     @test rand(Tetrahedron; N=N) isa Tetrahedron{N}
 end

--- a/test/Sets/Universe.jl
+++ b/test/Sets/Universe.jl
@@ -1,4 +1,9 @@
 using LazySets, Test
+if !isdefined(@__MODULE__, Symbol("@tN"))
+    macro tN(v)
+        return v
+    end
+end
 
 function isidentical(::Universe, ::Universe)
     return false
@@ -15,7 +20,7 @@ let
     @test U.dim == 2
 end
 
-for N in [Float64, Float32, Rational{Int}]
+for N in @tN([Float64, Float32, Rational{Int}])
     # auxiliary sets
     B = BallInf(ones(N, 2), N(1))
     E = EmptySet{N}(2)
@@ -451,7 +456,7 @@ for N in [Float64, Float32, Rational{Int}]
     end
 end
 
-for N in [Float64, Float32]
+for N in @tN([Float64, Float32])
     U = Universe{N}(2)
 
     # rationalize

--- a/test/Sets/ZeroSet.jl
+++ b/test/Sets/ZeroSet.jl
@@ -1,4 +1,9 @@
 using LazySets, Test
+if !isdefined(@__MODULE__, Symbol("@tN"))
+    macro tN(v)
+        return v
+    end
+end
 
 let
     # default Float64 constructor
@@ -6,7 +11,7 @@ let
     @test Z isa ZeroSet{Float64} && Z.dim == 2
 end
 
-for N in [Float64, Float32, Rational{Int}]
+for N in @tN([Float64, Float32, Rational{Int}])
     Z = ZeroSet{N}(2)
     B = BallInf(ones(N, 2), N(1))
 
@@ -98,7 +103,7 @@ for N in [Float64, Float32, Rational{Int}]
     @test scale(N(-2), Z) == Z2 == ZeroSet{N}(dim(Z))
 end
 
-for N in [Float64, Float32]
+for N in @tN([Float64, Float32])
     # rand
     @test rand(ZeroSet; N=N) isa ZeroSet{N}
 end

--- a/test/Sets/Zonotope.jl
+++ b/test/Sets/Zonotope.jl
@@ -1,7 +1,12 @@
 using LazySets, Test, LinearAlgebra, SparseArrays
 using LazySets.ReachabilityBase.Arrays: ispermutation
+if !isdefined(@__MODULE__, Symbol("@tN"))
+    macro tN(v)
+        return v
+    end
+end
 
-for N in [Float64, Float32, Rational{Int}]
+for N in @tN([Float64, Float32, Rational{Int}])
     # constructor from list of generators
     Z = Zonotope(N[1, 1], [N[1, 2], N[3, 4]])
     @test Z isa Zonotope{N} && Z == Zonotope(N[1, 1], N[1 3; 2 4])
@@ -325,7 +330,7 @@ for N in [Float64, Float32, Rational{Int}]
     @test norm(Z3, 1) == 6
 end
 
-for N in [Float64, Float32]
+for N in @tN([Float64, Float32])
     # rand
     @test rand(Zonotope; N=N) isa Zonotope{N}
 end

--- a/test/Sets/ZonotopeMD.jl
+++ b/test/Sets/ZonotopeMD.jl
@@ -1,6 +1,11 @@
 using LazySets, Test, LinearAlgebra
+if !isdefined(@__MODULE__, Symbol("@tN"))
+    macro tN(v)
+        return v
+    end
+end
 
-for N in [Float64, Float32, Rational{Int}]
+for N in @tN([Float64, Float32, Rational{Int}])
     # isoperationtype
     @test !isoperationtype(ZonotopeMD)
 

--- a/test/Utils/plot.jl
+++ b/test/Utils/plot.jl
@@ -1,7 +1,7 @@
 using LinearAlgebra, SparseArrays
 import Optim
 
-for N in [Float64, Float32, Rational{Int}]
+for N in @tN([Float64, Float32, Rational{Int}])
     for n in [1, 2]
         p0 = zero(N)
         p1 = one(N)

--- a/test/Utils/util.jl
+++ b/test/Utils/util.jl
@@ -31,7 +31,7 @@ let
     @test rank(Matrix(A)) == rank(A) == rank(view(A, :, :))
 end
 
-for N in [Float64, Float32, Rational{Int}]
+for N in @tN([Float64, Float32, Rational{Int}])
     # removal of zero columns
     A = N[1 2; 3 4]
     @test remove_zero_columns(A) === A
@@ -118,7 +118,7 @@ for N in [Float64, Float32, Rational{Int}]
     @assert matrix_type(typeof(mat)) == Diagonal{N,Vector{N}}
 end
 
-for N in [Float64, Float32]
+for N in @tN([Float64, Float32])
     # modified dot product
     @test isnan(dot(N[1, 0], N[Inf, -Inf]))
     @test LazySets.dot_zero(N[1, 0], N[Inf, -Inf]) == N(Inf)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,9 +4,11 @@ using Test
 begin
     __test_short = haskey(ENV, "JULIA_PKGEVAL")
 
+    __test_Float64_only = false
+
     macro ts(arg)
         if !__test_short
-            quote
+            return quote
                 $(esc(arg))
             end
         end
@@ -17,6 +19,16 @@ begin
             return v1
         else
             return @eval vcat($v1, $v2)
+        end
+    end
+
+    macro tN(v)
+        if __test_Float64_only
+            return quote
+                [$(esc(v))[1]]
+            end
+        else
+            return v
         end
     end
 end


### PR DESCRIPTION
This option is deactivated by default. If active, it speeds up the tests significantly by skipping the duplicates for `Float32` and `Rational{Int}`, which is useful for quick checks.