### PR TITLE
Fix creation of tagged docs versions

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -14,3 +14,4 @@ jobs:
         uses: JuliaRegistries/TagBot@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          ssh: ${{ secrets.DOCUMENTER_KEY }}


### PR DESCRIPTION
TagBot cannot trigger the creation of tagged documentation because it needs a key for that. This fix is documented [here](https://documenter.juliadocs.org/stable/man/hosting/#GitHub-Actions).