### PR TITLE
Remove redundant `togrep` method

### DIFF
--- a/docs/src/lib/sets/Zonotope.md
+++ b/docs/src/lib/sets/Zonotope.md
@@ -76,13 +76,6 @@ CurrentModule = LazySets
 CurrentModule = LazySets.API
 ```
 * [`isoperationtype`](@ref isoperationtype(::Type{LazySet}))
-```@meta
-CurrentModule = LazySets
-```
-* [`togrep`](@ref togrep(::AbstractZonotope))
-```@meta
-CurrentModule = LazySets.API
-```
 * [`permute`](@ref permute(::LazySet, ::AbstractVector{Int}))
 ```@meta
 CurrentModule = LazySets
@@ -171,6 +164,7 @@ Inherited from [`AbstractZonotope`](@ref):
 * [`constraints_list`](@ref constraints_list(::AbstractZonotope{<:AbstractFloat}; ::Bool=true))
 * [`order`](@ref order(::AbstractZonotope))
 * [`reflect`](@ref reflect(::AbstractZonotope))
+* [`togrep`](@ref togrep(::AbstractZonotope))
 * [`vertices_list`](@ref vertices_list(::AbstractZonotope))
 * [`∈`](@ref ∈(::AbstractVector, ::AbstractZonotope))
 * [`linear_map`](@ref linear_map(::AbstractMatrix, ::AbstractZonotope))

--- a/src/Sets/Zonotope/ZonotopeModule.jl
+++ b/src/Sets/Zonotope/ZonotopeModule.jl
@@ -14,7 +14,7 @@ using ReachabilityBase.Require: require
 @reexport import ..API: center, high, isoperationtype, low, rand,
                         permute, scale, scale!, translate!
 @reexport import ..LazySets: generators, genmat, ngens, reduce_order,
-                             remove_redundant_generators, togrep
+                             remove_redundant_generators
 import Base: convert
 @reexport using ..API
 
@@ -40,7 +40,6 @@ include("genmat.jl")
 include("ngens.jl")
 include("reduce_order.jl")
 include("remove_redundant_generators.jl")
-include("togrep.jl")
 include("remove_zero_generators.jl")
 include("split.jl")
 

--- a/src/Sets/Zonotope/togrep.jl
+++ b/src/Sets/Zonotope/togrep.jl
@@ -1,3 +1,0 @@
-function togrep(Z::Zonotope)
-    return Z
-end


### PR DESCRIPTION
The default implementation is already a no-op.