### PR TITLE
Deactivate Windows CI run

### DIFF
--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -22,7 +22,6 @@ jobs:
           - '1'
         os:
           - ubuntu-latest
-          - windows-latest
         arch:
           - x64
         include:


### PR DESCRIPTION
The Windows build takes 17 minutes longer. Since there is no OS-specific code, the run is also not generally insightful. To save time and energy, I propose to deactivate this build.