### PR TITLE
Add `overapproximation` for matrix zonotope multiplication

### DIFF
--- a/docs/src/refs.bib
+++ b/docs/src/refs.bib
@@ -565,3 +565,14 @@
   url          = {https://doi.org/10.1145/1967701.1967717},
   }
   
+  @article{AlthoffKS11,
+  author       = {Althoff, Matthias and Krogh, Bruce and Stursberg, Olaf},
+  title        = {Analyzing Reachability of Linear Dynamic Systems with Parametric Uncertainties},
+  journal      = {Mathematical Engineering},
+  volume       = {3},
+  year         = {2011},
+  month        = {05},
+  pages        = {69-94},
+  isbn         = {978-3-642-15955-8},
+  doi          = {10.1007/978-3-642-15956-5_4}
+}

--- a/src/Approximations/init_IntervalMatrices.jl
+++ b/src/Approximations/init_IntervalMatrices.jl
@@ -1,3 +1,3 @@
 eval(load_intervalmatrices_overapproximation())
 eval(load_intervalmatrices_overapproximation_expmap())
-eval(load_intervalmatrices_conversion())
+eval(load_intervalmatrices_overapproximation_matrixzonotope())

--- a/src/Approximations/init_IntervalMatrices.jl
+++ b/src/Approximations/init_IntervalMatrices.jl
@@ -1,2 +1,3 @@
 eval(load_intervalmatrices_overapproximation())
 eval(load_intervalmatrices_overapproximation_expmap())
+eval(load_intervalmatrices_conversion())

--- a/src/Approximations/overapproximate.jl
+++ b/src/Approximations/overapproximate.jl
@@ -883,7 +883,7 @@ end
 
 """
     overapproximate(MZP::MatrixZonotopeProduct{N,S},
-                         ::Type{<:MatrixZonotope{N}}) where {N,S<:AbstractMatrix{N}}
+                         ::Type{<:MatrixZonotope}) where {N,S<:AbstractMatrix{N}}
 
 Overapproximate the product of matrix zonotopes, following Equation 4.10 in [AlthoffKS11](@citet).
 
@@ -932,7 +932,7 @@ function overapproximate(MZP::MatrixZonotopeProduct{N,S},
     end
 end
 
-function load_intervalmatrices_conversion()
+function load_intervalmatrices_overapproximation_matrixzonotope()
     return quote
         using .IntervalMatrices: IntervalMatrix
         """
@@ -943,7 +943,7 @@ function load_intervalmatrices_conversion()
         ### Input
 
         - `A` -- a matrix zonotope
-        - `MatrixZonotope` -- target type
+        - `IntervalMatrix` -- target type
 
         ### Output 
 

--- a/src/Approximations/overapproximate.jl
+++ b/src/Approximations/overapproximate.jl
@@ -880,3 +880,80 @@ function overapproximate(lm::LinearMap{N,S,NM,MAT},
     reduced = foldr((A, acc) -> overapproximate(A * acc, T), MZs; init=P)
     return reduced
 end
+
+"""
+    overapproximate(MZP::MatrixZonotopeProduct{N,S},
+                         ::Type{<:MatrixZonotope{N}}) where {N,S<:AbstractMatrix{N}}
+
+Overapproximate the product of matrix zonotopes, following Equation 4.10 in [AlthoffKS11](@citet).
+
+### Input
+
+- `MZP` -- a `MatrixZonotopeProduct`
+- `MatrixZonotope` -- target type
+
+### Output 
+
+A matrix zonotope overapproximating the matrix zonotope product
+"""
+function overapproximate(MZP::MatrixZonotopeProduct{N,S},
+                         ::Type{<:MatrixZonotope}) where {N,S<:AbstractMatrix{N}}
+    if nfactors(MZP) == 1
+        return factors(MZP)[1]
+    end
+
+    return foldl(factors(MZP)) do A, B
+        nB = ngens(B)
+        nA = ngens(A)
+
+        if nA == 0
+            return linear_map(center(A), B)
+        elseif nB == 0
+            return linear_map(A, center(B))
+        end
+
+        gens = Vector{S}(undef, nB + nA * nB)
+
+        # G₀ · Hⱼ block
+        @inbounds for j in 1:nB
+            gens[j] = center(A) * generators(B)[j]
+        end
+
+        # Gᵢ ⋅ Hⱼ block 
+        idx = nB + 1
+        @inbounds for Gi in generators(A), Hj in generators(B)
+            gens[idx] = Gi * Hj
+            idx += 1
+        end
+
+        c = center(A) * center(B)
+        res = MatrixZonotope(c, gens)
+        return res
+    end
+end
+
+function load_intervalmatrices_conversion()
+    return quote
+        using .IntervalMatrices: IntervalMatrix
+        """
+            overapproximate(A::MatrixZonotope, ::Type{<:IntervalMatrix})
+
+        Overapproximate a matrix zonotope by an interval matrix
+
+        ### Input
+
+        - `A` -- a matrix zonotope
+        - `MatrixZonotope` -- target type
+
+        ### Output 
+
+        An interval matrix overapproximating the matrix zonotope
+        """
+        function overapproximate(A::MatrixZonotope, ::Type{<:IntervalMatrix})
+            A_abs = sum([abs.(Ai) for Ai in generators(A)])
+            A₊ = center(A) + A_abs
+            A₋ = center(A) - A_abs
+            return IntervalMatrix(A₋, A₊)
+        end
+    end
+end

--- a/test/Approximations/overapproximate.jl
+++ b/test/Approximations/overapproximate.jl
@@ -211,6 +211,24 @@ for N in @tN([Float64, Float32, Rational{Int}])
                                  [1, 2, 3])
     res = overapproximate(MZ * P, SparsePolynomialZonotope)
     @test res == linear_map(MZ, P)  # test fallback
+
+    #overapproximate matrix zonotope multiplication
+    A = MatrixZonotope(N[1 1; -1 1], [N[1 0; 1 2]])
+    B = MatrixZonotope(N[2 0; 1 -1], [N[0 1; 1 -1]])
+    res = overapproximate(A * B, MatrixZonotope)
+
+    @test center(res) == N[3 -1; -1 -1]
+    @test generators(res) == [N[1 0; 1 -2], N[0 1; 2 -1]]
+
+    C = MatrixZonotope(N[1 0; 0 -1], [N[0 0; 1 0]])
+    res2 = overapproximate(A * B * C, MatrixZonotope)
+    @test ngens(res2) == 3
+
+    #empty generator
+    D = MatrixZonotope(N[1 0; 0 -1], Matrix{N}[])
+    res3 = overapproximate(A * D, MatrixZonotope)
+    @test center(res3) == N[1 -1; -1 -1]
+    @test generators(res3) == [N[1 0; 1 -2]]
 end
 
 for N in @tN([Float64, Float32])
@@ -392,6 +410,11 @@ for N in @tN([Float64, Float32])
     PZ2 = SparsePolynomialZonotope(N[3, 3], N[1 -2 2; 2 3 1], hcat(N[1 // 2; 0]), [1 0 2; 0 1 1])
     PZ = overapproximate(CH(PZ1, PZ2), SparsePolynomialZonotope)
     @test center(PZ) == N[-1, 3 // 2]   # no reasonable tests available here
+
+    # overapproximate matrix zonotope with interval matrix 
+    MZ = MatrixZonotope(N[-1 -4; 4 -1], [N[0.1 0.1; 0.1 0.1]])
+    IM = overapproximate(MZ, IntervalMatrix)
+    @test IM == IntervalMatrix(N[-1.1 -4.1; 3.9 -1.1], N[-0.9 -3.9; 4.1 -0.9])
 end
 
 for N in [Float64]


### PR DESCRIPTION
In this PR I add:
- `overapproximation`  for a matrix zonotope multiplication based on [eq 4.10](https://mediatum.ub.tum.de/doc/1287218/1287218.pdf)
- `overapproximation` method to represent a matrix zonotope as an interval matrix 