### PR TITLE
Let `@validate` check `ispolytopic` for `vertices(_list)`

### DIFF
--- a/src/Interfaces/AbstractAffineMap.jl
+++ b/src/Interfaces/AbstractAffineMap.jl
@@ -235,7 +235,7 @@ under the affine map, pass `apply_convex_hull=false` as a keyword argument.
 Note that we assume that the underlying set `X` is polytopic, either concretely
 or lazily, i.e., the function `vertices_list` should be applicable.
 """
-function vertices_list(am::AbstractAffineMap; apply_convex_hull::Bool=true)
+@validate function vertices_list(am::AbstractAffineMap; apply_convex_hull::Bool=true)
     # for a zero linear map, the result is just the affine translation
     A = matrix(am)
     b = vector(am)

--- a/src/Interfaces/AbstractHPolygon.jl
+++ b/src/Interfaces/AbstractHPolygon.jl
@@ -142,9 +142,9 @@ polygon were actually feasible (i.e., they pointed in the *right* direction).
 For this we compute the *average* of all vertices and check membership in each
 constraint.
 """
-function vertices_list(P::AbstractHPolygon;
-                       apply_convex_hull::Bool=true,  # see docstring and #1405
-                       check_feasibility::Bool=true)
+@validate function vertices_list(P::AbstractHPolygon;
+                                 apply_convex_hull::Bool=true,  # see docstring and #1405
+                                 check_feasibility::Bool=true)
     n = length(P.constraints)
     N = eltype(P)
     points = Vector{Vector{N}}(undef, n)

--- a/src/Interfaces/AbstractHyperrectangle.jl
+++ b/src/Interfaces/AbstractHyperrectangle.jl
@@ -219,7 +219,7 @@ entry `1` (but changing it to `-1`).
 This way we only need to change the vertex in those dimensions where `v` has
 changed, which usually is a smaller number than `n`.
 """
-function vertices_list(H::AbstractHyperrectangle; kwargs...)
+@validate function vertices_list(H::AbstractHyperrectangle; kwargs...)
     n = dim(H)
 
     # identify flat dimensions and store them in a binary vector whose entry in

--- a/src/Interfaces/AbstractPolyhedron_functions.jl
+++ b/src/Interfaces/AbstractPolyhedron_functions.jl
@@ -785,7 +785,7 @@ julia> length(vertices_list(P))
 4
 ```
 """
-function vertices_list(P::AbstractPolyhedron; check_boundedness::Bool=true)
+@validate function vertices_list(P::AbstractPolyhedron; check_boundedness::Bool=true)
     if check_boundedness && !isbounded(P)
         throw(ArgumentError("the list of vertices of an unbounded " *
                             "polyhedron is not defined"))

--- a/src/Interfaces/AbstractSingleton.jl
+++ b/src/Interfaces/AbstractSingleton.jl
@@ -109,11 +109,11 @@ end
     return element(S, i)
 end
 
-function vertices(S::AbstractSingleton)
+@validate function vertices(S::AbstractSingleton)
     return SingletonIterator(element(S))
 end
 
-function vertices_list(S::AbstractSingleton)
+@validate function vertices_list(S::AbstractSingleton)
     return [element(S)]
 end
 

--- a/src/Interfaces/AbstractZonotope.jl
+++ b/src/Interfaces/AbstractZonotope.jl
@@ -374,7 +374,7 @@ There are at most ``2^p`` distinct vertices. Use the flag `apply_convex_hull` to
 control whether a convex-hull algorithm is applied to the vertices computed by
 this method; otherwise, redundant vertices may be present.
 """
-function vertices_list(Z::AbstractZonotope; apply_convex_hull::Bool=true)
+@validate function vertices_list(Z::AbstractZonotope; apply_convex_hull::Bool=true)
     c = center(Z)
     G = genmat(Z)
     n, p = size(G)

--- a/src/Interfaces/LazySet_functions.jl
+++ b/src/Interfaces/LazySet_functions.jl
@@ -1093,7 +1093,7 @@ end
 
 The default implementation computes all vertices via `vertices_list`.
 """
-function vertices(X::LazySet)
+@validate function vertices(X::LazySet)
     return vertices_list(X)
 end
 

--- a/src/LazyOperations/CartesianProduct.jl
+++ b/src/LazyOperations/CartesianProduct.jl
@@ -330,7 +330,7 @@ We assume that the underlying sets are polytopic.
 Then the high-dimensional set of vertices is just the Cartesian product of the
 low-dimensional sets of vertices.
 """
-function vertices_list(cp::CartesianProduct)
+@validate function vertices_list(cp::CartesianProduct)
     # collect low-dimensional vertices lists
     vlist1 = vertices_list(cp.X)
     vlist2 = vertices_list(cp.Y)

--- a/src/LazyOperations/CartesianProductArray.jl
+++ b/src/LazyOperations/CartesianProductArray.jl
@@ -420,7 +420,7 @@ We assume that the underlying sets are polytopic.
 Then the high-dimensional set of vertices is just the Cartesian product of the
 low-dimensional sets of vertices.
 """
-function vertices_list(cpa::CartesianProductArray)
+@validate function vertices_list(cpa::CartesianProductArray)
     # collect low-dimensional vertices lists
     vlist_low = [vertices_list(X) for X in cpa]
 

--- a/src/LazyOperations/ConvexHull.jl
+++ b/src/LazyOperations/ConvexHull.jl
@@ -211,9 +211,9 @@ Return a list of vertices of the convex hull of two sets.
 
 A list of vertices.
 """
-function vertices_list(ch::ConvexHull;
-                       apply_convex_hull::Bool=true,
-                       backend=nothing)
+@validate function vertices_list(ch::ConvexHull;
+                                 apply_convex_hull::Bool=true,
+                                 backend=nothing)
     vlist = vcat(vertices_list(ch.X), vertices_list(ch.Y))
     if apply_convex_hull
         convex_hull!(vlist; backend=backend)

--- a/src/LazyOperations/ConvexHullArray.jl
+++ b/src/LazyOperations/ConvexHullArray.jl
@@ -210,10 +210,10 @@ Return a list of vertices of the convex hull of a finite number of sets.
 
 A list of vertices.
 """
-function vertices_list(cha::ConvexHullArray;
-                       apply_convex_hull::Bool=true,
-                       backend=nothing,
-                       prune::Bool=apply_convex_hull)
+@validate function vertices_list(cha::ConvexHullArray;
+                                 apply_convex_hull::Bool=true,
+                                 backend=nothing,
+                                 prune::Bool=apply_convex_hull)
     vlist = vcat([vertices_list(Xi) for Xi in cha]...)
     if apply_convex_hull || prune
         convex_hull!(vlist; backend=backend)

--- a/src/LazyOperations/ExponentialMap.jl
+++ b/src/LazyOperations/ExponentialMap.jl
@@ -467,7 +467,7 @@ A list of vertices.
 We assume that the underlying set `X` is polytopic.
 Then the result is just the exponential map applied to the vertices of `X`.
 """
-function vertices_list(em::ExponentialMap; backend=get_exponential_backend())
+@validate function vertices_list(em::ExponentialMap; backend=get_exponential_backend())
     # collect vertices lists of wrapped set
     vlist_X = vertices_list(em.X)
 

--- a/src/LazyOperations/Intersection.jl
+++ b/src/LazyOperations/Intersection.jl
@@ -645,7 +645,7 @@ bounded.
 We compute the concrete intersection using `intersection` and then take the
 vertices of that representation.
 """
-function vertices_list(cap::Intersection)
+@validate function vertices_list(cap::Intersection)
     return vertices_list(intersection(cap.X, cap.Y))
 end
 

--- a/src/LazyOperations/InverseLinearMap.jl
+++ b/src/LazyOperations/InverseLinearMap.jl
@@ -267,7 +267,7 @@ A list of vertices.
 We assume that the underlying set `X` is polyhedral.
 Then the result is just the inverse linear map applied to the vertices of `X`.
 """
-function vertices_list(ilm::InverseLinearMap; prune::Bool=true)
+@validate function vertices_list(ilm::InverseLinearMap; prune::Bool=true)
     # collect vertices list of wrapped set
     vlist_X = vertices_list(ilm.X)
 

--- a/src/LazyOperations/LinearMap.jl
+++ b/src/LazyOperations/LinearMap.jl
@@ -389,7 +389,7 @@ A list of vertices.
 We assume that the underlying set `X` is polytopic and compute the vertices of
 `X`. The result is just the linear map applied to each vertex.
 """
-function vertices_list(lm::LinearMap; prune::Bool=true)
+@validate function vertices_list(lm::LinearMap; prune::Bool=true)
     # apply the linear map to each vertex
     vlist = broadcast(x -> lm.M * x, vertices(lm.X))
 

--- a/src/LazyOperations/MinkowskiSum.jl
+++ b/src/LazyOperations/MinkowskiSum.jl
@@ -287,7 +287,7 @@ A list of vertices of the Minkowski sum of two sets.
 We compute the concrete Minkowski sum (via `minkowski_sum`) and call
 `vertices_list` on the result.
 """
-function vertices_list(ms::MinkowskiSum)
+@validate function vertices_list(ms::MinkowskiSum)
     return vertices_list(minkowski_sum(ms.X, ms.Y))
 end
 

--- a/src/Sets/Ball1/vertices_list.jl
+++ b/src/Sets/Ball1/vertices_list.jl
@@ -7,7 +7,7 @@
 
 In ``n`` dimensions there are ``2n`` vertices (unless the radius is 0).
 """
-function vertices_list(B::Ball1)
+@validate function vertices_list(B::Ball1)
     # fast evaluation if B has radius 0
     if iszero(B.radius)
         return [B.center]

--- a/src/Sets/HPolytope/vertices_list.jl
+++ b/src/Sets/HPolytope/vertices_list.jl
@@ -30,7 +30,7 @@ backend; for the default backend used in `LazySets` see
 backends see
 [Polyhedra's documentation](https://juliapolyhedra.github.io/Polyhedra.jl/).
 """
-function vertices_list(P::HPolytope; backend=nothing, prune::Bool=true)
+@validate function vertices_list(P::HPolytope; backend=nothing, prune::Bool=true)
     N = eltype(P)
     if isempty(P.constraints)
         return Vector{N}(Vector{N}(undef, 0))  # illegal polytope

--- a/src/Sets/Interval/vertices_list.jl
+++ b/src/Sets/Interval/vertices_list.jl
@@ -9,7 +9,7 @@ The list of vertices of the interval, which are two one-dimensional vectors,
 or just one if the interval is degenerate (the endpoints match within the
 working tolerance).
 """
-function vertices_list(X::Interval; kwargs...)
+@validate function vertices_list(X::Interval; kwargs...)
     a = min(X)
     b = max(X)
     return _isapprox(a, b) ? [[a]] : [[a], [b]]

--- a/src/Sets/LineSegment/vertices_list.jl
+++ b/src/Sets/LineSegment/vertices_list.jl
@@ -1,3 +1,3 @@
-function vertices_list(L::LineSegment)
+@validate function vertices_list(L::LineSegment)
     return [L.p, L.q]
 end

--- a/src/Sets/Star/vertices_list.jl
+++ b/src/Sets/Star/vertices_list.jl
@@ -7,7 +7,7 @@
 
 See [`vertices_list(::LazySets.AbstractAffineMap)`](@ref).
 """
-function vertices_list(X::Star; apply_convex_hull::Bool=true)
+@validate function vertices_list(X::Star; apply_convex_hull::Bool=true)
     am = convert(STAR, X)
     return vertices_list(am; apply_convex_hull=apply_convex_hull)
 end

--- a/src/Sets/VPolygon/vertices_list.jl
+++ b/src/Sets/VPolygon/vertices_list.jl
@@ -1,3 +1,3 @@
-function vertices_list(P::VPolygon; kwargs...)
+@validate function vertices_list(P::VPolygon; kwargs...)
     return P.vertices
 end

--- a/src/Sets/VPolytope/vertices_list.jl
+++ b/src/Sets/VPolytope/vertices_list.jl
@@ -1,3 +1,3 @@
-function vertices_list(P::VPolytope)
+@validate function vertices_list(P::VPolytope)
     return P.vertices
 end

--- a/src/Validation/functions.jl
+++ b/src/Validation/functions.jl
@@ -79,11 +79,21 @@ function validate_triangulate_faces(X::LazySet)
 end
 push!(VALIDATE_DICT, :triangulate_faces => (validate_triangulate_faces, args1))
 
-# function validate_vertices_list(X::LazySet)
-#     # require polytopic set?
-# end
-# push!(VALIDATE_DICT, :vertices_list => (validate_vertices_list, args1))
-# push!(VALIDATE_DICT, :vertices => (validate_vertices, args1))
+function validate_vertices(X::LazySet)
+    if !ispolytopic(X)
+        throw(ArgumentError("`vertices` requires a polytopic set"))
+    end
+    return true
+end
+push!(VALIDATE_DICT, :vertices => (validate_vertices, args1))
+
+function validate_vertices_list(X::LazySet)
+    if !ispolytopic(X)
+        throw(ArgumentError("`vertices_list` requires a polytopic set"))
+    end
+    return true
+end
+push!(VALIDATE_DICT, :vertices_list => (validate_vertices_list, args1))
 
 # mixed set operations
 


### PR DESCRIPTION
Similar to #4012, this PR is skipping `EmptySet` because it is currently not defined as polytopic. But I think it should be.

Moreover, this PR is skipping `UnionSet(Array)`. It is unclear to me whether the implementation for `UnionSet(Array)` is correct. I suggest one should rather broadcast to obtain the result that the current implementation computes.