### PR TITLE
Fix numeric type of `center` and `genmat` for `HParallelotope`

### DIFF
--- a/src/Sets/HParallelotope/center.jl
+++ b/src/Sets/HParallelotope/center.jl
@@ -15,7 +15,8 @@ vertices with respect to ``q`` given by the set ``\\{v_i\\}`` for
 where ``s := ∑_{i=1}^n v_i`` is the sum of extremal vertices.
 """
 function center(P::HParallelotope)
-    n = dim(P)
+    N = eltype(P)
+    n = N(dim(P))
     q = base_vertex(P)
     E = extremal_vertices(P)
     s = sum(E)

--- a/src/Sets/HParallelotope/genmat.jl
+++ b/src/Sets/HParallelotope/genmat.jl
@@ -18,5 +18,5 @@ for ``i = 1, …, n``.
 function genmat(P::HParallelotope)
     q = base_vertex(P)
     E = extremal_vertices(P)
-    return 1 / 2 * reduce(hcat, E) .- q / 2
+    return reduce(hcat, E) / 2 .- q / 2
 end

--- a/test/Sets/HParallelotope.jl
+++ b/test/Sets/HParallelotope.jl
@@ -50,14 +50,16 @@ for N in @tN([Float64, Float32, Rational{Int}])
     P = HParallelotope(N[1 0; 0 1], N[1, 1, 1, 1])
 
     # test center
-    @test center(P) == N[0, 0]
+    c = center(P)
+    @test c isa Vector{N} && c == N[0, 0]
 
     # test vertices functions
     @test base_vertex(P) == N[-1, -1]
     @test extremal_vertices(P) == [N[1, -1], N[-1, 1]]
 
     # test generators getters
-    @test genmat(P) == N[1 0; 0 1]
+    G = genmat(P)
+    @test G isa Matrix{N} && G == N[1 0; 0 1]
 
     # emptiness
     @test !isempty(P)


### PR DESCRIPTION
These methods did not preserve a `Float32` numeric type.